### PR TITLE
🐛 Stabilize developer API error contracts

### DIFF
--- a/backend/islands/apps/remotes/src/components/remotes/DeveloperApiDocs/api-reference/posts.ts
+++ b/backend/islands/apps/remotes/src/components/remotes/DeveloperApiDocs/api-reference/posts.ts
@@ -82,7 +82,7 @@ Authorization: Bearer blex_pat_...`
         errors: [
             '403 auth.insufficient_scope: posts:write 권한이 없습니다.',
             '400 post.missing_published_at: 예약 발행 시각이 없습니다.',
-            '422 post.*: 제목, 본문, URL, 태그 등 글 검증에 실패했습니다.'
+            '400 post.*: 제목, 본문, URL, 태그 등 글 검증에 실패했습니다.'
         ],
         example: {
             title: '마크다운 임시 글 생성',
@@ -133,7 +133,7 @@ Authorization: Bearer blex_pat_...`
                 name: 'expected_updated_at',
                 type: 'ISO datetime',
                 requirement: '선택',
-                description: '현재 updated_at과 다르면 409를 반환합니다.'
+                description: '현재 updated_at과 다르면 409를 반환합니다. 충돌 응답에는 expected_updated_at, actual_updated_at, post_id가 포함됩니다.'
             },
             ...postMutationBodyFields
         ],
@@ -141,8 +141,8 @@ Authorization: Bearer blex_pat_...`
         errors: [
             '403 auth.insufficient_scope: posts:write 권한이 없습니다.',
             '404 post.not_found: 내 글에서 해당 ID를 찾을 수 없습니다.',
-            '409 post.version_conflict: expected_updated_at이 현재 값과 다릅니다.',
-            '422 post.*: 글 검증에 실패했습니다.'
+            '409 post.version_conflict: expected_updated_at이 현재 값과 다릅니다. error.fields로 expected_updated_at, actual_updated_at, post_id를 반환합니다.',
+            '400 post.*: 글 검증에 실패했습니다.'
         ],
         example: {
             title: '글 제목과 본문 수정',
@@ -233,7 +233,7 @@ Authorization: Bearer blex_pat_...`
             '403 auth.insufficient_scope: posts:write 권한이 없습니다.',
             '404 post.not_found: 내 글에서 해당 ID를 찾을 수 없습니다.',
             '409 post.not_draft: 이미 발행되었거나 예약된 글입니다.',
