### PR TITLE
♻️ Centralize public post visibility filters

### DIFF
--- a/backend/src/board/services/agent_content_service.py
+++ b/backend/src/board/services/agent_content_service.py
@@ -7,9 +7,9 @@ from bs4.element import NavigableString, Tag as SoupTag
 from django.db.models import Count, Q, QuerySet
 from django.http import Http404, HttpRequest
 from django.urls import reverse
-from django.utils import timezone
 
 from board.models import Post, PostContent, Series, SiteSetting, StaticPage
+from board.services.public_post_service import PublicPostService
 
 
 class AgentContentService:
@@ -47,14 +47,12 @@ class AgentContentService:
 
     @staticmethod
     def get_public_posts(limit: int | None = LATEST_POST_LIMIT) -> QuerySet[Post]:
-        posts = Post.objects.select_related(
-            'author',
-            'content',
-            'config',
-        ).filter(
-            published_date__isnull=False,
-            published_date__lte=timezone.now(),
-            config__hide=False,
+        posts = PublicPostService.filter_public_posts(
+            Post.objects.select_related(
+                'author',
+                'content',
+                'config',
+            )
         ).order_by('-published_date')
 
         if limit is None:
@@ -69,22 +67,16 @@ class AgentContentService:
                 'content',
                 'config',
             ).get(
+                PublicPostService.build_public_filter(),
                 author__username=username,
                 url=post_url,
-                published_date__isnull=False,
-                published_date__lte=timezone.now(),
-                config__hide=False,
             )
         except Post.DoesNotExist as error:
             raise Http404("Post does not exist") from error
 
     @staticmethod
     def get_public_series() -> QuerySet[Series]:
