### PR TITLE
♻️ Use JSON body parser for webhook APIs

### DIFF
--- a/backend/src/board/services/api_request_body_service.py
+++ b/backend/src/board/services/api_request_body_service.py
@@ -23,8 +23,20 @@ class ApiRequestBodyService:
         return json.loads(request.body.decode('utf-8'))
 
     @staticmethod
-    def parse_json_or_error(request, default=None, message=None, error_code=ErrorCode.VALIDATE):
+    def parse_json_or_error(
+        request,
+        default=None,
+        message=None,
+        error_code=ErrorCode.VALIDATE,
+        require_body=False,
+    ):
         """Parse JSON and return (data, error_response)."""
+        if require_body and not request.body:
+            return None, StatusError(
+                error_code,
+                message or ApiRequestBodyService.DEFAULT_INVALID_JSON_MESSAGE,
+            )
+
         try:
             return ApiRequestBodyService.parse_json(request, default=default), None
         except (json.JSONDecodeError, UnicodeDecodeError):

--- a/backend/src/board/tests/api/test_webhook.py
+++ b/backend/src/board/tests/api/test_webhook.py
@@ -87,6 +87,34 @@ class WebhookAPITestCase(TestCase):
             ).exists()
         )
 
+
+
+    def test_add_channel_empty_body_returns_invalid_parameter(self):
+        self.client.login(username='testauthor', password='testpass123')
+
+        response = self.client.post(
+            '/v1/webhook/channels',
+            data=b'',
+            content_type='application/json'
+        )
+
+        data = response.json()
+        self.assertEqual(data['status'], 'ERROR')
+        self.assertEqual(data['errorCode'], 'error:IP')
+
+    def test_add_channel_invalid_json_returns_invalid_parameter(self):
+        self.client.login(username='testauthor', password='testpass123')
+
+        response = self.client.post(
+            '/v1/webhook/channels',
+            data='{invalid',
+            content_type='application/json'
+        )
+
+        data = response.json()
+        self.assertEqual(data['status'], 'ERROR')
+        self.assertEqual(data['errorCode'], 'error:IP')
+
     def test_add_channel_invalid_url(self):
         """잘못된 URL로 채널 추가 시 실패"""
         self.client.login(username='testauthor', password='testpass123')
@@ -200,6 +228,38 @@ class WebhookAPITestCase(TestCase):
         data = response.json()
         self.assertEqual(data['status'], 'ERROR')
 
+
+
+    @patch('board.services.webhook_service.WebhookService.test_webhook')
+    def test_test_webhook_empty_body_returns_invalid_parameter(self, mock_test):
+        self.client.login(username='testauthor', password='testpass123')
+
+        response = self.client.post(
+            '/v1/webhook/test',
+            data=b'',
+            content_type='application/json'
+        )
+
+        data = response.json()
+        self.assertEqual(data['status'], 'ERROR')
+        self.assertEqual(data['errorCode'], 'error:IP')
+        mock_test.assert_not_called()
+
+    @patch('board.services.webhook_service.WebhookService.test_webhook')
+    def test_test_webhook_invalid_json_returns_invalid_parameter(self, mock_test):
+        self.client.login(username='testauthor', password='testpass123')
+
+        response = self.client.post(
+            '/v1/webhook/test',
+            data='{invalid',
+            content_type='application/json'
+        )
+
+        data = response.json()
+        self.assertEqual(data['status'], 'ERROR')
+        self.assertEqual(data['errorCode'], 'error:IP')
+        mock_test.assert_not_called()
+
     @patch('board.services.webhook_service.WebhookService.test_webhook')
     def test_test_webhook(self, mock_test):
         """웹훅 테스트 메시지 전송"""
@@ -282,6 +342,34 @@ class GlobalWebhookAPITestCase(TestCase):
         self.assertEqual(data['status'], 'DONE')
         self.assertEqual(len(data['body']['channels']), 1)
         self.assertEqual(data['body']['channels'][0]['name'], 'Global One')
+
+
+
+    def test_add_global_channel_empty_body_returns_invalid_parameter(self):
+        self.client.login(username='staff', password='testpass123')
+
+        response = self.client.post(
+            '/v1/webhook/global-channels',
+            data=b'',
+            content_type='application/json'
+        )
+
+        data = response.json()
+        self.assertEqual(data['status'], 'ERROR')
+        self.assertEqual(data['errorCode'], 'error:IP')
+
+    def test_add_global_channel_invalid_json_returns_invalid_parameter(self):
+        self.client.login(username='staff', password='testpass123')
+
+        response = self.client.post(
+            '/v1/webhook/global-channels',
+            data='{invalid',
+            content_type='application/json'
+        )
+
+        data = response.json()
+        self.assertEqual(data['status'], 'ERROR')
+        self.assertEqual(data['errorCode'], 'error:IP')
 
     def test_add_and_delete_global_channel_staff(self):
         self.client.login(username='staff', password='testpass123')

