### PR TITLE
♻️ Use site URL service for post detail metadata

### DIFF
--- a/backend/src/board/templates/board/posts/post_detail.html
+++ b/backend/src/board/templates/board/posts/post_detail.html
@@ -12,24 +12,24 @@
 
 <!-- Open Graph / Facebook -->
 <meta property="og:type" content="article">
-<meta property="og:url" content="{{ request.build_absolute_uri }}">
+<meta property="og:url" content="{{ canonical_url }}">
 <meta property="og:title" content="{{ post.title }}">
 <meta property="og:description" content="{{ post.meta_description }}">
-{% if post.image %}<meta property="og:image" content="{{ request.scheme }}://{{ request.get_host }}{{ post.image.url }}">{% endif %}
+{% if post.image %}<meta property="og:image" content="{{ post_image_url }}">{% endif %}
 <meta property="article:published_time" content="{{ post.published_date|date:'c' }}">
 <meta property="article:modified_time" content="{{ post.updated_date|date:'c' }}">
-<meta property="article:author" content="{{ request.scheme }}://{{ request.get_host }}/@{{ post.author_username }}">
+<meta property="article:author" content="{{ author_url }}">
 {% for tag in post.tags.all %}<meta property="article:tag" content="{{ tag }}">{% endfor %}
 
 <!-- Twitter -->
 <meta property="twitter:card" content="{% if post.image %}summary_large_image{% else %}summary{% endif %}">
-<meta property="twitter:url" content="{{ request.build_absolute_uri }}">
+<meta property="twitter:url" content="{{ canonical_url }}">
 <meta property="twitter:title" content="{{ post.title }}">
 <meta property="twitter:description" content="{{ post.meta_description }}">
-{% if post.image %}<meta property="twitter:image" content="{{ request.scheme }}://{{ request.get_host }}{{ post.image.url }}">{% endif %}
+{% if post.image %}<meta property="twitter:image" content="{{ post_image_url }}">{% endif %}
 
 <!-- Canonical URL -->
-<link rel="canonical" href="{{ request.build_absolute_uri }}">
+<link rel="canonical" href="{{ canonical_url }}">
 {% if aeo_enabled %}
 <link rel="alternate" type="text/markdown" href="{{ post_markdown_url }}">
 {% endif %}
@@ -73,7 +73,7 @@
                     <meta itemprop="datePublished" content="{{ post.published_date|date:'c' }}">
                     <meta itemprop="dateModified" content="{{ post.updated_date|date:'c' }}">
                     {% if post.image %}
-                    <meta itemprop="image" content="{{ request.scheme }}://{{ request.get_host }}{{ post.image.url }}">
+                    <meta itemprop="image" content="{{ post_image_url }}">
                     {% endif %}
                     
                     <!-- Article Header -->
@@ -531,15 +531,15 @@ class="xl:hidden">
   "@type": "BlogPosting",
   "mainEntityOfPage": {
     "@type": "WebPage",
-    "@id": "{{ request.build_absolute_uri }}"
+    "@id": "{{ canonical_url }}"
   },
   "headline": "{{ post.title|escapejs }}",
   "description": "{{ post.meta_description|escapejs }}",
