### PR TITLE
✨ Add publish checklist to post editor

### DIFF
--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/EditPostEditor.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/EditPostEditor.tsx
@@ -49,6 +49,7 @@ const EditPostEditor = ({ username, postUrl }: EditPostEditorProps) => {
         content: '',
         tags: [] as string[]
     });
+    const isIntentionalSubmitRef = useRef(false);
 
     // Fetch data
     useEffect(() => {
@@ -115,6 +116,10 @@ const EditPostEditor = ({ username, postUrl }: EditPostEditorProps) => {
     // Warn on page unload if there are unsaved changes
     useEffect(() => {
         const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+            if (isIntentionalSubmitRef.current) {
+                return;
+            }
+
             if (hasUnsavedChanges()) {
                 e.preventDefault();
             }
@@ -175,7 +180,7 @@ const EditPostEditor = ({ username, postUrl }: EditPostEditorProps) => {
         return true;
     };
 
-    const handleSubmit = async (isDraft = false) => {
+    const submitCurrentPost = async (isDraft = false) => {
         if (!validateForm()) return;
 
         setIsSubmitting(true);
@@ -209,11 +214,17 @@ const EditPostEditor = ({ username, postUrl }: EditPostEditorProps) => {
                 addHiddenField('image_delete', 'true');
             }
 
+            isIntentionalSubmitRef.current = true;
             form.submit();
         } catch {
+            isIntentionalSubmitRef.current = false;
             toast.error('포스트 수정에 실패했습니다.');
             setIsSubmitting(false);
         }
+    };
+
+    const handleSubmit = async (isDraft = false) => {
+        await submitCurrentPost(isDraft);
     };
 
     const handleDelete = async () => {

--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/NewPostEditor.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/NewPostEditor.tsx
@@ -2,6 +2,7 @@
 import {
     useState,
     useEffect,
+    useMemo,
     useRef
 } from 'react';
 import { toast } from '~/utils/toast';
@@ -11,9 +12,11 @@ import PostActions from './components/PostActions';
 import PostForm from './components/PostForm';
 import DraftsPanel from './components/DraftsPanel';
 import SettingsDrawer from './components/SettingsDrawer';
+import PublishChecklist from './components/PublishChecklist';
 import { useAutoSave } from './hooks/useAutoSave';
 import { useImageUpload } from './hooks/useImageUpload';
 import { useFormSubmit } from './hooks/useFormSubmit';
+import { getPublishChecklist } from './utils/publishChecklist';
 import { getSeries } from '~/lib/api/settings';
 import { getDraft } from '~/lib/api/posts';
 import { api } from '~/components/shared';
@@ -49,6 +52,7 @@ const NewPostEditor = ({ draftUrl }: NewPostEditorProps) => {
     const [isUrlAutoSync, setIsUrlAutoSync] = useState(true);
     const [currentDraftUrl, setCurrentDraftUrl] = useState(draftUrl);
     const [contentType, setContentType] = useState<ContentType>('html');
+    const [showPublishChecklist, setShowPublishChecklist] = useState(false);
 
     const [formData, setFormData] = useState({
         title: '',
@@ -73,6 +77,7 @@ const NewPostEditor = ({ draftUrl }: NewPostEditorProps) => {
         content: '',
         tags: [] as string[]
     });
+    const isIntentionalSubmitRef = useRef(false);
 
     // Custom hooks
     const {
@@ -149,10 +154,21 @@ const NewPostEditor = ({ draftUrl }: NewPostEditorProps) => {
 
     const submitOptions = {
         draftUrl: currentDraftUrl,
+        onBeforeSubmit: () => {
+            isIntentionalSubmitRef.current = true;
+        },
         onSubmitError: handleSubmitError
     };
 
     const { formRef, isSubmitting, submitForm } = useFormSubmit(submitOptions);
+
+    const publishChecklist = useMemo(() => getPublishChecklist({
+        title: formData.title,
+        content: formData.content,
+        description: formData.metaDescription,
+        tags,
+        hasCoverImage: Boolean(imagePreview)
+    }), [formData.title, formData.content, formData.metaDescription, tags, imagePreview]);
 
     // Fetch series list and draft data if draftUrl exists
     useEffect(() => {
@@ -241,6 +257,10 @@ const NewPostEditor = ({ draftUrl }: NewPostEditorProps) => {
     // Warn on page unload if there are unsaved changes
     useEffect(() => {
         const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+            if (isIntentionalSubmitRef.current) {
+                return;
+            }
+
             if (hasUnsavedChanges()) {
                 e.preventDefault();
             }
@@ -315,7 +335,7 @@ const NewPostEditor = ({ draftUrl }: NewPostEditorProps) => {
         }));
     };
 
-    const handleSubmit = async (isDraft = false) => {
+    const submitCurrentPost = async (isDraft = false) => {
         await submitForm(
             {
                 title: formData.title,
@@ -328,6 +348,30 @@ const NewPostEditor = ({ draftUrl }: NewPostEditorProps) => {
             isDraft,
             false // isEdit
         );
+    };
+
+    const handleSubmit = async (isDraft = false) => {
+        if (isDraft) {
+            await submitCurrentPost(true);
+            return;
+        }
+
+        setShowPublishChecklist(true);
+
+        if (!publishChecklist.canPublish) {
+            toast.error('발행에 필요한 항목을 먼저 채워주세요.');
+            return;
+        }
+    };
+
+    const handleConfirmPublish = async () => {
+        if (publishChecklist.missingRecommended.length > 0) {
+            const labels = publishChecklist.missingRecommended.map(item => item.label).join(', ');
+            toast.warning(`권장 항목이 비어 있습니다: ${labels}`);
+        }
+
+        setShowPublishChecklist(false);
+        await submitCurrentPost(false);
     };
 
     return (
@@ -367,6 +411,14 @@ const NewPostEditor = ({ draftUrl }: NewPostEditorProps) => {
                 onSubmit={() => handleSubmit()}
                 onOpenDrafts={() => setIsDraftsPanelOpen(true)}
                 onOpenSettings={() => setIsSettingsDrawerOpen(true)}
+            />
+
+            <PublishChecklist
+                isOpen={showPublishChecklist}
+                result={publishChecklist}
+                isSubmitting={isSubmitting}
+                onClose={() => setShowPublishChecklist(false)}
+                onConfirm={handleConfirmPublish}
             />
 
             {/* Settings Drawer */}

--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/NewPostEditor.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/NewPostEditor.tsx
@@ -359,7 +359,6 @@ const NewPostEditor = ({ draftUrl }: NewPostEditorProps) => {
         setShowPublishChecklist(true);
 
         if (!publishChecklist.canPublish) {
-            toast.error('발행에 필요한 항목을 먼저 채워주세요.');
             return;
         }
     };

--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/components/PublishChecklist.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/components/PublishChecklist.tsx
@@ -1,0 +1,118 @@
+import { AlertTriangle, CheckCircle, Info } from '@blex/ui/icons';
+import { Modal } from '@blex/ui/modal';
+import type { PublishChecklistItem, PublishChecklistResult } from '../utils/publishChecklist';
+
+interface PublishChecklistProps {
+    isOpen: boolean;
+    result: PublishChecklistResult;
+    isSubmitting: boolean;
+    onClose: () => void;
+    onConfirm: () => void;
+}
+
+const severityLabel = (item: PublishChecklistItem) => (
+    item.severity === 'required' ? '필수' : '권장'
+);
+
+const itemClassName = (item: PublishChecklistItem) => {
+    if (item.status === 'pass') {
+        return 'border-line bg-surface-subtle text-content-secondary';
+    }
+
+    if (item.severity === 'required') {
+        return 'border-danger-line bg-danger-surface text-content';
+    }
+
+    return 'border-warning-line bg-warning-surface text-content';
+};
+
+const itemIcon = (item: PublishChecklistItem) => {
+    if (item.status === 'pass') {
+        return <CheckCircle className="h-4 w-4 text-success" />;
+    }
+
+    if (item.severity === 'required') {
+        return <AlertTriangle className="h-4 w-4 text-danger" />;
+    }
+
+    return <Info className="h-4 w-4 text-warning" />;
+};
+
+const PublishChecklist = ({
+    isOpen,
+    result,
+    isSubmitting,
+    onClose,
+    onConfirm
+}: PublishChecklistProps) => {
+    const title = result.canPublish ? '발행 전 최종 확인' : '발행 전에 꼭 채워주세요';
+    const description = result.canPublish
+        ? '필수 항목은 준비되었습니다. 권장 항목은 나중에 보완할 수 있습니다.'
+        : '필수 항목을 채워주세요.';
+
+    return (
+        <Modal
+            isOpen={isOpen}
+            onClose={onClose}
+            title={title}
+            maxWidth="3xl">
+            <Modal.Body className="space-y-5">
+                <div>
+                    <p className="text-sm leading-relaxed text-content-secondary">{description}</p>
+                </div>
+
+                <div className="space-y-2" aria-live="polite">
+                    {result.items.map(item => (
+                        <div
+                            key={item.id}
+                            className={`rounded-xl border px-3 py-2 transition-colors duration-150 ${itemClassName(item)}`}>
+                            <div className="flex items-start gap-3">
+                                {itemIcon(item)}
+                                <div className="min-w-0 flex-1">
+                                    <div className="flex items-center gap-2">
+                                        <span className="text-sm font-semibold">{item.label}</span>
+                                        <span className="rounded-md border border-line px-1.5 py-0.5 text-[10px] text-content-hint">
+                                            {severityLabel(item)}
+                                        </span>
+                                        <span className="text-xs text-content-hint">
+                                            {item.status === 'pass' ? '작성됨' : '비어 있음'}
+                                        </span>
+                                    </div>
+                                    <p className="mt-1 text-xs leading-relaxed text-content-secondary">
+                                        {item.description}
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                    ))}
+                </div>
+
+                {result.missingRecommended.length > 0 && result.canPublish && (
+                    <div className="rounded-xl border border-warning-line bg-warning-surface px-4 py-3">
+                        <p className="text-sm font-semibold text-warning">권장 항목이 비어 있습니다.</p>
+                        <p className="mt-1 text-xs leading-relaxed text-content-secondary">
+                            {result.missingRecommended.map(item => item.label).join(', ')}은 나중에 보완할 수 있습니다.
+                        </p>
+                    </div>
+                )}
+            </Modal.Body>
+            <Modal.Footer>
+                <Modal.FooterAction
+                    type="button"
+                    variant="secondary"
+                    onClick={onClose}>
+                    취소
+                </Modal.FooterAction>
+                <Modal.FooterAction
+                    type="button"
+                    variant="primary"
+                    disabled={!result.canPublish || isSubmitting}
+                    onClick={onConfirm}>
+                    {isSubmitting ? '발행 중...' : '확인 후 발행'}
+                </Modal.FooterAction>
+            </Modal.Footer>
+        </Modal>
+    );
+};
+
+export default PublishChecklist;

--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/hooks/useFormSubmit.ts
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/hooks/useFormSubmit.ts
@@ -1,5 +1,6 @@
 import { useState, useRef } from 'react';
 import { toast } from '~/utils/toast';
+import { hasPublishableContent } from '../utils/publishChecklist';
 
 interface FormSubmitData {
     title: string;
@@ -37,9 +38,14 @@ export const useFormSubmit = (options: UseFormSubmitOptions) => {
         onSubmitError
     } = options;
 
-    const validateForm = (data: FormSubmitData, isEdit = false) => {
+    const validateForm = (data: FormSubmitData, isEdit = false, isDraft = false) => {
         if (!data.title.trim()) {
             toast.error('제목을 입력해주세요.');
+            return false;
+        }
+
+        if (!isDraft && !hasPublishableContent(data.content)) {
+            toast.error('내용을 입력해주세요.');
             return false;
         }
 
@@ -64,7 +70,7 @@ export const useFormSubmit = (options: UseFormSubmitOptions) => {
     };
 
     const submitForm = async (data: FormSubmitData, isDraft = false, isEdit = false) => {
-        if (!validateForm(data, isEdit)) return;
+        if (!validateForm(data, isEdit, isDraft)) return;
 
         setIsSubmitting(true);
         try {

--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/utils/publishChecklist.ts
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/utils/publishChecklist.ts
@@ -1,0 +1,90 @@
+export type PublishChecklistSeverity = 'required' | 'recommended';
+export type PublishChecklistStatus = 'pass' | 'missing';
+
+export interface PublishChecklistItem {
+    id: 'title' | 'content' | 'description' | 'tags' | 'coverImage';
+    label: string;
+    description: string;
+    severity: PublishChecklistSeverity;
+    status: PublishChecklistStatus;
+}
+
+export interface PublishChecklistInput {
+    title: string;
+    content: string;
+    description: string;
+    tags: string[];
+    hasCoverImage: boolean;
+}
+
+export interface PublishChecklistResult {
+    items: PublishChecklistItem[];
+    missingRequired: PublishChecklistItem[];
+    missingRecommended: PublishChecklistItem[];
+    canPublish: boolean;
+}
+
+const hasText = (value: string) => value.trim().length > 0;
+
+export const hasPublishableContent = (value: string) => {
+    if (/<(img|video|iframe|table|pre)\b/i.test(value)) {
+        return true;
+    }
+
+    const text = value
+        .replace(/<[^>]*>/g, '')
+        .replace(/&nbsp;/g, ' ')
+        .trim();
+
+    return text.length > 0;
+};
+
+export const getPublishChecklist = (input: PublishChecklistInput): PublishChecklistResult => {
+    const items: PublishChecklistItem[] = [
+        {
+            id: 'title',
+            label: '제목',
+            description: '독자가 글을 구분할 수 있는 제목이 필요합니다.',
+            severity: 'required',
+            status: hasText(input.title) ? 'pass' : 'missing'
+        },
+        {
+            id: 'content',
+            label: '본문',
+            description: '발행하려면 본문 내용이 필요합니다.',
+            severity: 'required',
+            status: hasPublishableContent(input.content) ? 'pass' : 'missing'
+        },
+        {
+            id: 'description',
+            label: '설명',
+            description: '검색과 공유 화면에서 글을 설명합니다.',
+            severity: 'recommended',
+            status: hasText(input.description) ? 'pass' : 'missing'
+        },
+        {
+            id: 'tags',
+            label: '태그',
+            description: '관련 글을 찾기 쉽게 만듭니다.',
+            severity: 'recommended',
+            status: input.tags.length > 0 ? 'pass' : 'missing'
+        },
+        {
+            id: 'coverImage',
+            label: '커버 이미지',
+            description: '목록과 공유 카드에서 글의 첫인상을 만듭니다.',
+            severity: 'recommended',
+            status: input.hasCoverImage ? 'pass' : 'missing'
+        }
+    ];
+
+    const missingRequired = items.filter(item => item.severity === 'required' && item.status === 'missing');
+    const missingRecommended = items.filter(item => item.severity === 'recommended' && item.status === 'missing');
+
+    return {
+        items,
+        missingRequired,
+        missingRecommended,
+        canPublish: missingRequired.length === 0
+    };
+};


### PR DESCRIPTION
## 🎯 Goal
- Help authors review required and recommended publishing fields before creating a post.
- Reduce failed publish attempts caused by missing title or body content.
- Avoid surprising browser leave-confirm prompts when the author intentionally publishes.

## 🔧 Core Changes
- Added a pre-publish checklist modal to the new post editor only.
- Block publish requests before they reach the server when required title/body content is missing.
- Show required/recommended checklist items as one-line rows, and let recommended gaps warn without blocking publish.
- Suppressed the unsaved-changes `beforeunload` guard for intentional form submissions.

## 🤔 Key Decisions
- Kept the existing save, draft, and publish API payloads unchanged.
- Extracted checklist evaluation into a reusable utility, but only show the checklist modal in the create/publish flow.
- Did not show the modal in the edit flow because editing should stay lightweight.
- Removed publish content preview from the modal; the modal only shows checklist state.

## 🧪 Verification Guide
### How to verify
1. Open the new post editor and try to publish with an empty title or body.
2. Publish a new post with title/body present but description, tags, or cover image missing.
3. Confirm the modal and complete the publish flow.
4. Edit an existing post and confirm it submits without the publish checklist modal.

### Expected result
- Missing title/body opens the modal, shows the missing required rows, and disables confirmation before a server request.
- Missing recommended items are shown as one-line warnings, but publish can continue after confirmation.
- Browser leave-confirm does not appear during intentional publish submission.
- Existing edit and draft flows remain unchanged.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [ ] Documentation updated (if needed)
