### PR TITLE
✨ Improve agent discovery for series and static pages

### DIFF
--- a/backend/src/board/services/agent_content_service.py
+++ b/backend/src/board/services/agent_content_service.py
@@ -4,12 +4,12 @@ import re
 
 from bs4 import BeautifulSoup
 from bs4.element import NavigableString, Tag as SoupTag
-from django.db.models import QuerySet
+from django.db.models import Count, Q, QuerySet
 from django.http import Http404, HttpRequest
 from django.urls import reverse
 from django.utils import timezone
 
-from board.models import Post, PostContent
+from board.models import Post, PostContent, Series, StaticPage
 
 
 class AgentContentService:
@@ -58,54 +58,167 @@ class AgentContentService:
             raise Http404("Post does not exist") from error
 
     @staticmethod
+    def get_public_series() -> QuerySet[Series]:
+        public_post_filter = Q(
+            posts__published_date__isnull=False,
+            posts__published_date__lte=timezone.now(),
+            posts__config__hide=False,
+        )
+        return Series.objects.select_related('owner').annotate(
+            public_post_count=Count('posts', filter=public_post_filter, distinct=True)
+        ).filter(
+            hide=False,
+            public_post_count__gte=1,
+        ).order_by('order', '-updated_date')
+
+    @staticmethod
+    def get_public_series_detail(username: str, series_url: str) -> Series:
+        try:
+            return AgentContentService.get_public_series().get(
+                owner__username=username,
+                url=series_url,
+            )
+        except Series.DoesNotExist as error:
+            raise Http404("Series does not exist") from error
+
+    @staticmethod
+    def get_public_series_posts(series: Series) -> QuerySet[Post]:
+        return Post.objects.select_related(
+            'author',
+            'config',
+        ).filter(
+            series=series,
+            published_date__isnull=False,
+            published_date__lte=timezone.now(),
+            config__hide=False,
+        ).order_by('-published_date')
+
+    @staticmethod
+    def get_public_static_pages() -> QuerySet[StaticPage]:
+        return StaticPage.objects.filter(
+            is_published=True,
+        ).order_by('order', 'slug')
+
+    @staticmethod
+    def get_public_static_page(slug: str) -> StaticPage:
+        try:
+            return AgentContentService.get_public_static_pages().get(slug=slug)
+        except StaticPage.DoesNotExist as error:
+            raise Http404("Static page does not exist") from error
+
+    @staticmethod
     def build_llms_txt(request: HttpRequest) -> str:
         site_url = request.build_absolute_uri(reverse('index')).rstrip('/')
-        latest_posts = AgentContentService.get_public_posts()
+        latest_posts = list(AgentContentService.get_public_posts())
+        public_series = list(AgentContentService.get_public_series())
+        public_static_pages = list(AgentContentService.get_public_static_pages())
 
         lines = [
             '# BLEX',
             '',
-            'BLEX is a blog platform for long-form posts, series, and author archives.',
-            'This file is optimized for AI agents. Prefer Markdown URLs when you need clean post content.',
+            '> BLEX is a long-form publishing site with public posts, curated series, and published static pages for readers and AI agents.',
             '',
-            '## Entry Points',
-            '',
-            f'- Site: {site_url}',
-            f'- Sitemap: {request.build_absolute_uri(reverse("sitemap"))}',
-            f'- Posts sitemap: {request.build_absolute_uri(reverse("sitemap_section", args=["posts"]))}',
-            f'- Series sitemap: {request.build_absolute_uri(reverse("sitemap_section", args=["series"]))}',
-            f'- Authors sitemap: {request.build_absolute_uri(reverse("sitemap_section", args=["user"]))}',
-            f'- RSS: {request.build_absolute_uri("/rss")}',
-            '',
-            '## URL Conventions',
-            '',
-            '- Post HTML: /@{username}/{post_url}',
-            '- Post Markdown: /@{username}/{post_url}.md',
-            '',
-            '## Latest Public Posts',
+            'Prefer Markdown endpoints when available, because they remove template noise and preserve the cleanest agent-readable content.',
+            'Recent posts are listed under `Optional` so agents with tight context budgets can skip them first.',
             '',
         ]
 
