### PR TITLE
🐛 Keep public surfaces from exposing non-public posts

### DIFF
--- a/backend/src/board/services/tag_service.py
+++ b/backend/src/board/services/tag_service.py
@@ -8,7 +8,7 @@ Extracted from views to improve testability and reusability.
 from __future__ import annotations
 
 from typing import Optional, Set, Dict
-from django.db.models import F, Count, Case, When, Exists, OuterRef
+from django.db.models import F, Count, Case, When, Exists, OuterRef, Q
 from django.utils import timezone
 from django.utils.text import slugify
 
@@ -87,16 +87,18 @@ class TagService:
         Returns:
             QuerySet of Tag with count annotation
         """
+        public_post_filter = Q(
+            posts__published_date__isnull=False,
+            posts__published_date__lte=timezone.now(),
+            posts__config__hide=False,
+        )
         return Tag.objects.filter(
-            posts__config__hide=False
+            public_post_filter
         ).annotate(
             count=Count(
-                Case(
-                    When(
-                        posts__config__hide=False,
-                        then='posts'
-                    ),
-                )
+                'posts',
+                filter=public_post_filter,
+                distinct=True,
             ),
         ).order_by('-count', 'value')
 
@@ -166,7 +168,9 @@ class TagService:
         """
         return Tag.objects.filter(
             value=tag_name,
-            posts__config__hide=False
+            posts__published_date__isnull=False,
+            posts__published_date__lte=timezone.now(),
+            posts__config__hide=False,
         ).exists()
 
     @staticmethod
@@ -180,17 +184,18 @@ class TagService:
         Returns:
             QuerySet of Tag with count annotation
         """
-        return Tag.objects.filter(
+        public_post_filter = Q(
             posts__author__username=username,
+            posts__published_date__isnull=False,
+            posts__published_date__lte=timezone.now(),
             posts__config__hide=False,
+        )
+        return Tag.objects.filter(
+            public_post_filter,
         ).annotate(
             count=Count(
-                Case(
-                    When(
-                        posts__author__username=username,
-                        posts__config__hide=False,
-                        then='posts'
-                    ),
-                )
+                'posts',
+                filter=public_post_filter,
+                distinct=True,
             )
         ).order_by('-count')

--- a/backend/src/board/services/user_service.py
+++ b/backend/src/board/services/user_service.py
@@ -86,13 +86,20 @@ class UserService:
         Excludes hidden posts to match the post list page.
         Uses distinct=True to prevent inflated counts from joins.
         """
+        public_post_filter = Q(
+            post__published_date__isnull=False,
+            post__published_date__lte=timezone.now(),
+            post__config__hide=False,
+        )
+        public_series_filter = Q(
+            series__posts__published_date__isnull=False,
+            series__posts__published_date__lte=timezone.now(),
+            series__posts__config__hide=False,
+            series__hide=False,
+        )
         return User.objects.filter(id=author.id).annotate(
-            post_count=Count('post', filter=Q(
-                post__published_date__isnull=False,
-                post__published_date__lte=timezone.now(),
-                post__config__hide=False,
-            ), distinct=True),
-            series_count=Count('series', distinct=True)
+            post_count=Count('post', filter=public_post_filter, distinct=True),
+            series_count=Count('series', filter=public_series_filter, distinct=True)
         ).values('post_count', 'series_count').first()
 
     @staticmethod

--- a/backend/src/board/sitemaps.py
+++ b/backend/src/board/sitemaps.py
@@ -1,6 +1,7 @@
 from django.contrib.sitemaps import Sitemap
 from django.urls import reverse
-from django.conf import settings
+from django.utils import timezone
+from django.db.models import Count, Q
 
 from board.models import Post, Series, Profile, StaticPage
 
