### PR TITLE
♻️ Separate admin settings navigation

### DIFF
--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/SettingsApp.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/SettingsApp.tsx
@@ -4,7 +4,8 @@ import {
     createRootRoute,
     createRoute,
     Outlet,
-    Navigate
+    Navigate,
+    useRouter
 } from '@tanstack/react-router';
 import { lazy, Suspense } from 'react';
 import { SettingsLayout } from './components/SettingsLayout';
@@ -42,6 +43,18 @@ export interface SettingsAppProps {
     isEditor: boolean;
     isStaff: boolean;
     adminUrl?: string;
+    settingsMode?: SettingsMode;
+    basePath?: string;
+}
+
+type SettingsMode = 'user' | 'admin';
+
+interface SettingsRouterContext {
+    isEditor: boolean;
+    isStaff: boolean;
+    adminUrl?: string;
+    settingsMode: SettingsMode;
+    basePath: string;
 }
 
 // Root route
@@ -60,11 +73,18 @@ const settingsRoute = createRoute({
     component: SettingsLayout
 });
 
-// Index route - redirect to /notify by default
+const SettingsIndexRedirect = () => {
+    const router = useRouter();
+    const { settingsMode } = router.options.context as SettingsRouterContext;
+
+    return <Navigate to={settingsMode === 'admin' ? '/site-settings' : '/notify'} replace />;
+};
+
+// Index route - redirect to the default page for each settings namespace
 const indexRoute = createRoute({
     getParentRoute: () => settingsRoute,
     path: '/',
-    component: () => <Navigate to="/notify" replace />
+    component: SettingsIndexRedirect
 });
 
 // Individual setting routes
@@ -292,16 +312,27 @@ const routeTree = rootRoute.addChildren([
     ])
 ]);
 
