### PR TITLE
♻️ Improve draft continue flow

### DIFF
--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/DraftsSetting/DraftsSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/DraftsSetting/DraftsSetting.tsx
@@ -72,9 +72,10 @@ const DraftsSetting = () => {
 
             {draftPosts && draftPosts.length > 0 ? (
                 <div className="space-y-3">
-                    {[...draftPosts].reverse().map((draftPost) => (
+                    {draftPosts.map((draftPost) => (
                         <SettingsListItem
                             key={draftPost.url}
+                            onClick={() => handleContinueDraft(draftPost.url)}
                             left={
                                 <div className={getIconClass('default')}>
                                     <i className="fas fa-file-alt text-sm" />
@@ -83,11 +84,6 @@ const DraftsSetting = () => {
                             actions={
                                 <Dropdown
                                     items={[
-                                        {
-                                            label: '이어서 작성',
-                                            icon: 'fas fa-pen',
-                                            onClick: () => handleContinueDraft(draftPost.url)
-                                        },
                                         {
                                             label: '삭제',
                                             icon: 'fas fa-trash',
@@ -103,7 +99,7 @@ const DraftsSetting = () => {
                             <div className={`${SUBTITLE} flex items-center gap-3`}>
                                 <span className="flex items-center">
                                     <i className="fas fa-clock mr-1.5" />
-                                    {draftPost.createdDate}
+                                    마지막 수정 {draftPost.updatedDate}
                                 </span>
                                 <span className="bg-surface-subtle text-content px-2 py-0.5 rounded-md text-xs font-medium">
                                     임시 포스트

--- a/backend/src/board/tests/api/test_draft.py
+++ b/backend/src/board/tests/api/test_draft.py
@@ -1,7 +1,9 @@
 import json
+from datetime import timedelta
 
 from django.test import TestCase
 from django.contrib.auth.models import User
+from django.utils import timezone
 
 from board.models import Post, PostContent, PostConfig, Profile
 
@@ -104,6 +106,36 @@ class DraftTestCase(TestCase):
         content = json.loads(response.content)
         self.assertEqual(content['status'], 'DONE')
         self.assertEqual(len(content['body']['drafts']), 2)
+
+    def test_get_draft_list_orders_recently_updated_first(self):
+        """드래프트 목록은 최근 수정한 글부터 조회"""
+        self.client.login(username='test', password='test')
+        older_draft = Post.objects.create(
+            author=self.user,
+            title='Older Draft',
+            url='older-draft',
+            published_date=None,
+            updated_date=timezone.now() - timedelta(days=1),
+        )
+        recent_draft = Post.objects.create(
+            author=self.user,
+            title='Recent Draft',
+            url='recent-draft',
+            published_date=None,
+            updated_date=timezone.now(),
+        )
+        for draft in (older_draft, recent_draft):
+            PostContent.objects.create(post=draft, content_html='')
+            PostConfig.objects.create(post=draft)
+
+        response = self.client.get('/v1/drafts')
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'DONE')
+        self.assertEqual(
+            [draft['url'] for draft in content['body']['drafts']],
+            ['recent-draft', 'older-draft'],
+        )
 
     def test_get_draft_detail(self):
         """드래프트 상세 조회 테스트"""


### PR DESCRIPTION
## 🎯 Goal
- Make the settings draft list better match the natural writing flow.
- Let users immediately continue the most recently edited draft without opening the overflow menu.

## 🔧 Core Changes
- Show draft posts in the API-provided recent-update order instead of reversing the list in the settings UI.
- Make each draft settings row open `/write?draft={url}` directly.
- Keep the overflow menu only for deletion.
- Display the last updated date in the row metadata.
- Add a backend contract test for recent-updated-first draft ordering.

## 🤔 Key Decisions
- Reused the existing draft list API ordering (`updated_date DESC`) instead of adding frontend sorting.
- Removed the duplicate “continue writing” overflow action because the row click now owns that primary behavior.

## 🧪 Verification Guide
### How to verify
1. Open Settings > Drafts with multiple draft posts.
2. Confirm the most recently edited draft appears first.
3. Click a draft row.
4. Open the row overflow menu.

### Expected result
- Clicking a row opens the draft editor directly.
- The overflow menu only contains delete.
- Draft order is newest updated first.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)
