### PR TITLE
♻️ Use JSON body parser for static page API

### DIFF
--- a/backend/src/board/tests/api/test_static_page.py
+++ b/backend/src/board/tests/api/test_static_page.py
@@ -137,6 +137,41 @@ class StaticPageAPITestCase(TestCase):
         self.assertEqual(content['status'], 'ERROR')
         self.assertEqual(content['errorCode'], 'error:AE')
 
+
+    def test_create_static_page_invalid_json_returns_validate_error(self):
+        response = self.client.post(
+            '/v1/static-pages',
+            '{invalid',
+            content_type='application/json'
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'ERROR')
+        self.assertEqual(content['errorCode'], 'error:VA')
+
+    def test_update_static_page_invalid_json_keeps_existing_fields(self):
+        page = StaticPage.objects.create(
+            title='Original Title',
+            slug='original-slug',
+            content='<p>Original</p>',
+            author=self.staff_user,
+        )
+
+        response = self.client.put(
+            f'/v1/static-pages/{page.id}',
+            '{invalid',
+            content_type='application/json'
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'DONE')
+        page.refresh_from_db()
+        self.assertEqual(page.title, 'Original Title')
+        self.assertEqual(page.slug, 'original-slug')
+        self.assertEqual(page.content, '<p>Original</p>')
+
     def test_get_static_page(self):
         """정적 페이지 상세 조회 테스트"""
         page = StaticPage.objects.create(

--- a/backend/src/board/views/api/v1/static_page.py
+++ b/backend/src/board/views/api/v1/static_page.py
@@ -1,8 +1,8 @@
-import json
 from django.http import Http404
 from django.shortcuts import get_object_or_404
 from board.models import StaticPage
 from board.modules.response import StatusDone, StatusError, ErrorCode
+from board.services.api_request_body_service import ApiRequestBodyService
 
 
 def static_pages(request, page_id=None):
@@ -59,10 +59,9 @@ def static_pages(request, page_id=None):
 
     # Create new static page
     if request.method == 'POST':
-        try:
-            post_data = json.loads(request.body.decode('utf-8')) if request.body else {}
-        except (json.JSONDecodeError, UnicodeDecodeError):
-            return StatusError(ErrorCode.VALIDATE, '잘못된 요청입니다.')
+        post_data, body_error = ApiRequestBodyService.parse_json_or_error(request)
+        if body_error:
+            return body_error
 
         title = post_data.get('title', '')
         slug = post_data.get('slug', '')
@@ -109,10 +108,7 @@ def static_pages(request, page_id=None):
     if request.method == 'PUT' and page_id:
         page = get_object_or_404(StaticPage, id=page_id)
 
-        try:
-            put_data = json.loads(request.body.decode('utf-8')) if request.body else {}
-        except (json.JSONDecodeError, UnicodeDecodeError):
-            put_data = {}
+        put_data = ApiRequestBodyService.parse_json_or_default(request)
 
         if 'title' in put_data:
             page.title = put_data['title']


### PR DESCRIPTION
## 🎯 Goal
- Continue centralizing repeated API JSON body parsing.
- Apply `ApiRequestBodyService` to the static page API without behavior changes.

## 🔧 Core Changes
- Replaced inline JSON parsing in static page create/update endpoints with `ApiRequestBodyService`.
- Added regression tests for malformed JSON on create/update paths.

## 🤔 Key Decisions
- Preserved existing behavior:
  - create invalid JSON returns `ErrorCode.VALIDATE`.
  - update invalid JSON falls back to an empty update payload and keeps existing fields.
- Kept the PR scoped to static pages to continue the incremental JSON parser rollout.
- Sub-agent review found no blockers.

## 🧪 Verification Guide
### How to verify
1. Run `npm run server:test -- board.tests.api.test_static_page board.tests.services.test_api_request_body_service`.
2. Send malformed JSON to `/v1/static-pages`; expect a validate error.
3. Send malformed JSON to an existing static page update endpoint; expect existing fields to remain unchanged.

### Expected result
- Tests pass.
- Static page behavior remains unchanged.
- JSON body parsing logic is no longer duplicated in this endpoint.

## ✅ Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [x] Tests completed
- [ ] Documentation updated (if needed)
