### PR TITLE
✨ Add AEO exposure controls

### DIFF
--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/SettingsApp.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/SettingsApp.tsx
@@ -28,6 +28,7 @@ const GlobalWebhookSetting = lazy(() => import('./pages/GlobalWebhookSetting'));
 const GlobalNoticeSetting = lazy(() => import('./pages/GlobalNoticeSetting'));
 const GlobalBannerSetting = lazy(() => import('./pages/GlobalBannerSetting'));
 const SiteSettingSetting = lazy(() => import('./pages/SiteSettingSetting'));
+const SeoAeoSetting = lazy(() => import('./pages/SeoAeoSetting'));
 const StaticPagesSetting = lazy(() => import('./pages/StaticPagesSetting'));
 const UtilitySetting = lazy(() => import('./pages/UtilitySetting'));
 
@@ -169,6 +170,12 @@ const siteSettingsRoute = createRoute({
     component: SiteSettingSetting
 });
 
+const seoAeoRoute = createRoute({
+    getParentRoute: () => settingsRoute,
+    path: '/seo-aeo',
+    component: SeoAeoSetting
+});
+
 const staticPagesRoute = createRoute({
     getParentRoute: () => settingsRoute,
     path: '/static-pages',
@@ -279,6 +286,7 @@ const routeTree = rootRoute.addChildren([
         globalNoticesRoute,
         globalBannersRoute,
         siteSettingsRoute,
+        seoAeoRoute,
         staticPagesRoute,
         utilitiesRoute
     ])

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/SettingsNavigation.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/SettingsNavigation.tsx
@@ -133,6 +133,12 @@ const navigationSections: NavigationSection[] = [
                 requiresStaff: true
             },
             {
+                name: 'SEO/AEO',
+                path: '/seo-aeo',
+                icon: 'fa-robot',
+                requiresStaff: true
+            },
+            {
                 name: '정적 페이지',
                 path: '/static-pages',
                 icon: 'fa-file-lines',

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SeoAeoSetting/SeoAeoSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SeoAeoSetting/SeoAeoSetting.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useState } from 'react';
+import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
+import { Toggle } from '@blex/ui/toggle';
+import { Card } from '~/components/shared';
+import { toast } from '~/utils/toast';
+import { getSiteSettings, updateSiteSettings } from '~/lib/api/settings';
+import { SettingsHeader } from '../../components';
+
+const SeoAeoSetting = () => {
+    const { data: settingData } = useSuspenseQuery({
+        queryKey: ['site-settings'],
+        queryFn: async () => {
+            const { data } = await getSiteSettings();
+            if (data.status === 'DONE') {
+                return data.body;
+            }
+            throw new Error('SEO/AEO 설정을 불러오는데 실패했습니다.');
+        }
+    });
+
+    const [aeoEnabled, setAeoEnabled] = useState(false);
+
+    useEffect(() => {
+        setAeoEnabled(settingData.aeoEnabled);
+    }, [settingData]);
+
+    const updateMutation = useMutation({
+        mutationFn: (enabled: boolean) => updateSiteSettings({ aeo_enabled: enabled }),
+        onSuccess: (_, enabled) => {
+            setAeoEnabled(enabled);
+            toast.success('SEO/AEO 설정이 저장되었습니다.');
+        },
+        onError: () => {
+            setAeoEnabled(settingData.aeoEnabled);
+            toast.error('SEO/AEO 설정 저장에 실패했습니다.');
+        }
+    });
+
+    const handleAeoChange = (enabled: boolean) => {
+        setAeoEnabled(enabled);
+        updateMutation.mutate(enabled);
+    };
+
+    return (
+        <div className="space-y-8">
+            <SettingsHeader
+                title="SEO/AEO"
+                description="검색엔진과 인공지능 에이전트 노출 정책을 관리합니다."
+            />
+
+            <Card
+                title="AEO(인공지능 노출)"
+                subtitle="llms.txt, Markdown endpoint, discovery header 공개 여부를 제어합니다."
+                icon={<i className="fas fa-robot" />}>
+                <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                    <div className="space-y-1">
+                        <div className="text-sm font-semibold text-content">AEO 활성화</div>
+                        <p className="text-xs leading-relaxed text-content-secondary">
+                            켜면 AI용 진입점과 Markdown 노출 표면이 함께 열립니다.
+                        </p>
+                    </div>
+                    <div className="flex items-center gap-3">
+                        <span className="text-xs font-medium text-content-secondary">
+                            {aeoEnabled ? 'ON' : 'OFF'}
+                        </span>
+                        <Toggle
+                            checked={aeoEnabled}
+                            disabled={updateMutation.isPending}
+                            onCheckedChange={handleAeoChange}
+                            aria-label="AEO 인공지능 노출 활성화"
+                        />
+                    </div>
+                </div>
+            </Card>
+        </div>
+    );
+};
+
+export default SeoAeoSetting;

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SeoAeoSetting/index.ts
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SeoAeoSetting/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SeoAeoSetting';

--- a/backend/islands/apps/remotes/src/lib/api/settings.ts
+++ b/backend/islands/apps/remotes/src/lib/api/settings.ts
@@ -580,6 +580,7 @@ export interface SiteSettingData {
     welcomeNotificationMessage: string;
     welcomeNotificationUrl: string;
     accountDeletionRedirectUrl: string;
+    aeoEnabled: boolean;
     updatedDate: string;
 }
 
@@ -589,6 +590,7 @@ export interface SiteSettingUpdateData {
     welcome_notification_message?: string;
     welcome_notification_url?: string;
     account_deletion_redirect_url?: string;
+    aeo_enabled?: boolean;
 }
 
 export const getSiteSettings = async () => {

--- a/backend/islands/apps/remotes/vite.config.ts
+++ b/backend/islands/apps/remotes/vite.config.ts
@@ -1,8 +1,50 @@
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin, type ViteDevServer } from 'vite';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
 import { visualizer } from 'rollup-plugin-visualizer';
-import { resolve } from 'path';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { dirname, resolve } from 'path';
+
+const DEFAULT_DEV_SERVER_PORT = 8100;
+const DEV_SERVER_HOST = process.env.VITE_DEV_SERVER_HOST || 'localhost';
+const DEV_SERVER_INFO_PATH = process.env.VITE_DEV_SERVER_INFO_PATH
+    || resolve(__dirname, '../../../src/resources/staticfiles/islands/.vite/dev-server.json');
+
+const getDevServerPort = () => {
+    const rawPort = process.env.VITE_DEV_SERVER_PORT;
+    if (!rawPort) return DEFAULT_DEV_SERVER_PORT;
+
+    const port = Number.parseInt(rawPort, 10);
+    return Number.isInteger(port) && port > 0 ? port : DEFAULT_DEV_SERVER_PORT;
+};
+
+const writeDevServerInfoPlugin = (): Plugin => ({
+    name: 'blex-dev-server-info',
+    configureServer(server: ViteDevServer) {
+        const writeDevServerInfo = () => {
+            const address = server.httpServer?.address();
+            const port = typeof address === 'object' && address ? address.port : getDevServerPort();
+            const protocol = server.config.server.https ? 'https' : 'http';
+            const url = `${protocol}://${DEV_SERVER_HOST}:${port}`;
+
+            mkdirSync(dirname(DEV_SERVER_INFO_PATH), { recursive: true });
+            writeFileSync(
+                DEV_SERVER_INFO_PATH,
+                JSON.stringify({ url, host: DEV_SERVER_HOST, port, protocol }, null, 2)
+            );
+        };
+
+        const removeDevServerInfo = () => {
+            if (existsSync(DEV_SERVER_INFO_PATH)) {
+                rmSync(DEV_SERVER_INFO_PATH, { force: true });
+            }
+        };
+
+        removeDevServerInfo();
+        server.httpServer?.once('listening', writeDevServerInfo);
+        server.httpServer?.once('close', removeDevServerInfo);
+    }
+});
 
 export default defineConfig(({ mode }) => {
     const isDevelopment = mode === 'development';
@@ -11,6 +53,7 @@ export default defineConfig(({ mode }) => {
         base: './',
 
         plugins: [
+            writeDevServerInfoPlugin(),
             tailwindcss(),
             react({
                 babel: {
@@ -27,10 +70,9 @@ export default defineConfig(({ mode }) => {
         ],
 
         server: {
-            port: 5173,
+            port: getDevServerPort(),
             host: true,
             cors: true,
-            origin: 'http://localhost:5173',
             hmr: true
         },
 

--- a/backend/nginx.conf
+++ b/backend/nginx.conf
@@ -119,13 +119,5 @@ http {
             add_header X-Content-Type-Options nosniff always;
         }
 
-        # Robots.txt
-        location = /robots.txt {
-            alias /resources/robots.txt;
-            expires 1d;
-            add_header Cache-Control "public";
-            add_header X-Frame-Options DENY always;
-            add_header X-Content-Type-Options nosniff always;
-        }
     }
 }

--- a/backend/src/board/migrations/0041_sitesetting_aeo_enabled.py
+++ b/backend/src/board/migrations/0041_sitesetting_aeo_enabled.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('board', '0040_migrate_content_types'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='sitesetting',
+            name='aeo_enabled',
+            field=models.BooleanField(
+                default=False,
+                help_text='AI 에이전트용 llms.txt, Markdown endpoint, discovery header 노출 여부',
+            ),
+        ),
+    ]

--- a/backend/src/board/models.py
+++ b/backend/src/board/models.py
@@ -799,6 +799,12 @@ class SiteSetting(models.Model):
         help_text='회원 탈퇴 시 리다이렉트할 URL (비워두면 메인 페이지로 이동, 설문 링크 등을 설정할 수 있습니다)'
     )
 
+    # Search and agent exposure settings
+    aeo_enabled = models.BooleanField(
+        default=False,
+        help_text='AI 에이전트용 llms.txt, Markdown endpoint, discovery header 노출 여부'
+    )
+
     # Metadata
     updated_date = models.DateTimeField(auto_now=True)
 

--- a/backend/src/board/services/agent_content_service.py
+++ b/backend/src/board/services/agent_content_service.py
@@ -9,7 +9,7 @@ from django.http import Http404, HttpRequest
 from django.urls import reverse
 from django.utils import timezone
 
-from board.models import Post, PostContent, Series, StaticPage
+from board.models import Post, PostContent, Series, SiteSetting, StaticPage
 
 
 class AgentContentService:
@@ -17,6 +17,15 @@ class AgentContentService:
     STRUCTURAL_CONTAINER_TAGS = {'article', 'section', 'main', 'aside', 'div', 'html', 'body'}
     INLINE_PASSTHROUGH_TAGS = {'span'}
     INLINE_RAW_TAGS = {'figcaption', 'mark', 'u', 'sub', 'sup'}
+
+    @staticmethod
+    def is_aeo_enabled() -> bool:
+        return SiteSetting.get_instance().aeo_enabled
+
+    @staticmethod
+    def require_aeo_enabled() -> None:
+        if not AgentContentService.is_aeo_enabled():
+            raise Http404("AEO is disabled")
 
     @staticmethod
     def estimate_tokens(text: str) -> int:
@@ -108,96 +117,11 @@ class AgentContentService:
 
     @staticmethod
     def build_llms_txt(request: HttpRequest) -> str:
-        site_url = request.build_absolute_uri(reverse('index')).rstrip('/')
-        latest_posts = list(AgentContentService.get_public_posts())
-        public_series = list(AgentContentService.get_public_series())
-        public_static_pages = list(AgentContentService.get_public_static_pages())
-
         lines = [
             '# BLEX',
             '',
-            '> BLEX is a long-form publishing site with public posts, curated series, and published static pages for readers and AI agents.',
-            '',
-            'Prefer Markdown endpoints when available, because they remove template noise and preserve the cleanest agent-readable content.',
-            'Recent posts are listed under `Optional` so agents with tight context budgets can skip them first.',
-            '',
+            '> BLEX is a publishing site.',
         ]
-
-        entry_points = [
-            AgentContentService.build_llms_link_line(
-                'Homepage',
-                site_url,
-                'Human-readable homepage for the latest published content.',
-            ),
-            AgentContentService.build_llms_link_line(
-                'Sitemap index',
-                request.build_absolute_uri(reverse('sitemap')),
-                'Top-level sitemap with links to posts, series, authors, and static pages.',
-            ),
-            AgentContentService.build_llms_link_line(
-                'Posts sitemap',
-                request.build_absolute_uri(reverse('sitemap_section', args=['posts'])),
-                'Complete list of public post HTML URLs.',
-            ),
-            AgentContentService.build_llms_link_line(
-                'Series sitemap',
-                request.build_absolute_uri(reverse('sitemap_section', args=['series'])),
-                'Complete list of public series HTML URLs.',
-            ),
-            AgentContentService.build_llms_link_line(
-                'Authors sitemap',
-                request.build_absolute_uri(reverse('sitemap_section', args=['user'])),
-                'Complete list of public author archive URLs.',
-            ),
-            AgentContentService.build_llms_link_line(
-                'Static pages sitemap',
-                request.build_absolute_uri(reverse('sitemap_section', args=['staticpages'])),
-                'Complete list of published static page HTML URLs.',
-            ),
-            AgentContentService.build_llms_link_line(
-                'RSS feed',
-                request.build_absolute_uri('/rss'),
-                'Recent published posts feed.',
-            ),
-        ]
-        AgentContentService.append_llms_section(lines, 'Entry Points', entry_points)
-
-        if public_series:
-            series_lines = [
-                AgentContentService.build_llms_link_line(
-                    series.name,
-                    AgentContentService.build_series_markdown_url(series, request),
-                    f'Series overview and public post list for @{series.owner.username}.',
-                )
-                for series in public_series
-            ]
-            AgentContentService.append_llms_section(lines, 'Series', series_lines)
-
-        if public_static_pages:
-            static_page_lines = [
-                AgentContentService.build_llms_link_line(
-                    page.title,
-                    AgentContentService.build_static_page_markdown_url(page, request),
-                    'Published static page in Markdown for agent use.',
-                )
-                for page in public_static_pages
-            ]
-            AgentContentService.append_llms_section(lines, 'Static Pages', static_page_lines)
-
-        optional_lines = []
-        for post in latest_posts:
-            markdown_url = AgentContentService.build_post_markdown_url(post, request)
-            source_url = request.build_absolute_uri(post.get_absolute_url())
-            optional_lines.append(
-                AgentContentService.build_llms_link_line(
-                    post.title,
-                    markdown_url,
-                    f'Recent post by @{post.author.username}. Source HTML: {source_url}',
-                )
-            )
-
-        if optional_lines:
-            AgentContentService.append_llms_section(lines, 'Optional', optional_lines)
 
         return '\n'.join(lines).strip() + '\n'
 
@@ -223,6 +147,39 @@ class AgentContentService:
     @staticmethod
     def build_llms_txt_url(request: HttpRequest) -> str:
         return request.build_absolute_uri(reverse('llms_txt'))
+
+    @staticmethod
+    def build_sitemap_url(request: HttpRequest) -> str:
+        return request.build_absolute_uri(reverse('sitemap'))
+
+    @staticmethod
+    def build_robots_txt(request: HttpRequest) -> str:
+        lines = [
+            'User-agent: *',
+            'Allow: /',
+            'Disallow: /*.preview.jpg',
+            'Disallow: /*.minify.*',
+            'Disallow: /settings/',
+            'Disallow: /write',
+            'Disallow: /v1/',
+        ]
+
+        if AgentContentService.is_aeo_enabled():
+            lines.extend([
+                '',
+                f'# AI agent entry point: {AgentContentService.build_llms_txt_url(request)}',
+            ])
+        else:
+            lines.extend([
+                'Disallow: /llms.txt',
+                'Disallow: /*.md',
+            ])
+
+        lines.extend([
+            f'Sitemap: {AgentContentService.build_sitemap_url(request)}',
+        ])
+
+        return '\n'.join(lines).strip() + '\n'
 
     @staticmethod
     def build_post_markdown_url(post: Post, request: HttpRequest) -> str:

--- a/backend/src/board/templates/board/pages/static_page.html
+++ b/backend/src/board/templates/board/pages/static_page.html
@@ -7,7 +7,9 @@
 {% block meta_description %}{{ meta_description }}{% endblock %}
 
 {% block meta %}
+{% if aeo_enabled %}
 <link rel="alternate" type="text/markdown" href="{{ static_page_markdown_url }}">
+{% endif %}
 {% endblock %}
 
 {% block extra_styles %}

--- a/backend/src/board/templates/board/posts/post_detail.html
+++ b/backend/src/board/templates/board/posts/post_detail.html
@@ -33,7 +33,9 @@
 
 <!-- Canonical URL -->
 <link rel="canonical" href="{{ request.build_absolute_uri }}">
+{% if aeo_enabled %}
 <link rel="alternate" type="text/markdown" href="{{ post_markdown_url }}">
+{% endif %}
 {% endblock %}
 
 {% block extra_styles %}
@@ -229,6 +231,7 @@
                         </button>
 
                         <!-- Copy for AI Button -->
+                        {% if aeo_enabled %}
                         <button @click="copyForAi($el.dataset.aiMarkdownUrl)"
                             data-ai-markdown-url="{% url 'post_markdown' post.author_username post.url %}"
                             class="w-11 h-11 flex items-center justify-center rounded-full text-content-secondary hover:text-content hover:bg-surface-subtle/80 transition-all duration-200 active:scale-95"
@@ -236,6 +239,7 @@
                             title="AI용 Markdown 복사">
                             <i class="fas fa-code"></i>
                         </button>
+                        {% endif %}
 
                         <!-- Edit Button -->
                         {% if user.is_authenticated and user.username == post.author_username %}

--- a/backend/src/board/templates/board/series/series_detail.html
+++ b/backend/src/board/templates/board/series/series_detail.html
@@ -6,7 +6,9 @@
 {% block title %}{{ series.name }} - {{ author.username }} | BLEX{% endblock %}
 
 {% block meta %}
+{% if aeo_enabled %}
 <link rel="alternate" type="text/markdown" href="{{ series_markdown_url }}">
+{% endif %}
 {% endblock %}
 
 {% block content %}

--- a/backend/src/board/templatetags/island.py
+++ b/backend/src/board/templatetags/island.py
@@ -13,6 +13,26 @@ register = template.Library()
 # Module-level cache for the Vite manifest
 _manifest_cache = None
 
+
+def get_vite_dev_server_url():
+    """
+    Resolve the Vite dev server URL from the runtime info file written by Vite.
+    Falls back to settings.VITE_DEV_SERVER_URL before the dev server has started.
+    """
+    info_path = getattr(settings, 'VITE_DEV_SERVER_INFO_PATH', None)
+    if info_path and os.path.exists(info_path):
+        try:
+            with open(info_path, 'r') as f:
+                info = json.load(f)
+            url = info.get('url')
+            if isinstance(url, str) and url:
+                return url.rstrip('/')
+        except (OSError, json.JSONDecodeError):
+            logger.warning("Failed to read Vite dev server info from %s", info_path)
+
+    return getattr(settings, 'VITE_DEV_SERVER_URL', 'http://localhost:8100').rstrip('/')
+
+
 def get_manifest():
     """
     Load the Vite manifest file and cache it in memory.
@@ -54,7 +74,7 @@ def island_entry(entry_name):
     """
     # Check if in development mode
     if getattr(settings, 'USE_VITE_DEV_SERVER', settings.DEBUG):
-        return f"http://localhost:5173/{entry_name}"
+        return f"{get_vite_dev_server_url()}/{entry_name}"
     
     manifest = get_manifest()
     entry_path = f"{entry_name}"
@@ -78,7 +98,7 @@ def island_css(entry_name):
     """
     # Check if in development mode
     if getattr(settings, 'USE_VITE_DEV_SERVER', settings.DEBUG):
-        return f"http://localhost:5173/{entry_name}"
+        return f"{get_vite_dev_server_url()}/{entry_name}"
     
     manifest = get_manifest()
     entry_path = f"{entry_name}"
@@ -125,15 +145,16 @@ def vite_hmr_client():
     DEBUG 모드일 때만 Vite HMR 클라이언트를 로드
     """
     if getattr(settings, 'USE_VITE_DEV_SERVER', settings.DEBUG):
-        preamble = """
+        vite_url = get_vite_dev_server_url()
+        preamble = f"""
         <script type="module">
-            import RefreshRuntime from 'http://localhost:5173/@react-refresh'
+            import RefreshRuntime from '{vite_url}/@react-refresh'
             RefreshRuntime.injectIntoGlobalHook(window)
-            window.$RefreshReg$ = () => {}
+            window.$RefreshReg$ = () => {{}}
             window.$RefreshSig$ = () => (type) => type
             window.__vite_plugin_react_preamble_installed__ = true
         </script>
         """
-        client = '<script type="module" src="http://localhost:5173/@vite/client"></script>'
+        client = f'<script type="module" src="{vite_url}/@vite/client"></script>'
         return mark_safe(preamble + client)
     return ""

--- a/backend/src/board/tests/api/test_site_setting.py
+++ b/backend/src/board/tests/api/test_site_setting.py
@@ -62,6 +62,8 @@ class SiteSettingAPITestCase(TestCase):
         self.assertIn('welcomeNotificationMessage', body)
         self.assertIn('welcomeNotificationUrl', body)
         self.assertIn('accountDeletionRedirectUrl', body)
+        self.assertIn('aeoEnabled', body)
+        self.assertFalse(body['aeoEnabled'])
         self.assertIn('updatedDate', body)
 
     def test_update_single_field(self):
@@ -91,6 +93,7 @@ class SiteSettingAPITestCase(TestCase):
             'welcome_notification_message': '환영합니다, {name}님!',
             'welcome_notification_url': '/welcome',
             'account_deletion_redirect_url': 'https://forms.example.com/exit',
+            'aeo_enabled': True,
         }
         response = self.client.put(
             '/v1/site-settings',
@@ -105,6 +108,10 @@ class SiteSettingAPITestCase(TestCase):
         self.assertEqual(content['body']['welcomeNotificationMessage'], '환영합니다, {name}님!')
         self.assertEqual(content['body']['welcomeNotificationUrl'], '/welcome')
         self.assertEqual(content['body']['accountDeletionRedirectUrl'], 'https://forms.example.com/exit')
+        self.assertTrue(content['body']['aeoEnabled'])
+
+        setting = SiteSetting.get_instance()
+        self.assertTrue(setting.aeo_enabled)
 
     def test_singleton_behavior(self):
         """싱글톤 동작 확인 - 여러 번 저장해도 하나의 인스턴스"""

--- a/backend/src/board/tests/templates/test_agent_discovery.py
+++ b/backend/src/board/tests/templates/test_agent_discovery.py
@@ -3,7 +3,7 @@ from django.test import Client, TestCase
 from django.urls import reverse
 from django.utils import timezone
 
-from board.models import Post, PostConfig, PostContent, Series, StaticPage
+from board.models import Post, PostConfig, PostContent, Series, SiteSetting, StaticPage
 
 
 class SeriesAgentDiscoveryTestCase(TestCase):
@@ -39,7 +39,28 @@ class SeriesAgentDiscoveryTestCase(TestCase):
             hide=False,
         )
 
+    def enable_aeo(self):
+        setting = SiteSetting.get_instance()
+        setting.aeo_enabled = True
+        setting.save(update_fields=['aeo_enabled'])
+
+    def test_series_detail_hides_markdown_alternate_when_aeo_disabled(self):
+        response = self.client.get(reverse('series_detail', kwargs={
+            'username': 'seriesauthor',
+            'series_url': 'agent-discovery-series',
+        }))
+
+        self.assertEqual(response.status_code, 200)
+
+        content = response.content.decode()
+
+        self.assertNotIn('rel=alternate type=text/markdown', content)
+        self.assertNotIn('http://testserver/@seriesauthor/series/agent-discovery-series.md', content)
+        self.assertNotIn('Link', response)
+        self.assertNotIn('X-Llms-Txt', response)
+
     def test_series_detail_advertises_markdown_alternate(self):
+        self.enable_aeo()
         response = self.client.get(reverse('series_detail', kwargs={
             'username': 'seriesauthor',
             'series_url': 'agent-discovery-series',
@@ -52,8 +73,7 @@ class SeriesAgentDiscoveryTestCase(TestCase):
         content = response.content.decode()
 
         self.assertIn(markdown_url, content)
-        self.assertIn('rel=alternate', content)
-        self.assertIn('type=text/markdown', content)
+        self.assertIn('rel=alternate type=text/markdown', content)
         self.assertIn(
             f'<{markdown_url}>; rel="alternate"; type="text/markdown"',
             response['Link'],
@@ -76,7 +96,27 @@ class StaticPageAgentDiscoveryTestCase(TestCase):
             is_published=True,
         )
 
+    def enable_aeo(self):
+        setting = SiteSetting.get_instance()
+        setting.aeo_enabled = True
+        setting.save(update_fields=['aeo_enabled'])
+
+    def test_static_page_hides_markdown_alternate_when_aeo_disabled(self):
+        response = self.client.get(reverse('static_page', kwargs={
+            'slug': 'agent-policy',
+        }))
+
+        self.assertEqual(response.status_code, 200)
+
+        content = response.content.decode()
+
+        self.assertNotIn('rel=alternate type=text/markdown', content)
+        self.assertNotIn('http://testserver/static/agent-policy.md', content)
+        self.assertNotIn('Link', response)
+        self.assertNotIn('X-Llms-Txt', response)
+
     def test_static_page_advertises_markdown_alternate(self):
+        self.enable_aeo()
         response = self.client.get(reverse('static_page', kwargs={
             'slug': 'agent-policy',
         }))
@@ -88,8 +128,7 @@ class StaticPageAgentDiscoveryTestCase(TestCase):
         content = response.content.decode()
 
         self.assertIn(markdown_url, content)
-        self.assertIn('rel=alternate', content)
-        self.assertIn('type=text/markdown', content)
+        self.assertIn('rel=alternate type=text/markdown', content)
         self.assertIn(
             f'<{markdown_url}>; rel="alternate"; type="text/markdown"',
             response['Link'],

--- a/backend/src/board/tests/templates/test_post_detail.py
+++ b/backend/src/board/tests/templates/test_post_detail.py
@@ -6,7 +6,7 @@ from django.contrib.auth.models import User
 from django.urls import reverse
 from django.utils import timezone
 
-from board.models import Post, PostContent, PostConfig
+from board.models import Post, PostContent, PostConfig, SiteSetting
 
 class PostDetailViewTestCase(TestCase):
     def setUp(self):
@@ -34,6 +34,11 @@ class PostDetailViewTestCase(TestCase):
             hide=False
         )
 
+    def enable_aeo(self):
+        setting = SiteSetting.get_instance()
+        setting.aeo_enabled = True
+        setting.save(update_fields=['aeo_enabled'])
+
     def test_post_detail_context_has_toc(self):
         url = reverse('post_detail', kwargs={
             'username': 'testauthor',
@@ -52,7 +57,19 @@ class PostDetailViewTestCase(TestCase):
         self.assertEqual(toc[1]['text'], 'Header 2')
         self.assertEqual(toc[1]['level'], 2)
 
-    def test_post_detail_has_copy_for_ai_action(self):
+    def test_post_detail_hides_copy_for_ai_action_when_aeo_disabled(self):
+        url = reverse('post_detail', kwargs={
+            'username': 'testauthor',
+            'post_url': 'test-post'
+        })
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, 'aria-label="AI용 Markdown 복사"')
+        self.assertNotContains(response, 'data-ai-markdown-url=')
+
+    def test_post_detail_has_copy_for_ai_action_when_aeo_enabled(self):
+        self.enable_aeo()
         url = reverse('post_detail', kwargs={
             'username': 'testauthor',
             'post_url': 'test-post'
@@ -63,8 +80,26 @@ class PostDetailViewTestCase(TestCase):
         self.assertContains(response, 'aria-label="AI용 Markdown 복사"')
         self.assertContains(response, 'data-ai-markdown-url=/@testauthor/test-post.md')
 
+    def test_post_detail_hides_markdown_alternate_when_aeo_disabled(self):
+        """AEO가 꺼져 있으면 포스트 상세가 Markdown endpoint를 광고하지 않는다."""
+        url = reverse('post_detail', kwargs={
+            'username': 'testauthor',
+            'post_url': 'test-post'
+        })
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+
+        content = response.content.decode()
+
+        self.assertNotIn('rel=alternate type=text/markdown', content)
+        self.assertNotIn('http://testserver/@testauthor/test-post.md', content)
+        self.assertNotIn('Link', response)
+        self.assertNotIn('X-Llms-Txt', response)
+
     def test_post_detail_advertises_markdown_alternate(self):
         """포스트 상세는 AI 에이전트가 Markdown export를 발견할 수 있게 힌트를 제공한다."""
+        self.enable_aeo()
         url = reverse('post_detail', kwargs={
             'username': 'testauthor',
             'post_url': 'test-post'
@@ -79,8 +114,7 @@ class PostDetailViewTestCase(TestCase):
         content = response.content.decode()
 
         self.assertIn(markdown_url, content)
-        self.assertIn('rel=alternate', content)
-        self.assertIn('type=text/markdown', content)
+        self.assertIn('rel=alternate type=text/markdown', content)
         self.assertIn(
             f'<{markdown_url}>; rel="alternate"; type="text/markdown"',
             response['Link']

--- a/backend/src/board/tests/test_agent_content.py
+++ b/backend/src/board/tests/test_agent_content.py
@@ -6,7 +6,7 @@ from django.contrib.auth.models import User
 from django.test import Client, TestCase, override_settings
 from django.utils import timezone
 
-from board.models import Post, PostConfig, PostContent, Series, StaticPage
+from board.models import Post, PostConfig, PostContent, Series, SiteSetting, StaticPage
 
 
 BASE_MIDDLEWARE = tuple(
@@ -186,6 +186,9 @@ class AgentContentTestCase(TestCase):
 
     def setUp(self):
         self.client = Client()
+        setting = SiteSetting.get_instance()
+        setting.aeo_enabled = True
+        setting.save(update_fields=['aeo_enabled'])
 
     @override_settings(MIDDLEWARE=AEO_MIDDLEWARE)
     def test_sitemap_allows_regular_user_agent(self):
@@ -201,22 +204,62 @@ class AgentContentTestCase(TestCase):
 
         self.assertEqual(response.status_code, 200)
 
-    def test_llms_txt_returns_agent_entrypoint(self):
-        """/llms.txt는 에이전트용 사이트 진입점을 제공한다."""
+    def test_aeo_disabled_hides_agent_entrypoints(self):
+        """AEO가 꺼져 있으면 llms.txt와 Markdown endpoint에 접근할 수 없다."""
+        setting = SiteSetting.get_instance()
+        setting.aeo_enabled = False
+        setting.save(update_fields=['aeo_enabled'])
+
+        urls = [
+            '/llms.txt',
+            '/@aeo-author/agent-ready-post.md',
+            '/@aeo-author/series/agent-ready-series.md',
+            '/static/about-ai.md',
+        ]
+
+        for url in urls:
+            with self.subTest(url=url):
+                response = self.client.get(url)
+                self.assertEqual(response.status_code, 404)
+
+    def test_robots_txt_hides_agent_entrypoint_when_aeo_disabled(self):
+        """AEO가 꺼져 있으면 robots.txt에서도 AI 진입점을 광고하지 않는다."""
+        setting = SiteSetting.get_instance()
+        setting.aeo_enabled = False
+        setting.save(update_fields=['aeo_enabled'])
+
+        response = self.client.get('/robots.txt')
+
+        self.assertEqual(response.status_code, 200)
+        body = response.content.decode()
+        self.assertIn('Disallow: /llms.txt', body)
+        self.assertIn('Disallow: /*.md', body)
+        self.assertNotIn('AI agent entry point', body)
+
+    def test_robots_txt_advertises_agent_entrypoint_when_aeo_enabled(self):
+        """AEO가 켜져 있으면 robots.txt에 AI 진입점을 표시한다."""
+        response = self.client.get('/robots.txt')
+
+        self.assertEqual(response.status_code, 200)
+        body = response.content.decode()
+        self.assertIn('# AI agent entry point: http://testserver/llms.txt', body)
+        self.assertNotIn('Disallow: /llms.txt', body)
+
+    def test_llms_txt_returns_minimal_site_summary(self):
+        """/llms.txt는 최소한의 사이트 요약만 제공한다."""
         response = self.client.get('/llms.txt')
 
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response['Content-Type'].startswith('text/plain'))
 
         body = response.content.decode()
-        self.assertIn('BLEX', body)
-        self.assertIn('/sitemap.xml', body)
-        self.assertIn('/posts/sitemap.xml', body)
-        self.assertIn('/rss', body)
-        self.assertIn('/@aeo-author/agent-ready-post.md', body)
+        self.assertEqual(
+            body,
+            '# BLEX\n\n> BLEX is a publishing site.\n',
+        )
 
-    def test_llms_txt_follows_llmstxt_structure_and_lists_series_static_markdown(self):
-        """llms.txt는 요약 blockquote와 H2 링크 목록 구조를 지키고 시리즈/정적 페이지를 노출한다."""
+    def test_llms_txt_does_not_expose_content_indexes_or_markdown_links(self):
+        """llms.txt는 sitemap, RSS, Markdown 목록을 노출하지 않는다."""
         response = self.client.get('/llms.txt')
 
         self.assertEqual(response.status_code, 200)
@@ -225,42 +268,12 @@ class AgentContentTestCase(TestCase):
 
         self.assertRegex(
             body,
-            r'^# BLEX\n\n> .+\n\n',
+            r'^# BLEX\n\n> .+\n$',
         )
-        self.assertIn('## Entry Points\n', body)
-        self.assertIn('## Series\n', body)
-        self.assertIn('## Static Pages\n', body)
-        self.assertIn('## Optional\n', body)
-        self.assertIn(
-            '[Static pages sitemap](http://testserver/staticpages/sitemap.xml)',
-            body,
-        )
-        self.assertIn(
-            '[Agent Ready Series](http://testserver/@aeo-author/series/agent-ready-series.md)',
-            body,
-        )
-        self.assertIn(
-            '[About AI](http://testserver/static/about-ai.md)',
-            body,
-        )
-        self.assertIn(
-            '[Agent Ready Post](http://testserver/@aeo-author/agent-ready-post.md)',
-            body,
-        )
-
-        in_link_section = False
-        for line in body.splitlines():
-            if line.startswith('## '):
-                in_link_section = True
-                continue
-
-            if not in_link_section or not line.strip():
-                continue
-
-            self.assertRegex(
-                line,
-                r'^- \[[^\]]+\]\([^)]+\)(: .+)?$',
-            )
+        self.assertNotIn('/sitemap.xml', body)
+        self.assertNotIn('/rss', body)
+        self.assertNotIn('.md', body)
+        self.assertNotIn('## ', body)
 
     def test_post_markdown_endpoint_returns_clean_markdown(self):
         """공개 포스트는 Markdown endpoint로 AI용 본문을 제공한다."""

--- a/backend/src/board/tests/test_island_templatetags.py
+++ b/backend/src/board/tests/test_island_templatetags.py
@@ -1,0 +1,55 @@
+import json
+import os
+import tempfile
+
+from django.test import SimpleTestCase, override_settings
+
+from board.templatetags import island
+
+
+class ViteDevServerTemplateTagTestCase(SimpleTestCase):
+    def test_dev_server_uses_fallback_url_before_info_file_exists(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            info_path = os.path.join(temp_dir, 'dev-server.json')
+
+            with override_settings(
+                USE_VITE_DEV_SERVER=True,
+                VITE_DEV_SERVER_URL='http://localhost:8100',
+                VITE_DEV_SERVER_INFO_PATH=info_path,
+            ):
+                self.assertEqual(
+                    island.island_entry('src/island.tsx'),
+                    'http://localhost:8100/src/island.tsx',
+                )
+                self.assertEqual(
+                    island.island_css('styles/main.scss'),
+                    'http://localhost:8100/styles/main.scss',
+                )
+                self.assertIn(
+                    'http://localhost:8100/@vite/client',
+                    str(island.vite_hmr_client()),
+                )
+
+    def test_dev_server_reads_actual_vite_port_from_info_file(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            info_path = os.path.join(temp_dir, 'dev-server.json')
+            with open(info_path, 'w') as f:
+                json.dump({'url': 'http://localhost:8101'}, f)
+
+            with override_settings(
+                USE_VITE_DEV_SERVER=True,
+                VITE_DEV_SERVER_URL='http://localhost:8100',
+                VITE_DEV_SERVER_INFO_PATH=info_path,
+            ):
+                self.assertEqual(
+                    island.island_entry('src/island.tsx'),
+                    'http://localhost:8101/src/island.tsx',
+                )
+                self.assertEqual(
+                    island.island_css('styles/main.scss'),
+                    'http://localhost:8101/styles/main.scss',
+                )
+                self.assertIn(
+                    'http://localhost:8101/@react-refresh',
+                    str(island.vite_hmr_client()),
+                )

--- a/backend/src/board/urls.py
+++ b/backend/src/board/urls.py
@@ -1,6 +1,5 @@
 from django.contrib.sitemaps.views import sitemap
 from django.urls import path
-from django.views.generic import TemplateView
 from django.contrib.auth import views as auth_views
 
 from board.sitemaps import sitemaps, sitemap_section
@@ -72,7 +71,7 @@ urlpatterns = [
     # RSS and Etc
     path('rss', SitePostsFeed()),
     path('rss/@<username>', UserPostsFeed(), name='user_rss_feed'),
-    path('robots.txt', TemplateView.as_view(template_name='robots.txt', content_type='text/plain')),
+    path('robots.txt', agent.robots_txt, name='robots_txt'),
 
     # API V1
     path('v1/login', api_v1.login),

--- a/backend/src/board/views/agent.py
+++ b/backend/src/board/views/agent.py
@@ -4,6 +4,7 @@ from board.services.agent_content_service import AgentContentService
 
 
 def llms_txt(request: HttpRequest) -> HttpResponse:
+    AgentContentService.require_aeo_enabled()
     content = AgentContentService.build_llms_txt(request)
     response = HttpResponse(content, content_type='text/plain; charset=utf-8')
     response['X-Estimated-Tokens'] = str(AgentContentService.estimate_tokens(content))
@@ -11,6 +12,7 @@ def llms_txt(request: HttpRequest) -> HttpResponse:
 
 
 def post_markdown(request: HttpRequest, username: str, post_url: str) -> HttpResponse:
+    AgentContentService.require_aeo_enabled()
     post = AgentContentService.get_public_post(username, post_url)
     content = AgentContentService.build_post_markdown(post, request)
     response = HttpResponse(content, content_type='text/markdown; charset=utf-8')
@@ -19,6 +21,7 @@ def post_markdown(request: HttpRequest, username: str, post_url: str) -> HttpRes
 
 
 def series_markdown(request: HttpRequest, username: str, series_url: str) -> HttpResponse:
+    AgentContentService.require_aeo_enabled()
     series = AgentContentService.get_public_series_detail(username, series_url)
     content = AgentContentService.build_series_markdown(series, request)
     response = HttpResponse(content, content_type='text/markdown; charset=utf-8')
@@ -27,8 +30,14 @@ def series_markdown(request: HttpRequest, username: str, series_url: str) -> Htt
 
 
 def static_page_markdown(request: HttpRequest, slug: str) -> HttpResponse:
+    AgentContentService.require_aeo_enabled()
     page = AgentContentService.get_public_static_page(slug)
     content = AgentContentService.build_static_page_markdown(page, request)
     response = HttpResponse(content, content_type='text/markdown; charset=utf-8')
     response['X-Estimated-Tokens'] = str(AgentContentService.estimate_tokens(content))
     return response
+
+
+def robots_txt(request: HttpRequest) -> HttpResponse:
+    content = AgentContentService.build_robots_txt(request)
+    return HttpResponse(content, content_type='text/plain; charset=utf-8')

--- a/backend/src/board/views/api/v1/site_setting.py
+++ b/backend/src/board/views/api/v1/site_setting.py
@@ -26,6 +26,7 @@ def site_settings(request):
             'welcome_notification_message': setting.welcome_notification_message,
             'welcome_notification_url': setting.welcome_notification_url,
             'account_deletion_redirect_url': setting.account_deletion_redirect_url,
+            'aeo_enabled': setting.aeo_enabled,
             'updated_date': setting.updated_date.isoformat(),
         })
 
@@ -50,6 +51,9 @@ def site_settings(request):
         if 'account_deletion_redirect_url' in put_data:
             setting.account_deletion_redirect_url = put_data['account_deletion_redirect_url']
 
+        if 'aeo_enabled' in put_data:
+            setting.aeo_enabled = put_data['aeo_enabled'] is True
+
         setting.save()
 
         return StatusDone({
@@ -58,6 +62,7 @@ def site_settings(request):
             'welcome_notification_message': setting.welcome_notification_message,
             'welcome_notification_url': setting.welcome_notification_url,
             'account_deletion_redirect_url': setting.account_deletion_redirect_url,
+            'aeo_enabled': setting.aeo_enabled,
             'updated_date': setting.updated_date.isoformat(),
         })
 

--- a/backend/src/board/views/post.py
+++ b/backend/src/board/views/post.py
@@ -48,17 +48,21 @@ def post_detail(request, username, post_url):
 
     banners = BannerService.get_all_banners_for_author(author)
 
+    aeo_enabled = AgentContentService.is_aeo_enabled()
     context = {
         'post': post,
         'banners': banners,
         'content_html': content_html_with_ids,
         'table_of_contents': table_of_contents,
-        'post_markdown_url': AgentContentService.build_post_markdown_url(post, request),
+        'aeo_enabled': aeo_enabled,
     }
+    if aeo_enabled:
+        context['post_markdown_url'] = AgentContentService.build_post_markdown_url(post, request)
 
     response = render(request, 'board/posts/post_detail.html', context)
-    response['Link'] = AgentContentService.build_agent_link_header(post, request)
-    response['X-Llms-Txt'] = AgentContentService.build_llms_txt_url(request)
+    if aeo_enabled:
+        response['Link'] = AgentContentService.build_agent_link_header(post, request)
+        response['X-Llms-Txt'] = AgentContentService.build_llms_txt_url(request)
     return response
 
 

--- a/backend/src/board/views/series.py
+++ b/backend/src/board/views/series.py
@@ -77,6 +77,7 @@ def series_detail(request, username, series_url):
     has_previous = page > 1
     has_next = page < total_pages
 
+    aeo_enabled = AgentContentService.is_aeo_enabled()
     context = {
         'author': author,
         'series': series,
@@ -90,13 +91,16 @@ def series_detail(request, username, series_url):
         'next_page': page + 1 if has_next else None,
         'sort_order': sort_order,
         'request': request,
-        'series_markdown_url': AgentContentService.build_series_markdown_url(series, request),
+        'aeo_enabled': aeo_enabled,
     }
+    if aeo_enabled:
+        context['series_markdown_url'] = AgentContentService.build_series_markdown_url(series, request)
 
     response = render(request, 'board/series/series_detail.html', context)
-    response['Link'] = AgentContentService.build_agent_link_header_for_markdown_url(
-        context['series_markdown_url'],
-        request,
-    )
-    response['X-Llms-Txt'] = AgentContentService.build_llms_txt_url(request)
+    if aeo_enabled:
+        response['Link'] = AgentContentService.build_agent_link_header_for_markdown_url(
+            context['series_markdown_url'],
+            request,
+        )
+        response['X-Llms-Txt'] = AgentContentService.build_llms_txt_url(request)
     return response

--- a/backend/src/board/views/static_pages.py
+++ b/backend/src/board/views/static_pages.py
@@ -19,17 +19,21 @@ def static_page_view(request, slug):
     # Get the page by slug, only if it's published
     page = get_object_or_404(StaticPage, slug=slug, is_published=True)
 
+    aeo_enabled = AgentContentService.is_aeo_enabled()
     context = {
         'page': page,
         'title': page.title,
         'meta_description': page.meta_description or page.title,
-        'static_page_markdown_url': AgentContentService.build_static_page_markdown_url(page, request),
+        'aeo_enabled': aeo_enabled,
     }
+    if aeo_enabled:
+        context['static_page_markdown_url'] = AgentContentService.build_static_page_markdown_url(page, request)
 
     response = render(request, 'board/pages/static_page.html', context)
-    response['Link'] = AgentContentService.build_agent_link_header_for_markdown_url(
-        context['static_page_markdown_url'],
-        request,
-    )
-    response['X-Llms-Txt'] = AgentContentService.build_llms_txt_url(request)
+    if aeo_enabled:
+        response['Link'] = AgentContentService.build_agent_link_header_for_markdown_url(
+            context['static_page_markdown_url'],
+            request,
+        )
+        response['X-Llms-Txt'] = AgentContentService.build_llms_txt_url(request)
     return response

--- a/backend/src/main/settings.py
+++ b/backend/src/main/settings.py
@@ -14,6 +14,7 @@ CIPHER_KEY = os.environ.get('CIPHER_KEY').encode()
 
 DEBUG = os.environ.get('DEBUG') == 'TRUE'
 USE_VITE_DEV_SERVER = DEBUG and os.environ.get('USE_VITE_DEV_SERVER', 'TRUE') == 'TRUE'
+VITE_DEV_SERVER_URL = os.environ.get('VITE_DEV_SERVER_URL', 'http://localhost:8100')
 
 TESTING = sys.argv[1:2] == ['test']
 
@@ -138,6 +139,10 @@ RESOURCE_URL = os.environ.get('RESOURCE_URL') + '/resources/'
 
 STATIC_URL = RESOURCE_URL + 'staticfiles/'
 STATIC_ROOT = os.path.join(BASE_DIR, 'resources', 'staticfiles')
+VITE_DEV_SERVER_INFO_PATH = os.environ.get(
+    'VITE_DEV_SERVER_INFO_PATH',
+    os.path.join(STATIC_ROOT, 'islands', '.vite', 'dev-server.json'),
+)
 
 MEDIA_URL = RESOURCE_URL + 'media/'
 MEDIA_ROOT = os.path.join(BASE_DIR, 'resources', 'media')

--- a/backend/src/resources/robots.txt
+++ b/backend/src/resources/robots.txt
@@ -5,6 +5,6 @@ Disallow: /*.minify.*
 Disallow: /settings/
 Disallow: /write
 Disallow: /v1/
-
-# AI agent entry point: https://blex.me/llms.txt
+Disallow: /llms.txt
+Disallow: /*.md
 Sitemap: https://blex.me/sitemap.xml


### PR DESCRIPTION
## 🎯 Goal
- Add a staff-controlled AEO opt-in switch so AI-facing surfaces are not exposed by default.
- Prevent local Vite dev server port conflicts from breaking Django-rendered island assets.

## 🔧 Core Changes
- Added `SiteSetting.aeo_enabled` with default OFF and exposed it through the site settings API.
- Added a separate `/settings/seo-aeo` admin settings page for the AEO control.
- Gates `/llms.txt`, `*.md` Markdown endpoints, HTML alternate links, `Link` headers, `X-Llms-Txt`, and the post AI copy action behind the single AEO switch.
- Moved `robots.txt` through Django so it follows the AEO setting in production, and removed the nginx static override.
- Made Vite write its actual dev server URL to a runtime info file, then made Django read that URL instead of hardcoding port 5173.

## 🤔 Key Decisions
- AEO is controlled by one top-level switch for this first pass, keeping the product behavior easy to reason about.
- Disabled AEO returns 404 for agent-only endpoints instead of serving empty content.
- The Vite dev server still has a fallback URL, but Django follows the actual port once Vite starts.

## 🧪 Verification Guide
### How to verify
1. Run `npm run server:migrate`.
2. Run `npm run server:test`.
3. Run `npm run islands:type-check`.
4. Run `npm run islands:lint`.

### Expected result
- Site settings include a separate SEO/AEO page.
- AEO OFF hides AI endpoints, discovery links, and headers.
- AEO ON restores the agent-readable surfaces.
- Django island assets use the actual Vite dev server port.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)