### PR TITLE
🐛 Align editor preview width with post layout

### DIFF
--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/PostEditorWrapper.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/PostEditorWrapper.tsx
@@ -7,8 +7,12 @@ interface PostEditorWrapperProps {
 const PostEditorWrapper = ({ children }: PostEditorWrapperProps) => {
     return (
         <div className="pt-8 pb-16 px-4 md:px-6">
-            <div className="max-w-4xl w-full mx-auto">
-                {children}
+            <div className="flex justify-center gap-6">
+                <aside className="hidden xl:block w-64 flex-shrink-0" aria-hidden="true" />
+                <main className="max-w-4xl w-full">
+                    {children}
+                </main>
+                <aside className="hidden xl:block w-64 flex-shrink-0" aria-hidden="true" />
             </div>
         </div>
     );

--- a/backend/islands/packages/editor/src/TiptapEditor/TiptapEditor.tsx
+++ b/backend/islands/packages/editor/src/TiptapEditor/TiptapEditor.tsx
@@ -42,7 +42,7 @@ const TiptapEditor = ({
         content,
         editable,
         editorProps: {
-            attributes: { class: 'blog-post-content' },
+            attributes: { class: 'prose prose-lg max-w-none blog-post-content' },
             handleDrop: (view, event, _slice, moved) => {
                 // 외부 파일 드롭은 React onDrop(useImageUpload)에서 처리
                 if (!moved) return false;


### PR DESCRIPTION
## 🎯 Goal
- Make the post editor preview closer to the published post layout.
- Reduce width and typography differences that make WYSIWYG editing unreliable.

## 🔧 Core Changes
- Added hidden desktop side rails to `PostEditorWrapper` so the editor body uses the same layout pressure as the post detail page with sidebars/TOC.
- Applied the same `prose prose-lg max-w-none blog-post-content` classes to the Tiptap editable body as the published article body.

## 🤔 Key Decisions
- Kept the published post layout unchanged.
- Adjusted the editor to assume the published page has side rails instead of forcing the article page width.
- Used hidden `aria-hidden` rails so the layout matches without adding accessible noise.

## 🧪 Verification Guide
### How to verify
1. Open `/write` or edit an existing post on a desktop-width viewport.
2. Type paragraphs/headings long enough to wrap.
3. Publish or preview the post detail page.

### Expected result
- Editor wrapping and typography should more closely match the published post body.
- The post detail sidebar/TOC layout should remain unchanged.

## ✅ Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [ ] Tests completed
- [x] Documentation updated (if needed)

## Note
- Local validation could not run in the current shell because `node`/`npm` are unavailable in PATH (`env: node: No such file or directory`).
