### PR TITLE
♻️ Introduce API permission guard for pinned posts

### DIFF
--- a/backend/src/board/services/api_permission_service.py
+++ b/backend/src/board/services/api_permission_service.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from django.contrib.auth.models import AnonymousUser, User
+from django.http import HttpResponse
+
+from board.modules.response import ErrorCode, StatusError
+
+
+class ApiPermissionService:
+    """Shared permission helpers for API views that return StatusError."""
+
+    @staticmethod
+    def require_login(user: User | AnonymousUser) -> Optional[HttpResponse]:
+        if not user.is_authenticated:
+            return StatusError(ErrorCode.NEED_LOGIN, '로그인이 필요합니다.')
+        return None
+
+    @staticmethod
+    def require_owner(user: User | AnonymousUser, owner: User) -> Optional[HttpResponse]:
+        login_error = ApiPermissionService.require_login(user)
+        if login_error:
+            return login_error
+
+        if user != owner:
+            return StatusError(ErrorCode.AUTHENTICATION, '권한이 없습니다.')
+
+        return None

--- a/backend/src/board/views/api/v1/pinned_post.py
+++ b/backend/src/board/views/api/v1/pinned_post.py
@@ -5,6 +5,7 @@ from django.shortcuts import get_object_or_404
 
 from board.models import User
 from board.services import PinnedPostService
+from board.services.api_permission_service import ApiPermissionService
 from board.services.pinned_post_service import PinnedPostError
 from board.modules.response import StatusDone, StatusError, ErrorCode
 
@@ -26,12 +27,9 @@ def pinned_posts(request, username):
             'max_count': PinnedPostService.MAX_PINNED_POSTS,
         })
 
-    # POST, DELETE require authentication and ownership
-    if not request.user.is_authenticated:
-        return StatusError(ErrorCode.NEED_LOGIN, '로그인이 필요합니다.')
-
-    if request.user != user:
-        return StatusError(ErrorCode.AUTHENTICATION, '권한이 없습니다.')
+    permission_error = ApiPermissionService.require_owner(request.user, user)
+    if permission_error:
+        return permission_error
 
     if request.method == 'POST':
         post_url = request.POST.get('post_url', '')
@@ -67,11 +65,9 @@ def pinned_posts_order(request, username):
     """
     user = get_object_or_404(User, username=username)
 
-    if not request.user.is_authenticated:
-        return StatusError(ErrorCode.NEED_LOGIN, '로그인이 필요합니다.')
-
-    if request.user != user:
-        return StatusError(ErrorCode.AUTHENTICATION, '권한이 없습니다.')
+    permission_error = ApiPermissionService.require_owner(request.user, user)
+    if permission_error:
+        return permission_error
 
     if request.method == 'PUT':
         put = QueryDict(request.body)
@@ -102,11 +98,9 @@ def pinnable_posts(request, username):
     """
     user = get_object_or_404(User, username=username)
 
-    if not request.user.is_authenticated:
-        return StatusError(ErrorCode.NEED_LOGIN, '로그인이 필요합니다.')
-
-    if request.user != user:
-        return StatusError(ErrorCode.AUTHENTICATION, '권한이 없습니다.')
+    permission_error = ApiPermissionService.require_owner(request.user, user)
+    if permission_error:
+        return permission_error
 
     if request.method == 'GET':
         posts = PinnedPostService.get_pinnable_posts(user)


### PR DESCRIPTION
## 🎯 Goal
- Start centralizing repeated API permission checks without changing behavior.
- Use pinned-post APIs as a small low-risk first migration target.

## 🔧 Core Changes
- Added `ApiPermissionService` for API views that return `StatusError`.
- Introduced `require_login()` and `require_owner()` helpers.
- Replaced repeated login/owner checks in pinned-post API views.

## 🤔 Key Decisions
- Kept the first guard small instead of migrating all APIs at once.
- Preserved existing response semantics:
  - unauthenticated users get `error:NL`
  - non-owner users get `error:AT`
  - public pinned-post GET remains public

## 🧪 Verification Guide
### How to verify
1. Call pinned-post mutation endpoints without login.
2. Call them while logged in as a different user.
3. Call public pinned-post GET without login.

### Expected result
- Permission responses match previous behavior.
- Public GET remains accessible.

## ✅ Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [x] Tests completed
- [ ] Documentation updated (if needed)

Tested with:

```bash
npm run server:test -- board.tests.api.test_pinned_post
```

Sub-agent review:
- No blocking findings; safe to open.
