### PR TITLE
🐛 Centralize public post visibility filters

### DIFF
--- a/backend/src/board/feeds.py
+++ b/backend/src/board/feeds.py
@@ -3,11 +3,11 @@ import re
 from django.contrib.syndication.views import Feed
 from django.utils.feedgenerator import Rss201rev2Feed
 from django.contrib.auth.models import User
-from django.utils import timezone
 from django.urls import reverse
 
 from board.models import Post
 from board.modules.time import convert_to_localtime
+from board.services.public_post_service import PublicPostService
 
 
 class CorrectMimeTypeFeed(Rss201rev2Feed):
@@ -34,11 +34,9 @@ class SitePostsFeed(Feed):
     description = 'BLOG EXPRESS ME'
 
     def items(self):
-        posts = Post.objects.filter(
-            config__hide=False,
-            published_date__isnull=False,
-            published_date__lte=timezone.now(),
-        ).select_related('content').order_by('-published_date')
+        posts = PublicPostService.filter_public_posts(
+            Post.objects.select_related('content')
+        ).order_by('-published_date')
         return posts[:20]
 
     def item_title(self, item):
@@ -58,12 +56,9 @@ class UserPostsFeed(Feed):
     feed_type = ImageRssFeedGenerator
 
     def items(self, item):
-        posts = Post.objects.filter(
-            author=item,
-            config__hide=False,
-            published_date__isnull=False,
-            published_date__lte=timezone.now(),
-        ).select_related('content').order_by('-published_date')
+        posts = PublicPostService.filter_public_posts(
+            Post.objects.select_related('content').filter(author=item)
+        ).order_by('-published_date')
         return posts[:20]
 
     def get_object(self, request, username):

--- a/backend/src/board/models.py
+++ b/backend/src/board/models.py
@@ -253,6 +253,8 @@ class Tag(models.Model):
     def get_image(self):
         post = self.posts.filter(
             config__hide=False,
+            published_date__isnull=False,
+            published_date__lte=timezone.now(),
             tags__value=self.value,
             image__contains='images'
         ).order_by('-created_date').first()
@@ -531,7 +533,12 @@ class Series(models.Model):
         self.url = url
 
     def thumbnail(self):
-        post = Post.objects.filter(series=self, config__hide=False).first()
+        post = Post.objects.filter(
+            series=self,
+            config__hide=False,
+            published_date__isnull=False,
+            published_date__lte=timezone.now(),
+        ).first()
         return post.get_thumbnail() if post else ''
 
     def get_absolute_url(self):

--- a/backend/src/board/services/pinned_post_service.py
+++ b/backend/src/board/services/pinned_post_service.py
@@ -10,10 +10,10 @@ from typing import List, Dict, Any
 from django.contrib.auth.models import User
 from django.db import transaction
 from django.db.models import F
-from django.utils import timezone
 
 from board.models import Post, PinnedPost
 from board.modules.response import ErrorCode
+from board.services.public_post_service import PublicPostService
 
 
 class PinnedPostError(Exception):
@@ -32,7 +32,7 @@ class PinnedPostService:
     @staticmethod
     def _is_published_post(post: Post) -> bool:
         """Return True when the post is published and already visible."""
-        return bool(post.published_date and post.published_date <= timezone.now())
+        return PublicPostService.is_public(post)
 
     @staticmethod
     def get_user_pinned_posts(user: User) -> List[Dict[str, Any]]:
