### PR TITLE
Refactor post content storage to content_html SSOT

### DIFF
--- a/backend/islands/apps/remotes/src/components/remotes/DeveloperApiDocs/api-reference/fields.ts
+++ b/backend/islands/apps/remotes/src/components/remotes/DeveloperApiDocs/api-reference/fields.ts
@@ -38,12 +38,6 @@ export const postSummaryFields: ApiField[] = [
         description: '현재 글 상태입니다.'
     },
     {
-        name: 'content_type',
-        type: 'html | markdown',
-        requirement: '필수',
-        description: '본문 저장 형식입니다.'
-    },
-    {
         name: 'tags',
         type: 'string[]',
         requirement: '필수',
@@ -99,7 +93,13 @@ export const postDetailFields: ApiField[] = [
         name: 'content',
         type: 'string',
         requirement: '필수',
-        description: '원본 본문입니다. markdown 글은 마크다운 원문이 반환됩니다.'
+        description: 'HTML 본문입니다. BLEX는 게시글 본문을 HTML 단일 원본으로 저장합니다.'
+    },
+    {
+        name: 'content_html',
+        type: 'string',
+        requirement: '필수',
+        description: 'HTML 본문 원본입니다.'
     },
     {
         name: 'rendered_html',
@@ -142,13 +142,13 @@ export const postMutationBodyFields: ApiField[] = [
         name: 'content',
         type: 'string',
         requirement: '조건부',
-        description: 'published/scheduled 생성에는 필요합니다. markdown이면 마크다운 원문을 보냅니다.'
+        description: 'published/scheduled 생성에는 필요합니다. 기본적으로 HTML 본문으로 처리됩니다.'
     },
     {
-        name: 'content_type',
-        type: 'html | markdown',
+        name: 'markdown',
+        type: 'string',
         requirement: '선택',
-        description: '기본값은 html입니다.'
+        description: 'Agent/Developer 작성용 Markdown 입력입니다. 저장 시 HTML로 변환됩니다.'
     },
     {
         name: 'subtitle',

--- a/backend/islands/apps/remotes/src/components/remotes/DeveloperApiDocs/api-reference/posts.ts
+++ b/backend/islands/apps/remotes/src/components/remotes/DeveloperApiDocs/api-reference/posts.ts
@@ -93,8 +93,7 @@ Content-Type: application/json
 {
   "status": "draft",
   "title": "새 글",
-  "content": "# Hello",
-  "content_type": "markdown",
+  "markdown": "# Hello",
   "tags": ["api", "mcp"]
 }`
         }

--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/EditPostEditor.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/EditPostEditor.tsx
@@ -9,7 +9,7 @@ import { getSeries } from '~/lib/api/settings';
 import { getPostForEdit } from '~/lib/api/posts';
 import { api } from '~/components/shared';
 import { logger } from '~/utils/logger';
-import type { ContentType, Series } from './types';
+import type { Series } from './types';
 
 interface EditPostEditorProps {
     username: string;
@@ -40,7 +40,6 @@ const EditPostEditor = ({ username, postUrl }: EditPostEditorProps) => {
         name: '',
         url: ''
     });
-    const [contentType, setContentType] = useState<ContentType>('html');
     const [isSubmitting, setIsSubmitting] = useState(false);
 
     const formRef = useRef<HTMLFormElement>(null);
@@ -75,16 +74,15 @@ const EditPostEditor = ({ username, postUrl }: EditPostEditorProps) => {
                         title: postData.title || '',
                         subtitle: postData.subtitle || '',
                         url: postData.url || '',
-                        content: postData.textHtml || '',
+                        content: postData.contentHtml || '',
                         metaDescription: postData.description || '',
                         hide: postData.isHide || false,
                         advertise: postData.isAdvertise || false
                     });
-                    setContentType(postData.contentType || 'html');
                     setTags(postData.tags || []);
                     initialDataRef.current = {
                         title: postData.title || '',
-                        content: postData.textHtml || '',
+                        content: postData.contentHtml || '',
                         tags: postData.tags || []
                     };
                     setImagePreview(postData.image || null);
@@ -202,8 +200,7 @@ const EditPostEditor = ({ username, postUrl }: EditPostEditorProps) => {
 
             addHiddenField('tag', tags.join(','));
             addHiddenField('series', selectedSeries.id);
-            addHiddenField('text_html', formData.content);
-            addHiddenField('content_type', contentType);
+            addHiddenField('content_html', formData.content);
 
             if (isDraft) {
                 addHiddenField('is_draft', 'true');
@@ -277,9 +274,6 @@ const EditPostEditor = ({ username, postUrl }: EditPostEditorProps) => {
                 tags={tags}
                 imagePreview={imagePreview}
                 selectedSeries={selectedSeries}
-                contentType={contentType}
-                onContentTypeChange={setContentType}
-                isContentTypeChangeable={!formData.content.trim()}
                 onTitleChange={handleTitleChange}
                 onSubtitleChange={handleSubtitleChange}
                 onContentChange={(content) => setFormData(prev => ({

--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/NewPostEditor.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/NewPostEditor.tsx
@@ -20,7 +20,7 @@ import { getPublishChecklist } from './utils/publishChecklist';
 import { getSeries } from '~/lib/api/settings';
 import { getDraft } from '~/lib/api/posts';
 import { api } from '~/components/shared';
-import type { ContentType, Series } from './types';
+import type { Series } from './types';
 
 interface NewPostEditorProps {
     draftUrl?: string;
@@ -51,7 +51,6 @@ const NewPostEditor = ({ draftUrl }: NewPostEditorProps) => {
     const [isSettingsDrawerOpen, setIsSettingsDrawerOpen] = useState(false);
     const [isUrlAutoSync, setIsUrlAutoSync] = useState(true);
     const [currentDraftUrl, setCurrentDraftUrl] = useState(draftUrl);
-    const [contentType, setContentType] = useState<ContentType>('html');
     const [showPublishChecklist, setShowPublishChecklist] = useState(false);
 
     const [formData, setFormData] = useState({
@@ -127,7 +126,6 @@ const NewPostEditor = ({ draftUrl }: NewPostEditorProps) => {
         description: formData.metaDescription,
         seriesUrl: selectedSeries.url || undefined,
         customUrl: sanitizedUrlForSubmit || undefined,
-        contentType,
         imageFile,
         imageDeleted
     };
@@ -193,7 +191,7 @@ const NewPostEditor = ({ draftUrl }: NewPostEditorProps) => {
                     if (draftResponse.status === 'DONE' && draftResponse.body) {
                         const draftData = draftResponse.body;
                         const newTitle = draftData.title || '';
-                        const newContent = draftData.textMd || '';
+                        const newContent = draftData.contentHtml || draftData.rawContent || '';
                         const newTags = draftData.tags ? draftData.tags.split(',').filter(Boolean) : [];
                         const newSubtitle = draftData.subtitle || '';
                         const newDescription = draftData.description || '';
@@ -206,7 +204,6 @@ const NewPostEditor = ({ draftUrl }: NewPostEditorProps) => {
                             content: newContent,
                             metaDescription: newDescription
                         }));
-                        setContentType(draftData.contentType || 'html');
                         setCurrentDraftUrl(draftData.url || draftUrl);
                         setIsUrlAutoSync(
                             !draftData.url || draftData.url === generateUrlFromTitle(newTitle)
@@ -342,8 +339,7 @@ const NewPostEditor = ({ draftUrl }: NewPostEditorProps) => {
                 url: normalizeUrlForSubmit(formData.url),
                 content: formData.content,
                 tags,
-                seriesId: selectedSeries.id,
-                contentType
+                seriesId: selectedSeries.id
             },
             isDraft,
             false // isEdit
@@ -382,9 +378,6 @@ const NewPostEditor = ({ draftUrl }: NewPostEditorProps) => {
                 tags={tags}
                 imagePreview={imagePreview}
                 selectedSeries={selectedSeries}
-                contentType={contentType}
-                onContentTypeChange={setContentType}
-                isContentTypeChangeable={!formData.content.trim()}
                 onTitleChange={handleTitleChange}
                 onSubtitleChange={handleSubtitleChange}
                 onContentChange={(content) => setFormData(prev => ({

--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/components/PostForm.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/components/PostForm.tsx
@@ -3,7 +3,6 @@ import { TiptapEditor } from '~/components/shared';
 import { getCsrfToken } from '~/utils/csrf';
 import ImageUploader from './ImageUploader';
 import TagManager from './TagManager';
-import type { ContentType } from '../types';
 
 interface PostFormData {
     title: string;
@@ -22,9 +21,6 @@ interface PostFormProps {
     tags: string[];
     imagePreview: string | null;
     selectedSeries: { id: string; name: string };
-    contentType: ContentType;
-    onContentTypeChange: (type: ContentType) => void;
-    isContentTypeChangeable: boolean;
 
     // Handlers
     onTitleChange: (title: string) => void;
@@ -43,9 +39,6 @@ const PostForm = ({
     tags,
     imagePreview,
     selectedSeries,
-    contentType,
-    onContentTypeChange,
-    isContentTypeChangeable,
     onTitleChange,
     onSubtitleChange,
     onContentChange,
@@ -60,7 +53,6 @@ const PostForm = ({
     return (
         <form ref={formRef} method="POST" encType="multipart/form-data">
             <input type="hidden" name="csrfmiddlewaretoken" value={getCsrfToken()} />
-            <input type="hidden" name="content_type" value={contentType} />
 
             <article>
                 <div className="mb-8">
@@ -98,49 +90,14 @@ const PostForm = ({
                 />
 
                 <div className="mb-8">
-                    <div className="flex items-center gap-1 mb-3">
-                        <button
-                            type="button"
-                            className={`px-3 py-1 text-xs font-medium rounded-full transition-colors ${
-                                contentType === 'html'
-                                    ? 'bg-action text-content-inverted'
-                                    : 'bg-surface-subtle text-content-secondary hover:bg-line'
-                            } ${!isContentTypeChangeable && contentType !== 'html' ? 'opacity-50 cursor-not-allowed' : ''}`}
-                            disabled={!isContentTypeChangeable && contentType !== 'html'}
-                            onClick={() => onContentTypeChange('html')}>
-                            WYSIWYG
-                        </button>
-                        <button
-                            type="button"
-                            className={`px-3 py-1 text-xs font-medium rounded-full transition-colors ${
-                                contentType === 'markdown'
-                                    ? 'bg-action text-content-inverted'
-                                    : 'bg-surface-subtle text-content-secondary hover:bg-line'
-                            } ${!isContentTypeChangeable && contentType !== 'markdown' ? 'opacity-50 cursor-not-allowed' : ''}`}
-                            disabled={!isContentTypeChangeable && contentType !== 'markdown'}
-                            onClick={() => onContentTypeChange('markdown')}>
-                            Markdown
-                        </button>
-                    </div>
-
                     <label htmlFor="content" className="sr-only">내용</label>
-                    {!isLoading && contentType === 'html' && (
+                    {!isLoading && (
                         <TiptapEditor
-                            name="text_md"
+                            name="content_html"
                             content={formData.content}
                             onChange={onContentChange}
                             placeholder="내용을 입력하세요"
                             onImageUpload={onEditorImageUpload}
-                        />
-                    )}
-                    {!isLoading && contentType === 'markdown' && (
-                        <textarea
-                            name="text_md"
-                            value={formData.content}
-                            onChange={(e) => onContentChange(e.target.value)}
-                            placeholder="마크다운으로 작성하세요..."
-                            className="w-full min-h-[500px] px-4 py-3 border border-line rounded-lg font-mono text-sm leading-relaxed resize-y focus:outline-none focus:ring-2 focus:ring-line-strong focus:border-transparent"
-                            spellCheck={false}
                         />
                     )}
                 </div>

--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/hooks/useAutoSave.ts
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/hooks/useAutoSave.ts
@@ -9,7 +9,6 @@ interface AutoSaveData {
     description?: string;
     seriesUrl?: string;
     customUrl?: string;
-    contentType?: string;
     imageFile?: File | null;
     imageDeleted?: boolean;
 }
@@ -32,7 +31,6 @@ const buildDraftPayload = (data: AutoSaveData, useFormData: boolean) => {
         if (data.description) formData.append('description', data.description);
         if (data.seriesUrl) formData.append('series_url', data.seriesUrl);
         if (data.customUrl) formData.append('custom_url', data.customUrl);
-        if (data.contentType) formData.append('content_type', data.contentType);
         if (data.imageFile) formData.append('image', data.imageFile);
         if (data.imageDeleted) formData.append('image_delete', 'true');
         return formData;
@@ -45,8 +43,7 @@ const buildDraftPayload = (data: AutoSaveData, useFormData: boolean) => {
         subtitle: data.subtitle,
         description: data.description,
         series_url: data.seriesUrl,
-        custom_url: data.customUrl,
-        content_type: data.contentType
+        custom_url: data.customUrl
     };
 };
 

--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/hooks/useFormSubmit.ts
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/hooks/useFormSubmit.ts
@@ -8,7 +8,6 @@ interface FormSubmitData {
     content: string;
     tags: string[];
     seriesId: string;
-    contentType?: string;
 }
 
 interface UseFormSubmitOptions {
@@ -82,11 +81,6 @@ export const useFormSubmit = (options: UseFormSubmitOptions) => {
             addHiddenField(form, 'url', normalizeUrlForSubmit(data.url));
             addHiddenField(form, 'tag', data.tags.join(','));
             addHiddenField(form, 'series', data.seriesId);
-            if (data.contentType) {
-                addHiddenField(form, 'content_type', data.contentType);
-            }
-            // Note: text_md is already added by TiptapEditor as a hidden input
-            // We don't need to add it here to avoid overwriting the editor's value
 
             if (isDraft) {
                 addHiddenField(form, 'is_draft', 'true');

--- a/backend/islands/apps/remotes/src/lib/api/posts.ts
+++ b/backend/islands/apps/remotes/src/lib/api/posts.ts
@@ -91,7 +91,7 @@ export interface DraftDetail {
     url: string;
     title: string;
     subtitle: string;
-    contentType: 'html' | 'markdown';
+    contentHtml: string;
     textMd: string;
     rawContent: string;
     tags: string;
@@ -141,7 +141,7 @@ export interface PostForEdit {
     title: string;
     subtitle: string;
     url: string;
-    contentType: 'html' | 'markdown';
+    contentHtml: string;
     textHtml: string;
     image: string;
     description: string;

--- a/backend/src/board/admin/post.py
+++ b/backend/src/board/admin/post.py
@@ -64,11 +64,11 @@ class PinnedPostAdmin(admin.ModelAdmin):
 
 
 class PostContentInline(admin.StackedInline):
-    """Inline editor for post content (markdown and HTML)."""
+    """Inline editor for post content HTML."""
     model = PostContent
     can_delete = False
     classes = ['collapse']
-    fields = ['text_md', 'text_html']
+    fields = ['content_html']
     extra = 0
     max_num = 1
 
@@ -91,7 +91,7 @@ class PostAdmin(admin.ModelAdmin):
     - 대량 작업 시 bulk operation 사용
     """
 
-    search_fields = ['title', 'content__text_md', 'author__username', 'series__name', 'tags__value']
+    search_fields = ['title', 'content__content_html', 'author__username', 'series__name', 'tags__value']
     ordering = ['-created_date']
     inlines = [PostContentInline, PostConfigInline]
     autocomplete_fields = ['author', 'series']
@@ -249,4 +249,3 @@ class PostAdmin(admin.ModelAdmin):
         count = queryset.filter(published_date__isnull=True).update(published_date=timezone.now())
         self.message_user(request, f'{count}개의 임시글을 발행했습니다.')
     publish_drafts.short_description = '선택한 임시글 즉시 발행'
-

--- a/backend/src/board/admin/utilities/image_cleaner.py
+++ b/backend/src/board/admin/utilities/image_cleaner.py
@@ -55,8 +55,8 @@ class ImageCleanerService:
         used_files = set()
 
         posts = Post.objects.all().annotate(
-            text_md=F('content__text_md'),
-            text_html=F('content__text_html')
+            text_md=F('content__content_html'),
+            text_html=F('content__content_html')
         )
         comments = Comment.objects.all()
         profiles = Profile.objects.all().annotate(

--- a/backend/src/board/feeds.py
+++ b/backend/src/board/feeds.py
@@ -45,7 +45,7 @@ class SitePostsFeed(Feed):
         return item.title
 
     def item_description(self, item):
-        return re.sub(r'[\x00-\x08\x0B-\x0C\x0E-\x1F]', '', item.content.text_html)
+        return re.sub(r'[\x00-\x08\x0B-\x0C\x0E-\x1F]', '', item.content.content_html)
 
     def item_link(self, item):
         return item.get_absolute_url()
@@ -88,7 +88,7 @@ class UserPostsFeed(Feed):
         return item.title
 
     def item_description(self, item):
-        return re.sub(r'[\x00-\x08\x0B-\x0C\x0E-\x1F]', '', item.content.text_html)
+        return re.sub(r'[\x00-\x08\x0B-\x0C\x0E-\x1F]', '', item.content.content_html)
 
     def item_link(self, item):
         return item.get_absolute_url()

--- a/backend/src/board/migrations/0045_postcontent_content_html_ssot.py
+++ b/backend/src/board/migrations/0045_postcontent_content_html_ssot.py
@@ -1,0 +1,24 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('board', '0044_merge_developer_api_and_runtime_robots'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='postcontent',
+            old_name='text_html',
+            new_name='content_html',
+        ),
+        migrations.RemoveField(
+            model_name='postcontent',
+            name='text_md',
+        ),
+        migrations.RemoveField(
+            model_name='postcontent',
+            name='content_type',
+        ),
+    ]

--- a/backend/src/board/models.py
+++ b/backend/src/board/models.py
@@ -365,22 +365,12 @@ class Post(models.Model):
 
 
 class PostContent(models.Model):
-    class ContentType(models.TextChoices):
-        HTML = 'html', 'HTML'
-        MARKDOWN = 'markdown', 'Markdown'
-
     post = models.OneToOneField('board.Post', related_name='content', on_delete=models.CASCADE)
-    content_type = models.CharField(
-        max_length=10,
-        choices=ContentType.choices,
-        default=ContentType.HTML,
-    )
-    text_md = models.TextField(blank=True)
-    text_html = models.TextField(blank=True)
+    content_html = models.TextField(blank=True)
 
     def save(self, *args, **kwargs):
         if self.post:
-            self.post.read_time = calc_read_time(self.text_html)
+            self.post.read_time = calc_read_time(self.content_html)
             self.post.save()
         super().save(*args, **kwargs)
 

--- a/backend/src/board/modules/developer_serializers.py
+++ b/backend/src/board/modules/developer_serializers.py
@@ -63,7 +63,6 @@ class DeveloperPostSerializer:
             'url': post.url,
             'public_url': f'/@{post.author.username}/{post.url}',
             'status': DeveloperPostSerializer.status(post),
-            'content_type': content.content_type if content else 'html',
             'tags': DeveloperPostSerializer.tags(post),
             'series': DeveloperPostSerializer.series(post),
             'is_hidden': config.hide if config else False,
@@ -77,20 +76,16 @@ class DeveloperPostSerializer:
     def detail(post):
         data = DeveloperPostSerializer.summary(post)
         content = DeveloperPostSerializer.content(post)
-        raw_content = ''
-        rendered_html = ''
+        content_html = ''
 
         if content:
-            rendered_html = content.text_html
-            if content.content_type == 'markdown':
-                raw_content = content.text_md
-            else:
-                raw_content = content.text_html
+            content_html = content.content_html
 
         data.update({
             'description': post.meta_description,
-            'content': raw_content,
-            'rendered_html': rendered_html,
+            'content': content_html,
+            'content_html': content_html,
+            'rendered_html': content_html,
             'read_time': post.read_time,
         })
         return data

--- a/backend/src/board/services/agent_content_service.py
+++ b/backend/src/board/services/agent_content_service.py
@@ -8,7 +8,7 @@ from django.db.models import Count, Q, QuerySet
 from django.http import Http404, HttpRequest
 from django.urls import reverse
 
-from board.models import Post, PostContent, Series, SiteSetting, StaticPage
+from board.models import Post, Series, SiteSetting, StaticPage
 from board.services.public_post_service import PublicPostService
 
 
@@ -331,18 +331,7 @@ class AgentContentService:
 
     @staticmethod
     def get_post_content_markdown(post: Post) -> str:
-        content = post.content
-        text_md = content.text_md.strip()
-
-        if (
-            content.content_type == PostContent.ContentType.MARKDOWN
-            and text_md
-            and not AgentContentService.looks_like_html(text_md)
-        ):
-            return text_md
-
-        html = content.text_html or content.text_md
-        return AgentContentService.html_to_markdown(html)
+        return AgentContentService.html_to_markdown(post.content.content_html)
 
     @staticmethod
     def get_series_content_markdown(series: Series) -> str:

--- a/backend/src/board/services/post_content_service.py
+++ b/backend/src/board/services/post_content_service.py
@@ -1,0 +1,23 @@
+from modules.markdown import parse_post_to_html
+
+
+class PostContentService:
+    @staticmethod
+    def normalize_content_html(html: str) -> str:
+        return html or ''
+
+    @staticmethod
+    def html_input_to_content_html(html: str) -> str:
+        return PostContentService.normalize_content_html(html)
+
+    @staticmethod
+    def markdown_input_to_content_html(markdown_text: str) -> str:
+        return PostContentService.normalize_content_html(
+            parse_post_to_html(markdown_text or '')
+        )
+
+    @staticmethod
+    def input_to_content_html(content: str, content_type: str | None = None) -> str:
+        if content_type == 'markdown':
+            return PostContentService.markdown_input_to_content_html(content)
+        return PostContentService.html_input_to_content_html(content)

--- a/backend/src/board/services/post_service.py
+++ b/backend/src/board/services/post_service.py
@@ -24,8 +24,8 @@ from board.models import Post, PostContent, PostConfig, Series, PostLikes
 from board.modules.post_description import create_post_description
 from board.services.tag_service import TagService
 from board.modules.response import ErrorCode
+from board.services.post_content_service import PostContentService
 from board.services.webhook_service import WebhookService
-from modules.markdown import parse_post_to_html
 
 
 class PostValidationError(Exception):
@@ -226,21 +226,19 @@ class PostService:
     @staticmethod
     def _resolve_content(
         text_content: str,
-        content_type: str,
-    ) -> Tuple[str, str]:
+        content_type: str | None = None,
+    ) -> str:
         """
-        Resolve text_md and text_html based on content_type.
+        Resolve incoming content to canonical HTML.
 
         Args:
             text_content: Raw content from the editor
-            content_type: 'html' or 'markdown'
+            content_type: Legacy input hint, 'html' or 'markdown'
 
         Returns:
-            Tuple of (text_md, text_html)
+            Canonical HTML
         """
-        if content_type == 'markdown':
-            return text_content, parse_post_to_html(text_content)
-        return text_content, text_content
+        return PostContentService.input_to_content_html(text_content, content_type)
 
     @staticmethod
     @transaction.atomic
@@ -285,7 +283,7 @@ class PostService:
 
         PostService.validate_post_data(title, text_html)
 
-        text_md, resolved_html = PostService._resolve_content(text_html, content_type)
+        resolved_html = PostService._resolve_content(text_html, content_type)
 
         post = Post()
         post.title = title
@@ -320,9 +318,7 @@ class PostService:
 
         post_content = PostContent.objects.create(
             post=post,
-            content_type=content_type,
-            text_md=text_md,
-            text_html=resolved_html,
+            content_html=resolved_html,
         )
 
         post_config = PostConfig.objects.create(
@@ -503,42 +499,18 @@ class PostService:
         if text_html is not None:
             PostService.validate_post_data(title or post.title, text_html)
 
-            effective_type = content_type
             try:
                 post_content = post.content
-                if effective_type is None:
-                    effective_type = post_content.content_type
-                text_md, resolved_html = PostService._resolve_content(text_html, effective_type)
-                if effective_type is not None:
-                    post_content.content_type = effective_type
-                post_content.text_html = resolved_html
-                post_content.text_md = text_md
+                resolved_html = PostService._resolve_content(text_html, content_type)
+                post_content.content_html = resolved_html
                 post_content.save()
             except PostContent.DoesNotExist:
-                if effective_type is None:
-                    effective_type = 'html'
-                text_md, resolved_html = PostService._resolve_content(text_html, effective_type)
+                resolved_html = PostService._resolve_content(text_html, content_type)
                 PostContent.objects.create(
                     post=post,
-                    content_type=effective_type,
-                    text_html=resolved_html,
-                    text_md=text_md,
+                    content_html=resolved_html,
                 )
             resolved_html_for_desc = resolved_html
-        elif content_type is not None:
-            try:
-                post_content = post.content
-                if post_content.content_type != content_type:
-                    post_content.content_type = content_type
-                    text_md, resolved_html = PostService._resolve_content(
-                        post_content.text_md if content_type == 'markdown' else post_content.text_html,
-                        content_type,
-                    )
-                    post_content.text_md = text_md
-                    post_content.text_html = resolved_html
-                    post_content.save()
-            except PostContent.DoesNotExist:
-                pass
 
         if description is not None:
             post.meta_description = description
@@ -656,7 +628,7 @@ class PostService:
                 f'임시 저장 글은 최대 {PostService.MAX_DRAFTS_PER_USER}개까지 가능합니다.'
             )
 
-        text_md, resolved_html = PostService._resolve_content(text_html, content_type)
+        resolved_html = PostService._resolve_content(text_html, content_type)
 
         post = Post()
         post.title = title or '제목 없음'
@@ -686,9 +658,7 @@ class PostService:
 
         PostContent.objects.create(
             post=post,
-            content_type=content_type,
-            text_md=text_md,
-            text_html=resolved_html,
+            content_html=resolved_html,
         )
 
         PostConfig.objects.create(post=post)
@@ -725,36 +695,18 @@ class PostService:
         resolved_html_for_desc = None
 
         if text_html is not None:
-            effective_type = content_type
             try:
                 post_content = post.content
-                if effective_type is None:
-                    effective_type = post_content.content_type
-                text_md, resolved_html = PostService._resolve_content(text_html, effective_type)
-                if effective_type is not None:
-                    post_content.content_type = effective_type
-                post_content.text_html = resolved_html
-                post_content.text_md = text_md
+                resolved_html = PostService._resolve_content(text_html, content_type)
+                post_content.content_html = resolved_html
                 post_content.save()
             except PostContent.DoesNotExist:
-                if effective_type is None:
-                    effective_type = 'html'
-                text_md, resolved_html = PostService._resolve_content(text_html, effective_type)
+                resolved_html = PostService._resolve_content(text_html, content_type)
                 PostContent.objects.create(
                     post=post,
-                    content_type=effective_type,
-                    text_html=resolved_html,
-                    text_md=text_md,
+                    content_html=resolved_html,
                 )
             resolved_html_for_desc = resolved_html
-        elif content_type is not None:
-            try:
-                post_content = post.content
-                if post_content.content_type != content_type:
-                    post_content.content_type = content_type
-                    post_content.save(update_fields=['content_type'])
-            except PostContent.DoesNotExist:
-                pass
 
         if description is not None:
             post.meta_description = description
@@ -812,41 +764,23 @@ class PostService:
         if subtitle is not None:
             post.subtitle = subtitle
 
-        PostService.validate_post_data(post.title, text_html or (post.content.text_html if hasattr(post, 'content') else ''))
+        PostService.validate_post_data(post.title, text_html or (post.content.content_html if hasattr(post, 'content') else ''))
 
         resolved_html_for_desc = None
 
         if text_html is not None:
-            effective_type = content_type
             try:
                 post_content = post.content
-                if effective_type is None:
-                    effective_type = post_content.content_type
-                text_md, resolved_html = PostService._resolve_content(text_html, effective_type)
-                if effective_type is not None:
-                    post_content.content_type = effective_type
-                post_content.text_html = resolved_html
-                post_content.text_md = text_md
+                resolved_html = PostService._resolve_content(text_html, content_type)
+                post_content.content_html = resolved_html
                 post_content.save()
             except PostContent.DoesNotExist:
-                if effective_type is None:
-                    effective_type = 'html'
-                text_md, resolved_html = PostService._resolve_content(text_html, effective_type)
+                resolved_html = PostService._resolve_content(text_html, content_type)
                 PostContent.objects.create(
                     post=post,
-                    content_type=effective_type,
-                    text_html=resolved_html,
-                    text_md=text_md,
+                    content_html=resolved_html,
                 )
             resolved_html_for_desc = resolved_html
-        elif content_type is not None:
-            try:
-                post_content = post.content
-                if post_content.content_type != content_type:
-                    post_content.content_type = content_type
-                    post_content.save(update_fields=['content_type'])
-            except PostContent.DoesNotExist:
-                pass
 
         if description is not None:
             post.meta_description = description

--- a/backend/src/board/tests/api/test_comment.py
+++ b/backend/src/board/tests/api/test_comment.py
@@ -49,8 +49,7 @@ class CommentTestCase(TestCase):
 
         PostContent.objects.create(
             post=Post.objects.get(url='test-post'),
-            text_md='# Post',
-            text_html='<h1>Post</h1>'
+            content_html='<h1>Post</h1>'
         )
 
         PostConfig.objects.create(

--- a/backend/src/board/tests/api/test_developer_posts.py
+++ b/backend/src/board/tests/api/test_developer_posts.py
@@ -99,13 +99,11 @@ class DeveloperPostsAPITestCase(TestCase):
         data = self.create_draft()
 
         self.assertEqual(data['status'], 'draft')
-        self.assertEqual(data['content_type'], 'markdown')
-        self.assertEqual(data['content'], '# Hello\n\nThis is **bold**')
+        self.assertIn('<strong>bold</strong>', data['content_html'])
         self.assertIn('<strong>bold</strong>', data['rendered_html'])
 
         post = Post.objects.get(id=data['id'])
         self.assertIsNone(post.published_date)
-        self.assertEqual(post.content.text_md, '# Hello\n\nThis is **bold**')
         self.assertEqual(sorted(post.tags.values_list('value', flat=True)), ['api', 'mcp'])
 
     def test_list_posts_includes_draft_status(self):
@@ -143,7 +141,7 @@ class DeveloperPostsAPITestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         data = response.json()['data']
         self.assertEqual(data['title'], 'Detail Draft')
-        self.assertEqual(data['content'], '# Hello\n\nThis is **bold**')
+        self.assertIn('<strong>bold</strong>', data['content_html'])
         self.assertIn('This is', data['rendered_html'])
 
     def test_create_published_post(self):

--- a/backend/src/board/tests/api/test_developer_workflow.py
+++ b/backend/src/board/tests/api/test_developer_workflow.py
@@ -77,7 +77,7 @@ class DeveloperWorkflowAPITestCase(TestCase):
         self.assertEqual(create_response.status_code, 201)
         draft = create_response.json()['data']
         self.assertEqual(draft['status'], 'draft')
-        self.assertEqual(draft['content_type'], 'markdown')
+        self.assertIn('<img', draft['content_html'])
 
         update_response = self.patch_json(f"/api/developer/v1/posts/{draft['id']}", {
             'expected_updated_at': draft['updated_at'],
@@ -102,7 +102,7 @@ class DeveloperWorkflowAPITestCase(TestCase):
         self.assertEqual(detail_response.status_code, 200)
         detail = detail_response.json()['data']
         self.assertEqual(detail['status'], 'published')
-        self.assertEqual(detail['content'], f'# Workflow\n\n![cover]({image_url})')
+        self.assertIn(image_url, detail['content_html'])
         self.assertIn('<img', detail['rendered_html'])
 
         post = Post.objects.get(id=draft['id'])

--- a/backend/src/board/tests/api/test_draft.py
+++ b/backend/src/board/tests/api/test_draft.py
@@ -229,10 +229,8 @@ class DraftTestCase(TestCase):
         self.assertEqual(content['status'], 'DONE')
 
         post = Post.objects.get(url=content['body']['url'])
-        self.assertEqual(post.content.content_type, 'markdown')
-        self.assertEqual(post.content.text_md, '# Hello\n\nThis is **bold**')
-        self.assertIn('<h2', post.content.text_html)
-        self.assertIn('<strong>bold</strong>', post.content.text_html)
+        self.assertIn('<h2', post.content.content_html)
+        self.assertIn('<strong>bold</strong>', post.content.content_html)
 
     def test_get_draft_detail_markdown_mode(self):
         """마크다운 모드 드래프트 상세 조회 시 text_md 반환 테스트"""
@@ -251,8 +249,7 @@ class DraftTestCase(TestCase):
 
         response = self.client.get(f'/v1/drafts/{draft_url}')
         content = json.loads(response.content)
-        self.assertEqual(content['body']['contentType'], 'markdown')
-        self.assertEqual(content['body']['textMd'], '# Heading')
+        self.assertIn('Heading', content['body']['contentHtml'])
 
     def test_update_draft_markdown_mode(self):
         """마크다운 모드 드래프트 수정 테스트"""
@@ -280,8 +277,7 @@ class DraftTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
 
         post = Post.objects.get(url=draft_url)
-        self.assertEqual(post.content.text_md, '# Updated\n\nNew content')
-        self.assertIn('<h2', post.content.text_html)
+        self.assertIn('<h2', post.content.content_html)
 
     def test_draft_limit(self):
         """드래프트 100개 제한 테스트"""
@@ -297,8 +293,7 @@ class DraftTestCase(TestCase):
             )
             PostContent.objects.create(
                 post=Post.objects.get(url=f'bulk-draft-{i}'),
-                text_html='',
-                text_md=''
+                content_html='',
             )
             PostConfig.objects.create(
                 post=Post.objects.get(url=f'bulk-draft-{i}')

--- a/backend/src/board/tests/api/test_pinned_post.py
+++ b/backend/src/board/tests/api/test_pinned_post.py
@@ -36,7 +36,7 @@ class PinnedPostAPITestCase(TestCase):
                 url=f'test-post-{i}',
                 published_date=timezone.now(),
             )
-            PostContent.objects.create(post=post, text_md='', text_html='')
+            PostContent.objects.create(post=post, content_html='')
             PostConfig.objects.create(post=post)
             cls.posts.append(post)
 
@@ -47,7 +47,7 @@ class PinnedPostAPITestCase(TestCase):
             url='hidden-post',
             published_date=timezone.now(),
         )
-        PostContent.objects.create(post=cls.hidden_post, text_md='', text_html='')
+        PostContent.objects.create(post=cls.hidden_post, content_html='')
         PostConfig.objects.create(post=cls.hidden_post, hide=True)
 
         # Create a draft post
@@ -57,7 +57,7 @@ class PinnedPostAPITestCase(TestCase):
             url='draft-post',
             published_date=None,
         )
-        PostContent.objects.create(post=cls.draft_post, text_md='', text_html='')
+        PostContent.objects.create(post=cls.draft_post, content_html='')
         PostConfig.objects.create(post=cls.draft_post)
 
     def setUp(self):

--- a/backend/src/board/tests/api/test_post.py
+++ b/backend/src/board/tests/api/test_post.py
@@ -45,8 +45,7 @@ class PostTestCase(TestCase):
             )
             PostContent.objects.create(
                 post=post,
-                text_md=f'# Test Post {post_num}',
-                text_html=f'<h1>Test Post {post_num}</h1>'
+                content_html=f'<h1>Test Post {post_num}</h1>'
             )
             PostConfig.objects.create(
                 post=post,
@@ -85,7 +84,7 @@ class PostTestCase(TestCase):
         post = Post.objects.get(url='test-post-1')
         response = self.client.post('/v1/users/@author/posts/test-post-1', {
             'title': f'{post.title} Updated',
-            'text_html': post.content.text_html,
+            'text_html': post.content.content_html,
             'is_hide': post.config.hide,
             'is_advertise': post.config.advertise,
         })
@@ -287,9 +286,7 @@ class PostTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
 
         post = Post.objects.get(url=content['body']['url'])
-        self.assertEqual(post.content.content_type, 'markdown')
-        self.assertEqual(post.content.text_md, '# Hello World\n\nThis is **markdown**.')
-        self.assertIn('<strong>markdown</strong>', post.content.text_html)
+        self.assertIn('<strong>markdown</strong>', post.content.content_html)
 
     def test_create_post_markdown_mode_does_not_render_mentions(self):
         """포스트 마크다운에서는 멘션이 링크로 변환되지 않아야 함"""
@@ -306,8 +303,8 @@ class PostTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
 
         post = Post.objects.get(url=content['body']['url'])
-        self.assertNotIn('class="mention"', post.content.text_html)
-        self.assertIn('<code>@viewer</code>', post.content.text_html)
+        self.assertNotIn('class="mention"', post.content.content_html)
+        self.assertIn('<code>@viewer</code>', post.content.content_html)
 
     def test_get_post_edit_mode_markdown(self):
         """마크다운 모드 포스트 편집 모드 조회 시 text_md 반환 테스트"""
@@ -326,8 +323,7 @@ class PostTestCase(TestCase):
         # Fetch in edit mode
         response = self.client.get(f'/v1/users/@author/posts/{post_url}', {'mode': 'edit'})
         content = json.loads(response.content)
-        self.assertEqual(content['body']['contentType'], 'markdown')
-        self.assertEqual(content['body']['textHtml'], '# Edit me')
+        self.assertIn('Edit me', content['body']['contentHtml'])
 
     def test_update_post_markdown_mode(self):
         """마크다운 모드 포스트 수정 테스트"""
@@ -354,8 +350,7 @@ class PostTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
 
         post = Post.objects.get(url=post_url)
-        self.assertEqual(post.content.text_md, '# After\n\nUpdated **content**.')
-        self.assertIn('<strong>content</strong>', post.content.text_html)
+        self.assertIn('<strong>content</strong>', post.content.content_html)
 
     def _create_test_image(self, name='test.jpg', size=(100, 100), color='red'):
         """테스트용 이미지 파일 생성 헬퍼 메소드"""
@@ -381,7 +376,7 @@ class PostTestCase(TestCase):
         image = self._create_test_image('new_image.jpg')
         response = self.client.post('/v1/users/@author/posts/test-post-1', {
             'title': post.title,
-            'text_html': post.content.text_html,
+            'text_html': post.content.content_html,
             'is_hide': post.config.hide,
             'is_advertise': post.config.advertise,
             'image': image,
@@ -412,7 +407,7 @@ class PostTestCase(TestCase):
         new_image = self._create_test_image('new_image.jpg', color='red')
         response = self.client.post('/v1/users/@author/posts/test-post-2', {
             'title': post.title,
-            'text_html': post.content.text_html,
+            'text_html': post.content.content_html,
             'is_hide': post.config.hide,
             'is_advertise': post.config.advertise,
             'image': new_image,
@@ -445,7 +440,7 @@ class PostTestCase(TestCase):
         # image_delete 플래그와 함께 업데이트
         response = self.client.post('/v1/users/@author/posts/test-post-3', {
             'title': post.title,
-            'text_html': post.content.text_html,
+            'text_html': post.content.content_html,
             'is_hide': post.config.hide,
             'is_advertise': post.config.advertise,
             'image_delete': 'true',
@@ -472,7 +467,7 @@ class PostTestCase(TestCase):
         # 이미지 필드 없이 다른 필드만 업데이트
         response = self.client.post('/v1/users/@author/posts/test-post-4', {
             'title': post.title + ' Updated',
-            'text_html': post.content.text_html,
+            'text_html': post.content.content_html,
             'is_hide': post.config.hide,
             'is_advertise': post.config.advertise,
             # image 필드 없음 - 기존 이미지 유지되어야 함

--- a/backend/src/board/tests/api/test_search_api.py
+++ b/backend/src/board/tests/api/test_search_api.py
@@ -133,8 +133,7 @@ class SearchAPITestCase(TestCase):
         )
         PostContent.objects.create(
             post=post,
-            text_md=content,
-            text_html=f'<h1>{title}</h1>',
+            content_html=f'<h1>{title}</h1>',
         )
         PostConfig.objects.create(
             post=post,

--- a/backend/src/board/tests/api/test_series_api.py
+++ b/backend/src/board/tests/api/test_series_api.py
@@ -42,8 +42,7 @@ class SeriesAPITestCase(TestCase):
             )
             PostContent.objects.create(
                 post=post,
-                text_md=f'# Test Post {i}',
-                text_html=f'<h1>Test Post {i}</h1>'
+                content_html=f'<h1>Test Post {i}</h1>'
             )
             PostConfig.objects.create(
                 post=post,

--- a/backend/src/board/tests/api/test_setting.py
+++ b/backend/src/board/tests/api/test_setting.py
@@ -135,8 +135,7 @@ class SettingTestCase(TestCase):
         )
         PostContent.objects.create(
             post=post,
-            text_md='# Test',
-            text_html='<h1>Test</h1>'
+            content_html='<h1>Test</h1>'
         )
         PostConfig.objects.create(
             post=post,

--- a/backend/src/board/tests/api/test_webhook.py
+++ b/backend/src/board/tests/api/test_webhook.py
@@ -328,8 +328,7 @@ class WebhookNotificationTestCase(TestCase):
         )
         PostContent.objects.create(
             post=cls.post,
-            text_md='Test content',
-            text_html='<p>Test content</p>'
+            content_html='<p>Test content</p>'
         )
 
     @patch('board.services.webhook_service.SubTaskProcessor.process')

--- a/backend/src/board/tests/services/test_image_dedup.py
+++ b/backend/src/board/tests/services/test_image_dedup.py
@@ -74,7 +74,7 @@ class ImageDedupTestCase(TestCase):
             published_date=timezone.now(),
             image='images/title/test.jpg',
         )
-        PostContent.objects.create(post=post, text_md='', text_html='')
+        PostContent.objects.create(post=post, content_html='')
         PostConfig.objects.create(post=post)
 
         self.assertFalse(PostService._is_image_shared('images/title/test.jpg', post.pk))
@@ -88,7 +88,7 @@ class ImageDedupTestCase(TestCase):
             published_date=timezone.now(),
             image='images/title/shared.jpg',
         )
-        PostContent.objects.create(post=post1, text_md='', text_html='')
+        PostContent.objects.create(post=post1, content_html='')
         PostConfig.objects.create(post=post1)
 
         post2 = Post.objects.create(
@@ -98,7 +98,7 @@ class ImageDedupTestCase(TestCase):
             published_date=timezone.now(),
             image='images/title/shared.jpg',
         )
-        PostContent.objects.create(post=post2, text_md='', text_html='')
+        PostContent.objects.create(post=post2, content_html='')
         PostConfig.objects.create(post=post2)
 
         self.assertTrue(PostService._is_image_shared('images/title/shared.jpg', post1.pk))
@@ -117,7 +117,7 @@ class ImageDedupTestCase(TestCase):
             image='images/title/existing.jpg',
             image_hash='a' * 64,
         )
-        PostContent.objects.create(post=existing_post, text_md='', text_html='')
+        PostContent.objects.create(post=existing_post, content_html='')
         PostConfig.objects.create(post=existing_post)
 
         new_image = self._create_test_image()
@@ -162,7 +162,7 @@ class ImageDedupTestCase(TestCase):
             published_date=timezone.now(),
             image_hash='c' * 64,
         )
-        PostContent.objects.create(post=post, text_md='', text_html='')
+        PostContent.objects.create(post=post, content_html='')
         PostConfig.objects.create(post=post)
 
         PostService._set_image_with_dedup(post, image=None, image_delete=True)
@@ -184,7 +184,7 @@ class ImageDedupTestCase(TestCase):
             image='images/title/thumb-test.jpg',
             image_hash='d' * 64,
         )
-        PostContent.objects.create(post=existing, text_md='', text_html='')
+        PostContent.objects.create(post=existing, content_html='')
         PostConfig.objects.create(post=existing)
 
         new_image = self._create_test_image()

--- a/backend/src/board/tests/templates/test_agent_discovery.py
+++ b/backend/src/board/tests/templates/test_agent_discovery.py
@@ -31,8 +31,7 @@ class SeriesAgentDiscoveryTestCase(TestCase):
         )
         PostContent.objects.create(
             post=self.post,
-            text_md='Series body',
-            text_html='<p>Series body</p>',
+            content_html='<p>Series body</p>',
         )
         PostConfig.objects.create(
             post=self.post,

--- a/backend/src/board/tests/templates/test_author.py
+++ b/backend/src/board/tests/templates/test_author.py
@@ -37,8 +37,7 @@ class AuthorPostsPageTestCase(TestCase):
         )
         PostContent.objects.create(
             post=self.post,
-            text_md='# Author Content',
-            text_html='<h1>Author Content</h1>'
+            content_html='<h1>Author Content</h1>'
         )
         PostConfig.objects.create(
             post=self.post,
@@ -62,8 +61,7 @@ class AuthorPostsPageTestCase(TestCase):
         )
         PostContent.objects.create(
             post=post,
-            text_md=f'# {title}',
-            text_html=f'<h1>{title}</h1>',
+            content_html=f'<h1>{title}</h1>',
         )
         PostConfig.objects.create(
             post=post,

--- a/backend/src/board/tests/templates/test_edge_cases.py
+++ b/backend/src/board/tests/templates/test_edge_cases.py
@@ -41,8 +41,7 @@ class TemplateEdgeCaseTestCase(TestCase):
         )
         PostContent.objects.create(
             post=post,
-            text_md='edge case content',
-            text_html='<p>edge case content</p>',
+            content_html='<p>edge case content</p>',
         )
         PostConfig.objects.create(
             post=post,

--- a/backend/src/board/tests/templates/test_main.py
+++ b/backend/src/board/tests/templates/test_main.py
@@ -30,8 +30,7 @@ class MainPageTemplateTestCase(TestCase):
         )
         PostContent.objects.create(
             post=self.post,
-            text_md='# Test Content',
-            text_html='<h1>Test Content</h1>',
+            content_html='<h1>Test Content</h1>',
         )
         PostConfig.objects.create(
             post=self.post,
@@ -101,8 +100,7 @@ class MainPageTemplateTestCase(TestCase):
         )
         PostContent.objects.create(
             post=hidden_post,
-            text_md='Hidden content',
-            text_html='<p>Hidden content</p>',
+            content_html='<p>Hidden content</p>',
         )
         PostConfig.objects.create(
             post=hidden_post,
@@ -127,8 +125,7 @@ class MainPageTemplateTestCase(TestCase):
         )
         PostContent.objects.create(
             post=future_post,
-            text_md='Future content',
-            text_html='<p>Future content</p>',
+            content_html='<p>Future content</p>',
         )
         PostConfig.objects.create(
             post=future_post,
@@ -159,8 +156,7 @@ class MainPageTemplateTestCase(TestCase):
             )
             PostContent.objects.create(
                 post=post,
-                text_md=f'Content {i}',
-                text_html=f'<p>Content {i}</p>',
+                content_html=f'<p>Content {i}</p>',
             )
             PostConfig.objects.create(
                 post=post,

--- a/backend/src/board/tests/templates/test_post_detail.py
+++ b/backend/src/board/tests/templates/test_post_detail.py
@@ -26,8 +26,7 @@ class PostDetailViewTestCase(TestCase):
         # Create PostContent with headers
         PostContent.objects.create(
             post=self.post,
-            text_md='# Header 1\n## Header 2',
-            text_html='<h1>Header 1</h1><h2>Header 2</h2>'
+            content_html='<h1>Header 1</h1><h2>Header 2</h2>'
         )
         PostConfig.objects.create(
             post=self.post,

--- a/backend/src/board/tests/templates/test_series_static_seo.py
+++ b/backend/src/board/tests/templates/test_series_static_seo.py
@@ -60,8 +60,7 @@ class SeriesSeoMetadataTestCase(StructuredDataAssertionMixin, TestCase):
         ]:
             PostContent.objects.create(
                 post=post,
-                text_md='body',
-                text_html=content,
+                content_html=content,
             )
             PostConfig.objects.create(
                 post=post,

--- a/backend/src/board/tests/templates/test_tag.py
+++ b/backend/src/board/tests/templates/test_tag.py
@@ -35,8 +35,7 @@ class TagListPageTestCase(TestCase):
                 )
                 PostContent.objects.create(
                     post=post,
-                    text_md=f'Content about {tag_name}',
-                    text_html=f'<p>Content about {tag_name}</p>',
+                    content_html=f'<p>Content about {tag_name}</p>',
                 )
                 PostConfig.objects.create(
                     post=post,
@@ -56,8 +55,7 @@ class TagListPageTestCase(TestCase):
         )
         PostContent.objects.create(
             post=post,
-            text_md=f'{title} content',
-            text_html=f'<p>{title} content</p>',
+            content_html=f'<p>{title} content</p>',
         )
         PostConfig.objects.create(
             post=post,
@@ -144,8 +142,7 @@ class TagDetailPageTestCase(TestCase):
             )
             PostContent.objects.create(
                 post=post,
-                text_md=f'Python content {i}',
-                text_html=f'<p>Python content {i}</p>',
+                content_html=f'<p>Python content {i}</p>',
             )
             PostConfig.objects.create(
                 post=post,
@@ -165,8 +162,7 @@ class TagDetailPageTestCase(TestCase):
         )
         PostContent.objects.create(
             post=post,
-            text_md=f'{title} content',
-            text_html=f'<p>{title} content</p>',
+            content_html=f'<p>{title} content</p>',
         )
         PostConfig.objects.create(
             post=post,
@@ -244,8 +240,7 @@ class TagDetailPageTestCase(TestCase):
         )
         PostContent.objects.create(
             post=hidden_post,
-            text_md='Hidden content',
-            text_html='<p>Hidden content</p>',
+            content_html='<p>Hidden content</p>',
         )
         PostConfig.objects.create(
             post=hidden_post,
@@ -272,8 +267,7 @@ class TagDetailPageTestCase(TestCase):
         )
         PostContent.objects.create(
             post=post,
-            text_md='Unicode content',
-            text_html='<p>Unicode content</p>',
+            content_html='<p>Unicode content</p>',
         )
         PostConfig.objects.create(
             post=post,

--- a/backend/src/board/tests/templates/test_username_redirect.py
+++ b/backend/src/board/tests/templates/test_username_redirect.py
@@ -38,8 +38,7 @@ class UsernameRedirectTestCase(TestCase):
         )
         PostContent.objects.create(
             post=self.post,
-            text_md='Test content',
-            text_html='<p>Test content</p>'
+            content_html='<p>Test content</p>'
         )
         PostConfig.objects.create(
             post=self.post,
@@ -116,8 +115,7 @@ class UsernameRedirectTestCase(TestCase):
         )
         PostContent.objects.create(
             post=reader_post,
-            text_md='Reader content',
-            text_html='<p>Reader content</p>'
+            content_html='<p>Reader content</p>'
         )
         PostConfig.objects.create(
             post=reader_post,

--- a/backend/src/board/tests/test_agent_content.py
+++ b/backend/src/board/tests/test_agent_content.py
@@ -52,7 +52,6 @@ class AgentContentTestCase(TestCase):
             url='html-agent-post',
             text_md=html_content,
             text_html=html_content,
-            content_type=PostContent.ContentType.HTML,
             published_date=now,
         )
         cls.html_post.series = cls.public_series
@@ -65,7 +64,6 @@ class AgentContentTestCase(TestCase):
                 '<h2>New Editor Outcome</h2>'
                 '<p>Markdown source is empty, but HTML exists.</p>'
             ),
-            content_type=PostContent.ContentType.HTML,
             published_date=now,
         )
         cls.rich_html_post = cls.create_post(
@@ -92,7 +90,6 @@ class AgentContentTestCase(TestCase):
                 '<figcaption>Embedded reference</figcaption>'
                 '</figure>'
             ),
-            content_type=PostContent.ContentType.HTML,
             published_date=now,
         )
         cls.lossless_html_post = cls.create_post(
@@ -112,7 +109,6 @@ class AgentContentTestCase(TestCase):
                 '<p>Inline <mark data-color="yellow">highlight</mark> '
                 'and <span style="color:red">red text</span>.</p>'
             ),
-            content_type=PostContent.ContentType.HTML,
             published_date=now,
         )
         cls.hidden_post = cls.create_post(
@@ -159,7 +155,6 @@ class AgentContentTestCase(TestCase):
         published_date,
         hide: bool = False,
         text_html: str | None = None,
-        content_type: str = PostContent.ContentType.MARKDOWN,
     ) -> Post:
         post = Post.objects.create(
             title=title,
@@ -170,9 +165,7 @@ class AgentContentTestCase(TestCase):
         )
         PostContent.objects.create(
             post=post,
-            content_type=content_type,
-            text_md=text_md,
-            text_html=(
+            content_html=(
                 text_html
                 if text_html is not None
                 else f'<h2>{title}</h2><p>{text_md}</p>'

--- a/backend/src/board/views/api/developer/v1/post.py
+++ b/backend/src/board/views/api/developer/v1/post.py
@@ -59,11 +59,16 @@ class DeveloperPostAPI:
 
     @staticmethod
     def content_value(data):
-        return data.get('content', data.get('text_html', data.get('text_md', '')))
+        return data.get(
+            'markdown',
+            data.get('content_html', data.get('content', data.get('text_html', data.get('text_md', '')))),
+        )
 
     @staticmethod
-    def content_type(data, default='html'):
-        content_type = data.get('content_type', default)
+    def content_type(data):
+        if 'markdown' in data:
+            return 'markdown'
+        content_type = data.get('content_type', 'html')
         if content_type not in ('html', 'markdown'):
             raise DeveloperAuthError(
                 'post.invalid_content_type',
@@ -303,15 +308,9 @@ class DeveloperPostAPI:
             return conflict_response
 
         content = None
-        if 'content' in data or 'text_html' in data or 'text_md' in data:
+        if 'markdown' in data or 'content_html' in data or 'content' in data or 'text_html' in data or 'text_md' in data:
             content = DeveloperPostAPI.content_value(data)
-
-        content_type = None
-        if 'content_type' in data:
-            content_type = DeveloperPostAPI.content_type(
-                data,
-                post.content.content_type if hasattr(post, 'content') else 'html',
-            )
+        content_type = DeveloperPostAPI.content_type(data) if content is not None else None
 
         try:
             if post.is_draft():
@@ -384,15 +383,9 @@ class DeveloperPostAPI:
 
         data = DeveloperPostAPI.json_body(request)
         content = None
-        if 'content' in data or 'text_html' in data or 'text_md' in data:
+        if 'markdown' in data or 'content_html' in data or 'content' in data or 'text_html' in data or 'text_md' in data:
             content = DeveloperPostAPI.content_value(data)
-
-        content_type = None
-        if 'content_type' in data:
-            content_type = DeveloperPostAPI.content_type(
-                data,
-                post.content.content_type if hasattr(post, 'content') else 'html',
-            )
+        content_type = DeveloperPostAPI.content_type(data) if content is not None else None
 
         try:
             PostService.publish_draft(

--- a/backend/src/board/views/api/developer/v1/publishing.py
+++ b/backend/src/board/views/api/developer/v1/publishing.py
@@ -37,8 +37,7 @@ class DeveloperPublishingAPI:
             | Q(url__icontains=query)
             | Q(meta_description__icontains=query)
             | Q(tags__value__icontains=query)
-            | Q(content__text_md__icontains=query)
-            | Q(content__text_html__icontains=query)
+            | Q(content__content_html__icontains=query)
         )
 
     @staticmethod

--- a/backend/src/board/views/api/v1/draft.py
+++ b/backend/src/board/views/api/v1/draft.py
@@ -4,7 +4,7 @@ from django.http import Http404
 from django.http.multipartparser import MultiPartParser
 from django.shortcuts import get_object_or_404
 
-from board.models import Post, PostContent
+from board.models import Post
 from board.services.post_service import PostService, PostValidationError
 from board.modules.response import StatusDone, StatusError, ErrorCode
 
@@ -36,7 +36,7 @@ def drafts_list(request):
             files = {}
 
         title = data.get('title', '')
-        content = data.get('content', '')
+        content = data.get('content_html') or data.get('content') or data.get('text_html') or data.get('text_md') or ''
         tags = data.get('tags', '')
         subtitle = data.get('subtitle', '')
         description = data.get('description', '')
@@ -80,13 +80,8 @@ def drafts_detail(request, url):
     )
 
     if request.method == 'GET':
-        content_type = 'html'
         if hasattr(draft, 'content'):
-            content_type = draft.content.content_type
-            if content_type == 'markdown':
-                raw_content = draft.content.text_md
-            else:
-                raw_content = draft.content.text_html
+            raw_content = draft.content.content_html
         else:
             raw_content = ''
 
@@ -94,7 +89,7 @@ def drafts_detail(request, url):
             'url': draft.url,
             'title': draft.title,
             'subtitle': draft.subtitle,
-            'content_type': content_type,
+            'content_html': raw_content,
             'text_md': raw_content,
             'raw_content': raw_content,
             'tags': ','.join(draft.tagging()),
@@ -126,7 +121,7 @@ def drafts_detail(request, url):
             PostService.update_draft(
                 post=draft,
                 title=data.get('title'),
-                text_html=data.get('content'),
+                text_html=data.get('content_html') or data.get('content') or data.get('text_html') or data.get('text_md'),
                 subtitle=data.get('subtitle'),
                 description=data.get('description'),
                 series_url=data.get('series_url'),

--- a/backend/src/board/views/api/v1/post.py
+++ b/backend/src/board/views/api/v1/post.py
@@ -30,11 +30,17 @@ def post_list(request):
 
         try:
             image = request.FILES.get('image', None)
+            content_html = (
+                request.POST.get('content_html')
+                or request.POST.get('text_html')
+                or request.POST.get('text_md')
+                or ''
+            )
 
             post, post_content, post_config = PostService.create_post(
                 user=request.user,
                 title=request.POST.get('title', ''),
-                text_html=request.POST.get('text_html', ''),
+                text_html=content_html,
                 subtitle=request.POST.get('subtitle', ''),
                 description=request.POST.get('description', ''),
                 reserved_date_str=request.POST.get('reserved_date', ''),
@@ -144,11 +150,7 @@ def user_posts(request, username, url=None):
                 if not request.user == post.author:
                     raise Http404
 
-                content_type = post.content.content_type if hasattr(post, 'content') else 'html'
-                if content_type == 'markdown':
-                    text_content = post.content.text_md
-                else:
-                    text_content = post.content.text_html
+                content_html = post.content.content_html if hasattr(post, 'content') else ''
 
                 return StatusDone({
                     'image': post.get_thumbnail(),
@@ -156,13 +158,13 @@ def user_posts(request, username, url=None):
                     'subtitle': post.subtitle,
                     'url': post.url,
                     'description': post.meta_description,
-                    'content_type': content_type,
                     'series': {
                         'id': str(post.series.id),
                         'name': post.series.name,
                         'url': post.series.url,
                     } if post.series else None,
-                    'text_html': text_content,
+                    'content_html': content_html,
+                    'text_html': content_html,
                     'tags': post.tagging(),
                     'is_hide': post.config.hide,
                     'is_advertise': post.config.advertise
@@ -189,7 +191,7 @@ def user_posts(request, username, url=None):
                     'updated_date': convert_to_localtime(post.updated_date).strftime('%Y-%m-%d %H:%M'),
                     'author_image': str(post.author_image),
                     'author': post.author_username,
-                    'rendered_content': post.content.text_html,
+                    'rendered_content': post.content.content_html,
                     'count_likes': post.count_likes,
                     'count_comments': post.count_comments,
                     'is_ad': post.config.advertise,
@@ -202,7 +204,12 @@ def user_posts(request, username, url=None):
                 raise Http404
 
             title = request.POST.get('title', '')
-            text_html = request.POST.get('text_html', '')
+            text_html = (
+                request.POST.get('content_html')
+                or request.POST.get('text_html')
+                or request.POST.get('text_md')
+                or ''
+            )
 
             try:
                 PostService.update_post(

--- a/backend/src/board/views/api/v1/search.py
+++ b/backend/src/board/views/api/v1/search.py
@@ -41,7 +41,7 @@ def search(request):
         title_match |= Q(title__icontains=keyword)
         description_match |= Q(meta_description__icontains=keyword)
         tag_match |= Q(tags__value__icontains=keyword)
-        content_match |= Q(content__text_md__icontains=keyword)
+        content_match |= Q(content__content_html__icontains=keyword)
 
     search_filter = title_match | description_match | tag_match | content_match
 

--- a/backend/src/board/views/author.py
+++ b/backend/src/board/views/author.py
@@ -96,8 +96,8 @@ def author_posts(request, username):
     if search_query:
         posts = posts.filter(
             Q(title__icontains=search_query) | 
-            Q(content__text_md__icontains=search_query) | 
-            Q(content__text_html__icontains=search_query)
+            Q(content__content_html__icontains=search_query) | 
+            Q(content__content_html__icontains=search_query)
         )
     
     if tag_filter:

--- a/backend/src/board/views/post.py
+++ b/backend/src/board/views/post.py
@@ -44,7 +44,7 @@ def post_detail(request, username, post_url):
         post.visible_series_posts = PostService.get_visible_series_posts(post)
 
     # Extract table of contents from post content
-    content_html_with_ids, table_of_contents = extract_table_of_contents(post.content.text_html)
+    content_html_with_ids, table_of_contents = extract_table_of_contents(post.content.content_html)
 
     banners = BannerService.get_all_banners_for_author(author)
 
@@ -116,8 +116,12 @@ def post_editor(request, username=None, post_url=None):
         title = request.POST.get('title')
         subtitle = request.POST.get('subtitle', '')
         url = request.POST.get('url')
-        text_html = request.POST.get('text_md')  # Now receiving HTML directly from editor
-        text_md = text_html  # Keep text_md for backward compatibility, but it's now HTML
+        text_html = (
+            request.POST.get('content_html')
+            or request.POST.get('text_html')
+            or request.POST.get('text_md')
+            or ''
+        )
         content_type = request.POST.get('content_type', 'html')
         meta_description = request.POST.get('meta_description', '')
         tags_str = request.POST.get('tag', '')


### PR DESCRIPTION
## Summary

- Consolidate `PostContent` storage around `content_html` as the single source of truth
- Remove stored `text_md`, `text_html`, and `content_type` fields via migration
- Treat Markdown as an input/output compatibility format that is converted to/from HTML at the boundaries
- Update post editor, Developer API docs, public/agent-readable surfaces, feeds, search, admin, and tests to use `content_html`

## Verification

- `./scripts/manage.sh check`
- `npm run server:test -- --failfast`
- `npm run islands:type-check`
- `npm run islands:lint`

## Notes

- Existing `PostContent.text_html` is renamed to `content_html`; existing `PostContent.text_md` is removed.
- Some request-level `content_type` inputs remain as legacy compatibility hints, but they are no longer stored on `PostContent`.
