### PR TITLE
♻️ Expand API permission guard to staff APIs

### DIFF
--- a/backend/src/board/services/api_permission_service.py
+++ b/backend/src/board/services/api_permission_service.py
@@ -29,6 +29,16 @@ class ApiPermissionService:
         return None
 
     @staticmethod
+    def require_staff(user: User | AnonymousUser) -> Optional[HttpResponse]:
+        if not user.is_authenticated or not user.is_active:
+            return StatusError(ErrorCode.NEED_LOGIN)
+
+        if not user.is_staff:
+            return StatusError(ErrorCode.REJECT, '관리자 권한이 필요합니다.')
+
+        return None
+
+    @staticmethod
     def require_owner(user: User | AnonymousUser, owner: User) -> Optional[HttpResponse]:
         login_error = ApiPermissionService.require_login(user)
         if login_error:

--- a/backend/src/board/tests/services/test_api_permission_service.py
+++ b/backend/src/board/tests/services/test_api_permission_service.py
@@ -17,6 +17,14 @@ class ApiPermissionServiceTestCase(TestCase):
         )
         Profile.objects.create(user=cls.editor, role=Profile.Role.EDITOR)
 
+        cls.staff_user = User.objects.create_user(
+            username='permission-staff',
+            password='test',
+            email='staff@example.com',
+            is_staff=True,
+        )
+        Profile.objects.create(user=cls.staff_user)
+
         cls.normal_user = User.objects.create_user(
             username='permission-normal',
             password='test',
@@ -32,11 +40,13 @@ class ApiPermissionServiceTestCase(TestCase):
         )
         Profile.objects.create(user=cls.inactive_user, role=Profile.Role.EDITOR)
 
-    def assert_error_code(self, response, error_code):
+    def assert_error_code(self, response, error_code, error_message=None):
         self.assertIsNotNone(response)
         content = json.loads(response.content)
         self.assertEqual(content['status'], 'ERROR')
         self.assertEqual(content['errorCode'], error_code)
+        if error_message is not None:
+            self.assertEqual(content['errorMessage'], error_message)
 
     def test_require_login_rejects_anonymous_and_inactive_users(self):
         self.assert_error_code(ApiPermissionService.require_login(AnonymousUser()), 'error:NL')
@@ -52,3 +62,11 @@ class ApiPermissionServiceTestCase(TestCase):
 
     def test_require_editor_allows_editor(self):
         self.assertIsNone(ApiPermissionService.require_editor(self.editor))
+
+    def test_require_staff_rejects_anonymous_inactive_and_normal_users(self):
+        self.assert_error_code(ApiPermissionService.require_staff(AnonymousUser()), 'error:NL', '')
+        self.assert_error_code(ApiPermissionService.require_staff(self.inactive_user), 'error:NL', '')
+        self.assert_error_code(ApiPermissionService.require_staff(self.normal_user), 'error:RJ')
+
+    def test_require_staff_allows_staff_user(self):
+        self.assertIsNone(ApiPermissionService.require_staff(self.staff_user))

--- a/backend/src/board/views/api/v1/global_banner.py
+++ b/backend/src/board/views/api/v1/global_banner.py
@@ -3,6 +3,7 @@ from django.http import Http404
 from django.shortcuts import get_object_or_404
 from board.models import SiteBanner, SiteContentScope
 from board.modules.response import StatusDone, StatusError, ErrorCode
+from board.services.api_permission_service import ApiPermissionService
 
 
 def _serialize_global_banner(banner):
@@ -30,11 +31,9 @@ def global_banners(request, banner_id=None):
     PUT /v1/global-banners/<id> - Update global banner
     DELETE /v1/global-banners/<id> - Delete global banner
     """
-    if not request.user.is_active:
-        return StatusError(ErrorCode.NEED_LOGIN)
-
-    if not request.user.is_staff:
-        return StatusError(ErrorCode.REJECT, '관리자 권한이 필요합니다.')
+    permission_error = ApiPermissionService.require_staff(request.user)
+    if permission_error:
+        return permission_error
 
     qs = SiteBanner.objects.filter(
         scope=SiteContentScope.GLOBAL,
@@ -149,11 +148,9 @@ def global_banner_order(request):
     PUT /v1/global-banners/order
     Body: { order: [[id1, order1], [id2, order2], ...] }
     """