@@ -48,10 +48,8 @@ class PinnedPostService:
         pinned_posts = PinnedPost.objects.select_related(
             'post', 'post__author'
         ).filter(
+            PublicPostService.build_public_filter('post'),
             user=user,
-            post__config__hide=False,
-            post__published_date__isnull=False,
-            post__published_date__lte=timezone.now(),
         ).order_by('order')
 
         return [{
@@ -81,11 +79,8 @@ class PinnedPostService:
             user=user
         ).values_list('post_id', flat=True)
 
-        posts = Post.objects.filter(
-            author=user,
-            config__hide=False,
-            published_date__isnull=False,
-            published_date__lte=timezone.now(),
+        posts = PublicPostService.filter_public_posts(
+            Post.objects.filter(author=user)
         ).exclude(
             id__in=pinned_post_ids
         ).order_by('-published_date')
@@ -115,10 +110,8 @@ class PinnedPostService:
         """
         # Check if user has reached the limit
         current_count = PinnedPost.objects.filter(
+            PublicPostService.build_public_filter('post'),
             user=user,
-            post__config__hide=False,
-            post__published_date__isnull=False,
-            post__published_date__lte=timezone.now(),
         ).count()
         if current_count >= PinnedPostService.MAX_PINNED_POSTS:
             raise PinnedPostError(

--- a/backend/src/board/services/post_service.py
+++ b/backend/src/board/services/post_service.py
@@ -25,6 +25,7 @@ from board.modules.post_description import create_post_description
 from board.services.tag_service import TagService
 from board.modules.response import ErrorCode
 from board.services.post_content_service import PostContentService
+from board.services.public_post_service import PublicPostService
 from board.services.webhook_service import WebhookService
 
 
@@ -406,13 +407,12 @@ class PostService:
         current_tags = list(post.tags.values_list('value', flat=True))
         current_tag_set = set(current_tags)
 
-        candidates = Post.objects.select_related(
-            'author', 'author__profile', 'config'
-        ).prefetch_related('tags').filter(
-            tags__value__in=current_tags,
-            config__hide=False,
-            published_date__isnull=False,
-            published_date__lte=timezone.now(),
+        candidates = PublicPostService.filter_public_posts(
+            Post.objects.select_related(
+                'author', 'author__profile', 'config'
+            ).prefetch_related('tags').filter(
+                tags__value__in=current_tags,
+            )
         ).exclude(
             id=post.id
         ).annotate(
@@ -846,9 +846,8 @@ class PostService:
         if not post.series:
             return []
 
-        series_posts = list(Post.objects.filter(
-            series=post.series,
-            config__hide=False,
+        series_posts = list(PublicPostService.filter_public_posts(
+            Post.objects.filter(series=post.series)
         ).order_by('published_date'))
         
         post.series_total = len(series_posts)

--- a/backend/src/board/services/public_post_service.py
+++ b/backend/src/board/services/public_post_service.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from django.db.models import Q, QuerySet
 from django.utils import timezone
+
+if TYPE_CHECKING:
+    from board.models import Post
 
 
 class PublicPostService:
@@ -26,3 +31,13 @@ class PublicPostService:
     @staticmethod
     def filter_public_posts(queryset: QuerySet) -> QuerySet:
         return queryset.filter(PublicPostService.build_public_filter())
+
+    @staticmethod
+    def is_public(post: Post) -> bool:
+        if post.published_date is None:
+            return False
+        if post.published_date > timezone.now():
+            return False
+        if hasattr(post, 'config') and post.config.hide:
+            return False
+        return True

--- a/backend/src/board/services/tag_service.py
+++ b/backend/src/board/services/tag_service.py
@@ -142,9 +142,8 @@ class TagService:
         Returns:
             Post instance or None
         """
-        return Post.objects.filter(
-            url=tag_name,
-            config__hide=False
+        return PublicPostService.filter_public_posts(
+            Post.objects.filter(url=tag_name)
         ).annotate(
             author_username=F('author__username'),
             author_image=F('author__profile__avatar'),

--- a/backend/src/board/services/user_service.py
+++ b/backend/src/board/services/user_service.py
@@ -12,7 +12,7 @@ from typing import Optional, Dict, Any, List
 
 from django.contrib.auth.models import User
 from django.db import transaction
-from django.db.models import F, Q, Count, Case, When
+from django.db.models import F, Q, Count
 from django.utils import timezone
 
 from board.models import (
@@ -121,18 +121,16 @@ class UserService:
         Returns:
             List of tag dictionaries
         """
-        tags = Tag.objects.filter(
+        public_post_filter = PublicPostService.build_public_filter('posts') & Q(
             posts__author=user,
-            posts__config__hide=False,
+        )
+        tags = Tag.objects.filter(
+            public_post_filter,
         ).annotate(
             count=Count(
-                Case(
-                    When(
-                        posts__author=user,
-                        posts__config__hide=False,
-                        then='posts'
-                    ),
-                )
+                'posts',
+                filter=public_post_filter,
+                distinct=True,
             )
         ).order_by('-count')
 
@@ -156,7 +154,8 @@ class UserService:
         pinned_posts = list(PinnedPost.objects.select_related(
             'post', 'user', 'user__profile'
         ).filter(
-            user=user
+            PublicPostService.build_public_filter('post'),
+            user=user,
         ).order_by('order')[:6])
 
         if pinned_posts:
@@ -170,13 +169,10 @@ class UserService:
                 'author': pinned_post.user.username,
             } for pinned_post in pinned_posts]
 
-        posts = Post.objects.select_related(
-            'config', 'author', 'author__profile'
-        ).filter(
-            author=user,
-            config__hide=False,
-            published_date__isnull=False,
-            published_date__lte=timezone.now(),
+        posts = PublicPostService.filter_public_posts(
+            Post.objects.select_related(
+                'config', 'author', 'author__profile'
+            ).filter(author=user)
         ).annotate(
             likes_count=Count('likes', distinct=True),
         ).order_by('-likes_count', '-published_date')[:6]
@@ -205,13 +201,10 @@ class UserService:
         """
         cutoff_date = timezone.now() - datetime.timedelta(days=days)
 
-        posts = Post.objects.filter(
+        posts = PublicPostService.filter_public_posts(Post.objects.filter(
             published_date__gte=cutoff_date,
-            published_date__isnull=False,
-            published_date__lte=timezone.now(),
             author=user,
-            config__hide=False
-        ).order_by('-published_date')
+        )).order_by('-published_date')
 
         series = Series.objects.filter(
             created_date__gte=cutoff_date,
@@ -220,10 +213,10 @@ class UserService:
         ).order_by('-created_date')
 
         comments = Comment.objects.filter(
+            PublicPostService.build_public_filter('post'),
             created_date__gte=cutoff_date,
             created_date__lte=timezone.now(),
             author=user,
-            post__config__hide=False
         ).order_by('-created_date')
 
         activity = sorted(

--- a/backend/src/board/tests/services/test_public_post_service.py
+++ b/backend/src/board/tests/services/test_public_post_service.py
@@ -46,6 +46,13 @@ class PublicPostServiceTestCase(TestCase):
 
         self.assertEqual(list(posts), [self.public_post])
 
+    def test_is_public_matches_public_post_rules(self):
+        """단일 포스트 공개 여부 검사도 공개 글 필터와 같은 기준을 따른다."""
+        self.assertTrue(PublicPostService.is_public(self.public_post))
+        self.assertFalse(PublicPostService.is_public(Post.objects.get(url='draft-post')))
+        self.assertFalse(PublicPostService.is_public(Post.objects.get(url='future-post')))
+        self.assertFalse(PublicPostService.is_public(Post.objects.get(url='hidden-post')))
+
     def test_build_public_filter_supports_related_post_prefix(self):
         """관계 prefix를 지정하면 공개 글이 있는 부모 객체를 안전하게 필터링한다."""
         series = Series.objects.filter(

--- a/backend/src/board/tests/templates/test_post_detail.py
+++ b/backend/src/board/tests/templates/test_post_detail.py
@@ -1,12 +1,14 @@
 """
 Tests for Post Detail View and ToC structure
 """
+import datetime
+
 from django.test import TestCase, Client
 from django.contrib.auth.models import User
 from django.urls import reverse
 from django.utils import timezone
 
-from board.models import Post, PostContent, PostConfig, SiteSetting
+from board.models import Post, PostContent, PostConfig, Series, SiteSetting
 
 class PostDetailViewTestCase(TestCase):
     def setUp(self):
@@ -55,6 +57,118 @@ class PostDetailViewTestCase(TestCase):
         self.assertEqual(toc[0]['level'], 1)
         self.assertEqual(toc[1]['text'], 'Header 2')
         self.assertEqual(toc[1]['level'], 2)
+
+    def test_post_detail_series_list_hides_drafts_and_future_posts(self):
+        """본문 상세의 시리즈 목록은 공개 발행 글만 노출한다."""
+        series = Series.objects.create(
+            owner=self.user,
+            name='Test Series',
+            url='test-series',
+        )
+        self.post.series = series
+        self.post.save(update_fields=['series'])
+
+        published_post = Post.objects.create(
+            title='Published Series Post',
+            url='published-series-post',
+            author=self.user,
+            series=series,
+            published_date=timezone.now(),
+        )
+        PostContent.objects.create(post=published_post, content_html='<p>Published</p>')
+        PostConfig.objects.create(post=published_post, hide=False)
+
+        draft_post = Post.objects.create(
+            title='Draft Series Post',
+            url='draft-series-post',
+            author=self.user,
+            series=series,
+            published_date=None,
+        )
+        PostContent.objects.create(post=draft_post, content_html='<p>Draft</p>')
+        PostConfig.objects.create(post=draft_post, hide=False)
+
+        future_post = Post.objects.create(
+            title='Future Series Post',
+            url='future-series-post',
+            author=self.user,
+            series=series,
+            published_date=timezone.now() + datetime.timedelta(days=1),
+        )
+        PostContent.objects.create(post=future_post, content_html='<p>Future</p>')
+        PostConfig.objects.create(post=future_post, hide=False)
+
+        url = reverse('post_detail', kwargs={
+            'username': 'testauthor',
+            'post_url': 'test-post'
+        })
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Published Series Post')
+        self.assertNotContains(response, 'Draft Series Post')
+        self.assertNotContains(response, 'Future Series Post')
+
+        visible_titles = [
+            series_post.title
+            for series_post in response.context['post'].visible_series_posts
+        ]
+        self.assertEqual(visible_titles, ['Test Post', 'Published Series Post'])
+
+    def test_post_detail_rejects_draft_for_non_owner(self):
+        """임시글 상세 URL을 알아도 작성자가 아니면 볼 수 없다."""
+        draft = Post.objects.create(
+            title='Private Draft',
+            url='private-draft',
+            author=self.user,
+            published_date=None,
+        )
+        PostContent.objects.create(post=draft, content_html='<p>Draft</p>')
+        PostConfig.objects.create(post=draft, hide=False)
+
+        response = self.client.get(reverse('post_detail', kwargs={
+            'username': 'testauthor',
+            'post_url': 'private-draft'
+        }))
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_post_detail_rejects_draft_for_owner(self):
+        """작성자여도 임시글은 공개 상세 화면으로 렌더링하지 않는다."""
+        draft = Post.objects.create(
+            title='Private Draft',
+            url='private-draft',
+            author=self.user,
+            published_date=None,
+        )
+        PostContent.objects.create(post=draft, content_html='<p>Draft</p>')
+        PostConfig.objects.create(post=draft, hide=False)
+
+        self.client.login(username='testauthor', password='password123')
+        response = self.client.get(reverse('post_detail', kwargs={
+            'username': 'testauthor',
+            'post_url': 'private-draft'
+        }))
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_post_detail_rejects_future_post_for_non_owner(self):
+        """미래 발행글 상세 URL을 알아도 작성자가 아니면 볼 수 없다."""
+        future_post = Post.objects.create(
+            title='Future Post',
+            url='future-post',
+            author=self.user,
+            published_date=timezone.now() + datetime.timedelta(days=1),
+        )
+        PostContent.objects.create(post=future_post, content_html='<p>Future</p>')
+        PostConfig.objects.create(post=future_post, hide=False)
+
+        response = self.client.get(reverse('post_detail', kwargs={
+            'username': 'testauthor',
+            'post_url': 'future-post'
+        }))
+
+        self.assertEqual(response.status_code, 404)
 
     def test_post_detail_hides_agent_link_copy_option_when_aeo_disabled(self):
         """AEO가 꺼져 있으면 에이전트 링크 복사 옵션을 노출하지 않는다."""

--- a/backend/src/board/views/api/developer/v1/post.py
+++ b/backend/src/board/views/api/developer/v1/post.py
@@ -12,6 +12,7 @@ from board.services.developer_token_service import (
     DeveloperTokenService,
 )
 from board.services.post_service import PostService, PostValidationError
+from board.services.public_post_service import PublicPostService
 
 
 class DeveloperPostAPI:
@@ -130,11 +131,7 @@ class DeveloperPostAPI:
         if status == 'draft':
             return queryset.filter(published_date__isnull=True)
         if status == 'published':
-            return queryset.filter(
-                published_date__isnull=False,
-                published_date__lte=now,
-                config__hide=False,
-            )
+            return PublicPostService.filter_public_posts(queryset)
         if status == 'scheduled':
             return queryset.filter(published_date__gt=now)
         if status == 'hidden':

--- a/backend/src/board/views/api/v1/author.py
+++ b/backend/src/board/views/api/v1/author.py
@@ -8,6 +8,7 @@ from django.core.cache import cache
 
 from board.models import User, Post, Comment, PostLikes
 from board.services import UserService
+from board.services.public_post_service import PublicPostService
 from board.modules.response import StatusDone, StatusError, ErrorCode
 
 
@@ -35,10 +36,10 @@ def get_author_heatmap(request, username):
 
         # Fetch posts
         posts = Post.objects.filter(
+            PublicPostService.build_public_filter(),
             author=user,
             published_date__date__gte=start_date,
             published_date__date__lte=end_date,
-            config__hide=False
         ).values('published_date__date').annotate(count=Count('id'))
 
         for post in posts:
@@ -47,10 +48,10 @@ def get_author_heatmap(request, username):
 
         # Fetch comments
         comments = Comment.objects.filter(
+            PublicPostService.build_public_filter('post'),
             author=user,
             created_date__date__gte=start_date,
             created_date__date__lte=end_date,
-            post__config__hide=False
         ).values('created_date__date').annotate(count=Count('id'))
 
         for comment in comments:
@@ -59,10 +60,10 @@ def get_author_heatmap(request, username):
 
         # Fetch likes
         likes = PostLikes.objects.filter(
+            PublicPostService.build_public_filter('post'),
             user=user,
             created_date__date__gte=start_date,
             created_date__date__lte=end_date,
-            post__config__hide=False
         ).values('created_date__date').annotate(count=Count('id'))
 
         for like in likes:

--- a/backend/src/board/views/api/v1/search.py
+++ b/backend/src/board/views/api/v1/search.py
@@ -2,12 +2,12 @@ import time
 
 from django.db.models import Case, F, IntegerField, Max, Q, Value, When
 from django.http import Http404
-from django.utils import timezone
 
 from board.models import Post
 from board.modules.paginator import Paginator
 from board.modules.response import ErrorCode, StatusDone, StatusError
 from board.modules.time import convert_to_localtime
+from board.services.public_post_service import PublicPostService
 
 
 def search(request):
@@ -45,11 +45,8 @@ def search(request):
 
     search_filter = title_match | description_match | tag_match | content_match
 
-    posts = Post.objects.filter(
-        search_filter,
-        config__hide=False,
-        published_date__isnull=False,
-        published_date__lte=timezone.now(),
+    posts = PublicPostService.filter_public_posts(
+        Post.objects.filter(search_filter)
     )
 
     if username:

--- a/backend/src/board/views/authors.py
+++ b/backend/src/board/views/authors.py
@@ -5,6 +5,8 @@ from django.contrib.auth.models import User
 from django.db.models import Count, Q
 from django.core.paginator import Paginator as DjangoPaginator, EmptyPage, PageNotAnInteger
 
+from board.services.public_post_service import PublicPostService
+
 DEFAULT_AVATAR_URL = '/resources/assets/images/default-avatar.jpg'
 
 
@@ -21,12 +23,13 @@ def authors_view(request):
     if query:
         start_time = time.time()
 
+        public_post_filter = PublicPostService.build_public_filter('post')
         users = User.objects.select_related('profile').filter(
             Q(username__icontains=query) |
             Q(first_name__icontains=query) |
             Q(profile__bio__icontains=query)
         ).annotate(
-            post_count=Count('post', filter=Q(post__config__hide=False))
+            post_count=Count('post', filter=public_post_filter)
         ).order_by('-post_count')
         
         paginator = DjangoPaginator(users, 10)
@@ -59,8 +62,9 @@ def authors_view(request):
             'page_count': paginator.num_pages,
         }
     else:
+        public_post_filter = PublicPostService.build_public_filter('post')
         authors = User.objects.select_related('profile').annotate(
-            post_count=Count('post', filter=Q(post__config__hide=False))
+            post_count=Count('post', filter=public_post_filter)
         ).filter(
             post_count__gt=0
         ).order_by('-post_count')

--- a/backend/src/board/views/main.py
+++ b/backend/src/board/views/main.py
@@ -1,19 +1,17 @@
 from django.shortcuts import render
-from django.utils import timezone
 from django.db.models import F, Count, Exists, OuterRef
 
 from board.models import Post, PostLikes
 from board.modules.paginator import Paginator
 from board.modules.time import time_since
+from board.services.public_post_service import PublicPostService
 
 
 def index(request):
-    posts = Post.objects.select_related(
-        'config', 'series', 'author', 'author__profile'
-    ).filter(
-        published_date__isnull=False,
-        published_date__lte=timezone.now(),
-        config__hide=False,
+    posts = PublicPostService.filter_public_posts(
+        Post.objects.select_related(
+            'config', 'series', 'author', 'author__profile'
+        )
     ).annotate(
         author_username=F('author__username'),
         author_image=F('author__profile__avatar'),
@@ -54,5 +52,4 @@ def index(request):
     }
 
     return render(request, 'board/posts/post_list.html', context)
-
 

--- a/backend/src/board/views/post.py
+++ b/backend/src/board/views/post.py
@@ -10,6 +10,7 @@ from board.models import Post, Series, PostLikes, UsernameChangeLog
 from board.services.post_service import PostService, PostValidationError
 from board.services.banner_service import BannerService
 from board.services.agent_content_service import AgentContentService
+from board.services.public_post_service import PublicPostService
 from board.html_utils import extract_table_of_contents
 
 def post_detail(request, username, post_url):
@@ -29,7 +30,10 @@ def post_detail(request, username, post_url):
     except Http404:
         raise Http404("Post does not exist")
 
-    if post.config.hide and (not request.user.is_authenticated or request.user != author):
+    is_owner = request.user.is_authenticated and request.user == author
+    if not PublicPostService.is_public(post) and (
+        not is_owner or post.published_date is None
+    ):
         raise Http404("Post does not exist")
 
     post.created_date_display = post.published_date.strftime('%Y-%m-%d')

--- a/backend/src/board/views/series.py
+++ b/backend/src/board/views/series.py
@@ -1,12 +1,12 @@
 from django.shortcuts import render, get_object_or_404
 from django.contrib.auth.models import User
 from django.db.models import Count, Exists, OuterRef
-from django.utils import timezone
 from django.http import Http404
 
 from board.models import Post, Series, PostLikes
 from board.services.agent_content_service import AgentContentService
 from board.services.discovery_metadata_service import DiscoveryMetadataService
+from board.services.public_post_service import PublicPostService
 
 
 def series_detail(request, username, series_url):
@@ -29,13 +29,10 @@ def series_detail(request, username, series_url):
 
     order_by = 'published_date' if sort_order == 'asc' else '-published_date'
 
-    all_posts = Post.objects.select_related(
-        'config', 'author', 'author__profile'
-    ).filter(
-        series=series,
-        published_date__isnull=False,
-        published_date__lte=timezone.now(),
-        config__hide=False,
+    all_posts = PublicPostService.filter_public_posts(
+        Post.objects.select_related(
+            'config', 'author', 'author__profile'
+        ).filter(series=series)
     ).annotate(
         count_likes=Count('likes', distinct=True),
         count_comments=Count('comments', distinct=True),


### PR DESCRIPTION
## 🎯 Goal
- Prevent draft and scheduled posts from leaking into public post surfaces such as post detail series lists.
- Reduce duplicated public visibility checks so future public surfaces share the same rule.

## 🔧 Core Changes
- Centralized public post visibility through `PublicPostService` helpers.
- Updated public surfaces to use the shared filter, including main lists, series lists, RSS, search, related posts, pinned posts, author/tag surfaces, and developer API published status.
- Added post detail guards so non-public posts cannot be rendered through public detail URLs.
- Added regression coverage for draft/scheduled posts in series lists and detail routes.

## 🤔 Key Decisions
- Used `PublicPostService.filter_public_posts()` and `build_public_filter()` for QuerySet-based code.
- Added `PublicPostService.is_public()` for single post checks.
- Left admin/management-specific filters mostly untouched because some of those screens intentionally distinguish published, scheduled, hidden, and draft states.

## 🧪 Verification Guide
### How to verify
1. Open a published post that belongs to a series containing a draft or future scheduled post.
2. Confirm the post detail series card only lists public posts.
3. Confirm draft/future post direct URLs return 404 on the public detail route.

### Expected result
- Draft, hidden, and scheduled posts are excluded from public surfaces.
- Published visible posts continue to render normally.

## ✅ Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [x] Tests completed
- [ ] Documentation updated (if needed)

Tested with:

```bash
npm run server:test -- board.tests.templates.test_post_detail board.tests.services.test_public_post_service board.tests.templates.test_main board.tests.templates.test_series_static_seo board.tests.api.test_search_api board.tests.api.test_pinned_post board.tests.api.test_user_api board.tests.templates.test_author board.tests.templates.test_tag board.tests.test_agent_content board.tests.api.test_developer_posts
```
