### PR TITLE
♻️ Use JSON body parser for series APIs

### DIFF
--- a/backend/src/board/services/api_request_body_service.py
+++ b/backend/src/board/services/api_request_body_service.py
@@ -1,5 +1,7 @@
 import json
 
+from django.http import QueryDict
+
 from board.modules.response import ErrorCode, StatusError
 
 
@@ -21,13 +23,13 @@ class ApiRequestBodyService:
         return json.loads(request.body.decode('utf-8'))
 
     @staticmethod
-    def parse_json_or_error(request, default=None, message=None):
+    def parse_json_or_error(request, default=None, message=None, error_code=ErrorCode.VALIDATE):
         """Parse JSON and return (data, error_response)."""
         try:
             return ApiRequestBodyService.parse_json(request, default=default), None
         except (json.JSONDecodeError, UnicodeDecodeError):
             return None, StatusError(
-                ErrorCode.VALIDATE,
+                error_code,
                 message or ApiRequestBodyService.DEFAULT_INVALID_JSON_MESSAGE,
             )
 
@@ -38,3 +40,11 @@ class ApiRequestBodyService:
             return ApiRequestBodyService.parse_json(request, default=default)
         except (json.JSONDecodeError, UnicodeDecodeError):
             return {} if default is None else default
+
+    @staticmethod
+    def parse_json_or_querydict(request):
+        """Parse JSON, falling back to QueryDict for form-encoded bodies."""
+        try:
+            return ApiRequestBodyService.parse_json(request)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return QueryDict(request.body)

--- a/backend/src/board/tests/api/test_series_api.py
+++ b/backend/src/board/tests/api/test_series_api.py
@@ -84,6 +84,27 @@ class SeriesAPITestCase(TestCase):
         self.assertEqual(content['status'], 'ERROR')
         self.assertEqual(content['errorCode'], 'error:NL')
 
+
+    def test_series_json_endpoints_invalid_json_return_invalid_parameter(self):
+        self.client.login(username='author', password='author')
+        series = Series.objects.get(url='test-series')
+        endpoints = (
+            ('post', '/v1/series'),
+            ('put', '/v1/series/order'),
+            ('put', f'/v1/series/{series.id}'),
+        )
+
+        for method, endpoint in endpoints:
+            with self.subTest(endpoint=endpoint):
+                response = getattr(self.client, method)(
+                    endpoint,
+                    data='{invalid',
+                    content_type='application/json'
+                )
+                content = json.loads(response.content)
+                self.assertEqual(content['status'], 'ERROR')
+                self.assertEqual(content['errorCode'], 'error:IP')
+
     # POST /v1/series - Create new series
     def test_create_series(self):
         """시리즈 생성 테스트"""
@@ -445,6 +466,36 @@ class SeriesAPITestCase(TestCase):
             content_type='application/json'
         )
         self.assertEqual(response.status_code, 200)
+
+
+    def test_create_series_with_form_encoded_body_via_user_endpoint(self):
+        """사용자 시리즈 생성 API는 기존 form body fallback을 유지한다."""
+        self.client.login(username='author', password='author')
+        response = self.client.post(
+            '/v1/users/@author/series',
+            data='title=Form+Series&description=Form+Description',
+            content_type='application/x-www-form-urlencoded'
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'DONE')
+        self.assertTrue(Series.objects.filter(name='Form Series').exists())
+
+    def test_update_series_with_form_encoded_body_via_user_endpoint(self):
+        """사용자 시리즈 수정 API는 기존 form body fallback을 유지한다."""
+        self.client.login(username='author', password='author')
+        response = self.client.put(
+            '/v1/users/@author/series/test-series',
+            data='title=Form+Updated&description=Form+Description',
+            content_type='application/x-www-form-urlencoded'
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'DONE')
+        series = Series.objects.get(url='test-series')
+        self.assertEqual(series.name, 'Form Updated')
 
     # DELETE /v1/users/@<username>/series/<url> - Delete series via user endpoint
     def test_delete_series_via_user_endpoint(self):

--- a/backend/src/board/tests/services/test_api_request_body_service.py
+++ b/backend/src/board/tests/services/test_api_request_body_service.py
@@ -30,6 +30,34 @@ class ApiRequestBodyServiceTestCase(TestCase):
         self.assertIsNotNone(error)
         self.assertEqual(error.status_code, 200)
 
+
+    def test_parse_json_or_error_allows_custom_error_code(self):
+        from board.modules.response import ErrorCode
+
+        request = self.factory.post('/v1/example', data=b'{invalid', content_type='application/json')
+
+        data, error = ApiRequestBodyService.parse_json_or_error(
+            request,
+            error_code=ErrorCode.INVALID_PARAMETER,
+            message='invalid payload',
+        )
+
+        self.assertIsNone(data)
+        self.assertIsNotNone(error)
+        self.assertContains(error, 'error:IP')
+
+    def test_parse_json_or_querydict_falls_back_to_form_body(self):
+        request = self.factory.post(
+            '/v1/example',
+            data='title=Form+Title&post_ids=1%2C2',
+            content_type='application/x-www-form-urlencoded',
+        )
+
+        data = ApiRequestBodyService.parse_json_or_querydict(request)
+
+        self.assertEqual(data.get('title'), 'Form Title')
+        self.assertEqual(data.get('post_ids'), '1,2')
+
     def test_parse_json_or_default_returns_default_for_invalid_json(self):
         request = self.factory.put('/v1/example/1', data=b'{invalid', content_type='application/json')
 

