### PR TITLE
🐛 Remove stale admin profile role references

### DIFF
--- a/backend/src/board/admin/user.py
+++ b/backend/src/board/admin/user.py
@@ -247,7 +247,7 @@ class ProfileAdmin(admin.ModelAdmin):
     list_per_page = LIST_PER_PAGE_DEFAULT
     save_on_top = True
 
-    actions = ['set_role_editor', 'set_role_reader', 'set_role_admin']
+    actions = ['set_role_editor', 'set_role_reader']
 
     fieldsets = (
         ('사용자 정보', {
@@ -255,7 +255,7 @@ class ProfileAdmin(admin.ModelAdmin):
         }),
         ('권한 설정', {
             'fields': ('role',),
-            'description': 'ADMIN: 전체 관리 권한 / EDITOR: 글 작성 및 통계 / READER: 읽기만 가능'
+            'description': 'EDITOR: 글 작성 및 통계 / READER: 읽기만 가능'
         }),
         ('프로필 정보', {
             'fields': ('bio', 'homepage', 'avatar', 'avatar_preview', 'cover', 'cover_preview'),
@@ -328,8 +328,3 @@ class ProfileAdmin(admin.ModelAdmin):
         count = queryset.update(role=Profile.Role.READER)
         self.message_user(request, f'{count}명의 프로필을 독자로 변경했습니다.')
     set_role_reader.short_description = '역할을 독자로 변경'
-
-    def set_role_admin(self, request: HttpRequest, queryset: QuerySet[Profile]) -> None:
-        count = queryset.update(role=Profile.Role.ADMIN)
-        self.message_user(request, f'{count}명의 프로필을 관리자로 변경했습니다.')
-    set_role_admin.short_description = '역할을 관리자로 변경'

--- a/backend/src/board/services/auth_service.py
+++ b/backend/src/board/services/auth_service.py
@@ -17,7 +17,7 @@ from django.contrib.auth.models import User
 from django.core.cache import cache
 from django.core.files import File
 from django.db import transaction
-from django.db.models import Count, Case, When, Value, Exists, OuterRef, Q
+from django.db.models import Count, Case, When, Value, Exists, OuterRef
 
 from board.constants.config_meta import CONFIG_TYPE
 from board.models import (
@@ -249,7 +249,7 @@ class AuthService:
             ),
             has_editor_role=Case(
                 When(
-                    Q(profile__role='EDITOR') | Q(profile__role='ADMIN'),
+                    profile__role=Profile.Role.EDITOR,
                     then=Value(True)
                 ),
                 default=Value(False)

--- a/backend/src/board/sitemaps.py
+++ b/backend/src/board/sitemaps.py
@@ -30,9 +30,9 @@ class UserSitemap(Sitemap):
     priority = 0.6
 
     def items(self):
-        # Only include users who have posts and are editors (EDITOR or ADMIN role)
+        # Only include users who have public posts and can publish content.
         users = PublicPostService.filter_public_posts(Post.objects).filter(
-            author__profile__role__in=[Profile.Role.EDITOR, Profile.Role.ADMIN]
+            author__profile__role=Profile.Role.EDITOR,
         ).values_list('author__username', flat=True).distinct()
         return users
 

--- a/backend/src/board/tests/test_profile_role_policy.py
+++ b/backend/src/board/tests/test_profile_role_policy.py
@@ -1,0 +1,74 @@
+from django.contrib.admin.sites import AdminSite
+from django.contrib.auth.models import User
+from django.test import RequestFactory, TestCase
+from django.utils import timezone
+
+from board.admin.user import ProfileAdmin
+from board.models import Config, Post, PostConfig, PostContent, Profile
+from board.services.auth_service import AuthService
+from board.sitemaps import UserSitemap
+
+
+class ProfileRolePolicyTestCase(TestCase):
+    def create_author(self, username: str, role: str, is_staff: bool = False) -> User:
+        user = User.objects.create_user(
+            username=username,
+            email=f'{username}@example.com',
+            password='password123',
+            is_staff=is_staff,
+        )
+        Profile.objects.create(user=user, role=role)
+        post = Post.objects.create(
+            title=f'{username} Post',
+            url=f'{username}-post',
+            author=user,
+            published_date=timezone.now(),
+        )
+        PostContent.objects.create(post=post, content_html='<p>Public</p>')
+        PostConfig.objects.create(post=post, hide=False)
+        return user
+
+    def test_user_sitemap_uses_existing_editor_role_only(self):
+        editor = self.create_author('editor-author', Profile.Role.EDITOR)
+        self.create_author('reader-author', Profile.Role.READER)
+        self.create_author('staff-reader-author', Profile.Role.READER, is_staff=True)
+
+        items = list(UserSitemap().items())
+
+        self.assertEqual(items, [editor.username])
+
+    def test_profile_admin_actions_match_defined_roles(self):
+        admin_user = User.objects.create_superuser(
+            username='admin',
+            email='admin@example.com',
+            password='password123',
+        )
+        admin_instance = ProfileAdmin(Profile, AdminSite())
+        request = RequestFactory().get('/admin/board/profile/')
+        request.user = admin_user
+
+        actions = admin_instance.get_actions(request)
+
+        self.assertIn('set_role_editor', actions)
+        self.assertIn('set_role_reader', actions)
+        self.assertNotIn('set_role_admin', actions)
+
+    def test_login_editor_role_ignores_legacy_admin_literal(self):
+        editor = User.objects.create_user(
+            username='login-editor',
+            email='login-editor@example.com',
+            password='password123',
+        )
+        Profile.objects.create(user=editor, role=Profile.Role.EDITOR)
+        Config.objects.create(user=editor)
+
+        legacy_admin = User.objects.create_user(
+            username='legacy-admin',
+            email='legacy-admin@example.com',
+            password='password123',
+        )
+        Profile.objects.create(user=legacy_admin, role='ADMIN')
+        Config.objects.create(user=legacy_admin)
+
+        self.assertTrue(AuthService.get_user_login_data(editor)['has_editor_role'])
+        self.assertFalse(AuthService.get_user_login_data(legacy_admin)['has_editor_role'])


### PR DESCRIPTION
## 🎯 Goal
- Remove stale `Profile.Role.ADMIN` references after the profile role enum was reduced to `READER` and `EDITOR`.
- Prevent sitemap/auth/admin code from crashing or drifting on an undefined role.

## 🔧 Core Changes
- User sitemap now includes authors with public posts and `EDITOR` profile role only.
- Profile admin actions now expose only defined role transitions: editor and reader.
- Login data now treats only `Profile.Role.EDITOR` as `has_editor_role`.
- Added regression tests for sitemap, admin actions, and legacy literal `ADMIN` login behavior.

## 🤔 Key Decisions
- Did not reintroduce an `ADMIN` profile role because Django `is_staff` already represents admin access elsewhere.
- Legacy literal `ADMIN` rows are no longer treated as editors; they should be normalized separately if they exist in production data.

## 🧪 Verification Guide
### How to verify
1. Open `/user/sitemap.xml` or instantiate `UserSitemap().items()`.
2. Open Profile admin actions.
3. Log in with an editor and with a legacy `profile.role = 'ADMIN'` row in test data.

### Expected result
- Sitemap does not crash on undefined `Profile.Role.ADMIN`.
- Profile admin has no admin-role action.
- Only `EDITOR` profile role returns `has_editor_role = true`.

## ✅ Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [x] Tests completed
- [ ] Documentation updated (if needed)

Tested with:

```bash
npm run server:test -- board.tests.test_profile_role_policy board.tests.api.test_auth board.tests.test_agent_content board.tests.admin.test_post_admin board.tests.admin.test_admin_service
```

Sub-agent review:
- No blocking findings; safe to open.
