### PR TITLE
✨ Add SEO/AEO exposure controls

### DIFF
--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SeoAeoSetting/SeoAeoSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SeoAeoSetting/SeoAeoSetting.tsx
@@ -6,6 +6,33 @@ import { toast } from '~/utils/toast';
 import { getSiteSettings, updateSiteSettings } from '~/lib/api/settings';
 import { SettingsHeader } from '../../components';
 
+const exposureItems = [
+    {
+        icon: 'fa-file-lines',
+        name: 'llms.txt',
+        path: '/llms.txt',
+        description: 'AI 에이전트가 사이트의 기본 정보를 먼저 확인할 수 있는 공개 안내 파일입니다.'
+    },
+    {
+        icon: 'fa-markdown',
+        name: 'Markdown endpoint',
+        path: '/@user/post.md, /static/page.md',
+        description: '포스트, 시리즈, 정적 페이지를 HTML 대신 읽기 쉬운 Markdown 형식으로 제공하는 주소입니다.'
+    },
+    {
+        icon: 'fa-signs-post',
+        name: 'Discovery header',
+        path: 'Link, X-Llms-Txt, rel=alternate',
+        description: '브라우저 화면에는 보이지 않지만, 에이전트와 크롤러가 AI용 Markdown 주소를 발견하도록 알려주는 신호입니다.'
+    },
+    {
+        icon: 'fa-route',
+        name: 'robots.txt',
+        path: '/robots.txt',
+        description: 'AEO가 켜지면 llms.txt 위치를 안내하고, 꺼지면 llms.txt와 .md 주소 접근을 막도록 안내합니다.'
+    }
+];
+
 const SeoAeoSetting = () => {
     const { data: settingData } = useSuspenseQuery({
         queryKey: ['site-settings'],
@@ -49,27 +76,77 @@ const SeoAeoSetting = () => {
             />
 
             <Card
-                title="AEO(인공지능 노출)"
-                subtitle="llms.txt, Markdown endpoint, discovery header 공개 여부를 제어합니다."
+                title="AEO 노출"
+                subtitle="AI 에이전트가 사이트와 공개 콘텐츠를 읽기 쉽게 찾을 수 있도록 별도 진입점을 열지 결정합니다."
                 icon={<i className="fas fa-robot" />}>
-                <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-                    <div className="space-y-1">
-                        <div className="text-sm font-semibold text-content">AEO 활성화</div>
-                        <p className="text-xs leading-relaxed text-content-secondary">
-                            켜면 AI용 진입점과 Markdown 노출 표면이 함께 열립니다.
+                <div className="space-y-6">
+                    <div className="rounded-xl border border-line bg-surface-subtle px-4 py-3">
+                        <p className="text-sm leading-relaxed text-content-secondary">
+                            이 스위치는 일반 검색엔진용 sitemap이나 RSS가 아니라 AI 에이전트용 노출 표면만 제어합니다.
+                            꺼두면 AI용 주소는 404로 숨기고, 페이지와 응답 헤더에서도 발견 신호를 제거합니다.
                         </p>
                     </div>
-                    <div className="flex items-center gap-3">
-                        <span className="text-xs font-medium text-content-secondary">
-                            {aeoEnabled ? 'ON' : 'OFF'}
-                        </span>
-                        <Toggle
-                            checked={aeoEnabled}
-                            disabled={updateMutation.isPending}
-                            onCheckedChange={handleAeoChange}
-                            aria-label="AEO 인공지능 노출 활성화"
-                        />
+
+                    <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                        <div className="space-y-1">
+                            <div className="text-sm font-semibold text-content">AEO 활성화</div>
+                            <p className="text-xs leading-relaxed text-content-secondary">
+                                켜면 아래의 AI용 진입점, Markdown 주소, 발견 헤더가 함께 공개됩니다.
+                            </p>
+                        </div>
+                        <div className="flex items-center gap-3">
+                            <span className="text-xs font-medium text-content-secondary">
+                                {aeoEnabled ? 'ON' : 'OFF'}
+                            </span>
+                            <Toggle
+                                checked={aeoEnabled}
+                                disabled={updateMutation.isPending}
+                                onCheckedChange={handleAeoChange}
+                                aria-label="AEO 인공지능 노출 활성화"
+                            />
+                        </div>
                     </div>
+
+                    <div className="grid gap-3 border-t border-line pt-5 sm:grid-cols-2">
+                        <div className="rounded-xl bg-surface-subtle px-4 py-3">
+                            <div className="text-xs font-semibold uppercase text-content-hint">ON</div>
+                            <p className="mt-1 text-sm leading-relaxed text-content-secondary">
+                                AI용 주소가 열리고 페이지와 응답 헤더가 Markdown 위치를 안내합니다.
+                            </p>
+                        </div>
+                        <div className="rounded-xl bg-surface-subtle px-4 py-3">
+                            <div className="text-xs font-semibold uppercase text-content-hint">OFF</div>
+                            <p className="mt-1 text-sm leading-relaxed text-content-secondary">
+                                AI용 주소는 404로 숨겨지고 robots.txt는 해당 경로를 허용하지 않도록 안내합니다.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </Card>
+
+            <Card
+                title="제어되는 노출면"
+                subtitle="AEO 스위치 하나로 함께 열리거나 닫히는 공개 표면입니다."
+                icon={<i className="fas fa-diagram-project" />}>
+                <div className="divide-y divide-line rounded-xl border border-line">
+                    {exposureItems.map((item) => (
+                        <div key={item.name} className="flex gap-4 p-4">
+                            <div className="mt-1 flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg bg-surface-subtle text-content-secondary">
+                                <i className={`fas ${item.icon}`} />
+                            </div>
+                            <div className="min-w-0 flex-1">
+                                <div className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between">
+                                    <h3 className="text-sm font-semibold text-content">{item.name}</h3>
+                                    <code className="break-all rounded-md bg-surface-subtle px-2 py-1 text-xs text-content-secondary">
+                                        {item.path}
+                                    </code>
+                                </div>
+                                <p className="mt-2 text-sm leading-relaxed text-content-secondary">
+                                    {item.description}
+                                </p>
+                            </div>
+                        </div>
+                    ))}
                 </div>
             </Card>
         </div>

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SeoAeoSetting/SeoAeoSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SeoAeoSetting/SeoAeoSetting.tsx
@@ -6,7 +6,28 @@ import { toast } from '~/utils/toast';
 import { getSiteSettings, updateSiteSettings } from '~/lib/api/settings';
 import { SettingsHeader } from '../../components';
 
-const exposureItems = [
+const seoExposureItems = [
+    {
+        icon: 'fa-route',
+        name: 'robots.txt',
+        path: '/robots.txt',
+        description: '검색엔진 크롤러가 사이트를 수집해도 되는지 먼저 확인하는 공개 정책 파일입니다.'
+    },
+    {
+        icon: 'fa-code',
+        name: 'Robots meta',
+        path: 'noindex, nofollow',
+        description: 'SEO가 꺼지면 HTML 페이지에 색인하지 말라는 신호를 함께 붙입니다.'
+    },
+    {
+        icon: 'fa-sitemap',
+        name: 'Sitemap 안내',
+        path: '/sitemap.xml',
+        description: 'SEO가 켜져 있을 때 robots.txt에서 sitemap 위치를 알려 공개 페이지 발견을 돕습니다.'
+    }
+];
+
+const aeoExposureItems = [
     {
         icon: 'fa-file-lines',
         name: 'llms.txt',
@@ -45,27 +66,46 @@ const SeoAeoSetting = () => {
         }
     });
 
+    const [seoEnabled, setSeoEnabled] = useState(true);
     const [aeoEnabled, setAeoEnabled] = useState(false);
 
     useEffect(() => {
+        setSeoEnabled(settingData.seoEnabled);
         setAeoEnabled(settingData.aeoEnabled);
     }, [settingData]);
 
-    const updateMutation = useMutation({
-        mutationFn: (enabled: boolean) => updateSiteSettings({ aeo_enabled: enabled }),
+    const seoMutation = useMutation({
+        mutationFn: (enabled: boolean) => updateSiteSettings({ seo_enabled: enabled }),
         onSuccess: (_, enabled) => {
-            setAeoEnabled(enabled);
-            toast.success('SEO/AEO 설정이 저장되었습니다.');
+            setSeoEnabled(enabled);
+            toast.success('SEO 설정이 저장되었습니다.');
         },
         onError: () => {
-            setAeoEnabled(settingData.aeoEnabled);
-            toast.error('SEO/AEO 설정 저장에 실패했습니다.');
+            setSeoEnabled(settingData.seoEnabled);
+            toast.error('SEO 설정 저장에 실패했습니다.');
         }
     });
 
+    const aeoMutation = useMutation({
+        mutationFn: (enabled: boolean) => updateSiteSettings({ aeo_enabled: enabled }),
+        onSuccess: (_, enabled) => {
+            setAeoEnabled(enabled);
+            toast.success('AEO 설정이 저장되었습니다.');
+        },
+        onError: () => {
+            setAeoEnabled(settingData.aeoEnabled);
+            toast.error('AEO 설정 저장에 실패했습니다.');
+        }
+    });
+
+    const handleSeoChange = (enabled: boolean) => {
+        setSeoEnabled(enabled);
+        seoMutation.mutate(enabled);
+    };
+
     const handleAeoChange = (enabled: boolean) => {
         setAeoEnabled(enabled);
-        updateMutation.mutate(enabled);
+        aeoMutation.mutate(enabled);
     };
 
     return (
@@ -76,16 +116,61 @@ const SeoAeoSetting = () => {
             />
 
             <Card
+                title="SEO 노출"
+                subtitle="검색엔진이 공개 페이지를 수집하고 색인할 수 있게 할지 결정합니다."
+                icon={<i className="fas fa-magnifying-glass" />}>
+                <div className="space-y-6">
+                    <p className="text-sm leading-relaxed text-content-secondary">
+                        이 스위치는 검색엔진에 보내는 색인 허용 신호를 제어합니다.
+                        꺼두면 robots.txt는 사이트 전체 수집을 막고, HTML 페이지에는 noindex 신호를 붙입니다.
+                    </p>
+
+                    <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                        <div className="space-y-1">
+                            <div className="text-sm font-semibold text-content">SEO 활성화</div>
+                            <p className="text-xs leading-relaxed text-content-secondary">
+                                켜면 검색엔진에 공개 페이지 수집과 sitemap 위치를 안내합니다.
+                            </p>
+                        </div>
+                        <div className="flex items-center gap-3">
+                            <span className="text-xs font-medium text-content-secondary">
+                                {seoEnabled ? 'ON' : 'OFF'}
+                            </span>
+                            <Toggle
+                                checked={seoEnabled}
+                                disabled={seoMutation.isPending}
+                                onCheckedChange={handleSeoChange}
+                                aria-label="SEO 검색엔진 노출 활성화"
+                            />
+                        </div>
+                    </div>
+
+                    <div className="grid gap-3 border-t border-line pt-5 sm:grid-cols-2">
+                        <div className="rounded-xl bg-surface-subtle px-4 py-3">
+                            <div className="text-xs font-semibold uppercase text-content-hint">ON</div>
+                            <p className="mt-1 text-sm leading-relaxed text-content-secondary">
+                                robots.txt가 공개 페이지 수집을 허용하고 sitemap 위치를 안내합니다.
+                            </p>
+                        </div>
+                        <div className="rounded-xl bg-surface-subtle px-4 py-3">
+                            <div className="text-xs font-semibold uppercase text-content-hint">OFF</div>
+                            <p className="mt-1 text-sm leading-relaxed text-content-secondary">
+                                robots.txt가 Disallow: /로 전체 수집을 막고 페이지에는 noindex,nofollow를 붙입니다.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </Card>
+
+            <Card
                 title="AEO 노출"
                 subtitle="AI 에이전트가 사이트와 공개 콘텐츠를 읽기 쉽게 찾을 수 있도록 별도 진입점을 열지 결정합니다."
                 icon={<i className="fas fa-robot" />}>
                 <div className="space-y-6">
-                    <div className="rounded-xl border border-line bg-surface-subtle px-4 py-3">
-                        <p className="text-sm leading-relaxed text-content-secondary">
-                            이 스위치는 일반 검색엔진용 sitemap이나 RSS가 아니라 AI 에이전트용 노출 표면만 제어합니다.
-                            꺼두면 AI용 주소는 404로 숨기고, 페이지와 응답 헤더에서도 발견 신호를 제거합니다.
-                        </p>
-                    </div>
+                    <p className="text-sm leading-relaxed text-content-secondary">
+                        이 스위치는 일반 검색엔진용 SEO가 아니라 AI 에이전트용 노출 표면만 제어합니다.
+                        꺼두면 AI용 주소는 404로 숨기고, 페이지와 응답 헤더에서도 발견 신호를 제거합니다.
+                    </p>
 
                     <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
                         <div className="space-y-1">
@@ -100,7 +185,7 @@ const SeoAeoSetting = () => {
                             </span>
                             <Toggle
                                 checked={aeoEnabled}
-                                disabled={updateMutation.isPending}
+                                disabled={aeoMutation.isPending}
                                 onCheckedChange={handleAeoChange}
                                 aria-label="AEO 인공지능 노출 활성화"
                             />
@@ -126,27 +211,56 @@ const SeoAeoSetting = () => {
 
             <Card
                 title="제어되는 노출면"
-                subtitle="AEO 스위치 하나로 함께 열리거나 닫히는 공개 표면입니다."
+                subtitle="각 스위치가 실제로 바꾸는 공개 표면입니다."
                 icon={<i className="fas fa-diagram-project" />}>
-                <div className="divide-y divide-line rounded-xl border border-line">
-                    {exposureItems.map((item) => (
-                        <div key={item.name} className="flex gap-4 p-4">
-                            <div className="mt-1 flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg bg-surface-subtle text-content-secondary">
-                                <i className={`fas ${item.icon}`} />
-                            </div>
-                            <div className="min-w-0 flex-1">
-                                <div className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between">
-                                    <h3 className="text-sm font-semibold text-content">{item.name}</h3>
-                                    <code className="break-all rounded-md bg-surface-subtle px-2 py-1 text-xs text-content-secondary">
-                                        {item.path}
-                                    </code>
+                <div className="space-y-6">
+                    <section className="space-y-3">
+                        <h3 className="text-sm font-semibold text-content">SEO</h3>
+                        <div className="divide-y divide-line rounded-xl border border-line">
+                            {seoExposureItems.map((item) => (
+                                <div key={item.name} className="flex gap-4 p-4">
+                                    <div className="mt-1 flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg bg-surface-subtle text-content-secondary">
+                                        <i className={`fas ${item.icon}`} />
+                                    </div>
+                                    <div className="min-w-0 flex-1">
+                                        <div className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between">
+                                            <h4 className="text-sm font-semibold text-content">{item.name}</h4>
+                                            <code className="break-all rounded-md bg-surface-subtle px-2 py-1 text-xs text-content-secondary">
+                                                {item.path}
+                                            </code>
+                                        </div>
+                                        <p className="mt-2 text-sm leading-relaxed text-content-secondary">
+                                            {item.description}
+                                        </p>
+                                    </div>
                                 </div>
-                                <p className="mt-2 text-sm leading-relaxed text-content-secondary">
-                                    {item.description}
-                                </p>
-                            </div>
+                            ))}
                         </div>
-                    ))}
+                    </section>
+
+                    <section className="space-y-3">
+                        <h3 className="text-sm font-semibold text-content">AEO</h3>
+                        <div className="divide-y divide-line rounded-xl border border-line">
+                            {aeoExposureItems.map((item) => (
+                                <div key={item.name} className="flex gap-4 p-4">
+                                    <div className="mt-1 flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg bg-surface-subtle text-content-secondary">
+                                        <i className={`fas ${item.icon}`} />
+                                    </div>
+                                    <div className="min-w-0 flex-1">
+                                        <div className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between">
+                                            <h4 className="text-sm font-semibold text-content">{item.name}</h4>
+                                            <code className="break-all rounded-md bg-surface-subtle px-2 py-1 text-xs text-content-secondary">
+                                                {item.path}
+                                            </code>
+                                        </div>
+                                        <p className="mt-2 text-sm leading-relaxed text-content-secondary">
+                                            {item.description}
+                                        </p>
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+                    </section>
                 </div>
             </Card>
         </div>

--- a/backend/islands/apps/remotes/src/lib/api/settings.ts
+++ b/backend/islands/apps/remotes/src/lib/api/settings.ts
@@ -580,6 +580,7 @@ export interface SiteSettingData {
     welcomeNotificationMessage: string;
     welcomeNotificationUrl: string;
     accountDeletionRedirectUrl: string;
+    seoEnabled: boolean;
     aeoEnabled: boolean;
     updatedDate: string;
 }
@@ -590,6 +591,7 @@ export interface SiteSettingUpdateData {
     welcome_notification_message?: string;
     welcome_notification_url?: string;
     account_deletion_redirect_url?: string;
+    seo_enabled?: boolean;
     aeo_enabled?: boolean;
 }
 

--- a/backend/src/board/migrations/0042_sitesetting_seo_enabled.py
+++ b/backend/src/board/migrations/0042_sitesetting_seo_enabled.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('board', '0041_sitesetting_aeo_enabled'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='sitesetting',
+            name='seo_enabled',
+            field=models.BooleanField(
+                default=True,
+                help_text='검색엔진용 robots.txt 색인 허용 및 HTML noindex 신호 제어 여부',
+            ),
+        ),
+    ]

--- a/backend/src/board/models.py
+++ b/backend/src/board/models.py
@@ -800,6 +800,10 @@ class SiteSetting(models.Model):
     )
 
     # Search and agent exposure settings
+    seo_enabled = models.BooleanField(
+        default=True,
+        help_text='검색엔진용 robots.txt 색인 허용 및 HTML noindex 신호 제어 여부'
+    )
     aeo_enabled = models.BooleanField(
         default=False,
         help_text='AI 에이전트용 llms.txt, Markdown endpoint, discovery header 노출 여부'

--- a/backend/src/board/services/agent_content_service.py
+++ b/backend/src/board/services/agent_content_service.py
@@ -19,6 +19,10 @@ class AgentContentService:
     INLINE_RAW_TAGS = {'figcaption', 'mark', 'u', 'sub', 'sup'}
 
     @staticmethod
+    def is_seo_enabled() -> bool:
+        return SiteSetting.get_instance().seo_enabled
+
+    @staticmethod
     def is_aeo_enabled() -> bool:
         return SiteSetting.get_instance().aeo_enabled
 
@@ -154,6 +158,9 @@ class AgentContentService:
 
     @staticmethod
     def build_robots_txt(request: HttpRequest) -> str:
+        if not AgentContentService.is_seo_enabled():
+            return 'User-agent: *\nDisallow: /\n'
+
         lines = [
             'User-agent: *',
             'Allow: /',

--- a/backend/src/board/templates/board/base.html
+++ b/backend/src/board/templates/board/base.html
@@ -62,6 +62,12 @@
     </script>
     <title>{% block title %}BLEX{% endblock %}</title>
     {% block meta %}{% endblock %}
+    {% block robots_meta %}
+        {% if site_setting and not site_setting.seo_enabled %}
+        <meta name="robots" content="noindex,nofollow">
+        <meta name="googlebot" content="noindex,nofollow">
+        {% endif %}
+    {% endblock %}
     <link rel="stylesheet" href="{% island_css 'styles/tailwind.css' %}">
     <link rel="stylesheet" href="{% island_css 'styles/main.scss' %}">
     <link rel="icon" href="{% resource 'favicon.ico' %}" />

--- a/backend/src/board/templates/board/posts/post_detail.html
+++ b/backend/src/board/templates/board/posts/post_detail.html
@@ -9,9 +9,6 @@
 <meta name="description" content="{{ post.meta_description }}">
 <meta name="keywords" content="{% for tag in post.tags.all %}{{ tag }}{% if not forloop.last %}, {% endif %}{% endfor %}">
 <meta name="author" content="{{ post.author_username }}">
-<!-- Robots and Indexing -->
-<meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1">
-<meta name="googlebot" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1">
 
 <!-- Open Graph / Facebook -->
 <meta property="og:type" content="article">
@@ -35,6 +32,17 @@
 <link rel="canonical" href="{{ request.build_absolute_uri }}">
 {% if aeo_enabled %}
 <link rel="alternate" type="text/markdown" href="{{ post_markdown_url }}">
+{% endif %}
+{% endblock %}
+
+{% block robots_meta %}
+{% if site_setting and not site_setting.seo_enabled %}
+<meta name="robots" content="noindex,nofollow">
+<meta name="googlebot" content="noindex,nofollow">
+{% else %}
+<!-- Robots and Indexing -->
+<meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1">
+<meta name="googlebot" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1">
 {% endif %}
 {% endblock %}
 

--- a/backend/src/board/tests/api/test_site_setting.py
+++ b/backend/src/board/tests/api/test_site_setting.py
@@ -62,6 +62,8 @@ class SiteSettingAPITestCase(TestCase):
         self.assertIn('welcomeNotificationMessage', body)
         self.assertIn('welcomeNotificationUrl', body)
         self.assertIn('accountDeletionRedirectUrl', body)
+        self.assertIn('seoEnabled', body)
+        self.assertTrue(body['seoEnabled'])
         self.assertIn('aeoEnabled', body)
         self.assertFalse(body['aeoEnabled'])
         self.assertIn('updatedDate', body)
@@ -93,6 +95,7 @@ class SiteSettingAPITestCase(TestCase):
             'welcome_notification_message': '환영합니다, {name}님!',
             'welcome_notification_url': '/welcome',
             'account_deletion_redirect_url': 'https://forms.example.com/exit',
+            'seo_enabled': False,
             'aeo_enabled': True,
         }
         response = self.client.put(
@@ -108,9 +111,11 @@ class SiteSettingAPITestCase(TestCase):
         self.assertEqual(content['body']['welcomeNotificationMessage'], '환영합니다, {name}님!')
         self.assertEqual(content['body']['welcomeNotificationUrl'], '/welcome')
         self.assertEqual(content['body']['accountDeletionRedirectUrl'], 'https://forms.example.com/exit')
+        self.assertFalse(content['body']['seoEnabled'])
         self.assertTrue(content['body']['aeoEnabled'])
 
         setting = SiteSetting.get_instance()
+        self.assertFalse(setting.seo_enabled)
         self.assertTrue(setting.aeo_enabled)
 
     def test_singleton_behavior(self):

--- a/backend/src/board/tests/templates/test_main.py
+++ b/backend/src/board/tests/templates/test_main.py
@@ -7,7 +7,7 @@ from django.test import Client, TestCase
 from django.urls import reverse
 from django.utils import timezone
 
-from board.models import Post, PostConfig, PostContent
+from board.models import Post, PostConfig, PostContent, SiteSetting
 
 
 class MainPageTemplateTestCase(TestCase):
@@ -47,6 +47,27 @@ class MainPageTemplateTestCase(TestCase):
         self.assertContains(response, 'window.__blexIslandMonitor')
         self.assertNotContains(response, 'name=LoginPrompt')
         self.assertNotContains(response, 'name=Toaster')
+
+    def test_index_page_adds_noindex_when_seo_disabled(self):
+        setting = SiteSetting.get_instance()
+        setting.seo_enabled = False
+        setting.save(update_fields=['seo_enabled'])
+
+        response = self.client.get(reverse('index'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '<meta name="robots" content="noindex,nofollow">', html=True)
+        self.assertContains(response, '<meta name="googlebot" content="noindex,nofollow">', html=True)
+
+    def test_index_page_omits_noindex_when_seo_enabled(self):
+        setting = SiteSetting.get_instance()
+        setting.seo_enabled = True
+        setting.save(update_fields=['seo_enabled'])
+
+        response = self.client.get(reverse('index'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, 'content="noindex,nofollow"')
 
     def test_index_page_has_required_context(self):
         response = self.client.get(reverse('index'))

--- a/backend/src/board/tests/test_agent_content.py
+++ b/backend/src/board/tests/test_agent_content.py
@@ -187,8 +187,9 @@ class AgentContentTestCase(TestCase):
     def setUp(self):
         self.client = Client()
         setting = SiteSetting.get_instance()
+        setting.seo_enabled = True
         setting.aeo_enabled = True
-        setting.save(update_fields=['aeo_enabled'])
+        setting.save(update_fields=['seo_enabled', 'aeo_enabled'])
 
     @override_settings(MIDDLEWARE=AEO_MIDDLEWARE)
     def test_sitemap_allows_regular_user_agent(self):
@@ -236,6 +237,18 @@ class AgentContentTestCase(TestCase):
         self.assertIn('Disallow: /*.md', body)
         self.assertIn('Disallow: /admin-settings/', body)
         self.assertNotIn('AI agent entry point', body)
+
+    def test_robots_txt_disallows_all_when_seo_disabled(self):
+        """SEO가 꺼져 있으면 robots.txt가 전체 수집을 막는다."""
+        setting = SiteSetting.get_instance()
+        setting.seo_enabled = False
+        setting.aeo_enabled = True
+        setting.save(update_fields=['seo_enabled', 'aeo_enabled'])
+
+        response = self.client.get('/robots.txt')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content.decode(), 'User-agent: *\nDisallow: /\n')
 
     def test_robots_txt_advertises_agent_entrypoint_when_aeo_enabled(self):
         """AEO가 켜져 있으면 robots.txt에 AI 진입점을 표시한다."""

--- a/backend/src/board/views/api/v1/site_setting.py
+++ b/backend/src/board/views/api/v1/site_setting.py
@@ -26,6 +26,7 @@ def site_settings(request):
             'welcome_notification_message': setting.welcome_notification_message,
             'welcome_notification_url': setting.welcome_notification_url,
             'account_deletion_redirect_url': setting.account_deletion_redirect_url,
+            'seo_enabled': setting.seo_enabled,
             'aeo_enabled': setting.aeo_enabled,
             'updated_date': setting.updated_date.isoformat(),
         })
@@ -51,6 +52,9 @@ def site_settings(request):
         if 'account_deletion_redirect_url' in put_data:
             setting.account_deletion_redirect_url = put_data['account_deletion_redirect_url']
 
+        if 'seo_enabled' in put_data:
+            setting.seo_enabled = put_data['seo_enabled'] is True
+
         if 'aeo_enabled' in put_data:
             setting.aeo_enabled = put_data['aeo_enabled'] is True
 
@@ -62,6 +66,7 @@ def site_settings(request):
             'welcome_notification_message': setting.welcome_notification_message,
             'welcome_notification_url': setting.welcome_notification_url,
             'account_deletion_redirect_url': setting.account_deletion_redirect_url,
+            'seo_enabled': setting.seo_enabled,
             'aeo_enabled': setting.aeo_enabled,
             'updated_date': setting.updated_date.isoformat(),
         })


### PR DESCRIPTION
## 🎯 Goal
- Let admins control SEO exposure itself, not only AEO-specific surfaces.
- Make the SEO/AEO settings screen understandable without prior knowledge of llms.txt, Markdown endpoints, discovery headers, or robots.txt.

## 🔧 Core Changes
- Added `seo_enabled` to `SiteSetting` with migration and site settings API support.
- Added SEO behavior: when SEO is off, `/robots.txt` returns `Disallow: /` and rendered HTML pages receive `noindex,nofollow` robots meta tags.
- Kept AEO behavior independent: the AEO switch still controls llms.txt, Markdown endpoints, and discovery headers.
- Updated the admin SEO/AEO page with separate SEO and AEO toggles, ON/OFF outcome summaries, and controlled-surface explanations.

## 🤔 Key Decisions
- Default SEO is enabled to preserve current public indexing behavior after migration.
- SEO off does not delete sitemap/RSS routes; it changes the crawler-facing signals through robots.txt and page-level noindex.
- AEO remains a separate control so AI-readable endpoints can be managed independently from search indexing.

## 🧪 Verification Guide
### How to verify
1. Open `/admin-settings/seo-aeo` as staff.
2. Toggle SEO off and confirm the UI explains robots.txt and noindex behavior.
3. Confirm `/robots.txt` returns `User-agent: *` and `Disallow: /` when SEO is disabled.
4. Toggle AEO independently and confirm AI surfaces are described separately.

### Expected result
- Admins can control SEO and AEO independently from one settings page.
- SEO off blocks crawler collection signals and adds page-level noindex.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)