-    if not request.user.is_active:
-        return StatusError(ErrorCode.NEED_LOGIN)
-
-    if not request.user.is_staff:
-        return StatusError(ErrorCode.REJECT, '관리자 권한이 필요합니다.')
+    permission_error = ApiPermissionService.require_staff(request.user)
+    if permission_error:
+        return permission_error
 
     if request.method != 'PUT':
         raise Http404

--- a/backend/src/board/views/api/v1/global_notice.py
+++ b/backend/src/board/views/api/v1/global_notice.py
@@ -3,6 +3,7 @@ from django.http import Http404
 from django.shortcuts import get_object_or_404
 from board.models import SiteNotice, SiteContentScope
 from board.modules.response import StatusDone, StatusError, ErrorCode
+from board.services.api_permission_service import ApiPermissionService
 
 
 def global_notices(request, notice_id=None):
@@ -15,11 +16,9 @@ def global_notices(request, notice_id=None):
     PUT /v1/global-notices/<id> - Update global notice
     DELETE /v1/global-notices/<id> - Delete global notice
     """
-    if not request.user.is_active:
-        return StatusError(ErrorCode.NEED_LOGIN)
-
-    if not request.user.is_staff:
-        return StatusError(ErrorCode.REJECT, '관리자 권한이 필요합니다.')
+    permission_error = ApiPermissionService.require_staff(request.user)
+    if permission_error:
+        return permission_error
 
     qs = SiteNotice.objects.filter(
         scope=SiteContentScope.GLOBAL,

--- a/backend/src/board/views/api/v1/site_setting.py
+++ b/backend/src/board/views/api/v1/site_setting.py
@@ -1,7 +1,8 @@
 import json
 from django.http import Http404
 from board.models import SiteSetting
-from board.modules.response import StatusDone, StatusError, ErrorCode
+from board.modules.response import StatusDone
+from board.services.api_permission_service import ApiPermissionService
 from board.services.agent_content_service import AgentContentService
 
 
@@ -27,11 +28,9 @@ def site_settings(request):
     GET /v1/site-settings - Get current site settings
     PUT /v1/site-settings - Update site settings
     """
-    if not request.user.is_active:
-        return StatusError(ErrorCode.NEED_LOGIN)
-
-    if not request.user.is_staff:
-        return StatusError(ErrorCode.REJECT, '관리자 권한이 필요합니다.')
+    permission_error = ApiPermissionService.require_staff(request.user)
+    if permission_error:
+        return permission_error
 
     setting = SiteSetting.get_instance()
 


### PR DESCRIPTION
## 🎯 Goal
- Continue the backend permission-policy refactor by centralizing repeated staff-only API guards.
- Keep global banner, global notice, and site-setting permission behavior stable while reducing inline policy duplication.

## 🔧 Core Changes
- Added `ApiPermissionService.require_staff()`.
- Applied the shared staff guard to `global_banner`, `global_notice`, and `site_setting` APIs.
- Extended `ApiPermissionService` tests for staff guard outcomes.
- Preserved the existing staff API `NEED_LOGIN` empty-message contract for anonymous/inactive users.

## 🤔 Key Decisions
- `require_staff()` intentionally does not reuse `require_login()` because existing staff APIs returned `NEED_LOGIN` with an empty message.
- This keeps the existing API contract while still giving staff checks a named policy entry point.

## 🧪 Verification Guide
### How to verify
1. Run `npm run server:test -- board.tests.services.test_api_permission_service board.tests.api.test_global_banner_api board.tests.api.test_global_notice board.tests.api.test_site_setting`.
2. Confirm unauthenticated global banner/notice/site-setting requests return `error:NL`.
3. Confirm authenticated non-staff users return `error:RJ`.
4. Confirm staff users can access and mutate the guarded resources.

### Expected result
- Staff-only APIs keep their existing permission contract while using centralized staff guard policy.

## ✅ Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)

Sub-agent review: completed; initial minor finding about `NEED_LOGIN` message was fixed, follow-up review found no blockers.