-        if not latest_posts:
-            lines.append('- No public posts are available.')
+        entry_points = [
+            AgentContentService.build_llms_link_line(
+                'Homepage',
+                site_url,
+                'Human-readable homepage for the latest published content.',
+            ),
+            AgentContentService.build_llms_link_line(
+                'Sitemap index',
+                request.build_absolute_uri(reverse('sitemap')),
+                'Top-level sitemap with links to posts, series, authors, and static pages.',
+            ),
+            AgentContentService.build_llms_link_line(
+                'Posts sitemap',
+                request.build_absolute_uri(reverse('sitemap_section', args=['posts'])),
+                'Complete list of public post HTML URLs.',
+            ),
+            AgentContentService.build_llms_link_line(
+                'Series sitemap',
+                request.build_absolute_uri(reverse('sitemap_section', args=['series'])),
+                'Complete list of public series HTML URLs.',
+            ),
+            AgentContentService.build_llms_link_line(
+                'Authors sitemap',
+                request.build_absolute_uri(reverse('sitemap_section', args=['user'])),
+                'Complete list of public author archive URLs.',
+            ),
+            AgentContentService.build_llms_link_line(
+                'Static pages sitemap',
+                request.build_absolute_uri(reverse('sitemap_section', args=['staticpages'])),
+                'Complete list of published static page HTML URLs.',
+            ),
+            AgentContentService.build_llms_link_line(
+                'RSS feed',
+                request.build_absolute_uri('/rss'),
+                'Recent published posts feed.',
+            ),
+        ]
+        AgentContentService.append_llms_section(lines, 'Entry Points', entry_points)
 
+        if public_series:
+            series_lines = [
+                AgentContentService.build_llms_link_line(
+                    series.name,
+                    AgentContentService.build_series_markdown_url(series, request),
+                    f'Series overview and public post list for @{series.owner.username}.',
+                )
+                for series in public_series
+            ]
+            AgentContentService.append_llms_section(lines, 'Series', series_lines)
+
+        if public_static_pages:
+            static_page_lines = [
+                AgentContentService.build_llms_link_line(
+                    page.title,
+                    AgentContentService.build_static_page_markdown_url(page, request),
+                    'Published static page in Markdown for agent use.',
+                )
+                for page in public_static_pages
+            ]
+            AgentContentService.append_llms_section(lines, 'Static Pages', static_page_lines)
+
+        optional_lines = []
         for post in latest_posts:
-            markdown_url = request.build_absolute_uri(
-                reverse('post_markdown', args=[post.author.username, post.url])
-            )
+            markdown_url = AgentContentService.build_post_markdown_url(post, request)
             source_url = request.build_absolute_uri(post.get_absolute_url())
-            markdown = AgentContentService.build_post_markdown(post, request)
-            token_count = AgentContentService.estimate_tokens(markdown)
-            title = AgentContentService.escape_link_text(post.title)
-
-            lines.append(
-                f'- [{title}]({markdown_url}) '
-                f'- author: @{post.author.username}; '
-                f'estimated tokens: {token_count}; '
-                f'source: {source_url}'
+            optional_lines.append(
+                AgentContentService.build_llms_link_line(
+                    post.title,
+                    markdown_url,
+                    f'Recent post by @{post.author.username}. Source HTML: {source_url}',
+                )
             )
+
+        if optional_lines:
+            AgentContentService.append_llms_section(lines, 'Optional', optional_lines)
 
         return '\n'.join(lines).strip() + '\n'
+
+    @staticmethod
+    def append_llms_section(lines: list[str], title: str, items: list[str]) -> None:
+        if not items:
+            return
+
+        lines.extend([
+            f'## {title}',
+            '',
+        ])
+        lines.extend(items)
+        lines.append('')
+
+    @staticmethod
+    def build_llms_link_line(title: str, url: str, description: str | None = None) -> str:
+        escaped_title = AgentContentService.escape_link_text(title)
+        if description:
+            return f'- [{escaped_title}]({url}): {description}'
+        return f'- [{escaped_title}]({url})'
 
     @staticmethod
     def build_llms_txt_url(request: HttpRequest) -> str:
@@ -118,10 +231,25 @@ class AgentContentService:
         )
 
     @staticmethod
