### PR TITLE
♻️ Introduce API JSON body parser

### DIFF
--- a/backend/src/board/services/api_request_body_service.py
+++ b/backend/src/board/services/api_request_body_service.py
@@ -1,0 +1,40 @@
+import json
+
+from board.modules.response import ErrorCode, StatusError
+
+
+class ApiRequestBodyService:
+    """Helpers for parsing API request bodies consistently."""
+
+    DEFAULT_INVALID_JSON_MESSAGE = '잘못된 요청입니다.'
+
+    @staticmethod
+    def parse_json(request, default=None):
+        """Return the JSON object in the request body, or default for an empty body.
+
+        JSONDecodeError and UnicodeDecodeError are intentionally allowed to bubble
+        so callers can preserve endpoint-specific error behavior where needed.
+        """
+        if not request.body:
+            return {} if default is None else default
+
+        return json.loads(request.body.decode('utf-8'))
+
+    @staticmethod
+    def parse_json_or_error(request, default=None, message=None):
+        """Parse JSON and return (data, error_response)."""
+        try:
+            return ApiRequestBodyService.parse_json(request, default=default), None
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return None, StatusError(
+                ErrorCode.VALIDATE,
+                message or ApiRequestBodyService.DEFAULT_INVALID_JSON_MESSAGE,
+            )
+
+    @staticmethod
+    def parse_json_or_default(request, default=None):
+        """Parse JSON, falling back to default when the body is invalid."""
+        try:
+            return ApiRequestBodyService.parse_json(request, default=default)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return {} if default is None else default

--- a/backend/src/board/tests/api/test_banner.py
+++ b/backend/src/board/tests/api/test_banner.py
@@ -132,6 +132,34 @@ class BannerAPITestCase(TestCase):
         content = json.loads(response.content)
         self.assertEqual(content['status'], 'ERROR')
 
+
+    def test_create_banner_invalid_json_returns_validate_error(self):
+        response = self.client.post(
+            '/v1/banners',
+            '{invalid',
+            content_type='application/json'
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'ERROR')
+        self.assertEqual(content['errorCode'], 'error:VA')
+
+    def test_update_banner_invalid_json_keeps_existing_fields(self):
+        banner = self._create_user_banner(title='Original Title')
+
+        response = self.client.put(
+            f'/v1/banners/{banner.id}',
+            '{invalid',
+            content_type='application/json'
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'DONE')
+        banner.refresh_from_db()
+        self.assertEqual(banner.title, 'Original Title')
+
     def test_get_banner(self):
         """배너 조회 테스트"""
         banner = self._create_user_banner()
@@ -201,6 +229,19 @@ class BannerAPITestCase(TestCase):
         banner2.refresh_from_db()
         self.assertEqual(banner1.order, 1)
         self.assertEqual(banner2.order, 0)
+
+
+    def test_update_banner_order_invalid_json_returns_validate_error(self):
+        response = self.client.put(
+            '/v1/banners/order',
+            '{invalid',
+            content_type='application/json'
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'ERROR')
+        self.assertEqual(content['errorCode'], 'error:VA')
 
     def test_get_banners_with_multiple_banners(self):
         """여러 배너 목록 조회 테스트"""

--- a/backend/src/board/tests/api/test_global_banner_api.py
+++ b/backend/src/board/tests/api/test_global_banner_api.py
@@ -156,6 +156,34 @@ class GlobalBannerAPITestCase(TestCase):
         self.assertEqual(content['status'], 'DONE')
         self.assertIn('<script>', content['body']['contentHtml'])
 
+
+    def test_create_banner_invalid_json_returns_validate_error(self):
+        response = self.client.post(
+            '/v1/global-banners',
+            '{invalid',
+            content_type='application/json'
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'ERROR')
+        self.assertEqual(content['errorCode'], 'error:VA')
+
+    def test_update_banner_invalid_json_keeps_existing_fields(self):
+        banner = self._create_global_banner(title='Original Title')
+
+        response = self.client.put(
+            f'/v1/global-banners/{banner.id}',
+            '{invalid',
+            content_type='application/json'
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'DONE')
+        banner.refresh_from_db()
+        self.assertEqual(banner.title, 'Original Title')
+
     def test_get_banner_detail(self):
         """글로벌 배너 상세 조회 테스트"""
         banner = self._create_global_banner(title='Detail Banner', content_html='<div>Detail</div>')