@@ -32,6 +33,8 @@ class UserSitemap(Sitemap):
         # Only include users who have posts and are editors (EDITOR or ADMIN role)
         users = Post.objects.filter(
             config__hide=False,
+            published_date__isnull=False,
+            published_date__lte=timezone.now(),
             author__profile__role__in=[Profile.Role.EDITOR, Profile.Role.ADMIN]
         ).values_list('author__username', flat=True).distinct()
         return users
@@ -48,6 +51,7 @@ class PostsSitemap(Sitemap):
         return Post.objects.filter(
             config__hide=False,
             published_date__isnull=False,
+            published_date__lte=timezone.now(),
         ).select_related('author').order_by('-updated_date')
 
     def location(self, element):
@@ -62,7 +66,17 @@ class SeriesSitemap(Sitemap):
     priority = 0.7
 
     def items(self):
-        return Series.objects.filter(hide=False, posts__config__hide=False).select_related('owner').distinct().order_by('-updated_date')
+        public_post_filter = Q(
+            posts__published_date__isnull=False,
+            posts__published_date__lte=timezone.now(),
+            posts__config__hide=False,
+        )
+        return Series.objects.annotate(
+            public_post_count=Count('posts', filter=public_post_filter, distinct=True),
+        ).filter(
+            hide=False,
+            public_post_count__gte=1,
+        ).select_related('owner').order_by('-updated_date')
 
     def location(self, element):
         return reverse('series_detail', args=[element.owner.username, element.url])

--- a/backend/src/board/tests/templates/test_author.py
+++ b/backend/src/board/tests/templates/test_author.py
@@ -51,6 +51,29 @@ class AuthorPostsPageTestCase(TestCase):
         self.tag = Tag.objects.create(value='python')
         self.post.tags.add(self.tag)
 
