### PR TITLE
♻️ Use site URL service for agent content URLs

### DIFF
--- a/backend/src/board/services/agent_content_service.py
+++ b/backend/src/board/services/agent_content_service.py
@@ -10,6 +10,7 @@ from django.urls import reverse
 
 from board.models import Post, Series, SiteSetting, StaticPage
 from board.services.public_post_service import PublicPostService
+from board.services.site_url_service import SiteUrlService
 
 
 class AgentContentService:
@@ -149,11 +150,11 @@ class AgentContentService:
 
     @staticmethod
     def build_llms_txt_url(request: HttpRequest) -> str:
-        return request.build_absolute_uri(reverse('llms_txt'))
+        return SiteUrlService.absolute_url(request, reverse('llms_txt'))
 
     @staticmethod
     def build_sitemap_url(request: HttpRequest) -> str:
-        return request.build_absolute_uri(reverse('sitemap'))
+        return SiteUrlService.absolute_url(request, reverse('sitemap'))
 
     @staticmethod
     def build_default_robots_txt_lines(request: HttpRequest, setting: SiteSetting) -> list[str]:
@@ -216,20 +217,23 @@ class AgentContentService:
 
     @staticmethod
     def build_post_markdown_url(post: Post, request: HttpRequest) -> str:
-        return request.build_absolute_uri(
-            reverse('post_markdown', args=[post.author.username, post.url])
+        return SiteUrlService.absolute_url(
+            request,
+            reverse('post_markdown', args=[post.author.username, post.url]),
         )
 
     @staticmethod
     def build_series_markdown_url(series: Series, request: HttpRequest) -> str:
-        return request.build_absolute_uri(
-            reverse('series_markdown', args=[series.owner.username, series.url])
+        return SiteUrlService.absolute_url(
+            request,
+            reverse('series_markdown', args=[series.owner.username, series.url]),
         )
 
     @staticmethod
     def build_static_page_markdown_url(page: StaticPage, request: HttpRequest) -> str:
-        return request.build_absolute_uri(
-            reverse('static_page_markdown', args=[page.slug])
+        return SiteUrlService.absolute_url(
+            request,
+            reverse('static_page_markdown', args=[page.slug]),
         )
 
     @staticmethod
@@ -248,7 +252,7 @@ class AgentContentService:
     @staticmethod
     def build_post_markdown(post: Post, request: HttpRequest) -> str:
         content = AgentContentService.get_post_content_markdown(post)
-        source_url = request.build_absolute_uri(post.get_absolute_url())
+        source_url = SiteUrlService.absolute_url(request, post.get_absolute_url())
 
         lines = [
             f'# {post.title}',
@@ -276,7 +280,7 @@ class AgentContentService:
     @staticmethod
     def build_series_markdown(series: Series, request: HttpRequest) -> str:
         content = AgentContentService.get_series_content_markdown(series)
-        source_url = request.build_absolute_uri(series.get_absolute_url())
+        source_url = SiteUrlService.absolute_url(request, series.get_absolute_url())
         public_posts = list(AgentContentService.get_public_series_posts(series))
 
         lines = [
@@ -314,7 +318,7 @@ class AgentContentService:
     @staticmethod
     def build_static_page_markdown(page: StaticPage, request: HttpRequest) -> str:
         content = AgentContentService.html_to_markdown(page.content)
-        source_url = request.build_absolute_uri(reverse('static_page', args=[page.slug]))
+        source_url = SiteUrlService.absolute_url(request, reverse('static_page', args=[page.slug]))
 
         lines = [
             f'# {page.title}',

--- a/backend/src/board/tests/api/test_site_setting.py
+++ b/backend/src/board/tests/api/test_site_setting.py
@@ -121,7 +121,7 @@ class SiteSettingAPITestCase(TestCase):
         self.assertFalse(content['body']['seoEnabled'])
         self.assertEqual(content['body']['robotsTxtExtraRules'], 'User-agent: ExampleBot\nDisallow: /private/')
         self.assertIn('robotsTxtDefault', content['body'])
-        self.assertIn('# AI agent entry point: http://testserver/llms.txt', content['body']['robotsTxtDefault'])
+        self.assertIn('# AI agent entry point: http://localhost:8000/llms.txt', content['body']['robotsTxtDefault'])
         self.assertIn('Search indexing is disabled at runtime.', content['body']['robotsTxtDefault'])
         self.assertNotIn('# Custom rules', content['body']['robotsTxtDefault'])
         self.assertNotIn('User-agent: ExampleBot', content['body']['robotsTxtDefault'])

--- a/backend/src/board/tests/templates/test_agent_discovery.py
+++ b/backend/src/board/tests/templates/test_agent_discovery.py
@@ -1,5 +1,5 @@
 from django.contrib.auth.models import User
-from django.test import Client, TestCase
+from django.test import Client, TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
 
@@ -54,7 +54,7 @@ class SeriesAgentDiscoveryTestCase(TestCase):
         content = response.content.decode()
 
         self.assertNotIn('rel=alternate type=text/markdown', content)
-        self.assertNotIn('http://testserver/@seriesauthor/series/agent-discovery-series.md', content)
+        self.assertNotIn('http://localhost:8000/@seriesauthor/series/agent-discovery-series.md', content)
         self.assertNotIn('Link', response)
         self.assertNotIn('X-Llms-Txt', response)
 
@@ -67,12 +67,37 @@ class SeriesAgentDiscoveryTestCase(TestCase):
 
         self.assertEqual(response.status_code, 200)
 
-        markdown_url = 'http://testserver/@seriesauthor/series/agent-discovery-series.md'
-        llms_txt_url = 'http://testserver/llms.txt'
+        markdown_url = 'http://localhost:8000/@seriesauthor/series/agent-discovery-series.md'
+        llms_txt_url = 'http://localhost:8000/llms.txt'
         content = response.content.decode()
 
         self.assertIn(markdown_url, content)
         self.assertIn('rel=alternate type=text/markdown', content)
+        self.assertIn(
+            f'<{markdown_url}>; rel="alternate"; type="text/markdown"',
+            response['Link'],
+        )
+        self.assertIn(
+            f'<{llms_txt_url}>; rel="llms-txt"',
+            response['Link'],
+        )
+        self.assertEqual(response['X-Llms-Txt'], llms_txt_url)
+
+    @override_settings(SITE_URL='https://blex.example')
+    def test_series_detail_uses_configured_site_url_for_markdown_alternate(self):
+        self.enable_aeo()
+        response = self.client.get(reverse('series_detail', kwargs={
+            'username': 'seriesauthor',
+            'series_url': 'agent-discovery-series',
+        }))
+
+        self.assertEqual(response.status_code, 200)
+
+        markdown_url = 'https://blex.example/@seriesauthor/series/agent-discovery-series.md'
+        llms_txt_url = 'https://blex.example/llms.txt'
+        content = response.content.decode()
+
+        self.assertIn(markdown_url, content)
         self.assertIn(
             f'<{markdown_url}>; rel="alternate"; type="text/markdown"',
             response['Link'],
@@ -110,7 +135,7 @@ class StaticPageAgentDiscoveryTestCase(TestCase):
         content = response.content.decode()
 
         self.assertNotIn('rel=alternate type=text/markdown', content)
-        self.assertNotIn('http://testserver/static/agent-policy.md', content)
+        self.assertNotIn('http://localhost:8000/static/agent-policy.md', content)
         self.assertNotIn('Link', response)
         self.assertNotIn('X-Llms-Txt', response)
 
@@ -122,12 +147,36 @@ class StaticPageAgentDiscoveryTestCase(TestCase):
 
         self.assertEqual(response.status_code, 200)
 
-        markdown_url = 'http://testserver/static/agent-policy.md'
-        llms_txt_url = 'http://testserver/llms.txt'
+        markdown_url = 'http://localhost:8000/static/agent-policy.md'
+        llms_txt_url = 'http://localhost:8000/llms.txt'
         content = response.content.decode()
 
         self.assertIn(markdown_url, content)
         self.assertIn('rel=alternate type=text/markdown', content)
+        self.assertIn(
+            f'<{markdown_url}>; rel="alternate"; type="text/markdown"',
+            response['Link'],
+        )
+        self.assertIn(
+            f'<{llms_txt_url}>; rel="llms-txt"',
+            response['Link'],
+        )
+        self.assertEqual(response['X-Llms-Txt'], llms_txt_url)
+
+    @override_settings(SITE_URL='https://blex.example')
+    def test_static_page_uses_configured_site_url_for_markdown_alternate(self):
+        self.enable_aeo()
+        response = self.client.get(reverse('static_page', kwargs={
+            'slug': 'agent-policy',
+        }))
+
+        self.assertEqual(response.status_code, 200)
+
+        markdown_url = 'https://blex.example/static/agent-policy.md'
+        llms_txt_url = 'https://blex.example/llms.txt'
+        content = response.content.decode()
+
+        self.assertIn(markdown_url, content)
         self.assertIn(
             f'<{markdown_url}>; rel="alternate"; type="text/markdown"',
             response['Link'],

--- a/backend/src/board/tests/templates/test_post_detail.py
+++ b/backend/src/board/tests/templates/test_post_detail.py
@@ -236,7 +236,7 @@ class PostDetailViewTestCase(TestCase):
         self.assertContains(response, '*.md 참조 주소')
 
         content = response.content.decode()
-        self.assertIn('data-agent-copy-url=http://testserver/@testauthor/test-post.md', content)
+        self.assertIn('data-agent-copy-url=http://localhost:8000/@testauthor/test-post.md', content)
 
     def test_post_detail_hides_markdown_alternate_when_aeo_disabled(self):
         """AEO가 꺼져 있으면 포스트 상세가 Markdown endpoint를 광고하지 않는다."""
@@ -251,7 +251,7 @@ class PostDetailViewTestCase(TestCase):
         content = response.content.decode()
 
         self.assertNotIn('rel=alternate type=text/markdown', content)
-        self.assertNotIn('http://testserver/@testauthor/test-post.md', content)
+        self.assertNotIn('http://localhost:8000/@testauthor/test-post.md', content)
         self.assertNotIn('Link', response)
         self.assertNotIn('X-Llms-Txt', response)
 
@@ -266,8 +266,8 @@ class PostDetailViewTestCase(TestCase):
 
         self.assertEqual(response.status_code, 200)
 
-        markdown_url = 'http://testserver/@testauthor/test-post.md'
-        llms_txt_url = 'http://testserver/llms.txt'
+        markdown_url = 'http://localhost:8000/@testauthor/test-post.md'
+        llms_txt_url = 'http://localhost:8000/llms.txt'
 
         content = response.content.decode()
 

--- a/backend/src/board/tests/test_agent_content.py
+++ b/backend/src/board/tests/test_agent_content.py
@@ -302,7 +302,7 @@ class AgentContentTestCase(TestCase):
         body = response.content.decode()
         self.assertIn('User-agent: *', body)
         self.assertIn('Search indexing is disabled at runtime.', body)
-        self.assertIn('# AI agent entry point: http://testserver/llms.txt', body)
+        self.assertIn('# AI agent entry point: http://localhost:8000/llms.txt', body)
         self.assertNotIn('Sitemap:', body)
         self.assertNotIn('Disallow: /\n', body)
 
@@ -326,9 +326,41 @@ class AgentContentTestCase(TestCase):
 
         self.assertEqual(response.status_code, 200)
         body = response.content.decode()
-        self.assertIn('# AI agent entry point: http://testserver/llms.txt', body)
+        self.assertIn('# AI agent entry point: http://localhost:8000/llms.txt', body)
         self.assertNotIn('Disallow: /llms.txt', body)
-        self.assertIn('Sitemap: http://testserver/sitemap.xml', body)
+        self.assertIn('Sitemap: http://localhost:8000/sitemap.xml', body)
+
+
+    @override_settings(SITE_URL='https://blex.example')
+    def test_robots_txt_uses_configured_site_url(self):
+        response = self.client.get('/robots.txt')
+
+        self.assertEqual(response.status_code, 200)
+        body = response.content.decode()
+        self.assertIn('# AI agent entry point: https://blex.example/llms.txt', body)
+        self.assertIn('Sitemap: https://blex.example/sitemap.xml', body)
+
+    @override_settings(SITE_URL='https://blex.example')
+    def test_markdown_endpoints_use_configured_site_url(self):
+        response = self.client.get('/@aeo-author/agent-ready-post.md')
+
+        self.assertEqual(response.status_code, 200)
+        body = response.content.decode()
+        self.assertIn('Source: https://blex.example/@aeo-author/agent-ready-post', body)
+
+        response = self.client.get('/@aeo-author/series/agent-ready-series.md')
+        self.assertEqual(response.status_code, 200)
+        body = response.content.decode()
+        self.assertIn('Source: https://blex.example/@aeo-author/series/agent-ready-series', body)
+        self.assertIn(
+            '- [Agent Ready Post](https://blex.example/@aeo-author/agent-ready-post.md)',
+            body,
+        )
+
+        response = self.client.get('/static/about-ai.md')
+        self.assertEqual(response.status_code, 200)
+        body = response.content.decode()
+        self.assertIn('Source: https://blex.example/static/about-ai', body)
 
     def test_llms_txt_returns_minimal_site_summary(self):
         """/llms.txt는 최소한의 사이트 요약만 제공한다."""
@@ -371,7 +403,7 @@ class AgentContentTestCase(TestCase):
         body = response.content.decode()
         self.assertIn('# Agent Ready Post', body)
         self.assertIn('Author: @aeo-author', body)
-        self.assertIn('Source: http://testserver/@aeo-author/agent-ready-post', body)
+        self.assertIn('Source: http://localhost:8000/@aeo-author/agent-ready-post', body)
         self.assertIn('## Outcome\nAgents can parse this post.', body)
 
     def test_series_markdown_endpoint_returns_clean_markdown(self):
@@ -385,10 +417,10 @@ class AgentContentTestCase(TestCase):
         body = response.content.decode()
         self.assertIn('# Agent Ready Series', body)
         self.assertIn('Author: @aeo-author', body)
-        self.assertIn('Source: http://testserver/@aeo-author/series/agent-ready-series', body)
+        self.assertIn('Source: http://localhost:8000/@aeo-author/series/agent-ready-series', body)
         self.assertIn('Series summary for agents.', body)
         self.assertIn(
-            '- [Agent Ready Post](http://testserver/@aeo-author/agent-ready-post.md)',
+            '- [Agent Ready Post](http://localhost:8000/@aeo-author/agent-ready-post.md)',
             body,
         )
 
@@ -402,7 +434,7 @@ class AgentContentTestCase(TestCase):
 
         body = response.content.decode()
         self.assertIn('# About AI', body)
-        self.assertIn('Source: http://testserver/static/about-ai', body)
+        self.assertIn('Source: http://localhost:8000/static/about-ai', body)
         self.assertIn('## About BLEX', body)
         self.assertIn('Static page content for agents.', body)
 


### PR DESCRIPTION
## 🎯 Goal
- Continue the URL/canonical policy refactor by moving agent-readable URL surfaces through `SiteUrlService`.
- Align robots, Markdown exports, and AEO discovery headers with the same public-origin policy used by canonical metadata.

## 🔧 Core Changes
- Updated `AgentContentService` URL builders to use `SiteUrlService`.
- Applied the shared URL policy to:
  - `/robots.txt` llms/sitemap hints
  - Markdown alternate URLs
  - Markdown export `Source` URLs
  - AEO `Link` / `X-Llms-Txt` headers
- Added/updated tests for default configured origin and explicit `SITE_URL` override behavior.

## 🤔 Key Decisions
- Default test behavior now reflects the configured `SITE_URL` value (`http://localhost:8000`) instead of Django's request host.
- Explicit `SITE_URL` override tests verify the production-style public origin path.

## 🧪 Verification Guide
### How to verify
1. Run `npm run server:test -- board.tests.test_agent_content board.tests.templates.test_agent_discovery board.tests.api.test_site_setting board.tests.templates.test_post_detail`.
2. Confirm `/robots.txt` uses the configured public origin for llms/sitemap hints.
3. Confirm Markdown exports and discovery headers use the configured public origin.

### Expected result
- Agent-readable URL surfaces use the same centralized public-origin policy as canonical metadata.

## ✅ Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)

Sub-agent review: completed with no blocking findings.
