### PR TITLE
♻️ Centralize public series visibility policy

### DIFF
--- a/backend/src/board/services/agent_content_service.py
+++ b/backend/src/board/services/agent_content_service.py
@@ -4,12 +4,13 @@ import re
 
 from bs4 import BeautifulSoup
 from bs4.element import NavigableString, Tag as SoupTag
-from django.db.models import Count, Q, QuerySet
+from django.db.models import QuerySet
 from django.http import Http404, HttpRequest
 from django.urls import reverse
 
 from board.models import Post, Series, SiteSetting, StaticPage
 from board.services.public_post_service import PublicPostService
+from board.services.public_series_service import PublicSeriesService
 from board.services.site_url_service import SiteUrlService
 
 
@@ -77,12 +78,8 @@ class AgentContentService:
 
     @staticmethod
     def get_public_series() -> QuerySet[Series]:
-        public_post_filter = PublicPostService.build_public_filter('posts')
-        return Series.objects.select_related('owner').annotate(
-            public_post_count=Count('posts', filter=public_post_filter, distinct=True)
-        ).filter(
-            hide=False,
-            public_post_count__gte=1,
+        return PublicSeriesService.filter_public_series(
+            Series.objects.select_related('owner')
         ).order_by('order', '-updated_date')
 
     @staticmethod

--- a/backend/src/board/services/public_series_service.py
+++ b/backend/src/board/services/public_series_service.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from django.db.models import Count, QuerySet
+
+from board.models import Series
+from board.services.public_post_service import PublicPostService
+
+
+class PublicSeriesService:
+    """Shared public visibility rules for Series surfaces."""
+
+    DEFAULT_PUBLIC_POST_COUNT_FIELD = 'public_post_count'
+
+    @staticmethod
+    def build_public_post_count_annotation(posts_prefix: str = 'posts') -> Count:
+        return Count(
+            posts_prefix,
+            filter=PublicPostService.build_public_filter(posts_prefix),
+            distinct=True,
+        )
+
+    @staticmethod
+    def with_public_post_count(
+        queryset: QuerySet[Series],
+        count_field: str = DEFAULT_PUBLIC_POST_COUNT_FIELD,
+    ) -> QuerySet[Series]:
+        return queryset.annotate(
+            **{count_field: PublicSeriesService.build_public_post_count_annotation()}
+        )
+
+    @staticmethod
+    def filter_public_series(
+        queryset: QuerySet[Series],
+        count_field: str = DEFAULT_PUBLIC_POST_COUNT_FIELD,
+    ) -> QuerySet[Series]:
+        return PublicSeriesService.with_public_post_count(queryset, count_field).filter(
+            hide=False,
+            **{f'{count_field}__gte': 1},
+        )
+
+    @staticmethod
+    def is_public(series: Series) -> bool:
+        if series.hide:
+            return False
+
+        return PublicPostService.filter_public_posts(series.posts).exists()

--- a/backend/src/board/services/series_service.py
+++ b/backend/src/board/services/series_service.py
@@ -8,10 +8,11 @@ Extracted from views to improve testability and reusability.
 from typing import Optional, List, Tuple
 from django.contrib.auth.models import User
 from django.db import transaction
-from django.db.models import Count, F
+from django.db.models import F
 
 from board.models import Series, Post
 from board.services.public_post_service import PublicPostService
+from board.services.public_series_service import PublicSeriesService
 from board.modules.response import ErrorCode
 
 
@@ -293,10 +294,7 @@ class SeriesService:
         query = Series.objects.filter(owner=user)
 
         if include_post_count:
-            public_post_filter = PublicPostService.build_public_filter('posts')
-            query = query.annotate(
-                total_posts=Count('posts', filter=public_post_filter, distinct=True)
-            )
+            query = PublicSeriesService.with_public_post_count(query, 'total_posts')
 
         return query.order_by('order', '-id')
 
@@ -329,12 +327,9 @@ class SeriesService:
         Returns:
             QuerySet of Series with annotations
         """
-        public_post_filter = PublicPostService.build_public_filter('posts')
-        return Series.objects.annotate(
-            owner_username=F('owner__username'),
-            total_posts=Count('posts', filter=public_post_filter, distinct=True)
+        return PublicSeriesService.filter_public_series(
+            Series.objects.annotate(owner_username=F('owner__username')),
+            'total_posts',
         ).filter(
             owner__username=username,
-            total_posts__gte=1,
-            hide=False,
         ).order_by('order', '-id')

--- a/backend/src/board/sitemaps.py
+++ b/backend/src/board/sitemaps.py
@@ -1,9 +1,8 @@
 from django.contrib.sitemaps import Sitemap
 from django.urls import reverse
-from django.db.models import Count
-
 from board.models import Post, Series, Profile, StaticPage
 from board.services.public_post_service import PublicPostService
+from board.services.public_series_service import PublicSeriesService
 
 
 class SiteSitemap(Sitemap):
@@ -61,13 +60,9 @@ class SeriesSitemap(Sitemap):
     priority = 0.7
 
     def items(self):
-        public_post_filter = PublicPostService.build_public_filter('posts')
-        return Series.objects.annotate(
-            public_post_count=Count('posts', filter=public_post_filter, distinct=True),
-        ).filter(
-            hide=False,
-            public_post_count__gte=1,
-        ).select_related('owner').order_by('-updated_date')
+        return PublicSeriesService.filter_public_series(
+            Series.objects.select_related('owner')
+        ).order_by('-updated_date')
 
     def location(self, element):
         return reverse('series_detail', args=[element.owner.username, element.url])

--- a/backend/src/board/tests/api/test_series_api.py
+++ b/backend/src/board/tests/api/test_series_api.py
@@ -382,6 +382,46 @@ class SeriesAPITestCase(TestCase):
         content = json.loads(response.content)
         self.assertIn('posts', content['body'])
 
+
+    def test_get_hidden_series_detail_keeps_existing_public_api_behavior(self):
+        """시리즈 상세 API는 기존처럼 숨김 시리즈도 조회하되 공개 글만 반환한다."""
+        author = User.objects.get(username='author')
+        series = Series.objects.create(
+            owner=author,
+            name='Hidden Series',
+            url='hidden-series',
+            text_md='Hidden series description',
+            hide=True,
+        )
+        post = Post.objects.get(url='test-post-3')
+        series.posts.add(post)
+
+        response = self.client.get('/v1/users/@author/series/hidden-series')
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['body']['name'], 'Hidden Series')
+        self.assertEqual(content['body']['totalPosts'], 1)
+        self.assertEqual(len(content['body']['posts']), 1)
+
+    def test_get_empty_series_detail_keeps_existing_public_api_behavior(self):
+        """시리즈 상세 API는 공개 글이 없어도 기존처럼 조회되고 total_posts만 0이다."""
+        author = User.objects.get(username='author')
+        Series.objects.create(
+            owner=author,
+            name='Empty Series',
+            url='empty-series',
+            text_md='Empty series description',
+        )
+
+        response = self.client.get('/v1/users/@author/series/empty-series')
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['body']['name'], 'Empty Series')
+        self.assertEqual(content['body']['totalPosts'], 0)
+        self.assertEqual(content['body']['posts'], [])
+
     def test_get_nonexistent_series(self):
         """존재하지 않는 시리즈 조회 시 404 에러"""
         response = self.client.get('/v1/users/@author/series/nonexistent-series')

--- a/backend/src/board/tests/services/test_public_series_service.py
+++ b/backend/src/board/tests/services/test_public_series_service.py
@@ -1,0 +1,93 @@
+from datetime import timedelta
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.utils import timezone
+
+from board.models import Post, PostConfig, PostContent, Series
+from board.services.public_series_service import PublicSeriesService
+
+
+class PublicSeriesServiceTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.author = User.objects.create_user(
+            username='public-series-author',
+            email='public-series@example.com',
+            password='password123',
+        )
+        now = timezone.now()
+
+        cls.public_series = Series.objects.create(
+            owner=cls.author,
+            name='Public Series',
+            url='public-series',
+            hide=False,
+        )
+        cls.create_post(cls.public_series, 'Public Post', 'public-post', now)
+
+        cls.hidden_series = Series.objects.create(
+            owner=cls.author,
+            name='Hidden Series',
+            url='hidden-series',
+            hide=True,
+        )
+        cls.create_post(cls.hidden_series, 'Hidden Series Public Post', 'hidden-series-public-post', now)
+
+        cls.draft_only_series = Series.objects.create(
+            owner=cls.author,
+            name='Draft Only Series',
+            url='draft-only-series',
+            hide=False,
+        )
+        cls.create_post(cls.draft_only_series, 'Draft Post', 'draft-post', None)
+
+        cls.future_only_series = Series.objects.create(
+            owner=cls.author,
+            name='Future Only Series',
+            url='future-only-series',
+            hide=False,
+        )
+        cls.create_post(cls.future_only_series, 'Future Post', 'future-post', now + timedelta(days=1))
+
+        cls.hidden_post_only_series = Series.objects.create(
+            owner=cls.author,
+            name='Hidden Post Only Series',
+            url='hidden-post-only-series',
+            hide=False,
+        )
+        cls.create_post(cls.hidden_post_only_series, 'Hidden Post', 'hidden-post', now, hide=True)
+
+    @classmethod
+    def create_post(cls, series, title, url, published_date, hide=False):
+        post = Post.objects.create(
+            title=title,
+            url=url,
+            author=cls.author,
+            series=series,
+            published_date=published_date,
+        )
+        PostContent.objects.create(post=post, content_html='')
+        PostConfig.objects.create(post=post, hide=hide)
+        return post
+
+    def test_filter_public_series_excludes_hidden_and_series_without_public_posts(self):
+        series = PublicSeriesService.filter_public_series(Series.objects).order_by('url')
+
+        self.assertEqual(list(series), [self.public_series])
+
+    def test_filter_public_series_supports_custom_count_field(self):
+        series = PublicSeriesService.filter_public_series(
+            Series.objects,
+            count_field='total_posts',
+        ).get()
+
+        self.assertEqual(series, self.public_series)
+        self.assertEqual(series.total_posts, 1)
+
+    def test_is_public_matches_public_series_rules(self):
+        self.assertTrue(PublicSeriesService.is_public(self.public_series))
+        self.assertFalse(PublicSeriesService.is_public(self.hidden_series))
+        self.assertFalse(PublicSeriesService.is_public(self.draft_only_series))
+        self.assertFalse(PublicSeriesService.is_public(self.future_only_series))
+        self.assertFalse(PublicSeriesService.is_public(self.hidden_post_only_series))

--- a/backend/src/board/views/api/v1/series.py
+++ b/backend/src/board/views/api/v1/series.py
@@ -1,5 +1,5 @@
 import json
-from django.db.models import F, Count, Q
+from django.db.models import F, Q
 from django.http import Http404, QueryDict
 from django.shortcuts import get_object_or_404
 
@@ -7,6 +7,7 @@ from board.models import User, Post, Series
 from board.services import SeriesService
 from board.services.series_service import SeriesValidationError
 from board.services.public_post_service import PublicPostService
+from board.services.public_series_service import PublicSeriesService
 from board.modules.paginator import Paginator
 from board.modules.response import StatusDone, StatusError, ErrorCode
 from board.modules.time import convert_to_localtime
@@ -129,11 +130,12 @@ def user_series(request, username, url=None):
 
     if url:
         user = get_object_or_404(User, username=username)
-        public_post_filter = PublicPostService.build_public_filter('posts')
-        series = get_object_or_404(Series.objects.annotate(
-            owner_username=F('owner__username'),
-            owner_avatar=F('owner__profile__avatar'),
-            total_posts=Count('posts', filter=public_post_filter, distinct=True)
+        series = get_object_or_404(PublicSeriesService.with_public_post_count(
+            Series.objects.annotate(
+                owner_username=F('owner__username'),
+                owner_avatar=F('owner__profile__avatar'),
+            ),
+            'total_posts',
         ), owner=user, url=url)
 
         if request.method == 'GET':

--- a/backend/src/board/views/author.py
+++ b/backend/src/board/views/author.py
@@ -10,6 +10,7 @@ from board.modules.paginator import Paginator
 from board.modules.time import time_since
 from board.services.user_service import UserService
 from board.services.public_post_service import PublicPostService
+from board.services.public_series_service import PublicSeriesService
 from board.models import Post, Series, PostLikes, Tag, Profile, SiteNotice, SiteContentScope
 from modules import markdown
 
@@ -123,14 +124,9 @@ def author_posts(request, username):
     else:  # default to 'recent'
         posts = posts.order_by('-published_date')
     
-    public_series_post_filter = PublicPostService.build_public_filter('posts')
-    series = Series.objects.filter(
-        owner__username=username,
-        hide=False,
-    ).annotate(
-        count_posts=Count('posts', filter=public_series_post_filter, distinct=True),
-    ).filter(
-        count_posts__gte=1,
+    series = PublicSeriesService.filter_public_series(
+        Series.objects.filter(owner__username=username),
+        'count_posts',
     ).order_by('-updated_date')
     
     public_author_tag_filter = PublicPostService.build_public_filter('posts') & Q(
@@ -212,10 +208,7 @@ def author_series(request, username):
             Q(text_md__icontains=search_query)
         )
     
-    public_series_post_filter = PublicPostService.build_public_filter('posts')
-    series_list = series_list.annotate(
-        post_count=Count('posts', filter=public_series_post_filter, distinct=True)
-    ).filter(post_count__gte=1)
+    series_list = PublicSeriesService.filter_public_series(series_list, 'post_count')
     
     if sort_option == 'newest':
         series_list = series_list.order_by('-created_date')


### PR DESCRIPTION
## 🎯 Goal
- Centralize the public visibility policy for Series surfaces.
- Keep public series list, sitemap, author pages, and agent content aligned on the same rule: visible series with at least one public post.

## 🔧 Core Changes
- Added `PublicSeriesService` for public post count annotation, public series filtering, and single-series visibility checks.
- Applied the shared service to:
  - agent content public series lookup
  - series sitemap
  - public user series list service
  - author posts/series pages
  - series API count annotations
- Added service tests for hidden series, draft-only/future-only/hidden-post-only series, and custom count aliases.
- Added regression tests documenting that the existing series detail API still annotates counts without applying public-list filtering.

## 🤔 Key Decisions
- `PublicSeriesService.filter_public_series()` is used for public list surfaces.
- Series detail API intentionally uses `with_public_post_count()` only, preserving existing behavior while removing duplicate count annotation code.

## 🧪 Verification Guide
### How to verify
1. Run `npm run server:test -- board.tests.services.test_public_series_service board.tests.test_agent_content board.tests.api.test_series_api`.
2. Run `npm run server:test -- board.tests.templates.test_author board.tests.services.test_public_series_service`.
3. Confirm series list/sitemap/author pages hide series without public posts.
4. Confirm series detail API still returns hidden/empty series with public post counts only.

### Expected result
- Public series surfaces share one visibility policy without changing the existing series detail API contract.

## ✅ Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)

Sub-agent review: completed with no blocking findings; suggested API detail regression tests were added.
