### PR TITLE
📦 Patch islands transitive dependency alerts

### DIFF
--- a/backend/islands/package.json
+++ b/backend/islands/package.json
@@ -20,10 +20,7 @@
             "minimatch@<10.2.3": "10.2.3",
             "ajv@<6.14.0": "6.14.0",
             "immutable@<5.1.5": "5.1.5",
-            "dompurify": "3.3.2",
-            "flatted": "3.4.2",
-            "follow-redirects": "1.16.0",
-            "picomatch": "4.0.4"
+            "dompurify": "3.3.2"
         }
     }
 }

--- a/backend/islands/package.json
+++ b/backend/islands/package.json
@@ -16,10 +16,7 @@
     "packageManager": "pnpm@9.0.0",
     "pnpm": {
         "overrides": {
-            "markdown-it@>=13.0.0 <14.1.1": "14.1.1",
             "minimatch@<10.2.3": "10.2.3",
-            "ajv@<6.14.0": "6.14.0",
-            "immutable@<5.1.5": "5.1.5",
             "dompurify": "3.3.2"
         }
     }

--- a/backend/islands/package.json
+++ b/backend/islands/package.json
@@ -19,7 +19,11 @@
             "markdown-it@>=13.0.0 <14.1.1": "14.1.1",
             "minimatch@<10.2.3": "10.2.3",
             "ajv@<6.14.0": "6.14.0",
-            "immutable@<5.1.5": "5.1.5"
+            "immutable@<5.1.5": "5.1.5",
+            "dompurify": "3.3.2",
+            "flatted": "3.4.2",
+            "follow-redirects": "1.16.0",
+            "picomatch": "4.0.4"
         }
     }
 }

--- a/backend/islands/pnpm-lock.yaml
+++ b/backend/islands/pnpm-lock.yaml
@@ -5,10 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  markdown-it@>=13.0.0 <14.1.1: 14.1.1
   minimatch@<10.2.3: 10.2.3
-  ajv@<6.14.0: 6.14.0
-  immutable@<5.1.5: 5.1.5
   dompurify: 3.3.2
 
 importers:

--- a/backend/islands/pnpm-lock.yaml
+++ b/backend/islands/pnpm-lock.yaml
@@ -10,9 +10,6 @@ overrides:
   ajv@<6.14.0: 6.14.0
   immutable@<5.1.5: 5.1.5
   dompurify: 3.3.2
-  flatted: 3.4.2
-  follow-redirects: 1.16.0
-  picomatch: 4.0.4
 
 importers:
 
@@ -2257,7 +2254,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: 4.0.4
+      picomatch: ^3 || ^4
     peerDependenciesMeta:
       picomatch:
         optional: true

--- a/backend/islands/pnpm-lock.yaml
+++ b/backend/islands/pnpm-lock.yaml
@@ -9,6 +9,10 @@ overrides:
   minimatch@<10.2.3: 10.2.3
   ajv@<6.14.0: 6.14.0
   immutable@<5.1.5: 5.1.5
+  dompurify: 3.3.2
+  flatted: 3.4.2
+  follow-redirects: 1.16.0
+  picomatch: 4.0.4
 
 importers:
 
@@ -2100,8 +2104,9 @@ packages:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
 
-  dompurify@3.2.7:
-    resolution: {integrity: sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==}
+  dompurify@3.3.2:
+    resolution: {integrity: sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==}
+    engines: {node: '>=20'}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -2252,7 +2257,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: ^3 || ^4
+      picomatch: 4.0.4
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -2272,11 +2277,11 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
-  flatted@3.3.3:
-    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -2846,8 +2851,8 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
   pirates@4.0.7:
@@ -3963,7 +3968,7 @@ snapshots:
       detect-libc: 2.1.2
       is-glob: 4.0.3
       node-addon-api: 7.1.1
-      picomatch: 4.0.3
+      picomatch: 4.0.4
     optionalDependencies:
       '@parcel/watcher-android-arm64': 2.5.6
       '@parcel/watcher-darwin-arm64': 2.5.6
@@ -5073,7 +5078,7 @@ snapshots:
 
   axios@1.15.0:
     dependencies:
-      follow-redirects: 1.15.11
+      follow-redirects: 1.16.0
       form-data: 4.0.5
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -5232,7 +5237,7 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
-  dompurify@3.2.7:
+  dompurify@3.3.2:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -5507,9 +5512,9 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fdir@6.5.0(picomatch@4.0.3):
+  fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -5528,12 +5533,12 @@ snapshots:
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.3.3
+      flatted: 3.4.2
       keyv: 4.5.4
 
-  flatted@3.3.3: {}
+  flatted@3.4.2: {}
 
-  follow-redirects@1.15.11: {}
+  follow-redirects@1.16.0: {}
 
   for-each@0.3.5:
     dependencies:
@@ -5961,7 +5966,7 @@ snapshots:
 
   monaco-editor@0.55.1:
     dependencies:
-      dompurify: 3.2.7
+      dompurify: 3.3.2
       marked: 14.0.0
 
   ms@2.1.3: {}
@@ -6074,7 +6079,7 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@4.0.3: {}
+  picomatch@4.0.4: {}
 
   pirates@4.0.7: {}
 
@@ -6303,7 +6308,7 @@ snapshots:
   rollup-plugin-visualizer@6.0.5(rollup@4.59.0):
     dependencies:
       open: 8.4.2
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       source-map: 0.7.6
       yargs: 17.7.2
     optionalDependencies:
@@ -6556,8 +6561,8 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tree-kill@1.2.2: {}
 
@@ -6720,8 +6725,8 @@ snapshots:
   vite@7.3.2(@types/node@25.0.6)(jiti@2.6.1)(lightningcss@1.31.1)(sass@1.97.3)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.3
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
       postcss: 8.5.6
       rollup: 4.59.0
       tinyglobby: 0.2.15


### PR DESCRIPTION
## 🎯 Goal
- Clear the remaining GitHub Dependabot alerts that are still open under `backend/islands/pnpm-lock.yaml`.
- Keep the fix scope small while reducing long-term version pinning in `pnpm.overrides`.
- Confirm which transitive dependencies truly need a persistent override versus a lockfile refresh only.

## 🔧 Core Changes
- Kept only two `pnpm.overrides` entries in `backend/islands/package.json`: `minimatch@<10.2.3 -> 10.2.3` and `dompurify@3.3.2`.
- Removed the temporary `flatted`, `follow-redirects`, and `picomatch` overrides after confirming the lockfile keeps their patched versions without manifest pins.
- Removed the older `markdown-it`, `ajv`, and `immutable` overrides after re-resolving the lockfile and confirming they stay on safe versions without override help.
- Regenerated `backend/islands/pnpm-lock.yaml` so the islands workspace resolves the patched transitive versions with the smallest necessary override surface.

## 🤔 Key Decisions
- Audited each security-related and legacy transitive override by removing pins and regenerating the lockfile in a separate worktree.
- `dompurify` still requires an override because `monaco-editor@0.55.1` resolves it back to `3.2.7` without a pin.
- `minimatch` still requires an override because multiple packages re-resolve to `3.1.5` and `9.0.9` without the guard.
- `flatted@3.4.2`, `follow-redirects@1.16.0`, `picomatch@4.0.4`, `markdown-it@14.1.1`, `ajv@6.14.0`, and `immutable@5.1.5` remain on safe versions without manifest pins, so keeping them pinned would be unnecessary maintenance.

## 🧪 Verification Guide
### How to verify
1. Open `backend/islands/package.json` and confirm only `minimatch` and `dompurify` remain in `pnpm.overrides`.
2. Open `backend/islands/pnpm-lock.yaml` and confirm the resolved versions for `dompurify`, `minimatch`, `flatted`, `follow-redirects`, `picomatch`, `markdown-it`, `ajv`, and `immutable` are all on the expected safe versions.
3. Run `pnpm lint` in `backend/islands`.
4. Run `pnpm type-check` in `backend/islands`.
5. Run `pnpm build` in `backend/islands`.
6. After merge, re-check `https://github.com/baealex/BLEX/security/dependabot` and confirm the remaining open alerts are auto-dismissed.

### Expected result
- The islands workspace resolves patched transitive package versions while keeping `pnpm.overrides` as small as possible.
- Lint, type-check, and build continue to pass.
- The remaining GitHub Dependabot alerts close after the lockfile lands on `main`.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [ ] Tests completed
- [ ] Documentation updated (if needed)
