### PR TITLE
♻️ Use JSON body parser for utility APIs

### DIFF
--- a/backend/src/board/tests/api/test_utility.py
+++ b/backend/src/board/tests/api/test_utility.py
@@ -353,6 +353,44 @@ class UtilityAPITestCase(TestCase):
             content = json.loads(response.content)
             self.assertEqual(content['status'], 'DONE')
 
+    def test_clean_endpoints_empty_body_use_default_dry_run(self):
+        expected_keys = {
+            '/v1/utilities/clean-tags': 'dryRun',
+            '/v1/utilities/clean-sessions': 'dryRun',
+            '/v1/utilities/clean-logs': 'dryRun',
+            '/v1/utilities/clean-images': 'dryRun',
+        }
+
+        for endpoint, dry_run_key in expected_keys.items():
+            with self.subTest(endpoint=endpoint):
+                response = self.client.post(
+                    endpoint,
+                    b'',
+                    content_type='application/json'
+                )
+                content = json.loads(response.content)
+                self.assertEqual(content['status'], 'DONE')
+                self.assertTrue(content['body'][dry_run_key])
+
+    def test_clean_endpoints_invalid_json_return_validate_error(self):
+        endpoints = (
+            '/v1/utilities/clean-tags',
+            '/v1/utilities/clean-sessions',
+            '/v1/utilities/clean-logs',
+            '/v1/utilities/clean-images',
+        )
+
+        for endpoint in endpoints:
+            with self.subTest(endpoint=endpoint):
+                response = self.client.post(
+                    endpoint,
+                    '{invalid',
+                    content_type='application/json'
+                )
+                content = json.loads(response.content)
+                self.assertEqual(content['status'], 'ERROR')
+                self.assertEqual(content['errorCode'], 'error:VA')
+
     # === Method checks ===
 
     def test_stats_rejects_post(self):

--- a/backend/src/board/views/api/v1/utility.py
+++ b/backend/src/board/views/api/v1/utility.py
@@ -1,4 +1,3 @@
-import json
 import os
 
 from django.conf import settings
@@ -6,6 +5,7 @@ from django.contrib.admin.models import LogEntry
 from django.contrib.sessions.models import Session
 
 from board.modules.response import StatusDone, StatusError, ErrorCode
+from board.services.api_request_body_service import ApiRequestBodyService
 from board.admin.utilities import (
     DatabaseStatsService,
     SessionCleanerService,
@@ -47,10 +47,9 @@ def utility_clean_tags(request):
     if request.method != 'POST':
         return StatusError(ErrorCode.REJECT)
 
-    try:
-        body = json.loads(request.body.decode('utf-8')) if request.body else {}
-    except (json.JSONDecodeError, UnicodeDecodeError):
-        return StatusError(ErrorCode.VALIDATE, '잘못된 요청입니다.')
+    body, body_error = ApiRequestBodyService.parse_json_or_error(request)
+    if body_error:
+        return body_error
 
     dry_run = body.get('dry_run', True)
 
@@ -83,10 +82,9 @@ def utility_clean_sessions(request):
     if request.method != 'POST':
         return StatusError(ErrorCode.REJECT)
 
-    try:
-        body = json.loads(request.body.decode('utf-8')) if request.body else {}
-    except (json.JSONDecodeError, UnicodeDecodeError):
-        return StatusError(ErrorCode.VALIDATE, '잘못된 요청입니다.')
+    body, body_error = ApiRequestBodyService.parse_json_or_error(request)
+    if body_error:
+        return body_error
 
     dry_run = body.get('dry_run', True)
     clean_all = body.get('clean_all', False)
@@ -124,10 +122,9 @@ def utility_clean_logs(request):
     if request.method != 'POST':
         return StatusError(ErrorCode.REJECT)
 
-    try:
-        body = json.loads(request.body.decode('utf-8')) if request.body else {}
-    except (json.JSONDecodeError, UnicodeDecodeError):
-        return StatusError(ErrorCode.VALIDATE, '잘못된 요청입니다.')
+    body, body_error = ApiRequestBodyService.parse_json_or_error(request)
+    if body_error:
+        return body_error
 
     dry_run = body.get('dry_run', True)
     log_count = LogEntry.objects.count()
@@ -158,10 +155,9 @@ def utility_clean_images(request):
     if request.method != 'POST':
         return StatusError(ErrorCode.REJECT)
 
-    try:
-        body = json.loads(request.body.decode('utf-8')) if request.body else {}
-    except (json.JSONDecodeError, UnicodeDecodeError):
-        return StatusError(ErrorCode.VALIDATE, '잘못된 요청입니다.')
+    body, body_error = ApiRequestBodyService.parse_json_or_error(request)
+    if body_error:
+        return body_error
 
     dry_run = body.get('dry_run', True)
     target = body.get('target', 'all')


### PR DESCRIPTION
## 🎯 Goal
- Continue centralizing repeated API JSON body parsing.
- Apply `ApiRequestBodyService` to utility cleanup APIs without behavior changes.

## 🔧 Core Changes
- Replaced inline JSON parsing in clean-tags, clean-sessions, clean-logs, and clean-images endpoints with `ApiRequestBodyService`.
- Added regression tests for malformed JSON returning validate errors.
- Added regression coverage for empty body preserving default dry-run behavior.

## 🤔 Key Decisions
- Preserved existing behavior:
  - invalid JSON returns `ErrorCode.VALIDATE`.
  - empty body resolves to `{}` so cleanup endpoints default to dry-run.
- Kept the PR scoped to utility cleanup APIs because other remaining API files have more complex JSON/QueryDict fallback semantics.
- Sub-agent review found no blockers; added its suggested empty-body regression test.

## 🧪 Verification Guide
### How to verify
1. Run `npm run server:test -- board.tests.api.test_utility board.tests.services.test_api_request_body_service`.
2. Send malformed JSON to each utility cleanup endpoint; expect validate errors.
3. Send an empty body to each cleanup endpoint; expect dry-run behavior.

### Expected result
- Tests pass.
- Utility cleanup behavior remains unchanged.
- JSON body parsing logic is no longer duplicated in these endpoints.

## ✅ Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [x] Tests completed
- [ ] Documentation updated (if needed)
