### PR TITLE
♻️ Use JSON body parser for site setting API

### DIFF
--- a/backend/src/board/tests/api/test_site_setting.py
+++ b/backend/src/board/tests/api/test_site_setting.py
@@ -132,6 +132,27 @@ class SiteSettingAPITestCase(TestCase):
         self.assertEqual(setting.robots_txt_extra_rules, 'User-agent: ExampleBot\nDisallow: /private/')
         self.assertTrue(setting.aeo_enabled)
 
+
+    def test_update_invalid_json_keeps_existing_fields(self):
+        setting = SiteSetting.get_instance()
+        setting.header_script = 'original header'
+        setting.footer_script = 'original footer'
+        setting.save()
+
+        response = self.client.put(
+            '/v1/site-settings',
+            '{invalid',
+            content_type='application/json'
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'DONE')
+
+        setting.refresh_from_db()
+        self.assertEqual(setting.header_script, 'original header')
+        self.assertEqual(setting.footer_script, 'original footer')
+
     def test_singleton_behavior(self):
         """싱글톤 동작 확인 - 여러 번 저장해도 하나의 인스턴스"""
         data1 = {'header_script': 'first'}

--- a/backend/src/board/views/api/v1/site_setting.py
+++ b/backend/src/board/views/api/v1/site_setting.py
@@ -1,8 +1,8 @@
-import json
 from django.http import Http404
 from board.models import SiteSetting
 from board.modules.response import StatusDone
 from board.services.api_permission_service import ApiPermissionService
+from board.services.api_request_body_service import ApiRequestBodyService
 from board.services.agent_content_service import AgentContentService
 
 
@@ -38,10 +38,7 @@ def site_settings(request):
         return StatusDone(serialize_site_setting(request, setting))
 
     if request.method == 'PUT':
-        try:
-            put_data = json.loads(request.body.decode('utf-8')) if request.body else {}
-        except (json.JSONDecodeError, UnicodeDecodeError):
-            put_data = {}
+        put_data = ApiRequestBodyService.parse_json_or_default(request)
 
         if 'header_script' in put_data:
             setting.header_script = put_data['header_script']


### PR DESCRIPTION
## 🎯 Goal
- Continue centralizing repeated API JSON body parsing.
- Apply `ApiRequestBodyService` to the site setting API without behavior changes.

## 🔧 Core Changes
- Replaced inline JSON parsing in the site setting update endpoint with `ApiRequestBodyService`.
- Added a regression test for malformed JSON preserving existing setting fields.

## 🤔 Key Decisions
- Preserved existing behavior: invalid JSON on PUT falls back to an empty update payload and still returns `DONE` with current settings.
- Kept this PR scoped to site settings to continue the incremental JSON parser rollout.
- Sub-agent review found no blockers.

## 🧪 Verification Guide
### How to verify
1. Run `npm run server:test -- board.tests.api.test_site_setting board.tests.services.test_api_request_body_service`.
2. Send malformed JSON to `/v1/site-settings` with PUT; expect existing fields to remain unchanged.

### Expected result
- Tests pass.
- Site setting behavior remains unchanged.
- JSON body parsing logic is no longer duplicated in this endpoint.

## ✅ Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [x] Tests completed
- [ ] Documentation updated (if needed)