-        public_post_filter = Q(
-            posts__published_date__isnull=False,
-            posts__published_date__lte=timezone.now(),
-            posts__config__hide=False,
-        )
+        public_post_filter = PublicPostService.build_public_filter('posts')
         return Series.objects.select_related('owner').annotate(
             public_post_count=Count('posts', filter=public_post_filter, distinct=True)
         ).filter(
@@ -104,14 +96,13 @@ class AgentContentService:
 
     @staticmethod
     def get_public_series_posts(series: Series) -> QuerySet[Post]:
-        return Post.objects.select_related(
-            'author',
-            'config',
+        return PublicPostService.filter_public_posts(
+            Post.objects.select_related(
+                'author',
+                'config',
+            )
         ).filter(
             series=series,
-            published_date__isnull=False,
-            published_date__lte=timezone.now(),
-            config__hide=False,
         ).order_by('-published_date')
 
     @staticmethod

--- a/backend/src/board/services/public_post_service.py
+++ b/backend/src/board/services/public_post_service.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from django.db.models import Q, QuerySet
+from django.utils import timezone
+
+
+class PublicPostService:
+    """Shared query helpers for posts visible on public surfaces."""
+
+    @staticmethod
+    def build_public_filter(relation: str = '') -> Q:
+        """
+        Build a reusable public-post condition.
+
+        Args:
+            relation: Optional relation path to Post, such as ``posts`` or
+                ``series__posts``. Leave empty when filtering Post directly.
+        """
+        prefix = f'{relation}__' if relation else ''
+        return Q(**{
+            f'{prefix}published_date__isnull': False,
+            f'{prefix}published_date__lte': timezone.now(),
+            f'{prefix}config__hide': False,
+        })
+
+    @staticmethod
+    def filter_public_posts(queryset: QuerySet) -> QuerySet:
+        return queryset.filter(PublicPostService.build_public_filter())

--- a/backend/src/board/services/series_service.py
+++ b/backend/src/board/services/series_service.py
@@ -8,10 +8,10 @@ Extracted from views to improve testability and reusability.
 from typing import Optional, List, Tuple
 from django.contrib.auth.models import User
 from django.db import transaction
-from django.db.models import Count, Case, When, F
-from django.utils import timezone
+from django.db.models import Count, F
 
 from board.models import Series, Post
+from board.services.public_post_service import PublicPostService
 from board.modules.response import ErrorCode
 
 
@@ -293,17 +293,9 @@ class SeriesService:
         query = Series.objects.filter(owner=user)
 
         if include_post_count:
+            public_post_filter = PublicPostService.build_public_filter('posts')
             query = query.annotate(
-                total_posts=Count(
-                    Case(
-                        When(
-                            posts__published_date__isnull=False,
-                            posts__published_date__lte=timezone.now(),
-                            posts__config__hide=False,
-                            then=1
-                        )
-                    )
-                )
+                total_posts=Count('posts', filter=public_post_filter, distinct=True)
             )
 
         return query.order_by('order', '-id')
@@ -319,12 +311,9 @@ class SeriesService:
         Returns:
             QuerySet of Post
         """
-        return Post.objects.filter(
+        return PublicPostService.filter_public_posts(Post.objects).filter(
             author=user,
             series=None,
-            config__hide=False,
-            published_date__isnull=False,
-            published_date__lte=timezone.now()
         ).order_by('-published_date')
 
     @staticmethod
@@ -340,18 +329,10 @@ class SeriesService:
         Returns:
             QuerySet of Series with annotations
         """
+        public_post_filter = PublicPostService.build_public_filter('posts')
         return Series.objects.annotate(
             owner_username=F('owner__username'),
-            total_posts=Count(
-                Case(
-                    When(
-                        posts__published_date__isnull=False,
-                            posts__published_date__lte=timezone.now(),
-                        posts__config__hide=False,
-                        then=1
-                    )
-                )
-            )
+            total_posts=Count('posts', filter=public_post_filter, distinct=True)
         ).filter(
             owner__username=username,
             total_posts__gte=1,

--- a/backend/src/board/services/tag_service.py
+++ b/backend/src/board/services/tag_service.py
@@ -8,11 +8,11 @@ Extracted from views to improve testability and reusability.
 from __future__ import annotations
 
 from typing import Optional, Set, Dict
-from django.db.models import F, Count, Case, When, Exists, OuterRef, Q
-from django.utils import timezone
+from django.db.models import F, Count, Exists, OuterRef, Q
 from django.utils.text import slugify
 
 from board.models import Tag, PostLikes, Post
+from board.services.public_post_service import PublicPostService
 
 
 class TagService:
@@ -87,11 +87,7 @@ class TagService:
         Returns:
             QuerySet of Tag with count annotation
         """
-        public_post_filter = Q(
-            posts__published_date__isnull=False,
-            posts__published_date__lte=timezone.now(),
-            posts__config__hide=False,
-        )
+        public_post_filter = PublicPostService.build_public_filter('posts')
         return Tag.objects.filter(
             public_post_filter
         ).annotate(
@@ -116,12 +112,11 @@ class TagService:
         Returns:
             QuerySet of Post with annotations
         """
-        return Post.objects.select_related(
-            'config', 'content'
+        return PublicPostService.filter_public_posts(
+            Post.objects.select_related(
+                'config', 'content'
+            )
         ).filter(
-            published_date__isnull=False,
-            published_date__lte=timezone.now(),
-            config__hide=False,
             tags__value=tag_name
         ).annotate(
             author_username=F('author__username'),
@@ -167,10 +162,8 @@ class TagService:
             True if tag exists with visible posts, False otherwise
         """
         return Tag.objects.filter(
+            PublicPostService.build_public_filter('posts'),
             value=tag_name,
-            posts__published_date__isnull=False,
-            posts__published_date__lte=timezone.now(),
-            posts__config__hide=False,
         ).exists()
 
     @staticmethod
@@ -184,11 +177,8 @@ class TagService:
         Returns:
             QuerySet of Tag with count annotation
         """
-        public_post_filter = Q(
+        public_post_filter = PublicPostService.build_public_filter('posts') & Q(
             posts__author__username=username,
-            posts__published_date__isnull=False,
-            posts__published_date__lte=timezone.now(),
-            posts__config__hide=False,
         )
         return Tag.objects.filter(
             public_post_filter,

--- a/backend/src/board/services/user_service.py
+++ b/backend/src/board/services/user_service.py
@@ -20,6 +20,7 @@ from board.models import (
     Series, Comment, Tag, PostLikes
 )
 from board.modules.response import ErrorCode
+from board.services.public_post_service import PublicPostService
 from modules.markdown import parse_post_to_html
 
 
@@ -86,15 +87,8 @@ class UserService:
         Excludes hidden posts to match the post list page.
         Uses distinct=True to prevent inflated counts from joins.
         """
-        public_post_filter = Q(
-            post__published_date__isnull=False,
-            post__published_date__lte=timezone.now(),
-            post__config__hide=False,
-        )
-        public_series_filter = Q(
-            series__posts__published_date__isnull=False,
-            series__posts__published_date__lte=timezone.now(),
-            series__posts__config__hide=False,
+        public_post_filter = PublicPostService.build_public_filter('post')
+        public_series_filter = PublicPostService.build_public_filter('series__posts') & Q(
             series__hide=False,
         )
         return User.objects.filter(id=author.id).annotate(

--- a/backend/src/board/sitemaps.py
+++ b/backend/src/board/sitemaps.py
@@ -1,9 +1,9 @@
 from django.contrib.sitemaps import Sitemap
 from django.urls import reverse
-from django.utils import timezone
-from django.db.models import Count, Q
+from django.db.models import Count
 
 from board.models import Post, Series, Profile, StaticPage
+from board.services.public_post_service import PublicPostService
 
 
 class SiteSitemap(Sitemap):
@@ -31,10 +31,7 @@ class UserSitemap(Sitemap):
 
     def items(self):
         # Only include users who have posts and are editors (EDITOR or ADMIN role)
-        users = Post.objects.filter(
-            config__hide=False,
-            published_date__isnull=False,
-            published_date__lte=timezone.now(),
+        users = PublicPostService.filter_public_posts(Post.objects).filter(
             author__profile__role__in=[Profile.Role.EDITOR, Profile.Role.ADMIN]
         ).values_list('author__username', flat=True).distinct()
         return users
@@ -48,11 +45,9 @@ class PostsSitemap(Sitemap):
     priority = 0.9
 
     def items(self):
-        return Post.objects.filter(
-            config__hide=False,
-            published_date__isnull=False,
-            published_date__lte=timezone.now(),
-        ).select_related('author').order_by('-updated_date')
+        return PublicPostService.filter_public_posts(Post.objects).select_related(
+            'author'
+        ).order_by('-updated_date')
 
     def location(self, element):
         return reverse('post_detail', args=[element.author.username, element.url])
@@ -66,11 +61,7 @@ class SeriesSitemap(Sitemap):
     priority = 0.7
 
     def items(self):
-        public_post_filter = Q(
-            posts__published_date__isnull=False,
-            posts__published_date__lte=timezone.now(),
-            posts__config__hide=False,
-        )
+        public_post_filter = PublicPostService.build_public_filter('posts')
         return Series.objects.annotate(
             public_post_count=Count('posts', filter=public_post_filter, distinct=True),
         ).filter(

--- a/backend/src/board/tests/services/test_public_post_service.py
+++ b/backend/src/board/tests/services/test_public_post_service.py
@@ -1,0 +1,55 @@
+from datetime import timedelta
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.utils import timezone
+
+from board.models import Post, PostConfig, Series
+from board.services.public_post_service import PublicPostService
+
+
+class PublicPostServiceTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.author = User.objects.create_user(
+            username='public-post-helper-author',
+            email='public-post-helper@example.com',
+            password='password123',
+        )
+        cls.series = Series.objects.create(
+            owner=cls.author,
+            name='Public Helper Series',
+            url='public-helper-series',
+            hide=False,
+        )
+        now = timezone.now()
+        cls.public_post = cls.create_post('Public Post', 'public-post', now)
+        cls.create_post('Draft Post', 'draft-post', None)
+        cls.create_post('Future Post', 'future-post', now + timedelta(days=1))
+        cls.create_post('Hidden Post', 'hidden-post', now, hide=True)
+
+    @classmethod
+    def create_post(cls, title: str, url: str, published_date, hide: bool = False) -> Post:
+        post = Post.objects.create(
+            title=title,
+            url=url,
+            author=cls.author,
+            published_date=published_date,
+            series=cls.series,
+        )
+        PostConfig.objects.create(post=post, hide=hide, advertise=False)
+        return post
+
+    def test_filter_public_posts_excludes_drafts_future_posts_and_hidden_posts(self):
+        """공개 글 필터는 임시저장, 미래 발행, 숨김 글을 제외한다."""
+        posts = PublicPostService.filter_public_posts(Post.objects).order_by('url')
+
+        self.assertEqual(list(posts), [self.public_post])
+
+    def test_build_public_filter_supports_related_post_prefix(self):
+        """관계 prefix를 지정하면 공개 글이 있는 부모 객체를 안전하게 필터링한다."""
+        series = Series.objects.filter(
+            PublicPostService.build_public_filter('posts'),
+        ).distinct()
+
+        self.assertEqual(list(series), [self.series])

--- a/backend/src/board/views/api/v1/series.py
+++ b/backend/src/board/views/api/v1/series.py
@@ -1,12 +1,12 @@
 import json
-from django.db.models import F, Count, Case, When, Q
+from django.db.models import F, Count, Q
 from django.http import Http404, QueryDict
 from django.shortcuts import get_object_or_404
-from django.utils import timezone
 
 from board.models import User, Post, Series
 from board.services import SeriesService
 from board.services.series_service import SeriesValidationError
+from board.services.public_post_service import PublicPostService
 from board.modules.paginator import Paginator
 from board.modules.response import StatusDone, StatusError, ErrorCode
 from board.modules.time import convert_to_localtime
@@ -32,11 +32,8 @@ def posts_can_add_series(request):
             posts = Post.objects.filter(
                 author=request.user
             ).filter(
-                Q(series=series) | Q(
-                    series__isnull=True,
-                    config__hide=False,
-                    published_date__isnull=False,
-                    published_date__lte=timezone.now()
+                Q(series=series) | (
+                    Q(series__isnull=True) & PublicPostService.build_public_filter()
                 )
             ).order_by('-published_date', '-id')
         else:
@@ -132,27 +129,16 @@ def user_series(request, username, url=None):
 
     if url:
         user = get_object_or_404(User, username=username)
+        public_post_filter = PublicPostService.build_public_filter('posts')
         series = get_object_or_404(Series.objects.annotate(
             owner_username=F('owner__username'),
             owner_avatar=F('owner__profile__avatar'),
-            total_posts=Count(
-                Case(
-                    When(
-                        posts__published_date__isnull=False,
-                        posts__published_date__lte=timezone.now(),
-                        posts__config__hide=False,
-                        then=1
-                    )
-                )
-            )
+            total_posts=Count('posts', filter=public_post_filter, distinct=True)
         ), owner=user, url=url)
 
         if request.method == 'GET':
             if request.GET.get('kind', '') == 'continue':
-                posts = Post.objects.filter(
-                    published_date__isnull=False,
-                    published_date__lte=timezone.now(),
-                    config__hide=False,
+                posts = PublicPostService.filter_public_posts(Post.objects).filter(
                     series=series,
                 ).values_list('title', 'url')
                 return StatusDone({
@@ -170,12 +156,9 @@ def user_series(request, username, url=None):
 
             page = request.GET.get('page', 1)
             order = request.GET.get('order', 'latest')
-            posts = Post.objects.select_related(
-                'content'
+            posts = PublicPostService.filter_public_posts(
+                Post.objects.select_related('content')
             ).filter(
-                published_date__isnull=False,
-                published_date__lte=timezone.now(),
-                config__hide=False,
                 series=series,
             ).order_by('-published_date' if order == 'latest' else 'published_date')
             posts = Paginator(

--- a/backend/src/board/views/author.py
+++ b/backend/src/board/views/author.py
@@ -2,14 +2,14 @@ import json
 
 from django.contrib.auth.models import User
 from django.contrib.auth.decorators import login_required
-from django.db.models import Case, When, Count, Exists, OuterRef, Q, F
+from django.db.models import Count, Exists, OuterRef, Q, F
 from django.shortcuts import render, get_object_or_404, redirect
-from django.utils import timezone
 from django.http import JsonResponse
 
 from board.modules.paginator import Paginator
 from board.modules.time import time_since
 from board.services.user_service import UserService
+from board.services.public_post_service import PublicPostService
 from board.models import Post, Series, PostLikes, Tag, Profile, SiteNotice, SiteContentScope
 from modules import markdown
 
@@ -85,13 +85,12 @@ def author_posts(request, username):
     sort_option = request.GET.get('sort', 'recent')
     tag_filter = request.GET.get('tag', '')
 
-    posts = Post.objects.select_related(
-        'config', 'series', 'author', 'author__profile', 'content'
+    posts = PublicPostService.filter_public_posts(
+        Post.objects.select_related(
+            'config', 'series', 'author', 'author__profile', 'content'
+        )
     ).filter(
         author=author,
-        published_date__isnull=False,
-        published_date__lte=timezone.now(),
-        config__hide=False,
     )
     
     if search_query:
@@ -124,11 +123,7 @@ def author_posts(request, username):
     else:  # default to 'recent'
         posts = posts.order_by('-published_date')
     
-    public_series_post_filter = Q(
-        posts__published_date__isnull=False,
-        posts__published_date__lte=timezone.now(),
-        posts__config__hide=False,
-    )
+    public_series_post_filter = PublicPostService.build_public_filter('posts')
     series = Series.objects.filter(
         owner__username=username,
         hide=False,
@@ -138,11 +133,8 @@ def author_posts(request, username):
         count_posts__gte=1,
     ).order_by('-updated_date')
     
-    public_author_tag_filter = Q(
+    public_author_tag_filter = PublicPostService.build_public_filter('posts') & Q(
         posts__author=author,
-        posts__published_date__isnull=False,
-        posts__published_date__lte=timezone.now(),
-        posts__config__hide=False,
     )
     author_tags = Tag.objects.filter(
         public_author_tag_filter
@@ -220,17 +212,9 @@ def author_series(request, username):
             Q(text_md__icontains=search_query)
         )
     
+    public_series_post_filter = PublicPostService.build_public_filter('posts')
     series_list = series_list.annotate(
-        post_count=Count(
-            Case(
-                When(
-                    posts__published_date__isnull=False,
-                    posts__published_date__lte=timezone.now(),
-                    posts__config__hide=False,
-                    then=1
-                )
-            )
-        )
+        post_count=Count('posts', filter=public_series_post_filter, distinct=True)
     ).filter(post_count__gte=1)
     
     if sort_option == 'newest':
@@ -259,11 +243,8 @@ def author_series(request, username):
     for series_item in paginated_series:
         series_item.updated_date = series_item.updated_date.strftime('%Y-%m-%d')
 
-    public_author_tag_filter = Q(
+    public_author_tag_filter = PublicPostService.build_public_filter('posts') & Q(
         posts__author=author,
-        posts__published_date__isnull=False,
-        posts__published_date__lte=timezone.now(),
-        posts__config__hide=False,
     )
     author_tags = Tag.objects.filter(
         public_author_tag_filter


### PR DESCRIPTION
## 🎯 Goal
- Centralize the public post visibility condition so sitemap, tags, author pages, series APIs, and agent-readable surfaces use the same contract.
- Reduce drift from duplicated `published_date` / `hide` filters across backend code.

## 🔧 Core Changes
- Added `PublicPostService` with reusable helpers for direct `Post` querysets and related `Q` filters.
- Replaced duplicated public post conditions in services, sitemaps, author views, and series API paths.
- Added focused service tests for public visibility filtering and related-prefix filtering.

## 🤔 Key Decisions
- Kept the helper in the service layer to match the backend convention that reusable business rules live in services.
- Supported relation prefixes such as `posts`, `post`, and `series__posts` so annotations can reuse the same visibility rule safely.

## 🧪 Verification Guide
### How to verify
1. Run `./scripts/manage.sh test board.tests.services.test_public_post_service`.
2. Run `./scripts/manage.sh test board.tests.test_agent_content board.tests.templates.test_tag board.tests.templates.test_author board.tests.api.test_series_api board.tests.services.test_public_post_service`.
3. Check public surfaces such as `/posts/sitemap.xml`, `/series/sitemap.xml`, author posts, tags, and series API responses still hide drafts, future posts, and hidden posts.

### Expected result
- Public surfaces only expose posts with a non-null published date, a published date not in the future, and `config.hide=False`.

## ✅ Checklist
- [x] Lint completed (not applicable: backend-only change)
- [x] Type-check completed (not applicable: backend-only change)
- [x] Tests completed
- [x] Documentation updated (not needed)