-  "image": {% if post.image %}"{{ request.scheme }}://{{ request.get_host }}{{ post.image.url }}"{% else %}null{% endif %},
+  "image": {% if post.image %}"{{ post_image_url }}"{% else %}null{% endif %},
   "author": {
     "@type": "Person",
     "name": "{{ post.author_username }}",
-    "url": "{{ request.scheme }}://{{ request.get_host }}/@{{ post.author_username }}"{% if post.author.profile.homepage or post.author.userlinkmeta_set.all %},
+    "url": "{{ author_url }}"{% if post.author.profile.homepage or post.author.userlinkmeta_set.all %},
     "sameAs": [
       {% if post.author.profile.homepage %}"{{ post.author.profile.homepage }}"{% if post.author.userlinkmeta_set.all %},{% endif %}{% endif %}{% for link in post.author.userlinkmeta_set.all %}
       "{{ link.value }}"{% if not forloop.last %},{% endif %}{% endfor %}
@@ -550,7 +550,7 @@ class="xl:hidden">
     "name": "BLEX",
     "logo": {
       "@type": "ImageObject",
-      "url": "{{ request.scheme }}://{{ request.get_host }}{% resource 'logo.png' %}"
+      "url": "{{ logo_url }}"
     }
   },
   "datePublished": "{{ post.published_date|date:'c' }}",

--- a/backend/src/board/tests/templates/test_post_detail.py
+++ b/backend/src/board/tests/templates/test_post_detail.py
@@ -3,7 +3,7 @@ Tests for Post Detail View and ToC structure
 """
 import datetime
 
-from django.test import TestCase, Client
+from django.test import TestCase, Client, override_settings
 from django.contrib.auth.models import User
 from django.urls import reverse
 from django.utils import timezone
@@ -169,6 +169,25 @@ class PostDetailViewTestCase(TestCase):
         }))
 
         self.assertEqual(response.status_code, 404)
+
+
+    @override_settings(SITE_URL='https://blex.example')
+    def test_post_detail_uses_configured_site_url_for_metadata(self):
+        url = reverse('post_detail', kwargs={
+            'username': 'testauthor',
+            'post_url': 'test-post'
+        })
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+
+        canonical_url = 'https://blex.example/@testauthor/test-post'
+        content = response.content.decode()
+        self.assertIn(f'<meta content={canonical_url} property=og:url>', content)
+        self.assertIn(f'<meta content={canonical_url} property=twitter:url>', content)
+        self.assertIn(f'<link href={canonical_url} rel=canonical>', content)
+        self.assertIn(f'"@id": "{canonical_url}"', content)
+        self.assertIn('"url": "https://blex.example/@testauthor"', content)
 
     def test_post_detail_hides_agent_link_copy_option_when_aeo_disabled(self):
         """AEO가 꺼져 있으면 에이전트 링크 복사 옵션을 노출하지 않는다."""

--- a/backend/src/board/views/post.py
+++ b/backend/src/board/views/post.py
@@ -1,9 +1,11 @@
 import json
 from django.shortcuts import render, get_object_or_404, redirect
+from django.urls import reverse
 from django.contrib.auth.models import User
 from django.db.models import Count, F, Exists, OuterRef
 from django.http import Http404
 from django.contrib import messages
+from django.conf import settings
 from django.utils import timezone
 
 from board.models import Post, Series, PostLikes, UsernameChangeLog
@@ -11,6 +13,7 @@ from board.services.post_service import PostService, PostValidationError
 from board.services.banner_service import BannerService
 from board.services.agent_content_service import AgentContentService
 from board.services.public_post_service import PublicPostService
+from board.services.site_url_service import SiteUrlService
 from board.html_utils import extract_table_of_contents
 
 def post_detail(request, username, post_url):
@@ -52,6 +55,12 @@ def post_detail(request, username, post_url):
 
     banners = BannerService.get_all_banners_for_author(author)
 
+    post_absolute_url = post.get_absolute_url()
+    canonical_url = SiteUrlService.absolute_url(request, post_absolute_url)
+    author_url = SiteUrlService.absolute_url(request, reverse('user_profile', args=[author.username]))
+    post_image_url = SiteUrlService.absolute_url(request, post.image.url) if post.image else ''
+    logo_url = SiteUrlService.absolute_url(request, f'{settings.RESOURCE_URL}logo.png')
+
     aeo_enabled = AgentContentService.is_aeo_enabled()
     context = {
         'post': post,
@@ -59,6 +68,10 @@ def post_detail(request, username, post_url):
         'content_html': content_html_with_ids,
         'table_of_contents': table_of_contents,
         'aeo_enabled': aeo_enabled,
+        'canonical_url': canonical_url,
+        'author_url': author_url,
+        'post_image_url': post_image_url,
+        'logo_url': logo_url,
     }
     if aeo_enabled:
         context['post_markdown_url'] = AgentContentService.build_post_markdown_url(post, request)


### PR DESCRIPTION
## 🎯 Goal
- Continue the URL/canonical policy refactor by moving post-detail metadata URL construction through `SiteUrlService`.
- Ensure post-detail canonical, social meta, and JSON-LD URLs use the configured public origin when `SITE_URL` is set.

## 🔧 Core Changes
- Added post-detail metadata URLs to the view context via `SiteUrlService`.
- Replaced direct template usage of `request.build_absolute_uri`, `request.scheme`, and `request.get_host` for post metadata URLs.
- Added coverage for `SITE_URL`-backed post-detail canonical/social/schema URLs.

## 🤔 Key Decisions
- AEO Markdown alternate URL and Link headers are intentionally left unchanged in this PR to keep the surface small.
- Image and logo URLs are normalized with the same service, preserving already absolute URLs.

## 🧪 Verification Guide
### How to verify
1. Run `npm run server:test -- board.tests.templates.test_post_detail board.tests.services.test_site_url_service`.
2. With `SITE_URL=https://blex.example`, open a post detail page and confirm canonical/og/twitter/schema URLs use that origin.
3. With empty `SITE_URL`, confirm local request-origin behavior is preserved.

### Expected result
- Post-detail metadata URL generation follows the shared public-origin policy.

## ✅ Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)

Sub-agent review: completed with no blocking findings.
