### PR TITLE
♻️ Use JSON body parser for notice APIs

### DIFF
--- a/backend/src/board/tests/api/test_global_notice.py
+++ b/backend/src/board/tests/api/test_global_notice.py
@@ -112,6 +112,34 @@ class GlobalNoticeAPITestCase(TestCase):
         content = json.loads(response.content)
         self.assertEqual(content['status'], 'ERROR')
 
+
+    def test_create_notice_invalid_json_returns_validate_error(self):
+        response = self.client.post(
+            '/v1/global-notices',
+            '{invalid',
+            content_type='application/json'
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'ERROR')
+        self.assertEqual(content['errorCode'], 'error:VA')
+
+    def test_update_notice_invalid_json_keeps_existing_fields(self):
+        notice = self._create_global_notice(title='Original Title')
+
+        response = self.client.put(
+            f'/v1/global-notices/{notice.id}',
+            '{invalid',
+            content_type='application/json'
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'DONE')
+        notice.refresh_from_db()
+        self.assertEqual(notice.title, 'Original Title')
+
     def test_get_notice_detail(self):
         """공지 상세 조회 테스트"""
         notice = self._create_global_notice(

--- a/backend/src/board/tests/api/test_notice.py
+++ b/backend/src/board/tests/api/test_notice.py
@@ -113,6 +113,34 @@ class NoticeAPITestCase(TestCase):
         content = json.loads(response.content)
         self.assertEqual(content['status'], 'ERROR')
 
+
+    def test_create_notice_invalid_json_returns_validate_error(self):
+        response = self.client.post(
+            '/v1/notices',
+            '{invalid',
+            content_type='application/json'
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'ERROR')
+        self.assertEqual(content['errorCode'], 'error:VA')
+
+    def test_update_notice_invalid_json_keeps_existing_fields(self):
+        notice = self._create_user_notice(title='Original Title')
+
+        response = self.client.put(
+            f'/v1/notices/{notice.id}',
+            '{invalid',
+            content_type='application/json'
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'DONE')
+        notice.refresh_from_db()
+        self.assertEqual(notice.title, 'Original Title')
+
     def test_get_notice_detail(self):
         """공지 상세 조회 테스트"""
         notice = self._create_user_notice(title='Detail Notice', url='https://example.com/detail')

--- a/backend/src/board/views/api/v1/global_notice.py
+++ b/backend/src/board/views/api/v1/global_notice.py
@@ -1,8 +1,8 @@
-import json
 from django.http import Http404
 from django.shortcuts import get_object_or_404
 from board.models import SiteNotice, SiteContentScope
 from board.modules.response import StatusDone, StatusError, ErrorCode
+from board.services.api_request_body_service import ApiRequestBodyService
 from board.services.api_permission_service import ApiPermissionService
 
 
@@ -54,10 +54,9 @@ def global_notices(request, notice_id=None):
 
     # Create new global notice
     if request.method == 'POST':
-        try:
-            post_data = json.loads(request.body.decode('utf-8')) if request.body else {}
-        except (json.JSONDecodeError, UnicodeDecodeError):
-            return StatusError(ErrorCode.VALIDATE, '잘못된 요청입니다.')
+        post_data, body_error = ApiRequestBodyService.parse_json_or_error(request)
+        if body_error:
+            return body_error
 
         title = post_data.get('title', '')
         url = post_data.get('url', '')
@@ -89,10 +88,7 @@ def global_notices(request, notice_id=None):
     if request.method == 'PUT' and notice_id:
         notice = get_object_or_404(qs, id=notice_id)
 
-        try:
-            put_data = json.loads(request.body.decode('utf-8')) if request.body else {}
-        except (json.JSONDecodeError, UnicodeDecodeError):
-            put_data = {}
+        put_data = ApiRequestBodyService.parse_json_or_default(request)
 
         if 'title' in put_data:
             notice.title = put_data['title']

--- a/backend/src/board/views/api/v1/notice.py
+++ b/backend/src/board/views/api/v1/notice.py
@@ -1,8 +1,8 @@
-import json
 from django.http import Http404
 from django.shortcuts import get_object_or_404
 from board.models import SiteNotice, SiteContentScope
 from board.modules.response import StatusDone, StatusError, ErrorCode
+from board.services.api_request_body_service import ApiRequestBodyService
 from board.services.api_permission_service import ApiPermissionService
 
 
@@ -57,10 +57,9 @@ def notices(request, notice_id=None):
 
     # Create new notice
     if request.method == 'POST':
-        try:
-            post_data = json.loads(request.body.decode('utf-8')) if request.body else {}
-        except (json.JSONDecodeError, UnicodeDecodeError):
-            return StatusError(ErrorCode.VALIDATE, '잘못된 요청입니다.')
+        post_data, body_error = ApiRequestBodyService.parse_json_or_error(request)
+        if body_error:
+            return body_error
 
         title = post_data.get('title', '')
         url = post_data.get('url', '')
@@ -93,10 +92,7 @@ def notices(request, notice_id=None):
     if request.method == 'PUT' and notice_id:
         notice = get_object_or_404(qs, id=notice_id)
 
-        try:
-            put_data = json.loads(request.body.decode('utf-8')) if request.body else {}
-        except (json.JSONDecodeError, UnicodeDecodeError):
-            put_data = {}
+        put_data = ApiRequestBodyService.parse_json_or_default(request)
 
         if 'title' in put_data:
             notice.title = put_data['title']


### PR DESCRIPTION
## 🎯 Goal
- Continue centralizing repeated API JSON body parsing in site-content APIs.
- Apply the existing `ApiRequestBodyService` to notice/global-notice endpoints without behavior changes.

## 🔧 Core Changes
- Replaced inline JSON parsing in notice create/update endpoints with `ApiRequestBodyService`.
- Replaced inline JSON parsing in global-notice create/update endpoints with `ApiRequestBodyService`.
- Added regression tests for malformed JSON on create/update paths.

## 🤔 Key Decisions
- Preserved existing endpoint-specific behavior:
  - create invalid JSON returns `ErrorCode.VALIDATE`.
  - update invalid JSON falls back to an empty update payload and keeps existing fields.
- Kept this PR scoped to notice APIs so the JSON parser rollout stays incremental.
- Sub-agent review found no blockers.

## 🧪 Verification Guide
### How to verify
1. Run `npm run server:test -- board.tests.api.test_notice board.tests.api.test_global_notice board.tests.services.test_api_request_body_service`.
2. Send malformed JSON to `/v1/notices` and `/v1/global-notices`; expect validate errors.
3. Send malformed JSON to existing notice update endpoints; expect existing fields to remain unchanged.

### Expected result
- Tests pass.
- Notice and global-notice behavior remains unchanged.
- JSON body parsing logic is no longer duplicated in these endpoints.

## ✅ Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [x] Tests completed
- [ ] Documentation updated (if needed)