--- a/backend/src/board/views/api/v1/series.py
+++ b/backend/src/board/views/api/v1/series.py
@@ -1,4 +1,3 @@
-import json
 from django.db.models import F, Q
 from django.http import Http404, QueryDict
 from django.shortcuts import get_object_or_404
@@ -8,6 +7,7 @@ from board.services import SeriesService
 from board.services.series_service import SeriesValidationError
 from board.services.public_post_service import PublicPostService
 from board.services.public_series_service import PublicSeriesService
+from board.services.api_request_body_service import ApiRequestBodyService
 from board.modules.paginator import Paginator
 from board.modules.response import StatusDone, StatusError, ErrorCode
 from board.modules.time import convert_to_localtime
@@ -101,10 +101,7 @@ def user_series(request, username, url=None):
                     return StatusError(e.code, e.message)
 
         if request.method == 'POST':
-            try:
-                body = json.loads(request.body)
-            except:
-                body = QueryDict(request.body)
+            body = ApiRequestBodyService.parse_json_or_querydict(request)
 
             try:
                 post_ids = []
@@ -193,10 +190,7 @@ def user_series(request, username, url=None):
             return StatusError(ErrorCode.AUTHENTICATION)
 
         if request.method == 'PUT':
-            try:
-                put = json.loads(request.body)
-            except:
-                put = QueryDict(request.body)
+            put = ApiRequestBodyService.parse_json_or_querydict(request)
 
             try:
                 post_ids = None
@@ -232,10 +226,13 @@ def series_order(request):
     Expects JSON data with 'order' field containing array of [id, order] pairs.
     """
     if request.method == 'PUT':
-        try:
-            body = json.loads(request.body)
-        except:
-            return StatusError(ErrorCode.INVALID_PARAMETER, '잘못된 요청 데이터입니다.')
+        body, body_error = ApiRequestBodyService.parse_json_or_error(
+            request,
+            error_code=ErrorCode.INVALID_PARAMETER,
+            message='잘못된 요청 데이터입니다.',
+        )
+        if body_error:
+            return body_error
 
         order_data = body.get('order', [])
         if not order_data:
@@ -274,10 +271,13 @@ def series_create_update(request):
         })
 
     elif request.method == 'POST':
-        try:
-            body = json.loads(request.body)
-        except:
-            return StatusError(ErrorCode.INVALID_PARAMETER, '잘못된 요청 데이터입니다.')
+        body, body_error = ApiRequestBodyService.parse_json_or_error(
+            request,
+            error_code=ErrorCode.INVALID_PARAMETER,
+            message='잘못된 요청 데이터입니다.',
+        )
+        if body_error:
+            return body_error
 
         try:
             post_ids = None
@@ -344,10 +344,13 @@ def series_detail(request, series_id):
         })
 
     if request.method == 'PUT':
-        try:
-            body = json.loads(request.body)
-        except:
-            return StatusError(ErrorCode.INVALID_PARAMETER, '잘못된 요청 데이터입니다.')
+        body, body_error = ApiRequestBodyService.parse_json_or_error(
+            request,
+            error_code=ErrorCode.INVALID_PARAMETER,
+            message='잘못된 요청 데이터입니다.',
+        )
+        if body_error:
+            return body_error
 
         try:
             post_ids = None


### PR DESCRIPTION
## 🎯 Goal
- Continue centralizing repeated API JSON body parsing.
- Apply `ApiRequestBodyService` to series APIs without behavior changes.

## 🔧 Core Changes
- Extended `ApiRequestBodyService` with:
  - custom error-code support for parse-or-error flows.
  - JSON-first / `QueryDict` fallback helper for mixed JSON/form endpoints.
- Replaced inline JSON parsing in series APIs with the shared helper.
- Added regression tests for invalid JSON and form-encoded fallback behavior.

## 🤔 Key Decisions
- Preserved existing behavior:
  - `/v1/series`, `/v1/series/order`, and `/v1/series/<id>` malformed JSON returns `ErrorCode.INVALID_PARAMETER`.
  - `/v1/users/@.../series` create/update keeps JSON-first parsing with `QueryDict` fallback.
- Kept default `parse_json_or_error()` behavior as `ErrorCode.VALIDATE` so existing callers are unaffected.
- Sub-agent review found no blockers.

## 🧪 Verification Guide
### How to verify
1. Run `npm run server:test -- board.tests.api.test_series_api board.tests.services.test_api_request_body_service`.
2. Send malformed JSON to `/v1/series`, `/v1/series/order`, and `/v1/series/<id>`; expect invalid-parameter errors.
3. Send form-encoded bodies to `/v1/users/@<username>/series` create/update endpoints; expect existing fallback behavior.

### Expected result
- Tests pass.
- Series API behavior remains unchanged.
- JSON body parsing policy is shared through `ApiRequestBodyService`.

## ✅ Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [x] Tests completed
- [ ] Documentation updated (if needed)
