### PR TITLE
♻️ Expand API permission guard to editor APIs

### DIFF
--- a/backend/src/board/services/api_permission_service.py
+++ b/backend/src/board/services/api_permission_service.py
@@ -13,8 +13,19 @@ class ApiPermissionService:
 
     @staticmethod
     def require_login(user: User | AnonymousUser) -> Optional[HttpResponse]:
-        if not user.is_authenticated:
+        if not user.is_authenticated or not user.is_active:
             return StatusError(ErrorCode.NEED_LOGIN, '로그인이 필요합니다.')
+        return None
+
+    @staticmethod
+    def require_editor(user: User | AnonymousUser) -> Optional[HttpResponse]:
+        login_error = ApiPermissionService.require_login(user)
+        if login_error:
+            return login_error
+
+        if not hasattr(user, 'profile') or not user.profile.is_editor():
+            return StatusError(ErrorCode.REJECT, '에디터 권한이 필요합니다.')
+
         return None
 
     @staticmethod

--- a/backend/src/board/tests/api/test_banner.py
+++ b/backend/src/board/tests/api/test_banner.py
@@ -21,6 +21,13 @@ class BannerAPITestCase(TestCase):
         profile.role = Profile.Role.EDITOR
         profile.save()
 
+        cls.normal_user = User.objects.create_user(
+            username='normaluser',
+            password='test',
+            email='normal@test.com',
+        )
+        Profile.objects.create(user=cls.normal_user)
+
     def setUp(self):
         self.client = Client(HTTP_USER_AGENT='Mozilla/5.0')
         self.client.login(username='test', password='test')
@@ -45,6 +52,16 @@ class BannerAPITestCase(TestCase):
         content = json.loads(response.content)
         self.assertEqual(content['status'], 'ERROR')
         self.assertEqual(content['errorCode'], 'error:NL')
+
+    def test_get_banners_normal_user(self):
+        """일반 유저(비에디터)가 배너 조회 시 권한 거부 테스트"""
+        client = Client(HTTP_USER_AGENT='Mozilla/5.0')
+        client.login(username='normaluser', password='test')
+        response = client.get('/v1/banners')
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'ERROR')
+        self.assertEqual(content['errorCode'], 'error:RJ')
 
     def test_get_banners_empty(self):
         """배너 목록 조회 - 빈 목록 테스트"""

--- a/backend/src/board/tests/services/test_api_permission_service.py
+++ b/backend/src/board/tests/services/test_api_permission_service.py
@@ -1,0 +1,54 @@
+import json
+
+from django.contrib.auth.models import AnonymousUser, User
+from django.test import TestCase
+
+from board.models import Profile
+from board.services.api_permission_service import ApiPermissionService
+
+
+class ApiPermissionServiceTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.editor = User.objects.create_user(
+            username='permission-editor',
+            password='test',
+            email='editor@example.com',
+        )
+        Profile.objects.create(user=cls.editor, role=Profile.Role.EDITOR)
+
+        cls.normal_user = User.objects.create_user(
+            username='permission-normal',
+            password='test',
+            email='normal@example.com',
+        )
+        Profile.objects.create(user=cls.normal_user)
+
+        cls.inactive_user = User.objects.create_user(
+            username='permission-inactive',
+            password='test',
+            email='inactive@example.com',
+            is_active=False,
+        )
+        Profile.objects.create(user=cls.inactive_user, role=Profile.Role.EDITOR)
+
+    def assert_error_code(self, response, error_code):
+        self.assertIsNotNone(response)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'ERROR')
+        self.assertEqual(content['errorCode'], error_code)
+
+    def test_require_login_rejects_anonymous_and_inactive_users(self):
+        self.assert_error_code(ApiPermissionService.require_login(AnonymousUser()), 'error:NL')
+        self.assert_error_code(ApiPermissionService.require_login(self.inactive_user), 'error:NL')
+
+    def test_require_login_allows_active_user(self):
+        self.assertIsNone(ApiPermissionService.require_login(self.normal_user))
+
+    def test_require_editor_rejects_anonymous_inactive_and_normal_users(self):
+        self.assert_error_code(ApiPermissionService.require_editor(AnonymousUser()), 'error:NL')
+        self.assert_error_code(ApiPermissionService.require_editor(self.inactive_user), 'error:NL')
+        self.assert_error_code(ApiPermissionService.require_editor(self.normal_user), 'error:RJ')
+
+    def test_require_editor_allows_editor(self):
+        self.assertIsNone(ApiPermissionService.require_editor(self.editor))