-const SettingsApp = ({ isEditor, isStaff, adminUrl }: SettingsAppProps) => {
+const SettingsApp = ({
+    isEditor,
+    isStaff,
+    adminUrl,
+    settingsMode = 'user',
+    basePath
+}: SettingsAppProps) => {
+    const normalizedSettingsMode = settingsMode === 'admin' ? 'admin' : 'user';
+    const normalizedBasePath = basePath ?? (normalizedSettingsMode === 'admin' ? '/admin-settings' : '/settings');
+
     const router = createRouter({
         routeTree,
         context: {
             isEditor,
             isStaff,
-            adminUrl
+            adminUrl,
+            settingsMode: normalizedSettingsMode,
+            basePath: normalizedBasePath
         },
         defaultPreload: 'intent',
-        basepath: '/settings'
+        basepath: normalizedBasePath
     });
 
     return <RouterProvider router={router} />;

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/SettingsNavigation.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/SettingsNavigation.tsx
@@ -209,40 +209,24 @@ const getNavigationSections = (settingsMode: SettingsMode) => (
     settingsMode === 'admin' ? adminNavigationSections : userNavigationSections
 );
 
-const SettingsModeSwitch = ({ settingsMode, isStaff }: { settingsMode: SettingsMode; isStaff: boolean }) => {
+const SettingsModeLink = ({ settingsMode, isStaff }: { settingsMode: SettingsMode; isStaff: boolean }) => {
     if (!isStaff) return null;
 
-    const modes = [
-        {
-            label: '내 설정',
-            href: '/settings/notify',
-            icon: 'fa-user',
-            active: settingsMode === 'user'
-        },
-        {
-            label: '관리자 설정',
-            href: '/admin-settings/site-settings',
-            icon: 'fa-shield-alt',
-            active: settingsMode === 'admin'
-        }
-    ];
+    const isAdminMode = settingsMode === 'admin';
+    const href = isAdminMode ? '/settings/notify' : '/admin-settings/site-settings';
+    const label = isAdminMode ? '내 설정으로 돌아가기' : '관리자 설정';
+    const icon = isAdminMode ? 'fa-arrow-left' : 'fa-shield-alt';
 
     return (
-        <div className="grid grid-cols-2 gap-1 rounded-xl border border-line bg-surface-subtle p-1">
-            {modes.map((mode) => (
-                <a
-                    key={mode.href}
-                    href={mode.href}
-                    className={`flex h-10 items-center justify-center gap-2 rounded-lg px-3 text-sm font-semibold transition-all ${INTERACTION_DURATION} active:scale-95 ${
-                        mode.active
-                            ? 'bg-surface text-content shadow-subtle'
-                            : 'text-content-secondary hover:text-content'
-                    }`}>
-                    <i className={`fas ${mode.icon} text-xs`} />
-                    <span>{mode.label}</span>
-                </a>
-            ))}
-        </div>
+        <a
+            href={href}
+            className={`inline-flex h-9 items-center gap-2 rounded-lg px-2 text-sm font-medium text-content-secondary transition-all ${INTERACTION_DURATION} hover:bg-surface-subtle hover:text-content active:scale-95`}>
+            <i className={`fas ${icon} text-xs text-content-hint`} />
+            <span>{label}</span>
+            {!isAdminMode && (
+                <i className="fas fa-chevron-right text-[10px] text-content-hint" />
+            )}
+        </a>
     );
 };
 
@@ -352,8 +336,8 @@ export const SettingsMobileNavigation = ({ currentPath }: SettingsNavigationProp
                                 </div>
 
                                 {isStaff && (
-                                    <div className="mb-8">
-                                        <SettingsModeSwitch settingsMode={settingsMode} isStaff={isStaff} />
+                                    <div className="-mt-5 mb-8">
+                                        <SettingsModeLink settingsMode={settingsMode} isStaff={isStaff} />
                                     </div>
                                 )}
 
@@ -458,8 +442,8 @@ export const SettingsDesktopNavigation = ({ currentPath }: SettingsNavigationPro
                     {settingsMode === 'admin' ? '관리자 설정' : '설정'}
                 </h2>
                 {isStaff && (
-                    <div className="mt-4">
-                        <SettingsModeSwitch settingsMode={settingsMode} isStaff={isStaff} />
+                    <div className="mt-3">
+                        <SettingsModeLink settingsMode={settingsMode} isStaff={isStaff} />
                     </div>
                 )}
             </div>

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/SettingsNavigation.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/SettingsNavigation.tsx
@@ -28,7 +28,17 @@ interface SettingsNavigationProps {
     currentPath: string;
 }
 
-const navigationSections: NavigationSection[] = [
+type SettingsMode = 'user' | 'admin';
+
+interface SettingsRouterContext {
+    isEditor: boolean;
+    isStaff: boolean;
+    adminUrl?: string;
+    settingsMode: SettingsMode;
+    basePath: string;
+}
+
+const userNavigationSections: NavigationSection[] = [
     {
         title: '일반',
         description: '알림, 계정, 프로필 관리',
@@ -120,10 +130,13 @@ const navigationSections: NavigationSection[] = [
                 requiresEditor: true
             }
         ]
-    },
+    }
+];
+
+const adminNavigationSections: NavigationSection[] = [
     {
-        title: '관리자',
-        description: '사이트 관리',
+        title: '사이트',
+        description: '전역 설정과 검색 노출',
         requiresStaff: true,
         items: [
             {
@@ -143,7 +156,14 @@ const navigationSections: NavigationSection[] = [
                 path: '/static-pages',
                 icon: 'fa-file-lines',
                 requiresStaff: true
-            },
+            }
+        ]
+    },
+    {
+        title: '운영',
+        description: '공지, 배너, 웹훅 관리',
+        requiresStaff: true,
+        items: [
             {
                 name: '전역 공지',
                 path: '/global-notices',
@@ -161,7 +181,14 @@ const navigationSections: NavigationSection[] = [
                 path: '/global-webhook',
                 icon: 'fa-bolt',
                 requiresStaff: true
-            },
+            }
+        ]
+    },
+    {
+        title: '관리',
+        description: '정리 도구와 Django 관리자',
+        requiresStaff: true,
+        items: [
             {
                 name: '유틸리티',
                 path: '/utilities',
@@ -178,18 +205,58 @@ const navigationSections: NavigationSection[] = [
     }
 ];
 
+const getNavigationSections = (settingsMode: SettingsMode) => (
+    settingsMode === 'admin' ? adminNavigationSections : userNavigationSections
+);
+
+const SettingsModeSwitch = ({ settingsMode, isStaff }: { settingsMode: SettingsMode; isStaff: boolean }) => {
+    if (!isStaff) return null;
+
+    const modes = [
+        {
+            label: '내 설정',
+            href: '/settings/notify',
+            icon: 'fa-user',
+            active: settingsMode === 'user'
+        },
+        {
+            label: '관리자 설정',
+            href: '/admin-settings/site-settings',
+            icon: 'fa-shield-alt',
+            active: settingsMode === 'admin'
+        }
+    ];
+
+    return (
+        <div className="grid grid-cols-2 gap-1 rounded-xl border border-line bg-surface-subtle p-1">
+            {modes.map((mode) => (
+                <a
+                    key={mode.href}
+                    href={mode.href}
+                    className={`flex h-10 items-center justify-center gap-2 rounded-lg px-3 text-sm font-semibold transition-all ${INTERACTION_DURATION} active:scale-95 ${
+                        mode.active
+                            ? 'bg-surface text-content shadow-subtle'
+                            : 'text-content-secondary hover:text-content'
+                    }`}>
+                    <i className={`fas ${mode.icon} text-xs`} />
+                    <span>{mode.label}</span>
+                </a>
+            ))}
+        </div>
+    );
+};
+
 export const SettingsMobileNavigation = ({ currentPath }: SettingsNavigationProps) => {
     const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
     const router = useRouter();
     const {
         isEditor,
         isStaff,
-        adminUrl
-    } = router.options.context as {
-        isEditor: boolean;
-        isStaff: boolean;
-        adminUrl?: string;
-    };
+        adminUrl,
+        settingsMode,
+        basePath
+    } = router.options.context as SettingsRouterContext;
+    const navigationSections = getNavigationSections(settingsMode);
 
     const handleNavClick = (item: NavigationItem) => {
         setMobileMenuOpen(false);
@@ -202,7 +269,7 @@ export const SettingsMobileNavigation = ({ currentPath }: SettingsNavigationProp
         if (item.requiresEditor && !isEditor) return null;
         if (item.requiresStaff && !isStaff) return null;
 
-        const isActive = currentPath === `/settings${item.path}` || currentPath === item.path;
+        const isActive = currentPath === `${basePath}${item.path}` || currentPath === item.path;
         const baseClasses = `flex items-center px-4 py-3 rounded-xl transition-all ${INTERACTION_DURATION} active:scale-95 group`;
         const activeClasses = isActive
             ? 'bg-surface-subtle text-content font-bold'
@@ -273,7 +340,9 @@ export const SettingsMobileNavigation = ({ currentPath }: SettingsNavigationProp
                             <div className="p-6">
                                 <Dialog.Title className="sr-only">Navigation Menu</Dialog.Title>
                                 <div className="flex items-center justify-between mb-8">
-                                    <h2 className="text-2xl font-bold text-content tracking-tight">설정</h2>
+                                    <h2 className="text-2xl font-bold text-content tracking-tight">
+                                        {settingsMode === 'admin' ? '관리자 설정' : '설정'}
+                                    </h2>
                                     <Dialog.Close asChild>
                                         <button
                                             className={`w-11 h-11 flex items-center justify-center rounded-full hover:bg-surface-subtle active:bg-line active:scale-95 transition-all ${INTERACTION_DURATION}`}>
@@ -281,6 +350,12 @@ export const SettingsMobileNavigation = ({ currentPath }: SettingsNavigationProp
                                         </button>
                                     </Dialog.Close>
                                 </div>
+
+                                {isStaff && (
+                                    <div className="mb-8">
+                                        <SettingsModeSwitch settingsMode={settingsMode} isStaff={isStaff} />
+                                    </div>
+                                )}
 
                                 <div className="space-y-8">
                                     {navigationSections.map(renderSection)}
@@ -290,7 +365,9 @@ export const SettingsMobileNavigation = ({ currentPath }: SettingsNavigationProp
                     </Dialog.Portal>
                 </Dialog.Root>
 
-                <h1 className="text-lg font-bold text-content">설정</h1>
+                <h1 className="text-lg font-bold text-content">
+                    {settingsMode === 'admin' ? '관리자 설정' : '설정'}
+                </h1>
                 <div className="w-10" />
             </div>
         </div>
@@ -302,12 +379,11 @@ export const SettingsDesktopNavigation = ({ currentPath }: SettingsNavigationPro
     const {
         isEditor,
         isStaff,
-        adminUrl
-    } = router.options.context as {
-        isEditor: boolean;
-        isStaff: boolean;
-        adminUrl?: string;
-    };
+        adminUrl,
+        settingsMode,
+        basePath
+    } = router.options.context as SettingsRouterContext;
+    const navigationSections = getNavigationSections(settingsMode);
 
     const handleNavClick = (item: NavigationItem) => {
         if (item.path === 'admin' && adminUrl) {
@@ -319,7 +395,7 @@ export const SettingsDesktopNavigation = ({ currentPath }: SettingsNavigationPro
         if (item.requiresEditor && !isEditor) return null;
         if (item.requiresStaff && !isStaff) return null;
 
-        const isActive = currentPath === `/settings${item.path}` || currentPath === item.path;
+        const isActive = currentPath === `${basePath}${item.path}` || currentPath === item.path;
         const baseClasses = `flex items-center px-5 rounded-xl transition-all ${INTERACTION_DURATION} active:scale-95`;
         const activeClasses = isActive
             ? 'bg-surface-subtle text-content font-semibold'
@@ -378,7 +454,14 @@ export const SettingsDesktopNavigation = ({ currentPath }: SettingsNavigationPro
     return (
         <aside className="hidden xl:block w-72 flex-shrink-0 mt-8 self-start sticky top-24">
             <div className="px-5 mb-6">
-                <h2 className="text-2xl font-semibold text-content tracking-tight">설정</h2>
+                <h2 className="text-2xl font-semibold text-content tracking-tight">
+                    {settingsMode === 'admin' ? '관리자 설정' : '설정'}
+                </h2>
+                {isStaff && (
+                    <div className="mt-4">
+                        <SettingsModeSwitch settingsMode={settingsMode} isStaff={isStaff} />
+                    </div>
+                )}
             </div>
             <div className="max-h-[calc(100vh-10rem)] overflow-y-auto overscroll-contain pr-2">
                 <nav className="space-y-8 pb-4">

--- a/backend/src/board/services/agent_content_service.py
+++ b/backend/src/board/services/agent_content_service.py
@@ -160,6 +160,7 @@ class AgentContentService:
             'Disallow: /*.preview.jpg',
             'Disallow: /*.minify.*',
             'Disallow: /settings/',
+            'Disallow: /admin-settings/',
             'Disallow: /write',
             'Disallow: /v1/',
         ]

--- a/backend/src/board/templates/board/settings.html
+++ b/backend/src/board/templates/board/settings.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% load island %}
 
-{% block title %}설정 | BLEX{% endblock %}
+{% block title %}{{ settings_title }} | BLEX{% endblock %}
 
 {% block extra_styles %}
 <link rel="stylesheet" href="{% island_css 'styles/post.scss' %}">
@@ -10,6 +10,6 @@
 
 {% block content %}
 <div>
-    {% island_component 'SettingsApp' isEditor=is_editor isStaff=is_staff adminUrl=admin_url %}
+    {% island_component 'SettingsApp' isEditor=is_editor isStaff=is_staff adminUrl=admin_url settingsMode=settings_mode basePath=settings_base_path %}
 </div>
 {% endblock %}

--- a/backend/src/board/tests/templates/test_settings.py
+++ b/backend/src/board/tests/templates/test_settings.py
@@ -51,13 +51,21 @@ class SettingsViewTestCase(TestCase):
         self.assertIn('"basePath": "/admin-settings"', body)
         self.assertContains(response, '관리자 설정 | BLEX')
 
-    def test_reader_cannot_open_admin_settings_namespace(self):
+    def test_reader_gets_404_for_admin_settings_namespace(self):
         client = Client(raise_request_exception=False)
         client.login(username='settings-reader', password='password123')
 
         response = client.get('/admin-settings/site-settings')
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 404)
+
+    def test_reader_gets_404_for_legacy_admin_settings_url(self):
+        client = Client(raise_request_exception=False)
+        client.login(username='settings-reader', password='password123')
+
+        response = client.get('/settings/seo-aeo')
+
+        self.assertEqual(response.status_code, 404)
 
     def test_legacy_admin_settings_url_redirects_to_admin_namespace(self):
         self.client.login(username='settings-staff', password='password123')

--- a/backend/src/board/tests/templates/test_settings.py
+++ b/backend/src/board/tests/templates/test_settings.py
@@ -1,0 +1,68 @@
+from urllib.parse import unquote
+
+from django.test import TestCase
+from django.test.client import Client
+
+from board.models import Profile, User
+
+
+class SettingsViewTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.reader = User.objects.create_user(
+            username='settings-reader',
+            password='password123',
+            email='reader@example.com',
+        )
+        Profile.objects.create(user=cls.reader, role=Profile.Role.READER)
+
+        cls.staff = User.objects.create_user(
+            username='settings-staff',
+            password='password123',
+            email='staff@example.com',
+            is_staff=True,
+        )
+        Profile.objects.create(user=cls.staff, role=Profile.Role.EDITOR)
+
+    def setUp(self):
+        self.client = Client()
+
+    def decode_body(self, response):
+        return unquote(response.content.decode())
+
+    def test_user_settings_render_user_namespace(self):
+        self.client.login(username='settings-reader', password='password123')
+
+        response = self.client.get('/settings/notify')
+
+        self.assertEqual(response.status_code, 200)
+        body = self.decode_body(response)
+        self.assertIn('"settingsMode": "user"', body)
+        self.assertIn('"basePath": "/settings"', body)
+
+    def test_staff_admin_settings_render_admin_namespace(self):
+        self.client.login(username='settings-staff', password='password123')
+
+        response = self.client.get('/admin-settings/site-settings')
+
+        self.assertEqual(response.status_code, 200)
+        body = self.decode_body(response)
+        self.assertIn('"settingsMode": "admin"', body)
+        self.assertIn('"basePath": "/admin-settings"', body)
+        self.assertContains(response, '관리자 설정 | BLEX')
+
+    def test_reader_cannot_open_admin_settings_namespace(self):
+        client = Client(raise_request_exception=False)
+        client.login(username='settings-reader', password='password123')
+
+        response = client.get('/admin-settings/site-settings')
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_legacy_admin_settings_url_redirects_to_admin_namespace(self):
+        self.client.login(username='settings-staff', password='password123')
+
+        response = self.client.get('/settings/seo-aeo')
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response['Location'], '/admin-settings/seo-aeo')

--- a/backend/src/board/tests/test_agent_content.py
+++ b/backend/src/board/tests/test_agent_content.py
@@ -234,6 +234,7 @@ class AgentContentTestCase(TestCase):
         body = response.content.decode()
         self.assertIn('Disallow: /llms.txt', body)
         self.assertIn('Disallow: /*.md', body)
+        self.assertIn('Disallow: /admin-settings/', body)
         self.assertNotIn('AI agent entry point', body)
 
     def test_robots_txt_advertises_agent_entrypoint_when_aeo_enabled(self):

--- a/backend/src/board/urls.py
+++ b/backend/src/board/urls.py
@@ -17,7 +17,7 @@ from board.views.auth import login_view, signup_view
 from board.views.oauth_callback import oauth_callback
 from board.views.tag import tag_list_view, tag_detail_view
 from board.views.static_pages import static_page_view
-from board.views.settings import settings
+from board.views.settings import settings, admin_settings
 from board.decorators import staff_member_required
 
 def empty():
@@ -40,6 +40,8 @@ urlpatterns = [
     # Settings - Unified Settings App with client-side routing
     path('settings/', settings, name='settings'),
     path('settings/<path:path>', settings, name='settings_path'),
+    path('admin-settings/', admin_settings, name='admin_settings'),
+    path('admin-settings/<path:path>', admin_settings, name='admin_settings_path'),
 
     # Post actions
     path('like/<url>', like_post, name='like_post'),

--- a/backend/src/board/views/settings.py
+++ b/backend/src/board/views/settings.py
@@ -1,8 +1,41 @@
 from django.shortcuts import render, redirect
 from django.contrib.auth.decorators import login_required
-from django.contrib import messages
 from django.core.exceptions import PermissionDenied
 from django.urls import reverse
+
+
+ADMIN_SETTINGS_PREFIXES = (
+    'site-settings',
+    'seo-aeo',
+    'static-pages',
+    'global-notices',
+    'global-banners',
+    'global-webhook',
+    'utilities',
+)
+
+
+def _is_admin_settings_path(path):
+    normalized_path = path.strip('/')
+    return any(
+        normalized_path == prefix or normalized_path.startswith(f'{prefix}/')
+        for prefix in ADMIN_SETTINGS_PREFIXES
+    )
+
+
+def _build_settings_context(request, settings_mode, base_path):
+    admin_url = None
+    if request.user.is_staff:
+        admin_url = reverse('admin:index')
+
+    return {
+        'is_editor': request.user.profile.is_editor(),
+        'is_staff': request.user.is_staff,
+        'admin_url': admin_url,
+        'settings_mode': settings_mode,
+        'settings_base_path': base_path,
+        'settings_title': '관리자 설정' if settings_mode == 'admin' else '설정',
+    }
 
 
 @login_required
@@ -12,15 +45,24 @@ def settings(request, path=''):
     Uses SettingsApp island with TanStack Router for client-side routing.
     The router automatically handles URL parsing and routing on the client side.
     """
-    # Get admin URL if user is staff
-    admin_url = None
-    if request.user.is_staff:
-        admin_url = reverse('admin:index')
+    if _is_admin_settings_path(path):
+        if not request.user.is_staff:
+            raise PermissionDenied
+        return redirect(f'/admin-settings/{path}')
 
-    context = {
-        'is_editor': request.user.profile.is_editor(),
-        'is_staff': request.user.is_staff,
-        'admin_url': admin_url
-    }
+    context = _build_settings_context(request, 'user', '/settings')
+
+    return render(request, 'board/settings.html', context)
+
+
+@login_required
+def admin_settings(request, path=''):
+    """
+    Staff-only settings view for site-wide administration pages.
+    """
+    if not request.user.is_staff:
+        raise PermissionDenied
+
+    context = _build_settings_context(request, 'admin', '/admin-settings')
 
     return render(request, 'board/settings.html', context)

--- a/backend/src/board/views/settings.py
+++ b/backend/src/board/views/settings.py
@@ -1,6 +1,6 @@
 from django.shortcuts import render, redirect
 from django.contrib.auth.decorators import login_required
-from django.core.exceptions import PermissionDenied
+from django.http import Http404
 from django.urls import reverse
 
 
@@ -47,7 +47,7 @@ def settings(request, path=''):
     """
     if _is_admin_settings_path(path):
         if not request.user.is_staff:
-            raise PermissionDenied
+            raise Http404
         return redirect(f'/admin-settings/{path}')
 
     context = _build_settings_context(request, 'user', '/settings')
@@ -61,7 +61,7 @@ def admin_settings(request, path=''):
     Staff-only settings view for site-wide administration pages.
     """
     if not request.user.is_staff:
-        raise PermissionDenied
+        raise Http404
 
     context = _build_settings_context(request, 'admin', '/admin-settings')
 

--- a/backend/src/resources/robots.txt
+++ b/backend/src/resources/robots.txt
@@ -3,6 +3,7 @@ Allow: /
 Disallow: /*.preview.jpg
 Disallow: /*.minify.*
 Disallow: /settings/
+Disallow: /admin-settings/
 Disallow: /write
 Disallow: /v1/
 Disallow: /llms.txt


### PR DESCRIPTION
## 🎯 Goal
- Separate staff-only site administration from personal settings so the settings sidebar is less crowded.
- Make SEO/AEO and other global admin pages live under a dedicated admin settings namespace.

## 🔧 Core Changes
- Added /admin-settings/* as the staff-only settings surface.
- Redirected legacy admin settings paths under /settings/* to /admin-settings/*.
- Split SettingsApp navigation into personal settings and admin settings modes.
- Added admin settings coverage and blocked /admin-settings/ in robots output.

## 🤔 Key Decisions
- Reused the existing SettingsApp router with a configurable basePath instead of creating a second island.
- Kept existing admin page components intact and only separated the routing/navigation boundary.

## 🧪 Verification Guide
### How to verify
1. Open /settings/notify and confirm only personal/blog/integration settings are shown.
2. Open /admin-settings/site-settings as staff and confirm site admin pages are shown.
3. Open /settings/seo-aeo as staff and confirm it redirects to /admin-settings/seo-aeo.

### Expected result
- Personal and site-wide admin settings are separated while existing admin pages keep working.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)