### PR TITLE
🐛 Harden public series detail visibility

### DIFF
--- a/backend/src/board/tests/api/test_series_api.py
+++ b/backend/src/board/tests/api/test_series_api.py
@@ -404,8 +404,8 @@ class SeriesAPITestCase(TestCase):
         self.assertIn('posts', content['body'])
 
 
-    def test_get_hidden_series_detail_keeps_existing_public_api_behavior(self):
-        """시리즈 상세 API는 기존처럼 숨김 시리즈도 조회하되 공개 글만 반환한다."""
+    def test_get_hidden_series_detail_returns_404(self):
+        """공개 시리즈 상세 API는 숨김 시리즈를 노출하지 않는다."""
         author = User.objects.get(username='author')
         series = Series.objects.create(
             owner=author,
@@ -419,14 +419,10 @@ class SeriesAPITestCase(TestCase):
 
         response = self.client.get('/v1/users/@author/series/hidden-series')
 
-        self.assertEqual(response.status_code, 200)
-        content = json.loads(response.content)
-        self.assertEqual(content['body']['name'], 'Hidden Series')
-        self.assertEqual(content['body']['totalPosts'], 1)
-        self.assertEqual(len(content['body']['posts']), 1)
+        self.assertEqual(response.status_code, 404)
 
-    def test_get_empty_series_detail_keeps_existing_public_api_behavior(self):
-        """시리즈 상세 API는 공개 글이 없어도 기존처럼 조회되고 total_posts만 0이다."""
+    def test_get_empty_series_detail_returns_404(self):
+        """공개 시리즈 상세 API는 공개 글이 없는 시리즈를 노출하지 않는다."""
         author = User.objects.get(username='author')
         Series.objects.create(
             owner=author,
@@ -437,11 +433,71 @@ class SeriesAPITestCase(TestCase):
 
         response = self.client.get('/v1/users/@author/series/empty-series')
 
-        self.assertEqual(response.status_code, 200)
-        content = json.loads(response.content)
-        self.assertEqual(content['body']['name'], 'Empty Series')
-        self.assertEqual(content['body']['totalPosts'], 0)
-        self.assertEqual(content['body']['posts'], [])
+        self.assertEqual(response.status_code, 404)
+
+
+    def test_get_draft_only_series_detail_returns_404(self):
+        """공개 시리즈 상세 API는 draft-only 시리즈를 노출하지 않는다."""
+        author = User.objects.get(username='author')
+        series = Series.objects.create(
+            owner=author,
+            name='Draft Only Series',
+            url='draft-only-series',
+        )
+        draft_post = Post.objects.create(
+            author=author,
+            title='Draft Post',
+            url='draft-post',
+            series=series,
+            published_date=None,
+        )
+        PostConfig.objects.create(post=draft_post, hide=False)
+
+        response = self.client.get('/v1/users/@author/series/draft-only-series')
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_get_scheduled_only_series_detail_returns_404(self):
+        """공개 시리즈 상세 API는 scheduled-only 시리즈를 노출하지 않는다."""
+        author = User.objects.get(username='author')
+        series = Series.objects.create(
+            owner=author,
+            name='Scheduled Only Series',
+            url='scheduled-only-series',
+        )
+        future_post = Post.objects.create(
+            author=author,
+            title='Future Post',
+            url='future-post',
+            series=series,
+            published_date=timezone.now() + timezone.timedelta(days=1),
+        )
+        PostConfig.objects.create(post=future_post, hide=False)
+
+        response = self.client.get('/v1/users/@author/series/scheduled-only-series')
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_get_hidden_post_only_series_detail_returns_404(self):
+        """공개 시리즈 상세 API는 hidden-post-only 시리즈를 노출하지 않는다."""
+        author = User.objects.get(username='author')
+        series = Series.objects.create(
+            owner=author,
+            name='Hidden Post Only Series',
+            url='hidden-post-only-series',
+        )
+        hidden_post = Post.objects.create(
+            author=author,
+            title='Hidden Only Post',
+            url='hidden-only-post',
+            series=series,
+            published_date=timezone.now(),
+        )
+        PostConfig.objects.create(post=hidden_post, hide=True)
+
+        response = self.client.get('/v1/users/@author/series/hidden-post-only-series')
+
+        self.assertEqual(response.status_code, 404)
 
     def test_get_nonexistent_series(self):
         """존재하지 않는 시리즈 조회 시 404 에러"""
@@ -497,6 +553,32 @@ class SeriesAPITestCase(TestCase):
         series = Series.objects.get(url='test-series')
         self.assertEqual(series.name, 'Form Updated')
 
+    def test_update_hidden_series_via_user_endpoint_still_works(self):
+        """공개 조회 필터는 숨김 시리즈의 owner 수정 경로를 막지 않는다."""
+        author = User.objects.get(username='author')
+        Series.objects.create(
+            owner=author,
+            name='Hidden Editable Series',
+            url='hidden-editable-series',
+            hide=True,
+        )
+        self.client.login(username='author', password='author')
+
+        response = self.client.put(
+            '/v1/users/@author/series/hidden-editable-series',
+            data=json.dumps({
+                'title': 'Updated Hidden Editable Series',
+                'description': 'Updated description',
+            }),
+            content_type='application/json'
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'DONE')
+        series = Series.objects.get(url='hidden-editable-series')
+        self.assertEqual(series.name, 'Updated Hidden Editable Series')
+
     # DELETE /v1/users/@<username>/series/<url> - Delete series via user endpoint
     def test_delete_series_via_user_endpoint(self):
         """사용자 엔드포인트를 통한 시리즈 삭제"""
@@ -512,6 +594,21 @@ class SeriesAPITestCase(TestCase):
         response = self.client.delete(f'/v1/users/@author/series/series-to-delete-2')
         self.assertEqual(response.status_code, 200)
         self.assertFalse(Series.objects.filter(url='series-to-delete-2').exists())
+
+    def test_delete_empty_series_via_user_endpoint_still_works(self):
+        """공개 조회 필터는 공개 글이 없는 시리즈의 owner 삭제 경로를 막지 않는다."""
+        author = User.objects.get(username='author')
+        Series.objects.create(
+            owner=author,
+            name='Empty Deletable Series',
+            url='empty-deletable-series',
+        )
+        self.client.login(username='author', password='author')
+
+        response = self.client.delete('/v1/users/@author/series/empty-deletable-series')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(Series.objects.filter(url='empty-deletable-series').exists())
 
     # POST /v1/users/@<username>/series - Create series with posts
     def test_create_series_with_posts(self):
@@ -575,6 +672,5 @@ class SeriesAPITestCase(TestCase):
         
         series_urls = [s['url'] for s in content['body']['series']]
         self.assertNotIn('hidden-series', series_urls)
-
 
 

--- a/backend/src/board/tests/templates/test_series_static_seo.py
+++ b/backend/src/board/tests/templates/test_series_static_seo.py
@@ -67,6 +67,130 @@ class SeriesSeoMetadataTestCase(StructuredDataAssertionMixin, TestCase):
                 hide=False,
             )
 
+
+    def test_series_detail_returns_404_for_hidden_series(self):
+        self.series.hide = True
+        self.series.save()
+
+        response = self.client.get(
+            reverse(
+                'series_detail',
+                kwargs={
+                    'username': 'seriesauthor',
+                    'series_url': 'structured-series',
+                },
+            )
+        )
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_series_detail_returns_404_for_empty_series(self):
+        empty_series = Series.objects.create(
+            owner=self.author,
+            name='Empty Series',
+            url='empty-series',
+            hide=False,
+        )
+
+        response = self.client.get(
+            reverse(
+                'series_detail',
+                kwargs={
+                    'username': 'seriesauthor',
+                    'series_url': empty_series.url,
+                },
+            )
+        )
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_series_detail_returns_404_for_hidden_post_only_series(self):
+        hidden_series = Series.objects.create(
+            owner=self.author,
+            name='Hidden Post Only Series',
+            url='hidden-post-only-series',
+            hide=False,
+        )
+        hidden_post = Post.objects.create(
+            title='Hidden Post',
+            url='hidden-series-post',
+            author=self.author,
+            series=hidden_series,
+            published_date=timezone.now(),
+        )
+        PostContent.objects.create(post=hidden_post, content_html='<p>Hidden</p>')
+        PostConfig.objects.create(post=hidden_post, hide=True)
+
+        response = self.client.get(
+            reverse(
+                'series_detail',
+                kwargs={
+                    'username': 'seriesauthor',
+                    'series_url': hidden_series.url,
+                },
+            )
+        )
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_series_detail_returns_404_for_draft_only_series(self):
+        draft_series = Series.objects.create(
+            owner=self.author,
+            name='Draft Only Series',
+            url='draft-only-series',
+            hide=False,
+        )
+        draft_post = Post.objects.create(
+            title='Draft Post',
+            url='draft-series-post',
+            author=self.author,
+            series=draft_series,
+            published_date=None,
+        )
+        PostContent.objects.create(post=draft_post, content_html='<p>Draft</p>')
+        PostConfig.objects.create(post=draft_post, hide=False)
+
+        response = self.client.get(
+            reverse(
+                'series_detail',
+                kwargs={
+                    'username': 'seriesauthor',
+                    'series_url': draft_series.url,
+                },
+            )
+        )
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_series_detail_returns_404_for_scheduled_only_series(self):
+        scheduled_series = Series.objects.create(
+            owner=self.author,
+            name='Scheduled Only Series',
+            url='scheduled-only-series',
+            hide=False,
+        )
+        scheduled_post = Post.objects.create(
+            title='Scheduled Post',
+            url='scheduled-series-post',
+            author=self.author,
+            series=scheduled_series,
+            published_date=timezone.now() + timezone.timedelta(days=1),
+        )
+        PostContent.objects.create(post=scheduled_post, content_html='<p>Scheduled</p>')
+        PostConfig.objects.create(post=scheduled_post, hide=False)
+
+        response = self.client.get(
+            reverse(
+                'series_detail',
+                kwargs={
+                    'username': 'seriesauthor',
+                    'series_url': scheduled_series.url,
+                },
+            )
+        )
+
+        self.assertEqual(response.status_code, 404)
+
     @override_settings(SITE_URL='')
     def test_series_detail_renders_canonical_meta_and_collection_json_ld(self):
         response = self.client.get(

--- a/backend/src/board/views/api/v1/series.py
+++ b/backend/src/board/views/api/v1/series.py
@@ -127,15 +127,17 @@ def user_series(request, username, url=None):
 
     if url:
         user = get_object_or_404(User, username=username)
-        series = get_object_or_404(PublicSeriesService.with_public_post_count(
-            Series.objects.annotate(
-                owner_username=F('owner__username'),
-                owner_avatar=F('owner__profile__avatar'),
-            ),
-            'total_posts',
-        ), owner=user, url=url)
+        series_queryset = Series.objects.annotate(
+            owner_username=F('owner__username'),
+            owner_avatar=F('owner__profile__avatar'),
+        )
 
         if request.method == 'GET':
+            series = get_object_or_404(
+                PublicSeriesService.filter_public_series(series_queryset, 'total_posts'),
+                owner=user,
+                url=url,
+            )
             if request.GET.get('kind', '') == 'continue':
                 posts = PublicPostService.filter_public_posts(Post.objects).filter(
                     series=series,
@@ -185,6 +187,12 @@ def user_series(request, username, url=None):
                 }, posts)),
                 'last_page': posts.paginator.num_pages
             })
