### PR TITLE
♻️ Introduce post status service

### DIFF
--- a/backend/src/board/admin/post.py
+++ b/backend/src/board/admin/post.py
@@ -4,8 +4,8 @@ Post Admin Configuration
 from django.contrib import admin
 from django.db.models import Count, QuerySet
 from django.http import HttpRequest
-from django.utils import timezone
 
+from board.services.post_status_service import PostStatusService
 from board.models import (
     EditHistory, EditRequest, Post, PinnedPost,
     PostConfig, PostContent,
@@ -31,13 +31,12 @@ class PublishStatusFilter(admin.SimpleListFilter):
         ]
 
     def queryset(self, request, queryset):
-        now = timezone.now()
         if self.value() == 'draft':
-            return queryset.filter(published_date__isnull=True)
+            return PostStatusService.filter_drafts(queryset)
         elif self.value() == 'published':
-            return queryset.filter(published_date__isnull=False, published_date__lte=now)
+            return PostStatusService.filter_published(queryset)
         elif self.value() == 'scheduled':
-            return queryset.filter(published_date__isnull=False, published_date__gt=now)
+            return PostStatusService.filter_scheduled(queryset)
 
 
 @admin.register(EditHistory)

--- a/backend/src/board/models.py
+++ b/backend/src/board/models.py
@@ -311,12 +311,12 @@ class Post(models.Model):
             return settings.RESOURCE_URL + 'assets/images/default-cover-1.jpg'
 
     def is_published(self):
-        if self.published_date is None:
-            return False
-        return self.published_date <= timezone.now()
+        from board.services.post_status_service import PostStatusService
+        return PostStatusService.is_published(self)
 
     def is_draft(self):
-        return self.published_date is None
+        from board.services.post_status_service import PostStatusService
+        return PostStatusService.is_draft(self)
 
     def time_stamp(self):
         return time_stamp(self.created_date)

--- a/backend/src/board/services/post_status_service.py
+++ b/backend/src/board/services/post_status_service.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from django.db.models import Q, QuerySet
+from django.utils import timezone
+
+if TYPE_CHECKING:
+    from board.models import Post
+
+
+class PostStatusService:
+    """Named helpers for draft, scheduled, and published post status."""
+
+    @staticmethod
+    def build_draft_filter(relation: str = '') -> Q:
+        prefix = f'{relation}__' if relation else ''
+        return Q(**{f'{prefix}published_date__isnull': True})
+
+    @staticmethod
+    def build_published_filter(relation: str = '') -> Q:
+        prefix = f'{relation}__' if relation else ''
+        return Q(**{
+            f'{prefix}published_date__isnull': False,
+            f'{prefix}published_date__lte': timezone.now(),
+        })
+
+    @staticmethod
+    def build_scheduled_filter(relation: str = '') -> Q:
+        prefix = f'{relation}__' if relation else ''
+        return Q(**{
+            f'{prefix}published_date__isnull': False,
+            f'{prefix}published_date__gt': timezone.now(),
+        })
+
+    @staticmethod
+    def filter_drafts(queryset: QuerySet) -> QuerySet:
+        return queryset.filter(PostStatusService.build_draft_filter())
+
+    @staticmethod
+    def filter_published(queryset: QuerySet) -> QuerySet:
+        return queryset.filter(PostStatusService.build_published_filter())
+
+    @staticmethod
+    def filter_scheduled(queryset: QuerySet) -> QuerySet:
+        return queryset.filter(PostStatusService.build_scheduled_filter())
+
+    @staticmethod
+    def is_draft(post: Post) -> bool:
+        return post.published_date is None
+
+    @staticmethod
+    def is_published(post: Post) -> bool:
+        if post.published_date is None:
+            return False
+        return post.published_date <= timezone.now()
+
+    @staticmethod
+    def is_scheduled(post: Post) -> bool:
+        if post.published_date is None:
+            return False
+        return post.published_date > timezone.now()

--- a/backend/src/board/services/public_post_service.py
+++ b/backend/src/board/services/public_post_service.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from django.db.models import Q, QuerySet
-from django.utils import timezone
 
 if TYPE_CHECKING:
     from board.models import Post
+
+from board.services.post_status_service import PostStatusService
 
 
 class PublicPostService:
@@ -22,9 +23,7 @@ class PublicPostService:
                 ``series__posts``. Leave empty when filtering Post directly.
         """
         prefix = f'{relation}__' if relation else ''
-        return Q(**{
-            f'{prefix}published_date__isnull': False,
-            f'{prefix}published_date__lte': timezone.now(),
+        return PostStatusService.build_published_filter(relation) & Q(**{
             f'{prefix}config__hide': False,
         })
 
@@ -34,9 +33,7 @@ class PublicPostService:
 
     @staticmethod
     def is_public(post: Post) -> bool:
-        if post.published_date is None:
-            return False
-        if post.published_date > timezone.now():
+        if not PostStatusService.is_published(post):
             return False
         if hasattr(post, 'config') and post.config.hide:
             return False

--- a/backend/src/board/tests/services/test_post_status_service.py
+++ b/backend/src/board/tests/services/test_post_status_service.py
@@ -1,0 +1,61 @@
+from datetime import timedelta
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.utils import timezone
+
+from board.models import Post
+from board.services.post_status_service import PostStatusService
+
+
+class PostStatusServiceTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.author = User.objects.create_user(
+            username='post-status-author',
+            email='post-status@example.com',
+            password='password123',
+        )
+        now = timezone.now()
+        cls.draft = Post.objects.create(
+            title='Draft Post',
+            url='draft-post',
+            author=cls.author,
+            published_date=None,
+        )
+        cls.published = Post.objects.create(
+            title='Published Post',
+            url='published-post',
+            author=cls.author,
+            published_date=now,
+        )
+        cls.scheduled = Post.objects.create(
+            title='Scheduled Post',
+            url='scheduled-post',
+            author=cls.author,
+            published_date=now + timedelta(days=1),
+        )
+
+    def test_status_predicates_match_published_date(self):
+        self.assertTrue(PostStatusService.is_draft(self.draft))
+        self.assertFalse(PostStatusService.is_published(self.draft))
+        self.assertFalse(PostStatusService.is_scheduled(self.draft))
+
+        self.assertFalse(PostStatusService.is_draft(self.published))
+        self.assertTrue(PostStatusService.is_published(self.published))
+        self.assertFalse(PostStatusService.is_scheduled(self.published))
+
+        self.assertFalse(PostStatusService.is_draft(self.scheduled))
+        self.assertFalse(PostStatusService.is_published(self.scheduled))
+        self.assertTrue(PostStatusService.is_scheduled(self.scheduled))
+
+    def test_status_filters_match_predicates(self):
+        self.assertEqual(list(PostStatusService.filter_drafts(Post.objects)), [self.draft])
+        self.assertEqual(list(PostStatusService.filter_published(Post.objects)), [self.published])
+        self.assertEqual(list(PostStatusService.filter_scheduled(Post.objects)), [self.scheduled])
+
+    def test_post_model_status_methods_delegate_to_same_policy(self):
+        self.assertTrue(self.draft.is_draft())
+        self.assertFalse(self.draft.is_published())
+        self.assertFalse(self.published.is_draft())
+        self.assertTrue(self.published.is_published())


### PR DESCRIPTION
## 🎯 Goal
- Name and centralize draft / published / scheduled post status policy.
- Reduce repeated inline `published_date` checks before continuing broader backend policy cleanup.

## 🔧 Core Changes
- Added `PostStatusService` for status predicates, `Q` builders, and QuerySet filters.
- Updated public post visibility to compose with the named published-status policy.
- Updated `Post` model status helpers and admin publish-status filter to reuse the service.
- Added service tests covering predicates, filters, and model method parity.

## 🤔 Key Decisions
- Kept visibility (`hide=False`) in `PublicPostService` and moved only temporal status semantics into `PostStatusService`.
- Used model-method delegation so existing callers can keep using `post.is_published()` / `post.is_draft()` while sharing the same policy.
- Sub-agent review found no blockers for opening this PR.

## 🧪 Verification Guide
### How to verify
1. Run `npm run server:test -- board.tests.services.test_post_status_service board.tests.services.test_public_post_service board.tests.api.test_draft board.tests.api.test_developer_posts`.
2. Check Django admin post publish status filter for draft / published / scheduled posts.
3. Check public post visibility still excludes draft, future, and hidden posts.

### Expected result
- Tests pass.
- Public visibility behavior remains unchanged.
- Admin status filtering remains unchanged.

## ✅ Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [x] Tests completed
- [ ] Documentation updated (if needed)