-            '422 post.*: 발행 검증에 실패했습니다.'
+            '400 post.*: 발행 검증에 실패했습니다.'
         ],
         example: {
             title: '임시 글 발행',

--- a/backend/src/board/tests/api/test_developer_posts.py
+++ b/backend/src/board/tests/api/test_developer_posts.py
@@ -50,6 +50,14 @@ class DeveloperPostsAPITestCase(TestCase):
     def setUp(self):
         self.client.defaults['HTTP_USER_AGENT'] = 'BLEX_TEST'
 
+    def assert_developer_error(self, response, status_code, code):
+        self.assertEqual(response.status_code, status_code)
+        body = response.json()
+        self.assertIn('error', body)
+        self.assertEqual(body['error']['code'], code)
+        self.assertIsInstance(body['error']['message'], str)
+        self.assertTrue(body['error']['message'])
+
     def auth_header(self, token=None):
         return {
             'HTTP_AUTHORIZATION': f'Bearer {token or self.raw_token}',
@@ -184,6 +192,58 @@ class DeveloperPostsAPITestCase(TestCase):
 
         post = Post.objects.get(id=draft['id'])
         self.assertEqual(post.title, 'Conflict Draft')
+
+    def test_error_responses_include_code_and_message_for_common_failures(self):
+        """개발자 API 주요 실패 응답은 code와 message를 일관되게 반환한다."""
+        draft = self.create_draft('Error Shape Draft')
+
+        missing_token = self.client.get('/api/developer/v1/posts')
+        self.assert_developer_error(missing_token, 401, 'auth.missing_token')
+
+        insufficient_scope = self.post_json('/api/developer/v1/posts', {
+            'title': 'Forbidden',
+            'content': 'No',
+        }, token=self.read_token)
+        self.assert_developer_error(insufficient_scope, 403, 'auth.insufficient_scope')
+
+        not_found = self.client.get(
+            f"/api/developer/v1/posts/{draft['id']}",
+            **self.auth_header(self.other_token),
+        )
+        self.assert_developer_error(not_found, 404, 'post.not_found')
+
+        invalid_payload = self.client.post(
+            '/api/developer/v1/posts',
+            '{invalid json',
+            content_type='application/json',
+            **self.auth_header(),
+        )
+        self.assert_developer_error(invalid_payload, 400, 'request.invalid_json')
+
+    def test_create_published_post_validation_returns_bad_request(self):
+        """발행 글 검증 실패는 400과 표준 오류 본문을 반환한다."""
+        response = self.post_json('/api/developer/v1/posts', {
+            'status': 'published',
+            'title': '',
+            'content': 'Body without title',
+        })
+
+        self.assert_developer_error(response, 400, 'post.va')
+
+    def test_patch_post_conflict_returns_current_version_fields(self):
+        """expected_updated_at 충돌 응답은 클라이언트가 최신 버전을 다시 판단할 정보를 제공한다."""
+        draft = self.create_draft('Conflict Fields Draft')
+
+        response = self.patch_json(f"/api/developer/v1/posts/{draft['id']}", {
+            'expected_updated_at': '2020-01-01T00:00:00+00:00',
+            'title': 'Should Not Apply',
+        })
+
+        self.assert_developer_error(response, 409, 'post.version_conflict')
+        fields = response.json()['error']['fields']
+        self.assertEqual(fields['expected_updated_at'], '2020-01-01T00:00:00+00:00')
+        self.assertEqual(fields['actual_updated_at'], draft['updated_at'])
+        self.assertEqual(fields['post_id'], draft['id'])
 
     def test_publish_draft(self):
         draft = self.create_draft('Publish Draft')

--- a/backend/src/board/tests/api/test_developer_workflow.py
+++ b/backend/src/board/tests/api/test_developer_workflow.py
@@ -1,0 +1,109 @@
+import json
+from unittest.mock import patch
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase
+
+from board.models import Config, Post, Profile, User
+from board.services.developer_token_service import DeveloperTokenService
+
+
+class DeveloperWorkflowAPITestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.author = User.objects.create_user(
+            username='workflow-author',
+            password='author',
+            email='workflow-author@example.com',
+            first_name='Workflow Author',
+        )
+        Profile.objects.create(user=cls.author, role=Profile.Role.EDITOR)
+        Config.objects.create(user=cls.author)
+        cls.raw_token, _ = DeveloperTokenService.create_token(
+            cls.author,
+            name='Workflow token',
+            scopes=['posts:read', 'posts:write'],
+        )
+
+    def setUp(self):
+        self.client.defaults['HTTP_USER_AGENT'] = 'BLEX_TEST'
+
+    def auth_header(self):
+        return {
+            'HTTP_AUTHORIZATION': f'Bearer {self.raw_token}',
+        }
+
+    def post_json(self, url, body):
+        return self.client.post(
+            url,
+            json.dumps(body),
+            content_type='application/json',
+            **self.auth_header(),
+        )
+
+    def patch_json(self, url, body):
+        return self.client.patch(
+            url,
+            json.dumps(body),
+            content_type='application/json',
+            **self.auth_header(),
+        )
+
+    @patch('board.views.api.developer.v1.publishing.ImageUploadService.upload_content_image')
+    def test_upload_create_update_publish_and_read_markdown_post(self, mock_upload):
+        """대표 자동화 워크플로는 이미지 업로드부터 발행 후 상세 조회까지 통과한다."""
+        mock_upload.return_value = '/media/images/content/workflow.png'
+        image = SimpleUploadedFile(
+            'workflow.png',
+            b'fake image',
+            content_type='image/png',
+        )
+
+        upload_response = self.client.post(
+            '/api/developer/v1/images',
+            {'image': image},
+            **self.auth_header(),
+        )
+        self.assertEqual(upload_response.status_code, 201)
+        image_url = upload_response.json()['data']['url']
+
+        create_response = self.post_json('/api/developer/v1/posts', {
+            'status': 'draft',
+            'title': 'Workflow Draft',
+            'content': f'# Workflow\n\n![cover]({image_url})',
+            'content_type': 'markdown',
+            'tags': ['workflow'],
+        })
+        self.assertEqual(create_response.status_code, 201)
+        draft = create_response.json()['data']
+        self.assertEqual(draft['status'], 'draft')
+        self.assertEqual(draft['content_type'], 'markdown')
+
+        update_response = self.patch_json(f"/api/developer/v1/posts/{draft['id']}", {
+            'expected_updated_at': draft['updated_at'],
+            'description': 'Workflow API description',
+            'tags': ['workflow', 'published'],
+        })
+        self.assertEqual(update_response.status_code, 200)
+        updated = update_response.json()['data']
+        self.assertEqual(updated['description'], 'Workflow API description')
+        self.assertEqual(updated['tags'], ['published', 'workflow'])
+
+        publish_response = self.post_json(f"/api/developer/v1/posts/{draft['id']}/publish", {})
+        self.assertEqual(publish_response.status_code, 200)
+        published = publish_response.json()['data']
+        self.assertEqual(published['status'], 'published')
+        self.assertIsNotNone(published['published_at'])
+
+        detail_response = self.client.get(
+            f"/api/developer/v1/posts/{draft['id']}",
+            **self.auth_header(),
+        )
+        self.assertEqual(detail_response.status_code, 200)
+        detail = detail_response.json()['data']
+        self.assertEqual(detail['status'], 'published')
+        self.assertEqual(detail['content'], f'# Workflow\n\n![cover]({image_url})')
+        self.assertIn('<img', detail['rendered_html'])
+
+        post = Post.objects.get(id=draft['id'])
+        self.assertTrue(post.is_published())

--- a/backend/src/board/views/api/developer/v1/post.py
+++ b/backend/src/board/views/api/developer/v1/post.py
@@ -238,11 +238,7 @@ class DeveloperPostAPI:
                     400,
                 )
         except PostValidationError as error:
-            return DeveloperResponse.error(
-                f'post.{error.code.value.lower()}',
-                error.message,
-                422,
-            )
+            return DeveloperPostAPI.post_validation_error(error)
 
         post = DeveloperPostAPI.get_owned_post(token.user, post.id)
         response = DeveloperResponse.success(
@@ -251,6 +247,14 @@ class DeveloperPostAPI:
         )
         DeveloperTokenService.record_request(request, token, response.status_code)
         return response
+
+    @staticmethod
+    def post_validation_error(error):
+        return DeveloperResponse.error(
+            f'post.{error.code.value.lower()}',
+            error.message,
+            400,
+        )
 
     @staticmethod
     def validate_expected_updated_at(post, data):
@@ -267,6 +271,7 @@ class DeveloperPostAPI:
                 fields={
                     'expected_updated_at': expected_updated_at,
                     'actual_updated_at': actual_updated_at,
+                    'post_id': post.id,
                 },
             )
         return None