+
+    def create_author_post(self, title, url, published_date, tag=None, hide=False):
+        post = Post.objects.create(
+            title=title,
+            url=url,
+            author=self.user,
+            created_date=timezone.now(),
+            published_date=published_date,
+        )
+        PostContent.objects.create(
+            post=post,
+            text_md=f'# {title}',
+            text_html=f'<h1>{title}</h1>',
+        )
+        PostConfig.objects.create(
+            post=post,
+            hide=hide,
+            advertise=False,
+        )
+        if tag:
+            post.tags.add(tag)
+        return post
+
     def test_author_posts_page_renders(self):
         """작가 포스트 페이지가 정상적으로 렌더링되는지 테스트"""
         response = self.client.get(
@@ -68,6 +91,49 @@ class AuthorPostsPageTestCase(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'board/author/author_overview.html')
+
+
+    def test_author_posts_page_exposes_public_posts_and_tags_only(self):
+        """작가 글 표면은 숨김, 임시저장, 미래 발행 글과 그 태그를 노출하지 않는다."""
+        private_tag = Tag.objects.create(value='private-only')
+        self.create_author_post('Draft Author Post', 'draft-author-post', None, private_tag)
+        self.create_author_post(
+            'Future Author Post',
+            'future-author-post',
+            timezone.now() + timezone.timedelta(days=1),
+            private_tag,
+        )
+        self.create_author_post('Hidden Author Post', 'hidden-author-post', timezone.now(), private_tag, hide=True)
+        future_series = Series.objects.create(
+            owner=self.user,
+            name='Future Only Series',
+            url='future-only-series',
+            text_md='Future only',
+            hide=False,
+        )
+        future_post = self.create_author_post(
+            'Future Series Post',
+            'future-series-post',
+            timezone.now() + timezone.timedelta(days=1),
+        )
+        future_post.series = future_series
+        future_post.save(update_fields=['series'])
+
+        response = self.client.get(
+            reverse('user_posts', kwargs={'username': self.user.username})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        post_titles = [post.title for post in response.context['posts']]
+        self.assertIn('Author Test Post', post_titles)
+        self.assertNotIn('Draft Author Post', post_titles)
+        self.assertNotIn('Future Author Post', post_titles)
+        self.assertNotIn('Hidden Author Post', post_titles)
+
+        author_tag_values = [tag.value for tag in response.context['author_tags']]
+        self.assertIn('python', author_tag_values)
+        self.assertNotIn('private-only', author_tag_values)
+        self.assertEqual(response.context['series_count'], 0)
 
     def test_author_posts_page_has_required_context(self):
         """작가 포스트 페이지 컨텍스트에 필수 필드 확인"""

--- a/backend/src/board/tests/templates/test_tag.py
+++ b/backend/src/board/tests/templates/test_tag.py
@@ -45,10 +45,62 @@ class TagListPageTestCase(TestCase):
                 )
                 post.tags.add(tag)
 
+
+    def create_tagged_post(self, title, url, tag, published_date, hide=False):
+        post = Post.objects.create(
+            title=title,
+            url=url,
+            author=self.user,
+            created_date=timezone.now(),
+            published_date=published_date,
+        )
+        PostContent.objects.create(
+            post=post,
+            text_md=f'{title} content',
+            text_html=f'<p>{title} content</p>',
+        )
+        PostConfig.objects.create(
+            post=post,
+            hide=hide,
+            advertise=False,
+        )
+        post.tags.add(tag)
+        return post
+
     def test_tag_list_page_renders(self):
         response = self.client.get(reverse('tag_list'))
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'board/tags/tag_list.html')
+
+
+    def test_tag_list_counts_public_posts_only(self):
+        """태그 목록은 공개 글에 연결된 태그만 집계한다."""
+        private_tag = Tag.objects.create(value='private-only')
+        self.create_tagged_post(
+            'Draft Private Tag Post',
+            'draft-private-tag-post',
+            private_tag,
+            None,
+        )
+        self.create_tagged_post(
+            'Future Private Tag Post',
+            'future-private-tag-post',
+            private_tag,
+            timezone.now() + timezone.timedelta(days=1),
+        )
+        self.create_tagged_post(
+            'Hidden Private Tag Post',
+            'hidden-private-tag-post',
+            private_tag,
+            timezone.now(),
+            hide=True,
+        )
+
+        response = self.client.get(reverse('tag_list'))
+
+        self.assertEqual(response.status_code, 200)
+        tag_names = [tag['name'] for tag in response.context['tags']]
+        self.assertNotIn('private-only', tag_names)
 
     def test_tag_list_supports_sort_options(self):
         for sort_type in ['popular', 'name', 'recent']:
@@ -102,6 +154,28 @@ class TagDetailPageTestCase(TestCase):
             )
             post.tags.add(self.tag)
 
+
+    def create_tagged_post(self, title, url, published_date, hide=False):
+        post = Post.objects.create(
+            title=title,
+            url=url,
+            author=self.user,
+            created_date=timezone.now(),
+            published_date=published_date,
+        )
+        PostContent.objects.create(
+            post=post,
+            text_md=f'{title} content',
+            text_html=f'<p>{title} content</p>',
+        )
+        PostConfig.objects.create(
+            post=post,
+            hide=hide,
+            advertise=False,
+        )
+        post.tags.add(self.tag)
+        return post
+
     def test_tag_detail_page_renders(self):
         response = self.client.get(reverse('tag_detail', kwargs={'name': 'python'}))
         self.assertEqual(response.status_code, 200)
@@ -114,6 +188,25 @@ class TagDetailPageTestCase(TestCase):
         for field in required_fields:
             with self.subTest(field=field):
                 self.assertIn(field, response.context)
