### PR TITLE
♻️ Make build workflow manually triggered

### DIFF
--- a/.github/workflows/BUILD.yml
+++ b/.github/workflows/BUILD.yml
@@ -1,21 +1,14 @@
 name: BUILD
 
 on:
-  workflow_run:
-    workflows: ["CI"]
-    types:
-      - completed
-    branches:
-      - main
   workflow_dispatch:
 
 concurrency:
-  group: build-${{ github.event.workflow_run.head_branch || github.ref_name }}
+  group: build-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:
   backend_image_build:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## 🎯 Goal
- Prevent Docker image builds from running automatically after CI completes on main.
- Allow maintainers to run the build only through manual workflow dispatch.

## 🔧 Core Changes
- Removed the `workflow_run` trigger from `BUILD`.
- Simplified build concurrency to use the dispatched ref name.
- Removed the `workflow_run` success guard so manual dispatch can run the job.

## 🤔 Key Decisions
- Kept `workflow_dispatch` as the only trigger because the Actions UI already lets maintainers choose the target ref for manual runs.

## 🧪 Verification Guide
### How to verify
1. Open GitHub Actions > BUILD.
2. Confirm the workflow exposes the Run workflow action.
3. Confirm CI completion on main no longer triggers BUILD automatically.

### Expected result
- BUILD runs only when manually dispatched.

## ✅ Checklist
- [ ] Lint completed (not applicable: workflow config only)
- [ ] Type-check completed (not applicable: workflow config only)
- [x] Tests completed (`git diff --check`; YAML parse)
- [x] Documentation updated (not needed for this workflow trigger change)