@@ -338,11 +343,7 @@ class DeveloperPostAPI:
                     content_type=content_type,
                 )
         except PostValidationError as error:
-            return DeveloperResponse.error(
-                f'post.{error.code.value.lower()}',
-                error.message,
-                422,
-            )
+            return DeveloperPostAPI.post_validation_error(error)
 
         if post.is_draft():
             DeveloperPostAPI.update_config(post, data)
@@ -409,11 +410,7 @@ class DeveloperPostAPI:
                 content_type=content_type,
             )
         except PostValidationError as error:
-            return DeveloperResponse.error(
-                f'post.{error.code.value.lower()}',
-                error.message,
-                422,
-            )
+            return DeveloperPostAPI.post_validation_error(error)
 
         post = DeveloperPostAPI.get_owned_post(token.user, post.id)
         response = DeveloperResponse.success(DeveloperPostSerializer.detail(post))


### PR DESCRIPTION
## 🎯 Goal
- Stabilize Developer API error contracts before clients depend on inconsistent responses.
- Keep `expected_updated_at` conflict handling and Developer API docs aligned with actual endpoint behavior.

## 🔧 Core Changes
- Normalize Developer API post validation failures to `400` with the standard `{ error: { code, message } }` shape.
- Add `post_id` to `post.version_conflict` error fields alongside `expected_updated_at` and `actual_updated_at`.
- Add API tests for common error shapes, validation status, conflict fields, and the representative automation workflow.
- Update Developer API reference text to match the stabilized validation and conflict responses.

## 🤔 Key Decisions
- Use `400` for post validation failures because the plan defines validation failure as a bad request and existing Developer API docs already use `400` for request contract errors.
- Keep the existing `post.*` error code namespace to avoid a broader client-facing rename.
- Add one workflow-level test instead of many narrow implementation tests so the important automation path is protected end-to-end.

## 🧪 Verification Guide
### How to verify
1. `npm run server:test`
2. `npm run islands:type-check`
3. `npm run islands:lint`

### Expected result
- Backend tests pass.
- Islands type-check passes.
- Islands lint passes with existing warnings only.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)