+
+
+    def test_tag_detail_shows_public_posts_only(self):
+        """태그 상세는 숨김, 임시저장, 미래 발행 글을 노출하지 않는다."""
+        self.create_tagged_post('Draft Python Post', 'draft-python-post', None)
+        self.create_tagged_post(
+            'Future Python Post',
+            'future-python-post',
+            timezone.now() + timezone.timedelta(days=1),
+        )
+        self.create_tagged_post('Hidden Python Post', 'hidden-python-post', timezone.now(), hide=True)
+
+        response = self.client.get(reverse('tag_detail', kwargs={'name': 'python'}))
+
+        self.assertEqual(response.status_code, 200)
+        post_titles = [post.title for post in response.context['posts']]
+        self.assertNotIn('Draft Python Post', post_titles)
+        self.assertNotIn('Future Python Post', post_titles)
+        self.assertNotIn('Hidden Python Post', post_titles)
 
     def test_tag_detail_page_shows_correct_tag(self):
         response = self.client.get(reverse('tag_detail', kwargs={'name': 'python'}))

--- a/backend/src/board/tests/test_agent_content.py
+++ b/backend/src/board/tests/test_agent_content.py
@@ -6,7 +6,7 @@ from django.contrib.auth.models import User
 from django.test import Client, TestCase, override_settings
 from django.utils import timezone
 
-from board.models import Post, PostConfig, PostContent, Series, SiteSetting, StaticPage
+from board.models import Post, PostConfig, PostContent, Profile, Series, SiteSetting, StaticPage
 
 
 BASE_MIDDLEWARE = tuple(
@@ -25,6 +25,7 @@ class AgentContentTestCase(TestCase):
             email='aeo@example.com',
             password='password123',
         )