@@ -219,6 +247,19 @@ class GlobalBannerAPITestCase(TestCase):
         banner2.refresh_from_db()
         self.assertEqual(banner1.order, 1)
         self.assertEqual(banner2.order, 0)
+
+
+    def test_update_banner_order_invalid_json_returns_validate_error(self):
+        response = self.client.put(
+            '/v1/global-banners/order',
+            '{invalid',
+            content_type='application/json'
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'ERROR')
+        self.assertEqual(content['errorCode'], 'error:VA')
 
     def test_normal_user_cannot_create(self):
         """일반 유저가 글로벌 배너 생성 불가 테스트"""

--- a/backend/src/board/tests/services/test_api_request_body_service.py
+++ b/backend/src/board/tests/services/test_api_request_body_service.py
@@ -1,0 +1,36 @@
+from django.test import RequestFactory, TestCase
+
+from board.services.api_request_body_service import ApiRequestBodyService
+
+
+class ApiRequestBodyServiceTestCase(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_parse_json_returns_empty_dict_for_empty_body(self):
+        request = self.factory.post('/v1/example', data=b'', content_type='application/json')
+
+        self.assertEqual(ApiRequestBodyService.parse_json(request), {})
+
+    def test_parse_json_decodes_utf8_json_body(self):
+        request = self.factory.post(
+            '/v1/example',
+            data='{"title": "테스트"}'.encode('utf-8'),
+            content_type='application/json',
+        )
+
+        self.assertEqual(ApiRequestBodyService.parse_json(request), {'title': '테스트'})
+
+    def test_parse_json_or_error_returns_validate_error_for_invalid_json(self):
+        request = self.factory.post('/v1/example', data=b'{invalid', content_type='application/json')
+
+        data, error = ApiRequestBodyService.parse_json_or_error(request)
+
+        self.assertIsNone(data)
+        self.assertIsNotNone(error)
+        self.assertEqual(error.status_code, 200)
+
+    def test_parse_json_or_default_returns_default_for_invalid_json(self):
+        request = self.factory.put('/v1/example/1', data=b'{invalid', content_type='application/json')
+
+        self.assertEqual(ApiRequestBodyService.parse_json_or_default(request), {})

--- a/backend/src/board/views/api/v1/banner.py
+++ b/backend/src/board/views/api/v1/banner.py
@@ -1,8 +1,8 @@
-import json
-from django.http import Http404, QueryDict
+from django.http import Http404
 from django.shortcuts import get_object_or_404
 from board.models import SiteBanner, SiteContentScope
 from board.modules.response import StatusDone, StatusError, ErrorCode
+from board.services.api_request_body_service import ApiRequestBodyService
 from board.services.api_permission_service import ApiPermissionService
 from board.html_utils import sanitize_html
 
@@ -65,10 +65,9 @@ def banner(request, banner_id=None):
 
     # Create new banner
     if request.method == 'POST':
-        try:
-            post_data = json.loads(request.body.decode('utf-8')) if request.body else {}
-        except (json.JSONDecodeError, UnicodeDecodeError):
-            return StatusError(ErrorCode.VALIDATE, '잘못된 요청입니다.')
+        post_data, body_error = ApiRequestBodyService.parse_json_or_error(request)
+        if body_error:
+            return body_error
 
         title = post_data.get('title', '')
         content_html = post_data.get('content_html', '')
@@ -125,10 +124,7 @@ def banner(request, banner_id=None):
             user=user,
         )
 
-        try:
-            put_data = json.loads(request.body.decode('utf-8')) if request.body else {}
-        except (json.JSONDecodeError, UnicodeDecodeError):
-            put_data = {}
+        put_data = ApiRequestBodyService.parse_json_or_default(request)
 
         # Update fields if provided
         if 'title' in put_data:
@@ -198,10 +194,9 @@ def banner_order(request):
     if request.method != 'PUT':
         raise Http404
 
-    try:
-        put_data = json.loads(request.body.decode('utf-8')) if request.body else {}
-    except (json.JSONDecodeError, UnicodeDecodeError):
-        return StatusError(ErrorCode.VALIDATE, '잘못된 요청입니다.')
+    put_data, body_error = ApiRequestBodyService.parse_json_or_error(request)
+    if body_error:
+        return body_error
 
     order_list = put_data.get('order', [])
 

--- a/backend/src/board/views/api/v1/global_banner.py
+++ b/backend/src/board/views/api/v1/global_banner.py
@@ -1,8 +1,8 @@
-import json
 from django.http import Http404
 from django.shortcuts import get_object_or_404
 from board.models import SiteBanner, SiteContentScope
 from board.modules.response import StatusDone, StatusError, ErrorCode
+from board.services.api_request_body_service import ApiRequestBodyService
 from board.services.api_permission_service import ApiPermissionService
 
 
@@ -55,10 +55,9 @@ def global_banners(request, banner_id=None):
 
     # Create new global banner
     if request.method == 'POST':
-        try:
-            post_data = json.loads(request.body.decode('utf-8')) if request.body else {}
-        except (json.JSONDecodeError, UnicodeDecodeError):
-            return StatusError(ErrorCode.VALIDATE, '잘못된 요청입니다.')
+        post_data, body_error = ApiRequestBodyService.parse_json_or_error(request)
+        if body_error:
+            return body_error
 
         title = post_data.get('title', '')
         content_html = post_data.get('content_html', '')
@@ -97,10 +96,7 @@ def global_banners(request, banner_id=None):
     if request.method == 'PUT' and banner_id:
         banner = get_object_or_404(qs.select_related('user'), id=banner_id)
 
-        try:
-            put_data = json.loads(request.body.decode('utf-8')) if request.body else {}
-        except (json.JSONDecodeError, UnicodeDecodeError):
-            put_data = {}
+        put_data = ApiRequestBodyService.parse_json_or_default(request)
 
         if 'title' in put_data:
             banner.title = put_data['title']
@@ -155,10 +151,9 @@ def global_banner_order(request):
     if request.method != 'PUT':
         raise Http404
 
-    try:
-        put_data = json.loads(request.body.decode('utf-8')) if request.body else {}
-    except (json.JSONDecodeError, UnicodeDecodeError):
-        return StatusError(ErrorCode.VALIDATE, '잘못된 요청입니다.')
+    put_data, body_error = ApiRequestBodyService.parse_json_or_error(request)
+    if body_error:
+        return body_error
 
     order_list = put_data.get('order', [])
 


### PR DESCRIPTION
## 🎯 Goal
- Start centralizing repeated API JSON body parsing without changing endpoint behavior.
- Make invalid-body handling explicit before broader site-content CRUD cleanup.

## 🔧 Core Changes
- Added `ApiRequestBodyService` with helpers for parse-or-error and parse-or-default behavior.
- Applied the helper to user banner and global banner create/update/order endpoints.
- Added service tests and API regression tests for invalid JSON behavior.

## 🤔 Key Decisions
- Kept endpoint-specific behavior intact:
  - create/order invalid JSON returns `ErrorCode.VALIDATE`.
  - update invalid JSON falls back to an empty update payload.
- Limited the first application to banner/global-banner APIs so the helper can land in a small, reviewable PR.
- Added order invalid JSON regression tests after sub-agent review called out that gap.

## 🧪 Verification Guide
### How to verify
1. Run `npm run server:test -- board.tests.services.test_api_request_body_service board.tests.api.test_banner board.tests.api.test_global_banner_api`.
2. Send malformed JSON to `/v1/banners` and `/v1/global-banners`; expect validate errors.
3. Send malformed JSON to existing banner update endpoints; expect no field changes.

### Expected result
- Tests pass.
- Banner and global-banner behavior remains unchanged.
- JSON body parsing logic is no longer duplicated in these endpoints.

## ✅ Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [x] Tests completed
- [ ] Documentation updated (if needed)
