### PR TITLE
✨ Extend developer publishing API

### DIFF
--- a/backend/islands/apps/remotes/src/components/remotes/DeveloperApiDocs/apiReference.ts
+++ b/backend/islands/apps/remotes/src/components/remotes/DeveloperApiDocs/apiReference.ts
@@ -143,6 +143,13 @@ const postDetailFields: ApiField[] = [
     }
 ];
 
+const paginationField: ApiField = {
+    name: 'pagination',
+    type: '{ page, limit, total }',
+    requirement: '필수',
+    description: '현재 페이지와 전체 개수입니다.'
+};
+
 const postIdPathParams: ApiField[] = [
     {
         name: 'id',
@@ -289,12 +296,7 @@ Authorization: Bearer blex_pat_...`
                 requirement: '필수',
                 description: '글 요약 목록입니다.'
             },
-            {
-                name: 'pagination',
-                type: '{ page, limit, total }',
-                requirement: '필수',
-                description: '현재 페이지와 전체 개수입니다.'
-            }
+            paginationField
         ],
         errors: [
             '401 auth.missing_token: Authorization 헤더가 없습니다.',
@@ -304,6 +306,122 @@ Authorization: Bearer blex_pat_...`
         example: {
             title: '글 목록 조회',
             code: `GET /api/developer/v1/posts?status=draft&page=1&limit=10 HTTP/1.1
+Authorization: Bearer blex_pat_...`
+        }
+    },
+    {
+        id: 'search-posts',
+        method: 'GET',
+        path: '/api/developer/v1/posts/search',
+        summary: '내 글 검색',
+        scope: 'posts:read',
+        description: 'AI 에이전트가 기존 발행물과 임시 글을 찾을 수 있도록 제목, URL, 설명, 태그, 본문을 검색합니다.',
+        successStatus: '200',
+        queryParams: [
+            {
+                name: 'q',
+                type: 'string',
+                requirement: '선택',
+                description: '검색어입니다. 제목, URL, 설명, 태그, 원문/렌더링 본문을 대상으로 검색합니다.'
+            },
+            {
+                name: 'tag',
+                type: 'string',
+                requirement: '선택',
+                description: '태그 이름입니다. 여러 tag 파라미터 또는 쉼표 구분 값을 사용할 수 있습니다.'
+            },
+            {
+                name: 'status',
+                type: 'draft | published | scheduled | hidden',
+                requirement: '선택',
+                description: '상태별로 필터링합니다.'
+            },
+            {
+                name: 'series_id',
+                type: 'number',
+                requirement: '선택',
+                description: '시리즈 ID로 필터링합니다.'
+            },
+            {
+                name: 'page',
+                type: 'number',
+                requirement: '선택',
+                description: '페이지 번호입니다. 기본값은 1입니다.'
+            },
+            {
+                name: 'limit',
+                type: 'number',
+                requirement: '선택',
+                description: '페이지당 개수입니다. 기본값은 20, 최대값은 100입니다.'
+            }
+        ],
+        responseBody: [
+            {
+                name: 'posts',
+                type: 'PostSummary[]',
+                requirement: '필수',
+                description: '검색된 글 요약 목록입니다.'
+            },
+            paginationField
+        ],
+        errors: [
+            '403 auth.insufficient_scope: posts:read 권한이 없습니다.',
+            '400 request.invalid_series_id: series_id가 숫자가 아닙니다.',
+            '400 post.invalid_status: 지원하지 않는 status입니다.'
+        ],
+        example: {
+            title: '태그와 본문 검색',
+            code: `GET /api/developer/v1/posts/search?q=publishing&tag=mcp&status=draft HTTP/1.1
+Authorization: Bearer blex_pat_...`
+        }
+    },
+    {
+        id: 'list-tags',
+        method: 'GET',
+        path: '/api/developer/v1/tags',
+        summary: '내 글 태그 목록',
+        scope: 'posts:read',
+        description: '토큰 소유자의 글에 연결된 태그와 각 태그의 글 수를 조회합니다.',
+        successStatus: '200',
+        responseBody: [
+            {
+                name: 'tags',
+                type: '{ name, post_count }[]',
+                requirement: '필수',
+                description: '태그 이름과 연결된 내 글 수입니다.'
+            }
+        ],
+        errors: [
+            '403 auth.insufficient_scope: posts:read 권한이 없습니다.'
+        ],
+        example: {
+            title: '태그 목록 조회',
+            code: `GET /api/developer/v1/tags HTTP/1.1
+Authorization: Bearer blex_pat_...`
+        }
+    },
+    {
+        id: 'list-series',
+        method: 'GET',
+        path: '/api/developer/v1/series',
+        summary: '내 시리즈 목록',
+        scope: 'posts:read',
+        description: '토큰 소유자의 시리즈와 연결된 글 수를 조회합니다.',
+        successStatus: '200',
+        responseBody: [
+            {
+                name: 'series',
+                type: '{ id, name, url, description, is_hidden, post_count, created_at, updated_at }[]',
+                requirement: '필수',
+                description: '내 시리즈 목록입니다.'
+            }
+        ],
+        errors: [
+            '403 auth.insufficient_scope: posts:read 권한이 없습니다.'
+        ],
+        example: {
+            title: '시리즈 목록 조회',
+            code: `GET /api/developer/v1/series HTTP/1.1
 Authorization: Bearer blex_pat_...`
         }
     },
@@ -497,6 +615,45 @@ Content-Type: application/json
   "title": "발행할 제목",
   "content": "# Published"
 }`
+        }
+    },
+    {
+        id: 'upload-image',
+        method: 'POST',
+        path: '/api/developer/v1/images',
+        summary: '본문 이미지 업로드',
+        scope: 'posts:write',
+        description: 'AI 에이전트가 생성하거나 로컬에 저장한 이미지를 업로드하고, 글 본문에 삽입할 수 있는 URL을 받습니다.',
+        successStatus: '201',
+        requestBody: [
+            {
+                name: 'image',
+                type: 'multipart file',
+                requirement: '필수',
+                description: 'jpg, jpeg, png, gif, mp4, webm 파일입니다.'
+            }
+        ],
+        responseBody: [
+            {
+                name: 'url',
+                type: 'string',
+                requirement: '필수',
+                description: '업로드된 이미지 또는 영상의 미디어 URL입니다.'
+            }
+        ],
+        errors: [
+            '403 auth.insufficient_scope: posts:write 권한이 없습니다.',
+            '400 image.missing: 이미지 파일이 없습니다.',
+            '400 image.invalid_extension: 허용되지 않은 확장자입니다.',
+            '422 image.upload_failed: 이미지 처리에 실패했습니다.'
+        ],
+        example: {
+            title: '이미지 업로드',
+            code: `POST /api/developer/v1/images HTTP/1.1
+Authorization: Bearer blex_pat_...
+Content-Type: multipart/form-data
+
+image=@cover.png`
         }
     }
 ];

--- a/backend/src/board/modules/developer_serializers.py
+++ b/backend/src/board/modules/developer_serializers.py
@@ -109,3 +109,27 @@ class DeveloperTokenSerializer:
             'last_used_at': DeveloperPostSerializer.isoformat(token.last_used_at),
             'created_at': DeveloperPostSerializer.isoformat(token.created_date),
         }
+
+
+class DeveloperTagSerializer:
+    @staticmethod
+    def serialize(tag):
+        return {
+            'name': tag.value,
+            'post_count': getattr(tag, 'post_count', 0),
+        }
+
+
+class DeveloperSeriesSerializer:
+    @staticmethod
+    def serialize(series):
+        return {
+            'id': series.id,
+            'name': series.name,
+            'url': series.url,
+            'description': series.text_md,
+            'is_hidden': series.hide,
+            'post_count': getattr(series, 'post_count', 0),
+            'created_at': DeveloperPostSerializer.isoformat(series.created_date),
+            'updated_at': DeveloperPostSerializer.isoformat(series.updated_date),
+        }

--- a/backend/src/board/services/image_upload_service.py
+++ b/backend/src/board/services/image_upload_service.py
@@ -1,0 +1,186 @@
+import datetime
+import os
+import subprocess
+import traceback
+
+import imageio_ffmpeg
+from django.conf import settings
+from PIL import Image, ImageFilter
+
+from board.models import ImageCache
+from modules.hash import get_sha256
+from modules.randomness import randstr
+from modules.sysutil import make_path
+
+
+class ImageUploadError(Exception):
+    def __init__(self, code, message):
+        self.code = code
+        self.message = message
+        super().__init__(message)
+
+
+class ImageUploadService:
+    ALLOWED_EXTENSIONS = {'jpg', 'jpeg', 'png', 'gif', 'mp4', 'webm'}
+
+    @staticmethod
+    def upload_content_image(image, user=None):
+        if image is None:
+            raise ImageUploadError('image.missing', '이미지가 없습니다.')
+
+        image_key = get_sha256(image.read())
+        image.seek(0)
+        image_cache = ImageCache.objects.filter(key=image_key).first()
+
+        if image_cache:
+            return settings.MEDIA_URL + image_cache.path
+
+        ext = str(image).split('.')[-1].lower()
+        if ext not in ImageUploadService.ALLOWED_EXTENSIONS:
+            raise ImageUploadError('image.invalid_extension', '허용된 확장자가 아닙니다.')
+
+        image_cache = ImageCache(
+            user=user,
+            key=image_key,
+            size=image.size
+        )
+
+        dt = datetime.datetime.now()
+        upload_path = make_path([
+            'resources',
+            'media',
+            'images',
+            'content',
+            str(dt.year),
+            str(dt.month),
+            str(dt.day)
+        ])
+
+        file_name = f'{dt.year}{dt.month}{dt.day}{dt.hour}_{randstr(20)}'
+        with open(upload_path + '/' + file_name + '.' + ext, 'wb+') as destination:
+            for chunk in image.chunks():
+                destination.write(chunk)
+
+        ext = ImageUploadService.process_uploaded_file(upload_path, file_name, ext)
+        image_cache.path = upload_path.replace(
+            'resources/media/', ''
+        ) + file_name + '.' + ext
+        image_cache.save()
+        return settings.MEDIA_URL + image_cache.path
+
+    @staticmethod
+    def process_uploaded_file(upload_path, file_name, ext):
+        if ext == 'gif':
+            return ImageUploadService.process_gif(upload_path, file_name, ext)
+        if ext in ['mp4', 'webm']:
+            ImageUploadService.process_video(upload_path, file_name, ext)
+            return ext
+        if ext == 'png':
+            return ImageUploadService.process_png(upload_path, file_name, ext)
+        ImageUploadService.process_raster_image(upload_path, file_name, ext)
+        return ext
+
+    @staticmethod
+    def process_gif(upload_path, file_name, ext):
+        try:
+            image_path = upload_path + '/' + file_name
+            convert_image = Image.open(
+                image_path + '.' + ext
+            ).convert('RGB')
+            preview_image = convert_image.filter(
+                ImageFilter.GaussianBlur(50)
+            )
+            preview_image.save(
+                image_path + '.mp4.preview.jpg', quality=50
+            )
+
+            ffmpeg_exe = imageio_ffmpeg.get_ffmpeg_exe()
+            subprocess.run([
+                ffmpeg_exe,
+                '-i', f'{upload_path}/{file_name}.gif',
+                '-vf', 'scale=trunc(iw/2)*2:trunc(ih/2)*2',
+                '-c:v', 'libx264',
+                '-pix_fmt', 'yuv420p',
+                '-movflags', '+faststart',
+                f'{upload_path}/{file_name}.mp4'
+            ], check=True)
+            os.remove(f'{upload_path}/{file_name}.gif')
+            return 'mp4'
+        except Exception:
+            raise ImageUploadError('image.upload_failed', '이미지 업로드를 실패했습니다.')
+
+    @staticmethod
+    def process_video(upload_path, file_name, ext):
+        try:
+            video_path = upload_path + '/' + file_name + '.' + ext
+            preview_path = video_path + '.preview.jpg'
+
+            ffmpeg_exe = imageio_ffmpeg.get_ffmpeg_exe()
+            subprocess.run([
+                ffmpeg_exe,
+                '-i', video_path,
+                '-ss', '00:00:00',
+                '-vframes', '1',
+                '-vf', 'scale=480:-1',
+                '-q:v', '10',
+                preview_path
+            ], check=True)
+
+            if os.path.exists(preview_path):
+                preview_image = Image.open(preview_path).convert('RGB')
+                preview_image = preview_image.filter(ImageFilter.GaussianBlur(50))
+                preview_image.save(preview_path, quality=50)
+        except Exception:
+            traceback.print_exc()
+            raise ImageUploadError('image.upload_failed', '비디오 업로드를 실패했습니다.')
+
+    @staticmethod
+    def process_png(upload_path, file_name, ext):
+        try:
+            image_path = upload_path + '/' + file_name + '.' + ext
+            image_size = os.stat(image_path).st_size
+            resize_image = Image.open(image_path)
+
+            if image_size > 1024 * 1024 * 2:
+                resize_image = resize_image.convert('RGB')
+                ext = 'jpg'
+
+            image_path = upload_path + '/' + file_name + '.' + ext
+            resize_image.thumbnail((1920, 1920), Image.LANCZOS)
+            resize_image.save(image_path)
+
+            if ext == 'jpg':
+                os.system(f'rm {upload_path}/{file_name}.png')
+
+            if ext == 'png':
+                resize_image = resize_image.convert('RGB')
+
+            preview_image = resize_image.filter(
+                ImageFilter.GaussianBlur(50)
+            )
+            preview_image.save(
+                image_path + '.preview.jpg', quality=50
+            )
+            return ext
+        except Exception:
+            traceback.print_exc()
+            raise ImageUploadError('image.upload_failed', '이미지 업로드를 실패했습니다.')
+
+    @staticmethod
+    def process_raster_image(upload_path, file_name, ext):
+        try:
+            image_path = upload_path + '/' + file_name + '.' + ext
+            resize_image = Image.open(image_path)
+            resize_image.thumbnail((1920, 1920), Image.LANCZOS)
+            resize_image.save(image_path)
+
+            if ext != 'jpg':
+                resize_image = resize_image.convert('RGB')
+            preview_image = resize_image.filter(
+                ImageFilter.GaussianBlur(50)
+            )
+            preview_image.save(
+                image_path + '.preview.jpg', quality=50
+            )
+        except Exception:
+            raise ImageUploadError('image.upload_failed', '이미지 업로드를 실패했습니다.')

--- a/backend/src/board/tests/api/test_developer_posts.py
+++ b/backend/src/board/tests/api/test_developer_posts.py
@@ -1,10 +1,12 @@
 import json
+from unittest.mock import patch
 
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.db import connection
 from django.test import TestCase
 from django.test.utils import CaptureQueriesContext
 
-from board.models import Config, Post, Profile, User
+from board.models import Config, Post, Profile, Series, User
 from board.modules.developer_serializers import DeveloperPostSerializer
 from board.services.developer_token_service import DeveloperTokenService
 
@@ -69,12 +71,18 @@ class DeveloperPostsAPITestCase(TestCase):
             **self.auth_header(token),
         )
 
-    def create_draft(self, title='API Draft'):
-        response = self.post_json('/api/developer/v1/posts', {
+    def create_draft(self, title='API Draft', content='# Hello\n\nThis is **bold**', tags=None, series_id=None):
+        body = {
             'title': title,
-            'content': '# Hello\n\nThis is **bold**',
+            'content': content,
             'content_type': 'markdown',
-            'tags': ['api', 'mcp'],
+            'tags': tags if tags is not None else ['api', 'mcp'],
+        }
+        if series_id is not None:
+            body['series_id'] = series_id
+
+        response = self.post_json('/api/developer/v1/posts', {
+            **body,
         })
         self.assertEqual(response.status_code, 201)
         return response.json()['data']
@@ -229,3 +237,119 @@ class DeveloperPostsAPITestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()['data']['deleted'], True)
         self.assertFalse(Post.objects.filter(id=draft['id']).exists())
+
+    def test_search_posts_filters_by_query_tag_and_status(self):
+        """개발자 API 글 검색은 내 글의 본문, 태그, 상태를 함께 필터링한다."""
+        matched = self.create_draft(
+            'MCP Publish Draft',
+            content='AI publishing adapter content',
+            tags=['mcp', 'publish'],
+        )
+        self.create_draft(
+            'Unrelated Draft',
+            content='private wiki content',
+            tags=['wiki'],
+        )
+
+        response = self.client.get(
+            '/api/developer/v1/posts/search?q=publishing&tag=mcp&status=draft',
+            **self.auth_header(),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()['data']
+        self.assertEqual(data['pagination']['total'], 1)
+        self.assertEqual(data['posts'][0]['id'], matched['id'])
+
+    def test_list_tags_returns_author_tags_only(self):
+        """태그 목록은 토큰 소유자의 글에 연결된 태그만 반환한다."""
+        self.create_draft('Tagged Draft', tags=['api', 'mcp'])
+        self.post_json('/api/developer/v1/posts', {
+            'title': 'Other Tagged Draft',
+            'content': 'Other content',
+            'content_type': 'markdown',
+            'tags': ['secret'],
+        }, token=self.other_token)
+
+        response = self.client.get(
+            '/api/developer/v1/tags',
+            **self.auth_header(),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        tags = {
+            tag['name']: tag['post_count']
+            for tag in response.json()['data']['tags']
+        }
+        self.assertEqual(tags, {'api': 1, 'mcp': 1})
+        self.assertNotIn('secret', tags)
+
+    def test_list_series_returns_owned_series_with_post_count(self):
+        """시리즈 목록은 내 시리즈와 연결된 글 수를 반환한다."""
+        series = Series.objects.create(
+            owner=self.author,
+            name='MCP Guide',
+            text_md='Guide description',
+            url='mcp-guide',
+        )
+        Series.objects.create(
+            owner=self.other,
+            name='Other Guide',
+            url='other-guide',
+        )
+        self.create_draft('Series Draft', series_id=series.id)
+
+        response = self.client.get(
+            '/api/developer/v1/series',
+            **self.auth_header(),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()['data']['series']
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['id'], series.id)
+        self.assertEqual(data[0]['name'], 'MCP Guide')
+        self.assertEqual(data[0]['description'], 'Guide description')
+        self.assertEqual(data[0]['post_count'], 1)
+
+    @patch('board.views.api.developer.v1.publishing.ImageUploadService.upload_content_image')
+    def test_upload_image_uses_developer_token(self, mock_upload):
+        """개발자 API 이미지 업로드는 posts:write 토큰으로 이미지 URL을 반환한다."""
+        mock_upload.return_value = '/media/images/content/test.png'
+        uploaded_file = SimpleUploadedFile(
+            'test.png',
+            b'fake image',
+            content_type='image/png',
+        )
+
+        response = self.client.post(
+            '/api/developer/v1/images',
+            {'image': uploaded_file},
+            **self.auth_header(),
+        )
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(
+            response.json()['data']['url'],
+            '/media/images/content/test.png',
+        )
+        self.assertEqual(mock_upload.call_args.kwargs['user'], self.author)
+
+    @patch('board.views.api.developer.v1.publishing.ImageUploadService.upload_content_image')
+    def test_upload_image_requires_write_scope(self, mock_upload):
+        """읽기 전용 토큰은 이미지 업로드를 할 수 없다."""
+        uploaded_file = SimpleUploadedFile(
+            'test.png',
+            b'fake image',
+            content_type='image/png',
+        )
+
+        response = self.client.post(
+            '/api/developer/v1/images',
+            {'image': uploaded_file},
+            **self.auth_header(self.read_token),
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()['error']['code'], 'auth.insufficient_scope')
+        mock_upload.assert_not_called()

--- a/backend/src/board/tests/api/test_image_upload.py
+++ b/backend/src/board/tests/api/test_image_upload.py
@@ -63,7 +63,7 @@ class ImageUploadTestCase(TestCase):
             content_type="image/jpeg"
         )
 
-        with patch('board.views.api.v1.image.make_path') as mock_make_path:
+        with patch('board.services.image_upload_service.make_path') as mock_make_path:
             with patch('builtins.open', create=True) as mock_open:
                 with patch('PIL.Image.open') as mock_pil:
                     mock_make_path.return_value = tempfile.gettempdir()
@@ -96,7 +96,7 @@ class ImageUploadTestCase(TestCase):
             content_type="image/png"
         )
 
-        with patch('board.views.api.v1.image.make_path') as mock_make_path:
+        with patch('board.services.image_upload_service.make_path') as mock_make_path:
             with patch('builtins.open', create=True):
                 with patch('PIL.Image.open') as mock_pil:
                     with patch('os.stat') as mock_stat:
@@ -162,7 +162,7 @@ class ImageUploadTestCase(TestCase):
             content_type="image/bmp"
         )
 
-        with patch('board.views.api.v1.image.make_path') as mock_make_path:
+        with patch('board.services.image_upload_service.make_path') as mock_make_path:
             with patch('builtins.open', create=True):
                 mock_make_path.return_value = tempfile.gettempdir()
                 response = self.client.post('/v1/image', {'image': invalid_file})
@@ -212,7 +212,7 @@ class ImageUploadTestCase(TestCase):
             content_type="image/gif"
         )
 
-        with patch('board.views.api.v1.image.make_path') as mock_make_path:
+        with patch('board.services.image_upload_service.make_path') as mock_make_path:
             with patch('builtins.open', create=True):
                 with patch('PIL.Image.open') as mock_pil:
                     with patch('os.remove'):
@@ -241,7 +241,7 @@ class ImageUploadTestCase(TestCase):
             content_type="image/png"
         )
 
-        with patch('board.views.api.v1.image.make_path') as mock_make_path:
+        with patch('board.services.image_upload_service.make_path') as mock_make_path:
             with patch('builtins.open', create=True):
                 with patch('PIL.Image.open') as mock_pil:
                     with patch('os.stat') as mock_stat:

--- a/backend/src/board/urls.py
+++ b/backend/src/board/urls.py
@@ -151,6 +151,10 @@ urlpatterns = [
     # Developer API V1
     path('api/developer/v1/me', developer_api_v1.me),
     path('api/developer/v1/posts', developer_api_v1.posts),
+    path('api/developer/v1/posts/search', developer_api_v1.search_posts),
     path('api/developer/v1/posts/<int:post_id>', developer_api_v1.post_detail),
     path('api/developer/v1/posts/<int:post_id>/publish', developer_api_v1.publish_post),
+    path('api/developer/v1/tags', developer_api_v1.tags),
+    path('api/developer/v1/series', developer_api_v1.series),
+    path('api/developer/v1/images', developer_api_v1.images),
 ]

--- a/backend/src/board/views/api/developer/v1/__init__.py
+++ b/backend/src/board/views/api/developer/v1/__init__.py
@@ -1,2 +1,3 @@
 from .auth import *
 from .post import *
+from .publishing import *

--- a/backend/src/board/views/api/developer/v1/publishing.py
+++ b/backend/src/board/views/api/developer/v1/publishing.py
@@ -1,0 +1,212 @@
+from django.db.models import Count, Q
+from django.http import Http404
+from django.views.decorators.csrf import csrf_exempt
+
+from board.models import Series, Tag
+from board.modules.developer_response import DeveloperResponse
+from board.modules.developer_serializers import (
+    DeveloperPostSerializer,
+    DeveloperSeriesSerializer,
+    DeveloperTagSerializer,
+)
+from board.services.developer_token_service import (
+    DeveloperAuthError,
+    DeveloperTokenService,
+)
+from board.services.image_upload_service import ImageUploadError, ImageUploadService
+from board.views.api.developer.v1.post import DeveloperPostAPI
+
+
+class DeveloperPublishingAPI:
+    @staticmethod
+    def tags_param(request):
+        tags = []
+        for value in request.GET.getlist('tag'):
+            tags.extend(value.split(','))
+        return [tag.strip() for tag in tags if tag.strip()]
+
+    @staticmethod
+    def filter_by_search_query(queryset, query):
+        query = (query or '').strip()
+        if not query:
+            return queryset
+
+        return queryset.filter(
+            Q(title__icontains=query)
+            | Q(subtitle__icontains=query)
+            | Q(url__icontains=query)
+            | Q(meta_description__icontains=query)
+            | Q(tags__value__icontains=query)
+            | Q(content__text_md__icontains=query)
+            | Q(content__text_html__icontains=query)
+        )
+
+    @staticmethod
+    def filter_by_series_id(queryset, series_id):
+        if series_id in (None, ''):
+            return queryset
+
+        try:
+            series_id = int(series_id)
+        except (TypeError, ValueError):
+            raise DeveloperAuthError(
+                'request.invalid_series_id',
+                'series_id는 숫자여야 합니다.',
+                400,
+            )
+
+        return queryset.filter(series_id=series_id)
+
+    @staticmethod
+    def search_posts(request, token):
+        queryset = DeveloperPostAPI.post_queryset(token.user)
+        queryset = DeveloperPublishingAPI.filter_by_search_query(
+            queryset,
+            request.GET.get('q', ''),
+        )
+        queryset = DeveloperPostAPI.status_filter(
+            queryset,
+            request.GET.get('status', ''),
+        )
+        queryset = DeveloperPublishingAPI.filter_by_series_id(
+            queryset,
+            request.GET.get('series_id'),
+        )
+
+        tags = DeveloperPublishingAPI.tags_param(request)
+        if tags:
+            queryset = queryset.filter(tags__value__in=tags)
+
+        queryset = queryset.distinct().order_by('-updated_date')
+        page, limit, offset = DeveloperPostAPI.pagination(request)
+
+        total = queryset.count()
+        posts = queryset[offset:offset + limit]
+        response = DeveloperResponse.success({
+            'posts': [
+                DeveloperPostSerializer.summary(post)
+                for post in posts
+            ],
+            'pagination': {
+                'page': page,
+                'limit': limit,
+                'total': total,
+            },
+        })
+        DeveloperTokenService.record_request(request, token, response.status_code)
+        return response
+
+    @staticmethod
+    def list_tags(request, token):
+        tags = Tag.objects.filter(
+            posts__author=token.user,
+        ).annotate(
+            post_count=Count(
+                'posts',
+                filter=Q(posts__author=token.user),
+                distinct=True,
+            ),
+        ).order_by(
+            'value',
+        ).distinct()
+
+        response = DeveloperResponse.success({
+            'tags': [
+                DeveloperTagSerializer.serialize(tag)
+                for tag in tags
+            ],
+        })
+        DeveloperTokenService.record_request(request, token, response.status_code)
+        return response
+
+    @staticmethod
+    def list_series(request, token):
+        series = Series.objects.filter(
+            owner=token.user,
+        ).annotate(
+            post_count=Count('posts', distinct=True),
+        ).order_by(
+            'order',
+            'name',
+            'id',
+        )
+
+        response = DeveloperResponse.success({
+            'series': [
+                DeveloperSeriesSerializer.serialize(item)
+                for item in series
+            ],
+        })
+        DeveloperTokenService.record_request(request, token, response.status_code)
+        return response
+
+    @staticmethod
+    def upload_image(request, token):
+        try:
+            url = ImageUploadService.upload_content_image(
+                request.FILES.get('image'),
+                user=token.user,
+            )
+        except ImageUploadError as error:
+            status = 422 if error.code == 'image.upload_failed' else 400
+            response = DeveloperResponse.error(
+                error.code,
+                error.message,
+                status,
+            )
+            DeveloperTokenService.record_request(request, token, response.status_code)
+            return response
+
+        response = DeveloperResponse.success({
+            'url': url,
+        }, status=201)
+        DeveloperTokenService.record_request(request, token, response.status_code)
+        return response
+
+
+@csrf_exempt
+def search_posts(request):
+    if request.method != 'GET':
+        raise Http404
+
+    try:
+        token = DeveloperPostAPI.authenticate(request, 'posts:read')
+        return DeveloperPublishingAPI.search_posts(request, token)
+    except DeveloperAuthError as error:
+        return DeveloperPostAPI.auth_error(error)
+
+
+@csrf_exempt
+def tags(request):
+    if request.method != 'GET':
+        raise Http404
+
+    try:
+        token = DeveloperPostAPI.authenticate(request, 'posts:read')
+        return DeveloperPublishingAPI.list_tags(request, token)
+    except DeveloperAuthError as error:
+        return DeveloperPostAPI.auth_error(error)
+
+
+@csrf_exempt
+def series(request):
+    if request.method != 'GET':
+        raise Http404
+
+    try:
+        token = DeveloperPostAPI.authenticate(request, 'posts:read')
+        return DeveloperPublishingAPI.list_series(request, token)
+    except DeveloperAuthError as error:
+        return DeveloperPostAPI.auth_error(error)
+
+
+@csrf_exempt
+def images(request):
+    if request.method != 'POST':
+        raise Http404
+
+    try:
+        token = DeveloperPostAPI.authenticate(request, 'posts:write')
+        return DeveloperPublishingAPI.upload_image(request, token)
+    except DeveloperAuthError as error:
+        return DeveloperPostAPI.auth_error(error)

--- a/backend/src/board/views/api/v1/image.py
+++ b/backend/src/board/views/api/v1/image.py
@@ -1,18 +1,7 @@
-import os
-import datetime
-import traceback
-import subprocess
-import imageio_ffmpeg
-
-from django.conf import settings
 from django.http import Http404
-from PIL import Image, ImageFilter
 
-from board.models import ImageCache
 from board.modules.response import StatusDone, StatusError, ErrorCode
-from modules.hash import get_sha256
-from modules.randomness import randstr
-from modules.sysutil import make_path
+from board.services.image_upload_service import ImageUploadError, ImageUploadService
 
 
 def image(request):
@@ -20,142 +9,15 @@ def image(request):
         if not request.user.is_active:
             raise Http404
 
-        if 'image' not in request.FILES:
-            return StatusError(ErrorCode.VALIDATE, '이미지가 없습니다.')
-
-        allowed_ext = ['jpg', 'jpeg', 'png', 'gif', 'mp4', 'webm']
-
-        image = request.FILES['image']
-        image_key = get_sha256(image.read())
-        image_cache = ImageCache.objects.filter(key=image_key)
-
-        if image_cache.exists():
-            return StatusDone({
-                'url': settings.MEDIA_URL + image_cache.first().path,
-            })
-
-        image_cache = ImageCache(
-            key=image_key,
-            size=image.size
-        )
-        ext = str(image).split('.')[-1].lower()
-
-        if not ext in allowed_ext:
-            return StatusError(ErrorCode.VALIDATE, '허용된 확장자가 아닙니다.')
-
-        dt = datetime.datetime.now()
-        upload_path = make_path([
-            'resources',
-            'media',
-            'images',
-            'content',
-            str(dt.year),
-            str(dt.month),
-            str(dt.day)
-        ])
-
-        file_name = f'{dt.year}{dt.month}{dt.day}{dt.hour}_{randstr(20)}'
-        with open(upload_path + '/' + file_name + '.' + ext, 'wb+') as destination:
-            for chunk in image.chunks():
-                destination.write(chunk)
-
-        if ext == 'gif':
-            try:
-                image_path = upload_path + '/' + file_name
-                convert_image = Image.open(
-                    image_path + '.' + ext).convert('RGB')
-                preview_image = convert_image.filter(
-                    ImageFilter.GaussianBlur(50))
-                preview_image.save(
-                    image_path + '.mp4.preview.jpg', quality=50)
-
-                ffmpeg_exe = imageio_ffmpeg.get_ffmpeg_exe()
-                subprocess.run([
-                    ffmpeg_exe,
-                    '-i', f'{upload_path}/{file_name}.gif',
-                    '-vf', 'scale=trunc(iw/2)*2:trunc(ih/2)*2',
-                    '-c:v', 'libx264',
-                    '-pix_fmt', 'yuv420p',
-                    '-movflags', '+faststart',
-                    f'{upload_path}/{file_name}.mp4'
-                ], check=True)
-                os.remove(f'{upload_path}/{file_name}.gif')
-                ext = 'mp4'
-            except:
-                return StatusError(ErrorCode.REJECT, '이미지 업로드를 실패했습니다.')
-
-        elif ext in ['mp4', 'webm']:
-            try:
-                video_path = upload_path + '/' + file_name + '.' + ext
-                preview_path = video_path + '.preview.jpg'
-
-                ffmpeg_exe = imageio_ffmpeg.get_ffmpeg_exe()
-                subprocess.run([
-                    ffmpeg_exe,
-                    '-i', video_path,
-                    '-ss', '00:00:00',
-                    '-vframes', '1',
-                    '-vf', 'scale=480:-1',
-                    '-q:v', '10',
-                    preview_path
-                ], check=True)
-
-                if os.path.exists(preview_path):
-                    preview_image = Image.open(preview_path).convert('RGB')
-                    preview_image = preview_image.filter(ImageFilter.GaussianBlur(50))
-                    preview_image.save(preview_path, quality=50)
-            except:
-                traceback.print_exc()
-                return StatusError(ErrorCode.REJECT, '비디오 업로드를 실패했습니다.')
-
-        elif ext == 'png':
-            try:
-                image_path = upload_path + '/' + file_name + '.' + ext
-                image_size = os.stat(image_path).st_size
-                resize_image = Image.open(image_path)
-
-                if image_size > 1024 * 1024 * 2:
-                    resize_image = resize_image.convert('RGB')
-                    ext = 'jpg'
-
-                image_path = upload_path + '/' + file_name + '.' + ext
-                resize_image.thumbnail((1920, 1920), Image.LANCZOS)
-                resize_image.save(image_path)
-
-                if ext == 'jpg':
-                    os.system(f'rm {upload_path}/{file_name}.png')
-
-                if ext == 'png':
-                    resize_image = resize_image.convert('RGB')
-
-                preview_image = resize_image.filter(
-                    ImageFilter.GaussianBlur(50))
-                preview_image.save(
-                    image_path + '.preview.jpg', quality=50)
-            except:
-                traceback.print_exc()
-                return StatusError(ErrorCode.REJECT, '이미지 업로드를 실패했습니다.')
-
-        else:
-            try:
-                image_path = upload_path + '/' + file_name + '.' + ext
-                resize_image = Image.open(image_path)
-                resize_image.thumbnail((1920, 1920), Image.LANCZOS)
-                resize_image.save(image_path)
-
-                if not ext == 'jpg':
-                    resize_image = resize_image.convert('RGB')
-                preview_image = resize_image.filter(
-                    ImageFilter.GaussianBlur(50))
-                preview_image.save(
-                    image_path + '.preview.jpg', quality=50)
-            except:
-                return StatusError(ErrorCode.REJECT, '이미지 업로드를 실패했습니다.')
-        image_cache.path = upload_path.replace(
-            'resources/media/', '') + file_name + '.' + ext
-        image_cache.save()
-        return StatusDone({
-            'url': settings.MEDIA_URL + image_cache.path,
-        })
+        try:
+            url = ImageUploadService.upload_content_image(
+                request.FILES.get('image'),
+                user=request.user,
+            )
+            return StatusDone({'url': url})
+        except ImageUploadError as error:
+            if error.code in ('image.missing', 'image.invalid_extension'):
+                return StatusError(ErrorCode.VALIDATE, error.message)
+            return StatusError(ErrorCode.REJECT, error.message)
 
     raise Http404


### PR DESCRIPTION
## 🎯 Goal
- Expand the BLEX Developer API so the official MCP server can act as a publishing adapter, not just a basic post CRUD wrapper.
- Give agents enough API surface to search existing posts, reuse tags/series, upload generated/local images, and publish safely.

## 🔧 Core Changes
- Added Developer API endpoints for post search, tag list, series list, and authenticated image upload.
- Extracted shared content image upload behavior into `ImageUploadService` so the session API and Developer API use the same processing path.
- Added serializers, routes, backend tests, and developer API docs for the new publishing endpoints.

## 🤔 Key Decisions
- Kept BLEX as the public publishing surface: drafts, tags, series, images, updates, publish/delete.
- Left private knowledge/wiki behavior outside BLEX; the API only exposes publishing-oriented capabilities.
- Reused existing `posts:read` and `posts:write` scopes instead of adding new scopes for tags/series/images.

## 🧪 Verification Guide
### How to verify
1. Create a Developer API token with `posts:read` and `posts:write`.
2. Call `GET /api/developer/v1/posts/search`, `GET /api/developer/v1/tags`, and `GET /api/developer/v1/series` with `Authorization: Bearer <token>`.
3. Upload a small image with `POST /api/developer/v1/images` using `multipart/form-data` field `image`.

### Expected result
- Search returns owned post summaries with pagination.
- Tags and series only include resources owned/used by the token owner.
- Image upload returns a media URL usable in post content.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)

## Local verification
- `./scripts/manage.sh test board.tests.api.test_developer_posts board.tests.api.test_image_upload`
- `npm run islands:type-check`
- `npm run islands:lint`
- Local `curl` smoke against `runserver 127.0.0.1:8765`:
  - `GET /api/developer/v1/me` -> 200
  - `POST /api/developer/v1/posts` -> 201
  - `GET /api/developer/v1/posts/search` -> 200
  - `GET /api/developer/v1/tags` -> 200
  - `GET /api/developer/v1/series` -> 200
  - `POST /api/developer/v1/images` -> 201
  - `DELETE /api/developer/v1/posts/{id}` -> 200