--- a/backend/src/board/views/api/v1/banner.py
+++ b/backend/src/board/views/api/v1/banner.py
@@ -3,6 +3,7 @@ from django.http import Http404, QueryDict
 from django.shortcuts import get_object_or_404
 from board.models import SiteBanner, SiteContentScope
 from board.modules.response import StatusDone, StatusError, ErrorCode
+from board.services.api_permission_service import ApiPermissionService
 from board.html_utils import sanitize_html
 
 
@@ -16,12 +17,9 @@ def banner(request, banner_id=None):
     PUT /v1/banners/:id - Update banner
     DELETE /v1/banners/:id - Delete banner
     """
-    if not request.user.is_active:
-        return StatusError(ErrorCode.NEED_LOGIN)
-
-    # Check if user is an editor
-    if not request.user.profile.is_editor():
-        return StatusError(ErrorCode.REJECT, '에디터 권한이 필요합니다.')
+    permission_error = ApiPermissionService.require_editor(request.user)
+    if permission_error:
+        return permission_error
 
     user = request.user
 
@@ -193,12 +191,9 @@ def banner_order(request):
     PUT /v1/banners/order
     Body: { order: [[id1, order1], [id2, order2], ...] }
     """
-    if not request.user.is_active:
-        return StatusError(ErrorCode.NEED_LOGIN)
-
-    # Check if user is an editor
-    if not request.user.profile.is_editor():
-        return StatusError(ErrorCode.REJECT, '에디터 권한이 필요합니다.')
+    permission_error = ApiPermissionService.require_editor(request.user)
+    if permission_error:
+        return permission_error
 
     if request.method != 'PUT':
         raise Http404

--- a/backend/src/board/views/api/v1/notice.py
+++ b/backend/src/board/views/api/v1/notice.py
@@ -3,6 +3,7 @@ from django.http import Http404
 from django.shortcuts import get_object_or_404
 from board.models import SiteNotice, SiteContentScope
 from board.modules.response import StatusDone, StatusError, ErrorCode
+from board.services.api_permission_service import ApiPermissionService
 
 
 def notices(request, notice_id=None):
@@ -15,11 +16,9 @@ def notices(request, notice_id=None):
     PUT /v1/notices/<id> - Update notice
     DELETE /v1/notices/<id> - Delete notice
     """
-    if not request.user.is_active:
-        return StatusError(ErrorCode.NEED_LOGIN)
-
-    if not request.user.profile.is_editor():
-        return StatusError(ErrorCode.REJECT, '에디터 권한이 필요합니다.')
+    permission_error = ApiPermissionService.require_editor(request.user)
+    if permission_error:
+        return permission_error
 
     user = request.user
 


### PR DESCRIPTION
## 🎯 Goal
- Continue the backend permission-policy refactor by moving repeated editor API checks into `ApiPermissionService`.
- Keep banner/notice API behavior consistent while reducing inline policy duplication.

## 🔧 Core Changes
- Added `ApiPermissionService.require_editor()` for login + editor guard checks.
- Applied the shared editor guard to `banner` and `notice` APIs.
- Added service-level permission tests for login/editor guard outcomes.
- Added banner API coverage for normal non-editor users.

## 🤔 Key Decisions
- `require_login()` now treats inactive users as needing login, matching the existing editor API guard behavior and preventing inactive sessions from mutating guarded APIs.
- Profile-less active users now receive a permission rejection instead of potentially raising from direct profile access.

## 🧪 Verification Guide
### How to verify
1. Run `npm run server:test -- board.tests.services.test_api_permission_service board.tests.api.test_banner board.tests.api.test_notice board.tests.api.test_pinned_post`.
2. Confirm unauthenticated banner/notice requests return `error:NL`.
3. Confirm authenticated non-editor banner/notice requests return `error:RJ`.

### Expected result
- Guarded editor APIs keep the same public contract while using centralized permission policy.

## ✅ Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)

Sub-agent review: completed with no blocking findings.
