### PR TITLE
♻️ Centralize discovery canonical URL origin

### DIFF
--- a/backend/src/board/services/discovery_metadata_service.py
+++ b/backend/src/board/services/discovery_metadata_service.py
@@ -1,7 +1,5 @@
 import json
 import re
-from urllib.parse import urlencode
-
 from django.contrib.auth.models import User
 from django.http import HttpRequest
 from django.urls import reverse
@@ -9,6 +7,7 @@ from django.utils.html import strip_tags
 from django.utils.text import Truncator
 
 from board.models import Post, Series, StaticPage
+from board.services.site_url_service import SiteUrlService
 
 
 class DiscoveryMetadataService:
@@ -52,8 +51,9 @@ class DiscoveryMetadataService:
 
     @staticmethod
     def build_static_page_metadata(page: StaticPage, request: HttpRequest) -> dict[str, str]:
-        canonical_url = request.build_absolute_uri(
-            reverse('static_page', kwargs={'slug': page.slug})
+        canonical_url = SiteUrlService.absolute_url(
+            request,
+            reverse('static_page', kwargs={'slug': page.slug}),
         )
         meta_description = DiscoveryMetadataService.build_meta_description(
             raw_text=page.meta_description or page.content,
@@ -86,14 +86,12 @@ class DiscoveryMetadataService:
         page: int,
         sort_order: str,
     ) -> str:
-        base_url = request.build_absolute_uri(
-            reverse(
-                'series_detail',
-                kwargs={
-                    'username': author.username,
-                    'series_url': series.url,
-                },
-            )
+        series_path = reverse(
+            'series_detail',
+            kwargs={
+                'username': author.username,
+                'series_url': series.url,
+            },
         )
 
         query_items: list[tuple[str, str]] = []
@@ -102,10 +100,7 @@ class DiscoveryMetadataService:
         if page > 1:
             query_items.append(('page', str(page)))
 
-        if not query_items:
-            return base_url
-
-        return f'{base_url}?{urlencode(query_items)}'
+        return SiteUrlService.absolute_url_with_query(request, series_path, query_items)
 
     @staticmethod
     def build_series_structured_data(
@@ -118,21 +113,23 @@ class DiscoveryMetadataService:
         canonical_url: str,
         meta_description: str,
     ) -> str:
-        author_url = request.build_absolute_uri(
-            reverse('user_profile', kwargs={'username': author.username})
+        author_url = SiteUrlService.absolute_url(
+            request,
+            reverse('user_profile', kwargs={'username': author.username}),
         )
-        site_url = request.build_absolute_uri(reverse('index'))
+        site_url = SiteUrlService.absolute_url(request, reverse('index'))
 
         item_list_elements = []
         for position, post in enumerate(posts, start=1):
-            post_url = request.build_absolute_uri(
+            post_url = SiteUrlService.absolute_url(
+                request,
                 reverse(
                     'post_detail',
                     kwargs={
                         'username': author.username,
                         'post_url': post.url,
                     },
-                )
+                ),
             )
             item_list_elements.append(
                 {
@@ -204,7 +201,7 @@ class DiscoveryMetadataService:
             'isPartOf': {
                 '@type': 'WebSite',
                 'name': 'BLEX',
-                'url': request.build_absolute_uri(reverse('index')),
+                'url': SiteUrlService.absolute_url(request, reverse('index')),
             },
         }
 
@@ -212,8 +209,9 @@ class DiscoveryMetadataService:
             payload['author'] = {
                 '@type': 'Person',
                 'name': page.author.username,
-                'url': request.build_absolute_uri(
-                    reverse('user_profile', kwargs={'username': page.author.username})
+                'url': SiteUrlService.absolute_url(
+                    request,
+                    reverse('user_profile', kwargs={'username': page.author.username}),
                 ),
             }
 

--- a/backend/src/board/services/site_url_service.py
+++ b/backend/src/board/services/site_url_service.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from urllib.parse import urlencode
+
+from django.conf import settings
+from django.http import HttpRequest
+
+
+class SiteUrlService:
+    """Build public absolute URLs from one origin policy."""
+
+    @staticmethod
+    def public_origin(request: HttpRequest) -> str:
+        configured_origin = (settings.SITE_URL or '').strip().rstrip('/')
+        if configured_origin:
+            return configured_origin
+
+        return request.build_absolute_uri('/').rstrip('/')
+
+    @staticmethod
+    def absolute_url(request: HttpRequest, path: str) -> str:
+        if path.startswith(('http://', 'https://')):
+            return path
+
+        normalized_path = path if path.startswith('/') else f'/{path}'
+        return f'{SiteUrlService.public_origin(request)}{normalized_path}'
+
+    @staticmethod
+    def absolute_url_with_query(
+        request: HttpRequest,
+        path: str,
+        query_items: list[tuple[str, str]],
+    ) -> str:
+        url = SiteUrlService.absolute_url(request, path)
+        if not query_items:
+            return url
+
+        return f'{url}?{urlencode(query_items)}'

--- a/backend/src/board/tests/services/test_site_url_service.py
+++ b/backend/src/board/tests/services/test_site_url_service.py
@@ -1,0 +1,39 @@
+from django.test import RequestFactory, SimpleTestCase, override_settings
+
+from board.services.site_url_service import SiteUrlService
+
+
+class SiteUrlServiceTestCase(SimpleTestCase):
+    def setUp(self):
+        self.request = RequestFactory().get('/', HTTP_HOST='testserver')
+
+    @override_settings(SITE_URL='https://blex.example/')
+    def test_public_origin_uses_configured_site_url_without_trailing_slash(self):
+        self.assertEqual(SiteUrlService.public_origin(self.request), 'https://blex.example')
+
+    @override_settings(SITE_URL='')
+    def test_public_origin_falls_back_to_request_origin(self):
+        self.assertEqual(SiteUrlService.public_origin(self.request), 'http://testserver')
+
+    @override_settings(SITE_URL='https://blex.example')
+    def test_absolute_url_normalizes_relative_paths(self):
+        self.assertEqual(SiteUrlService.absolute_url(self.request, 'static/page'), 'https://blex.example/static/page')
+        self.assertEqual(SiteUrlService.absolute_url(self.request, '/static/page'), 'https://blex.example/static/page')
+
+    @override_settings(SITE_URL='https://blex.example')
+    def test_absolute_url_keeps_absolute_input(self):
+        self.assertEqual(
+            SiteUrlService.absolute_url(self.request, 'https://cdn.example/file.png'),
+            'https://cdn.example/file.png',
+        )
+
+    @override_settings(SITE_URL='https://blex.example')
+    def test_absolute_url_with_query_omits_empty_query_and_encodes_items(self):
+        self.assertEqual(
+            SiteUrlService.absolute_url_with_query(self.request, '/path', []),
+            'https://blex.example/path',
+        )
+        self.assertEqual(
+            SiteUrlService.absolute_url_with_query(self.request, '/path', [('sort', 'asc'), ('page', '2')]),
+            'https://blex.example/path?sort=asc&page=2',
+        )

--- a/backend/src/board/tests/templates/test_series_static_seo.py
+++ b/backend/src/board/tests/templates/test_series_static_seo.py
@@ -2,7 +2,7 @@ import json
 import re
 
 from django.contrib.auth.models import User
-from django.test import Client, TestCase
+from django.test import Client, TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
 
@@ -67,6 +67,7 @@ class SeriesSeoMetadataTestCase(StructuredDataAssertionMixin, TestCase):
                 hide=False,
             )
 
+    @override_settings(SITE_URL='')
     def test_series_detail_renders_canonical_meta_and_collection_json_ld(self):
         response = self.client.get(
             reverse(
@@ -130,6 +131,40 @@ class SeriesSeoMetadataTestCase(StructuredDataAssertionMixin, TestCase):
             ],
         )
 
+
+    @override_settings(SITE_URL='https://blex.example')
+    def test_series_detail_uses_configured_site_url_for_canonical_metadata(self):
+        response = self.client.get(
+            reverse(
+                'series_detail',
+                kwargs={
+                    'username': 'seriesauthor',
+                    'series_url': 'structured-series',
+                },
+            ),
+            {'sort': 'asc'},
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        canonical_url = 'https://blex.example/@seriesauthor/series/structured-series?sort=asc'
+        self.assertContains(
+            response,
+            f'<link rel="canonical" href="{canonical_url}">',
+            html=True,
+        )
+
+        structured_data = self.extract_structured_data(response)
+        self.assertEqual(structured_data['url'], canonical_url)
+        self.assertEqual(structured_data['isPartOf']['url'], 'https://blex.example/')
+        self.assertTrue(
+            all(
+                element['item']['url'].startswith('https://blex.example/')
+                for element in structured_data['mainEntity']['itemListElement']
+            )
+        )
+
+    @override_settings(SITE_URL='')
     def test_series_detail_canonical_normalizes_default_query_parameters(self):
         response = self.client.get(
             reverse(
@@ -170,6 +205,7 @@ class StaticPageSeoMetadataTestCase(StructuredDataAssertionMixin, TestCase):
             author=self.author,
         )
 
+    @override_settings(SITE_URL='')
     def test_static_page_renders_canonical_meta_and_webpage_json_ld(self):
         response = self.client.get(
             reverse('static_page', kwargs={'slug': 'seo-page'})
@@ -209,6 +245,28 @@ class StaticPageSeoMetadataTestCase(StructuredDataAssertionMixin, TestCase):
         self.assertEqual(structured_data['description'], meta_description)
         self.assertEqual(structured_data['author']['name'], 'pageauthor')
 
+
+    @override_settings(SITE_URL='https://blex.example/')
+    def test_static_page_uses_configured_site_url_for_canonical_metadata(self):
+        response = self.client.get(
+            reverse('static_page', kwargs={'slug': 'seo-page'})
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        canonical_url = 'https://blex.example/static/seo-page'
+        self.assertContains(
+            response,
+            f'<link rel="canonical" href="{canonical_url}">',
+            html=True,
+        )
+
+        structured_data = self.extract_structured_data(response)
+        self.assertEqual(structured_data['url'], canonical_url)
+        self.assertEqual(structured_data['isPartOf']['url'], 'https://blex.example/')
+        self.assertEqual(structured_data['author']['url'], 'https://blex.example/@pageauthor')
+
+    @override_settings(SITE_URL='')
     def test_static_page_uses_content_fallback_for_meta_description(self):
         self.page.meta_description = ''
         self.page.save(update_fields=['meta_description'])


### PR DESCRIPTION
## 🎯 Goal
- Start centralizing URL/canonical policy with a reusable public-origin URL service.
- Make discovery metadata canonical and structured-data URLs use the configured public origin when `SITE_URL` is set.

## 🔧 Core Changes
- Added `SiteUrlService` for public origin and absolute URL construction.
- Updated series/static-page discovery metadata to use `SiteUrlService` instead of direct `request.build_absolute_uri()` calls.
- Kept canonical query normalization behavior for series pages.
- Added service tests for origin fallback, trailing slash handling, relative path normalization, and query construction.
- Added template metadata tests for `SITE_URL`-backed canonical/structured-data URLs.

## 🤔 Key Decisions
- `SITE_URL` is treated as the public origin and normalized by removing a trailing slash.
- If `SITE_URL` is empty, the service falls back to the request origin, preserving existing local/test behavior.
- This PR limits the migration to discovery metadata first; sitemap/robots/post-detail URL surfaces can be moved in later PRs.

## 🧪 Verification Guide
### How to verify
1. Run `npm run server:test -- board.tests.services.test_site_url_service board.tests.templates.test_series_static_seo`.
2. With `SITE_URL=https://blex.example`, confirm series/static-page canonical URLs use that origin.
3. With empty `SITE_URL`, confirm existing request-origin URLs are preserved.

### Expected result
- Discovery metadata uses one public-origin policy without changing default local behavior.

## ✅ Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)

Sub-agent review: completed with no blocking findings.