+        Profile.objects.create(user=cls.author, role=Profile.Role.EDITOR)
         now = timezone.now()
 
         cls.public_post = cls.create_post(
@@ -204,6 +205,63 @@ class AgentContentTestCase(TestCase):
         response = self.client.get('/posts/sitemap.xml', HTTP_USER_AGENT='curl/8.4.0')
 
         self.assertEqual(response.status_code, 200)
+
+
+    def test_posts_sitemap_hides_non_public_posts(self):
+        """posts sitemap은 숨김, 임시저장, 미래 발행 포스트를 노출하지 않는다."""
+        response = self.client.get('/posts/sitemap.xml')
+
+        self.assertEqual(response.status_code, 200)
+        body = response.content.decode()
+        self.assertIn('/@aeo-author/agent-ready-post', body)
+        self.assertNotIn('/@aeo-author/hidden-agent-post', body)
+        self.assertNotIn('/@aeo-author/draft-agent-post', body)
+        self.assertNotIn('/@aeo-author/future-agent-post', body)
+
+    def test_series_sitemap_hides_series_without_public_posts(self):
+        """series sitemap은 공개 글이 있는 공개 시리즈만 노출한다."""
+        future_series = Series.objects.create(
+            owner=self.author,
+            name='Future Only Series',
+            text_md='Future only',
+            url='future-only-series',
+            hide=False,
+        )
+        self.future_post.series = future_series
+        self.future_post.save(update_fields=['series'])
+
+        hidden_series = Series.objects.create(
+            owner=self.author,
+            name='Hidden Only Series',
+            text_md='Hidden only',
+            url='hidden-only-series',
+            hide=False,
+        )
+        self.hidden_post.series = hidden_series
+        self.hidden_post.save(update_fields=['series'])
+
+        response = self.client.get('/series/sitemap.xml')
+
+        self.assertEqual(response.status_code, 200)
+        body = response.content.decode()
+        self.assertIn('/@aeo-author/series/agent-ready-series', body)
+        self.assertNotIn('/@aeo-author/series/future-only-series', body)
+        self.assertNotIn('/@aeo-author/series/hidden-only-series', body)
+
+    def test_rss_feeds_hide_non_public_posts(self):
+        """RSS 피드는 숨김, 임시저장, 미래 발행 포스트를 노출하지 않는다."""
+        urls = ['/rss', '/rss/@aeo-author']
+
+        for url in urls:
+            with self.subTest(url=url):
+                response = self.client.get(url)
+
+                self.assertEqual(response.status_code, 200)
+                body = response.content.decode()
+                self.assertIn('Agent Ready Post', body)
+                self.assertNotIn('Hidden Agent Post', body)
+                self.assertNotIn('Draft Agent Post', body)
+                self.assertNotIn('Future Agent Post', body)
 
     def test_aeo_disabled_hides_agent_entrypoints(self):
         """AEO가 꺼져 있으면 llms.txt와 Markdown endpoint에 접근할 수 없다."""

--- a/backend/src/board/views/author.py
+++ b/backend/src/board/views/author.py
@@ -124,18 +124,30 @@ def author_posts(request, username):
     else:  # default to 'recent'
         posts = posts.order_by('-published_date')
     
+    public_series_post_filter = Q(
+        posts__published_date__isnull=False,
+        posts__published_date__lte=timezone.now(),
+        posts__config__hide=False,
+    )
     series = Series.objects.filter(
         owner__username=username,
         hide=False,
     ).annotate(
-        count_posts=Count('posts', filter=Q(posts__config__hide=False)),
+        count_posts=Count('posts', filter=public_series_post_filter, distinct=True),
+    ).filter(
+        count_posts__gte=1,
     ).order_by('-updated_date')
     
-    author_tags = Tag.objects.filter(
+    public_author_tag_filter = Q(
         posts__author=author,
-        posts__config__hide=False
+        posts__published_date__isnull=False,
+        posts__published_date__lte=timezone.now(),
+        posts__config__hide=False,
+    )
+    author_tags = Tag.objects.filter(
+        public_author_tag_filter
     ).annotate(
-        count=Count('posts', distinct=True)
+        count=Count('posts', filter=public_author_tag_filter, distinct=True)
     ).order_by('-count', 'value')
 
     tag_options = [{'value': '', 'label': '전체 태그'}] # Default option
@@ -247,11 +259,16 @@ def author_series(request, username):
     for series_item in paginated_series:
         series_item.updated_date = series_item.updated_date.strftime('%Y-%m-%d')
 
-    author_tags = Tag.objects.filter(
+    public_author_tag_filter = Q(
         posts__author=author,
-        posts__config__hide=False
+        posts__published_date__isnull=False,
+        posts__published_date__lte=timezone.now(),
+        posts__config__hide=False,
+    )
+    author_tags = Tag.objects.filter(
+        public_author_tag_filter
     ).annotate(
-        count=Count('posts', distinct=True)
+        count=Count('posts', filter=public_author_tag_filter, distinct=True)
     ).order_by('-count', 'value')
 
     stats = UserService.get_author_stats(author)


### PR DESCRIPTION
## 🎯 Goal
- Prevent non-public posts from leaking through human-facing discovery pages and agent-readable/public feed surfaces.
- Keep the shared policy consistent: drafts, hidden posts, and scheduled future posts must not appear as public content.

## 🔧 Core Changes
- Tighten sitemap filters for users, posts, and series to require public posts only.
- Tighten tag list/user tag/author tag queries to count only public posts.
- Tighten author series counts so future-only or otherwise non-public series are not counted as public series.
- Add regression tests for posts sitemap, series sitemap, RSS feeds, tag pages, and author post/tag/series counts.

## 🤔 Key Decisions
- Reused the same public-post conditions everywhere: `published_date` exists, `published_date <= now`, and `config.hide = False`.
- Kept RSS behavior unchanged where it was already correct, but added regression coverage to lock it down.
- Focused this PR on visibility contracts first; card layout and empty-state UX can follow separately.

## 🧪 Verification Guide
### How to verify
1. `npm run server:test`
2. Visit `/posts/sitemap.xml` and confirm hidden/draft/future posts are absent.
3. Visit `/tags` or an author posts page with non-public posts and confirm their tags/counts are absent.

### Expected result
- Backend tests pass.
- Public sitemap/tag/author surfaces expose public posts only.

## ✅ Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [x] Tests completed
- [ ] Documentation updated (if needed)