--- a/backend/src/board/tests/services/test_api_request_body_service.py
+++ b/backend/src/board/tests/services/test_api_request_body_service.py
@@ -31,6 +31,23 @@ class ApiRequestBodyServiceTestCase(TestCase):
         self.assertEqual(error.status_code, 200)
 
 
+
+    def test_parse_json_or_error_can_require_body(self):
+        from board.modules.response import ErrorCode
+
+        request = self.factory.post('/v1/example', data=b'', content_type='application/json')
+
+        data, error = ApiRequestBodyService.parse_json_or_error(
+            request,
+            error_code=ErrorCode.INVALID_PARAMETER,
+            message='body required',
+            require_body=True,
+        )
+
+        self.assertIsNone(data)
+        self.assertIsNotNone(error)
+        self.assertContains(error, 'error:IP')
+
     def test_parse_json_or_error_allows_custom_error_code(self):
         from board.modules.response import ErrorCode
 

--- a/backend/src/board/views/api/v1/webhook.py
+++ b/backend/src/board/views/api/v1/webhook.py
@@ -6,12 +6,11 @@ When a new post is published, notifications are sent to:
 - the author's channels
 - global channels (staff-managed)
 """
-import json
-
 from django.views.decorators.http import require_http_methods
 
 from board.models import Profile, WebhookSubscription, SiteContentScope
 from board.services import WebhookService
+from board.services.api_request_body_service import ApiRequestBodyService
 from board.modules.response import StatusDone, StatusError, ErrorCode
 
 
@@ -28,10 +27,14 @@ def _get_authenticated_profile(request):
 
 
 def _validate_webhook_payload(request):
-    try:
-        data = json.loads(request.body)
-    except json.JSONDecodeError:
-        return None, None, StatusError(ErrorCode.INVALID_PARAMETER, 'Invalid JSON body')
+    data, body_error = ApiRequestBodyService.parse_json_or_error(
+        request,
+        error_code=ErrorCode.INVALID_PARAMETER,
+        message='Invalid JSON body',
+        require_body=True,
+    )
+    if body_error:
+        return None, None, body_error
 
     webhook_url = data.get('webhook_url', '').strip()
     name = data.get('name', '').strip()
@@ -198,10 +201,14 @@ def test_channel(request):
     if error:
         return error
 
-    try:
-        data = json.loads(request.body)
-    except json.JSONDecodeError:
-        return StatusError(ErrorCode.INVALID_PARAMETER, 'Invalid JSON body')
+    data, body_error = ApiRequestBodyService.parse_json_or_error(
+        request,
+        error_code=ErrorCode.INVALID_PARAMETER,
+        message='Invalid JSON body',
+        require_body=True,
+    )
+    if body_error:
+        return body_error
 
     webhook_url = data.get('webhook_url', '').strip()
 


### PR DESCRIPTION
## 🎯 Goal
- Continue centralizing repeated API JSON body parsing.
- Apply `ApiRequestBodyService` to webhook APIs without behavior changes.

## 🔧 Core Changes
- Extended `ApiRequestBodyService.parse_json_or_error()` with an opt-in `require_body` flag.
- Replaced inline webhook JSON parsing with the shared helper.
- Added regression tests for malformed JSON and empty-body behavior on webhook endpoints.

## 🤔 Key Decisions
- Preserved existing webhook behavior:
  - malformed JSON returns `ErrorCode.INVALID_PARAMETER`.
  - empty body also returns `ErrorCode.INVALID_PARAMETER` for webhook endpoints.
  - webhook test endpoint does not call `WebhookService.test_webhook` when body parsing fails.
- Kept `require_body=False` as the default so existing `ApiRequestBodyService` callers are unaffected.
- Sub-agent review initially caught an empty-body behavior change; after adding `require_body=True` and regression tests, re-review found no blockers.

## 🧪 Verification Guide
### How to verify
1. Run `npm run server:test -- board.tests.api.test_webhook board.tests.services.test_api_request_body_service`.
2. Send malformed JSON and empty bodies to webhook create/test endpoints; expect invalid-parameter errors.
3. Verify valid webhook create/test flows still pass.

### Expected result
- Tests pass.
- Webhook API body parsing behavior remains unchanged.
- JSON body parsing policy is shared through `ApiRequestBodyService`.

## ✅ Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [x] Tests completed
- [ ] Documentation updated (if needed)