+
+        series = get_object_or_404(
+            PublicSeriesService.with_public_post_count(series_queryset, 'total_posts'),
+            owner=user,
+            url=url,
+        )
 
         if not SeriesService.can_user_edit_series(request.user, series):
             return StatusError(ErrorCode.AUTHENTICATION)

--- a/backend/src/board/views/series.py
+++ b/backend/src/board/views/series.py
@@ -7,6 +7,7 @@ from board.models import Post, Series, PostLikes
 from board.services.agent_content_service import AgentContentService
 from board.services.discovery_metadata_service import DiscoveryMetadataService
 from board.services.public_post_service import PublicPostService
+from board.services.public_series_service import PublicSeriesService
 
 
 def series_detail(request, username, series_url):
@@ -19,13 +20,11 @@ def series_detail(request, username, series_url):
     if sort_order not in ['asc', 'desc']:
         sort_order = 'desc'
 
-    try:
-        series = Series.objects.get(
-            owner=author,
-            url=series_url,
-        )
-    except Series.DoesNotExist:
-        raise Http404("Series does not exist")
+    series = get_object_or_404(
+        PublicSeriesService.filter_public_series(Series.objects),
+        owner=author,
+        url=series_url,
+    )
 
     order_by = 'published_date' if sort_order == 'asc' else '-published_date'
 