+    def build_series_markdown_url(series: Series, request: HttpRequest) -> str:
+        return request.build_absolute_uri(
+            reverse('series_markdown', args=[series.owner.username, series.url])
+        )
+
+    @staticmethod
+    def build_static_page_markdown_url(page: StaticPage, request: HttpRequest) -> str:
+        return request.build_absolute_uri(
+            reverse('static_page_markdown', args=[page.slug])
+        )
+
+    @staticmethod
     def build_agent_link_header(post: Post, request: HttpRequest) -> str:
         markdown_url = AgentContentService.build_post_markdown_url(post, request)
-        llms_txt_url = AgentContentService.build_llms_txt_url(request)
+        return AgentContentService.build_agent_link_header_for_markdown_url(markdown_url, request)
 
+    @staticmethod
+    def build_agent_link_header_for_markdown_url(markdown_url: str, request: HttpRequest) -> str:
+        llms_txt_url = AgentContentService.build_llms_txt_url(request)
         return (
             f'<{markdown_url}>; rel="alternate"; type="text/markdown", '
             f'<{llms_txt_url}>; rel="llms-txt"'
@@ -156,6 +284,62 @@ class AgentContentService:
         return AgentContentService.collapse_blank_lines('\n'.join(lines)).strip() + '\n'
 
     @staticmethod
+    def build_series_markdown(series: Series, request: HttpRequest) -> str:
+        content = AgentContentService.get_series_content_markdown(series)
+        source_url = request.build_absolute_uri(series.get_absolute_url())
+        public_posts = list(AgentContentService.get_public_series_posts(series))
+
+        lines = [
+            f'# {series.name}',
+            '',
+            f'- Author: @{series.owner.username}',
+            f'- Updated: {series.updated_date.date().isoformat()}',
+            f'- Source: {source_url}',
+            '',
+            '---',
+            '',
+        ]
+
+        if content:
+            lines.extend([content, ''])
+
+        if public_posts:
+            lines.extend([
+                '## Posts',
+                '',
+            ])
+            lines.extend(
+                AgentContentService.build_llms_link_line(
+                    post.title,
+                    AgentContentService.build_post_markdown_url(post, request),
+                    f'Published {post.published_date.date().isoformat()}.',
+                )
+                for post in public_posts
+            )
+        else:
+            lines.append('No public posts are available in this series.')
+
+        return AgentContentService.collapse_blank_lines('\n'.join(lines)).strip() + '\n'
+
+    @staticmethod
+    def build_static_page_markdown(page: StaticPage, request: HttpRequest) -> str:
+        content = AgentContentService.html_to_markdown(page.content)
+        source_url = request.build_absolute_uri(reverse('static_page', args=[page.slug]))
+
+        lines = [
+            f'# {page.title}',
+            '',
+            f'- Updated: {page.updated_date.date().isoformat()}',
+            f'- Source: {source_url}',
+            '',
+            '---',
+            '',
+            content,
+        ]
+
+        return AgentContentService.collapse_blank_lines('\n'.join(lines)).strip() + '\n'
+
+    @staticmethod
     def get_post_content_markdown(post: Post) -> str:
         content = post.content
         text_md = content.text_md.strip()
@@ -169,6 +353,15 @@ class AgentContentService:
 
         html = content.text_html or content.text_md
         return AgentContentService.html_to_markdown(html)
+
+    @staticmethod
+    def get_series_content_markdown(series: Series) -> str:
+        text_md = series.text_md.strip()
+
+        if text_md and not AgentContentService.looks_like_html(text_md):
+            return text_md
+
+        return AgentContentService.html_to_markdown(series.text_html or series.text_md)
 
     @staticmethod
     def looks_like_html(text: str) -> bool:

--- a/backend/src/board/templates/board/pages/static_page.html
+++ b/backend/src/board/templates/board/pages/static_page.html
@@ -6,6 +6,10 @@
 
 {% block meta_description %}{{ meta_description }}{% endblock %}
 
+{% block meta %}
+<link rel="alternate" type="text/markdown" href="{{ static_page_markdown_url }}">
+{% endblock %}
+
 {% block extra_styles %}
 <link rel="stylesheet" href="{% island_css 'styles/post.scss' %}">
 {% endblock %}

--- a/backend/src/board/templates/board/series/series_detail.html
+++ b/backend/src/board/templates/board/series/series_detail.html
@@ -5,6 +5,10 @@
 
 {% block title %}{{ series.name }} - {{ author.username }} | BLEX{% endblock %}
 
+{% block meta %}
+<link rel="alternate" type="text/markdown" href="{{ series_markdown_url }}">
+{% endblock %}
+
 {% block content %}
 <div class="max-w-3xl w-full mx-auto px-4 sm:px-6 py-8 sm:py-12">
     <!-- 시리즈 헤더 -->

--- a/backend/src/board/tests/templates/test_agent_discovery.py
+++ b/backend/src/board/tests/templates/test_agent_discovery.py
@@ -1,0 +1,101 @@
+from django.contrib.auth.models import User
+from django.test import Client, TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from board.models import Post, PostConfig, PostContent, Series, StaticPage
+
+
+class SeriesAgentDiscoveryTestCase(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.author = User.objects.create_user(
+            username='seriesauthor',
+            email='series@example.com',
+            password='password123',
+        )
+        self.series = Series.objects.create(
+            owner=self.author,
+            name='Agent Discovery Series',
+            text_md='Series intro',
+            url='agent-discovery-series',
+            hide=False,
+        )
+        self.post = Post.objects.create(
+            title='Series Post',
+            url='series-post',
+            author=self.author,
+            series=self.series,
+            created_date=timezone.now(),
+            published_date=timezone.now(),
+        )
+        PostContent.objects.create(
+            post=self.post,
+            text_md='Series body',
+            text_html='<p>Series body</p>',
+        )
+        PostConfig.objects.create(
+            post=self.post,
+            hide=False,
+        )
+
+    def test_series_detail_advertises_markdown_alternate(self):
+        response = self.client.get(reverse('series_detail', kwargs={
+            'username': 'seriesauthor',
+            'series_url': 'agent-discovery-series',
+        }))
+
+        self.assertEqual(response.status_code, 200)
+
+        markdown_url = 'http://testserver/@seriesauthor/series/agent-discovery-series.md'
+        llms_txt_url = 'http://testserver/llms.txt'
+        content = response.content.decode()
+
+        self.assertIn(markdown_url, content)
+        self.assertIn('rel=alternate', content)
+        self.assertIn('type=text/markdown', content)
+        self.assertIn(
+            f'<{markdown_url}>; rel="alternate"; type="text/markdown"',
+            response['Link'],
+        )
+        self.assertIn(
+            f'<{llms_txt_url}>; rel="llms-txt"',
+            response['Link'],
+        )
+        self.assertEqual(response['X-Llms-Txt'], llms_txt_url)
+
+
+class StaticPageAgentDiscoveryTestCase(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.page = StaticPage.objects.create(
+            slug='agent-policy',
+            title='Agent Policy',
+            content='<h2>Policy</h2><p>Agent-readable policy page.</p>',
+            meta_description='Agent policy page',
+            is_published=True,
+        )
+
+    def test_static_page_advertises_markdown_alternate(self):
+        response = self.client.get(reverse('static_page', kwargs={
+            'slug': 'agent-policy',
+        }))
+
+        self.assertEqual(response.status_code, 200)
+
+        markdown_url = 'http://testserver/static/agent-policy.md'
+        llms_txt_url = 'http://testserver/llms.txt'
+        content = response.content.decode()
+
+        self.assertIn(markdown_url, content)
+        self.assertIn('rel=alternate', content)
+        self.assertIn('type=text/markdown', content)
+        self.assertIn(
+            f'<{markdown_url}>; rel="alternate"; type="text/markdown"',
+            response['Link'],
+        )
+        self.assertIn(
+            f'<{llms_txt_url}>; rel="llms-txt"',
+            response['Link'],
+        )
+        self.assertEqual(response['X-Llms-Txt'], llms_txt_url)

--- a/backend/src/board/tests/test_agent_content.py
+++ b/backend/src/board/tests/test_agent_content.py
@@ -1,3 +1,4 @@
+import re
 from datetime import timedelta
 
 from django.conf import settings
@@ -5,7 +6,7 @@ from django.contrib.auth.models import User
 from django.test import Client, TestCase, override_settings
 from django.utils import timezone
 
-from board.models import Post, PostConfig, PostContent
+from board.models import Post, PostConfig, PostContent, Series, StaticPage
 
 
 BASE_MIDDLEWARE = tuple(
@@ -32,6 +33,15 @@ class AgentContentTestCase(TestCase):
             text_md='## Outcome\nAgents can parse this post.\n',
             published_date=now,
         )
+        cls.public_series = Series.objects.create(
+            owner=cls.author,
+            name='Agent Ready Series',
+            text_md='Series summary for agents.',
+            url='agent-ready-series',
+            hide=False,
+        )
+        cls.public_post.series = cls.public_series
+        cls.public_post.save(update_fields=['series'])
         html_content = (
             '<h2>HTML Outcome</h2>'
             '<p>Agents <strong>parse</strong> links <a href="/source">source</a>.</p>'
@@ -44,6 +54,8 @@ class AgentContentTestCase(TestCase):
             content_type=PostContent.ContentType.HTML,
             published_date=now,
         )
+        cls.html_post.series = cls.public_series
+        cls.html_post.save(update_fields=['series'])
         cls.html_without_markdown_post = cls.create_post(
             title='New Editor Agent Post',
             url='new-editor-agent-post',
@@ -121,6 +133,20 @@ class AgentContentTestCase(TestCase):
             text_md='Future content',
             published_date=now + timedelta(days=1),
         )
+        cls.public_static_page = StaticPage.objects.create(
+            slug='about-ai',
+            title='About AI',
+            content='<h2>About BLEX</h2><p>Static page content for agents.</p>',
+            meta_description='About page for agents',
+            is_published=True,
+        )
+        cls.unpublished_static_page = StaticPage.objects.create(
+            slug='internal-ai',
+            title='Internal AI Page',
+            content='<p>Not public</p>',
+            meta_description='Hidden page',
+            is_published=False,
+        )
 
     @classmethod
     def create_post(
@@ -189,6 +215,53 @@ class AgentContentTestCase(TestCase):
         self.assertIn('/rss', body)
         self.assertIn('/@aeo-author/agent-ready-post.md', body)
 
+    def test_llms_txt_follows_llmstxt_structure_and_lists_series_static_markdown(self):
+        """llms.txt는 요약 blockquote와 H2 링크 목록 구조를 지키고 시리즈/정적 페이지를 노출한다."""
+        response = self.client.get('/llms.txt')
+
+        self.assertEqual(response.status_code, 200)
+
+        body = response.content.decode()
+
+        self.assertRegex(
+            body,
+            r'^# BLEX\n\n> .+\n\n',
+        )
+        self.assertIn('## Entry Points\n', body)
+        self.assertIn('## Series\n', body)
+        self.assertIn('## Static Pages\n', body)
+        self.assertIn('## Optional\n', body)
+        self.assertIn(
+            '[Static pages sitemap](http://testserver/staticpages/sitemap.xml)',
+            body,
+        )
+        self.assertIn(
+            '[Agent Ready Series](http://testserver/@aeo-author/series/agent-ready-series.md)',
+            body,
+        )
+        self.assertIn(
+            '[About AI](http://testserver/static/about-ai.md)',
+            body,
+        )
+        self.assertIn(
+            '[Agent Ready Post](http://testserver/@aeo-author/agent-ready-post.md)',
+            body,
+        )
+
+        in_link_section = False
+        for line in body.splitlines():
+            if line.startswith('## '):
+                in_link_section = True
+                continue
+
+            if not in_link_section or not line.strip():
+                continue
+
+            self.assertRegex(
+                line,
+                r'^- \[[^\]]+\]\([^)]+\)(: .+)?$',
+            )
+
     def test_post_markdown_endpoint_returns_clean_markdown(self):
         """공개 포스트는 Markdown endpoint로 AI용 본문을 제공한다."""
         response = self.client.get('/@aeo-author/agent-ready-post.md')
@@ -202,6 +275,44 @@ class AgentContentTestCase(TestCase):
         self.assertIn('Author: @aeo-author', body)
         self.assertIn('Source: http://testserver/@aeo-author/agent-ready-post', body)
         self.assertIn('## Outcome\nAgents can parse this post.', body)
+
+    def test_series_markdown_endpoint_returns_clean_markdown(self):
+        """공개 시리즈는 Markdown endpoint로 시리즈 설명과 공개 포스트 링크를 제공한다."""
+        response = self.client.get('/@aeo-author/series/agent-ready-series.md')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response['Content-Type'].startswith('text/markdown'))
+        self.assertTrue(response['X-Estimated-Tokens'].isdigit())
+
+        body = response.content.decode()
+        self.assertIn('# Agent Ready Series', body)
+        self.assertIn('Author: @aeo-author', body)
+        self.assertIn('Source: http://testserver/@aeo-author/series/agent-ready-series', body)
+        self.assertIn('Series summary for agents.', body)
+        self.assertIn(
+            '- [Agent Ready Post](http://testserver/@aeo-author/agent-ready-post.md)',
+            body,
+        )
+
+    def test_static_page_markdown_endpoint_returns_clean_markdown(self):
+        """공개 정적 페이지는 Markdown endpoint로 AI용 본문을 제공한다."""
+        response = self.client.get('/static/about-ai.md')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response['Content-Type'].startswith('text/markdown'))
+        self.assertTrue(response['X-Estimated-Tokens'].isdigit())
+
+        body = response.content.decode()
+        self.assertIn('# About AI', body)
+        self.assertIn('Source: http://testserver/static/about-ai', body)
+        self.assertIn('## About BLEX', body)
+        self.assertIn('Static page content for agents.', body)
+
+    def test_static_page_markdown_endpoint_hides_unpublished_page(self):
+        """비공개 정적 페이지는 Markdown endpoint로 노출하지 않는다."""
+        response = self.client.get('/static/internal-ai.md')
+
+        self.assertEqual(response.status_code, 404)
 
     def test_post_markdown_endpoint_converts_html_content(self):
         """HTML 기반 포스트도 태그 잡음 없이 Markdown fallback을 제공한다."""

--- a/backend/src/board/urls.py
+++ b/backend/src/board/urls.py
@@ -35,6 +35,7 @@ urlpatterns = [
     path('llms.txt', agent.llms_txt, name='llms_txt'),
 
     # Static pages
+    path('static/<path:slug>.md', agent.static_page_markdown, name='static_page_markdown'),
     path('static/<path:slug>', static_page_view, name='static_page'),
 
     # Settings - Unified Settings App with client-side routing
@@ -48,6 +49,7 @@ urlpatterns = [
     path('@<username>/series', author_series, name='user_series'),
     path('@<username>/about', author_about, name='user_about'),
     path('@<username>/about/edit', author_about_edit, name='user_about_edit'),
+    path('@<username>/series/<series_url>.md', agent.series_markdown, name='series_markdown'),
     path('@<username>/series/<series_url>', series_detail, name='series_detail'),
     path('@<username>/posts', author_posts, name='user_posts'),
     path('@<username>/<post_url>.md', agent.post_markdown, name='post_markdown'),

--- a/backend/src/board/views/agent.py
+++ b/backend/src/board/views/agent.py
@@ -16,3 +16,19 @@ def post_markdown(request: HttpRequest, username: str, post_url: str) -> HttpRes
     response = HttpResponse(content, content_type='text/markdown; charset=utf-8')
     response['X-Estimated-Tokens'] = str(AgentContentService.estimate_tokens(content))
     return response
+
+
+def series_markdown(request: HttpRequest, username: str, series_url: str) -> HttpResponse:
+    series = AgentContentService.get_public_series_detail(username, series_url)
+    content = AgentContentService.build_series_markdown(series, request)
+    response = HttpResponse(content, content_type='text/markdown; charset=utf-8')
+    response['X-Estimated-Tokens'] = str(AgentContentService.estimate_tokens(content))
+    return response
+
+
+def static_page_markdown(request: HttpRequest, slug: str) -> HttpResponse:
+    page = AgentContentService.get_public_static_page(slug)
+    content = AgentContentService.build_static_page_markdown(page, request)
+    response = HttpResponse(content, content_type='text/markdown; charset=utf-8')
+    response['X-Estimated-Tokens'] = str(AgentContentService.estimate_tokens(content))
+    return response

--- a/backend/src/board/views/series.py
+++ b/backend/src/board/views/series.py
@@ -5,6 +5,7 @@ from django.utils import timezone
 from django.http import Http404
 
 from board.models import Post, Series, PostLikes
+from board.services.agent_content_service import AgentContentService
 
 
 def series_detail(request, username, series_url):
@@ -89,6 +90,13 @@ def series_detail(request, username, series_url):
         'next_page': page + 1 if has_next else None,
         'sort_order': sort_order,
         'request': request,
+        'series_markdown_url': AgentContentService.build_series_markdown_url(series, request),
     }
 
-    return render(request, 'board/series/series_detail.html', context)
+    response = render(request, 'board/series/series_detail.html', context)
+    response['Link'] = AgentContentService.build_agent_link_header_for_markdown_url(
+        context['series_markdown_url'],
+        request,
+    )
+    response['X-Llms-Txt'] = AgentContentService.build_llms_txt_url(request)
+    return response

--- a/backend/src/board/views/static_pages.py
+++ b/backend/src/board/views/static_pages.py
@@ -1,6 +1,7 @@
 from django.shortcuts import render, get_object_or_404
 
 from board.models import StaticPage
+from board.services.agent_content_service import AgentContentService
 
 
 def custom_404_view(request, exception=None):
@@ -22,6 +23,13 @@ def static_page_view(request, slug):
         'page': page,
         'title': page.title,
         'meta_description': page.meta_description or page.title,
+        'static_page_markdown_url': AgentContentService.build_static_page_markdown_url(page, request),
     }
 
-    return render(request, 'board/pages/static_page.html', context)
+    response = render(request, 'board/pages/static_page.html', context)
+    response['Link'] = AgentContentService.build_agent_link_header_for_markdown_url(
+        context['static_page_markdown_url'],
+        request,
+    )
+    response['X-Llms-Txt'] = AgentContentService.build_llms_txt_url(request)
+    return response


### PR DESCRIPTION
## 🎯 Goal
- Improve agent discoverability for BLEX content beyond post detail pages.
- Make series and static pages easier for search engines and AI agents to discover through `llms.txt`, Markdown exports, and HTML/header hints.

## 🔧 Core Changes
- Restructured `/llms.txt` to follow the llms.txt-style layout more closely and expose series/static page discovery links.
- Added agent-readable Markdown endpoints for public series and public static pages.
- Added markdown alternate discovery hints to series detail and static page HTML.
- Added `Link` and `X-Llms-Txt` headers so agents can discover Markdown and `/llms.txt` from page responses.
- Added contract tests for llms discovery surface and series/static page agent discovery.

## 🤔 Key Decisions
- Kept the implementation focused on discovery surfaces instead of adding AI traffic logging first.
- Reused a shared helper for response headers so post/series/static discovery hints stay consistent.
- Added tests at the contract level to verify real outward behavior (`llms.txt`, markdown endpoint, HTML alternate, response headers).

## 🧪 Verification Guide
### How to verify
1. Run `npm run server:test -- --pattern=test_agent_content.py`
2. Run `npm run server:test -- --pattern=test_agent_discovery.py`
3. Open a public series detail page and a public static page, then confirm the HTML contains `rel="alternate" type="text/markdown"` and the response headers include `Link` + `X-Llms-Txt`

### Expected result
- `/llms.txt` exposes series/static markdown links in a structured format.
- Public series and static pages expose agent-readable Markdown endpoints.
- Series/static HTML responses advertise their Markdown alternate and `/llms.txt` entry point.

## ✅ Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [x] Tests completed
- [ ] Documentation updated (if needed)