### PR DESCRIPTION
## 🎯 Goal
- Prevent hidden or non-public series from being exposed through public series detail HTML/API.
- Align series detail surfaces with `PublicSeriesService` used by sitemap/listing surfaces.

## 🔧 Core Changes
- Use `PublicSeriesService.filter_public_series()` for public series detail HTML.
- Use `PublicSeriesService.filter_public_series(..., 'total_posts')` for public series detail API GET.
- Preserve non-GET owner/staff edit/delete lookup behavior by only applying public filtering to GET detail.
- Add regression tests for hidden, empty, draft-only, scheduled-only, hidden-post-only series.
- Add behavior-preservation tests for updating hidden series and deleting empty series via owner endpoint.

## 🤔 Key Decisions
- Treat previous hidden/empty series detail exposure as a visibility bug, not behavior to preserve.
- Keep management/edit paths unchanged so owners can still manage non-public series.

## 🧪 Verification Guide
### How to verify
1. Run `npm run server:test -- board.tests.api.test_series_api board.tests.templates.test_series_static_seo board.tests.test_agent_content`.
2. Visit public series detail for hidden/empty/draft-only/future-only/hidden-post-only series; expect 404.
3. Visit normal public series detail; expect 200 and unchanged metadata.

### Expected result
- Tests pass.
- Public detail HTML/API only exposes public series with at least one public post.
- Series sitemap/markdown behavior remains aligned.
- Owner update/delete remains possible for non-public series.

## ✅ Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [x] Tests completed
- [ ] Documentation updated (if needed)
