### PR TITLE
🐛 Harden public author activity visibility

### DIFF
--- a/backend/src/board/services/user_service.py
+++ b/backend/src/board/services/user_service.py
@@ -21,6 +21,7 @@ from board.models import (
 )
 from board.modules.response import ErrorCode
 from board.services.public_post_service import PublicPostService
+from board.services.public_series_service import PublicSeriesService
 from modules.markdown import parse_post_to_html
 
 
@@ -199,7 +200,8 @@ class UserService:
         Returns:
             List of activity dictionaries
         """
-        cutoff_date = timezone.now() - datetime.timedelta(days=days)
+        now = timezone.now()
+        cutoff_date = now - datetime.timedelta(days=days)
 
         posts = PublicPostService.filter_public_posts(Post.objects.filter(
             published_date__gte=cutoff_date,
@@ -208,14 +210,14 @@ class UserService:
 
         series = Series.objects.filter(
             created_date__gte=cutoff_date,
-            created_date__lte=timezone.now(),
+            created_date__lte=now,
             owner=user
         ).order_by('-created_date')
 
         comments = Comment.objects.filter(
             PublicPostService.build_public_filter('post'),
             created_date__gte=cutoff_date,
-            created_date__lte=timezone.now(),
+            created_date__lte=now,
             author=user,
         ).order_by('-created_date')
 
@@ -389,13 +391,14 @@ class UserService:
         Returns:
             List of activity dictionaries (max 5 items, sorted by date)
         """
-        cutoff_date = timezone.now() - datetime.timedelta(days=days)
+        now = timezone.now()
+        cutoff_date = now - datetime.timedelta(days=days)
 
         recent_posts = Post.objects.filter(
             author=user,
             published_date__gte=cutoff_date,
             published_date__isnull=False,
-            published_date__lte=timezone.now(),
+            published_date__lte=now,
         ).select_related('author').only(
             'title', 'url', 'published_date', 'author__username'
         ).order_by('-published_date')[:5]
@@ -403,7 +406,7 @@ class UserService:
         recent_series = Series.objects.filter(
             owner=user,
             created_date__gte=cutoff_date,
-            created_date__lte=timezone.now(),
+            created_date__lte=now,
         ).select_related('owner').only(
             'name', 'url', 'created_date', 'owner__username'
         ).order_by('-created_date')[:5]
@@ -462,6 +465,107 @@ class UserService:
 
         recent_activities = sorted(activities, key=lambda x: x['sort_date'], reverse=True)
         
+        for activity in recent_activities:
+            del activity['sort_date']
+
+        return recent_activities
+
+    @staticmethod
+    def get_public_author_activities(user: User, days: int = 30) -> List[Dict[str, Any]]:
+        """
+        Get recent activities safe for public author overview surfaces.
+        Dashboard activities include private ownership context; this method only
+        exposes activity attached to public posts and public series.
+        """
+        now = timezone.now()
+        cutoff_date = now - datetime.timedelta(days=days)
+
+        recent_posts = PublicPostService.filter_public_posts(Post.objects.filter(
+            author=user,
+            published_date__gte=cutoff_date,
+        )).select_related('author', 'config').only(
+            'title',
+            'url',
+            'created_date',
+            'published_date',
+            'author__username',
+            'config__hide',
+        ).order_by('-published_date')[:5]
+
+        recent_series = PublicSeriesService.filter_public_series(Series.objects.filter(
+            owner=user,
+            created_date__gte=cutoff_date,
+            created_date__lte=now,
+        )).select_related('owner').only(
+            'name', 'url', 'created_date', 'owner__username'
+        ).order_by('-created_date')[:5]
+
+        recent_comments = Comment.objects.filter(
+            PublicPostService.build_public_filter('post'),
+            author=user,
+            created_date__gte=cutoff_date,
+        ).select_related('post', 'post__author', 'post__config').only(
+            'created_date',
+            'post__title',
+            'post__url',
+            'post__published_date',
+            'post__author__username',
+            'post__config__hide',
+        ).order_by('-created_date')[:5]
+
+        recent_likes = PostLikes.objects.filter(
+            PublicPostService.build_public_filter('post'),
+            user=user,
+            created_date__gte=cutoff_date,
+        ).select_related('post', 'post__author', 'post__config').only(
+            'created_date',
+            'post__title',
+            'post__url',
+            'post__published_date',
+            'post__author__username',
+            'post__config__hide',
+        ).order_by('-created_date')[:5]
+
+        activities = []
+
+        for post in recent_posts:
+            activities.append({
+                'type': 'post',
+                'title': post.title,
+                'url': post.get_absolute_url(),
+                'date': post.time_since(),
+                'sort_date': post.published_date,
+            })
+
+        for series_item in recent_series:
+            activities.append({
+                'type': 'series',
+                'title': series_item.name,
+                'url': series_item.get_absolute_url(),
+                'date': series_item.time_since(),
+                'sort_date': series_item.created_date,
+            })
+
+        for comment in recent_comments:
+            activities.append({
+                'type': 'comment',
+                'postTitle': comment.post.title,
+                'url': comment.get_absolute_url(),
+                'date': comment.time_since(),
+                'sort_date': comment.created_date,
+            })
+
+        for like in recent_likes:
+            activities.append({
+                'type': 'like',
+                'postTitle': like.post.title,
+                'url': like.post.get_absolute_url(),
+                'date': like.time_since(),
+                'sort_date': like.created_date,
+            })
+
+        recent_activities = sorted(activities, key=lambda x: x['sort_date'], reverse=True)
+
         for activity in recent_activities:
             del activity['sort_date']
 

--- a/backend/src/board/tests/templates/test_author.py
+++ b/backend/src/board/tests/templates/test_author.py
@@ -7,7 +7,9 @@ from django.contrib.auth.models import User
 from django.urls import reverse
 from django.utils import timezone
 
-from board.models import Post, PostContent, PostConfig, Series, Profile, Tag
+from board.models import (
+    Comment, Post, PostContent, PostConfig, PostLikes, Series, Profile, Tag
+)
 
 
 class AuthorPostsPageTestCase(TestCase):
@@ -90,6 +92,141 @@ class AuthorPostsPageTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'board/author/author_overview.html')
 
+    def test_author_overview_recent_activities_are_public_only(self):
+        """작가 개요 최근 활동은 공개 가능한 글/시리즈 대상만 노출한다."""
+        public_series = Series.objects.create(
+            owner=self.user,
+            name='Public Activity Series',
+            url='public-activity-series',
+            hide=False,
+        )
+        public_series_post = self.create_author_post(
+            'Public Series Activity Post',
+            'public-series-activity-post',
+            timezone.now(),
+        )
+        public_series_post.series = public_series
+        public_series_post.save(update_fields=['series'])
+
+        hidden_post = self.create_author_post(
+            'Hidden Activity Post',
+            'hidden-activity-post',
+            timezone.now(),
+            hide=True,
+        )
+        draft_post = self.create_author_post(
+            'Draft Activity Post',
+            'draft-activity-post',
+            None,
+        )
+        future_post = self.create_author_post(
+            'Future Activity Post',
+            'future-activity-post',
+            timezone.now() + timezone.timedelta(days=1),
+        )
+
+        hidden_series = Series.objects.create(
+            owner=self.user,
+            name='Hidden Activity Series',
+            url='hidden-activity-series',
+            hide=True,
+        )
+        hidden_series_post = self.create_author_post(
+            'Hidden Series Public Post',
+            'hidden-series-public-post',
+            timezone.now(),
+        )
+        hidden_series_post.series = hidden_series
+        hidden_series_post.save(update_fields=['series'])
+        Series.objects.create(
+            owner=self.user,
+            name='Empty Activity Series',
+            url='empty-activity-series',
+            hide=False,
+        )
+        draft_series = Series.objects.create(
+            owner=self.user,
+            name='Draft Only Activity Series',
+            url='draft-only-activity-series',
+            hide=False,
+        )
+        draft_post.series = draft_series
+        draft_post.save(update_fields=['series'])
+        future_series = Series.objects.create(
+            owner=self.user,
+            name='Future Only Activity Series',
+            url='future-only-activity-series',
+            hide=False,
+        )
+        future_post.series = future_series
+        future_post.save(update_fields=['series'])
+        hidden_post_series = Series.objects.create(
+            owner=self.user,
+            name='Hidden Post Only Activity Series',
+            url='hidden-post-only-activity-series',
+            hide=False,
+        )
+        hidden_post.series = hidden_post_series
+        hidden_post.save(update_fields=['series'])
+
+        Comment.objects.create(
+            author=self.user,
+            post=self.post,
+            text_md='Public comment',
+            text_html='<p>Public comment</p>',
+        )
+        Comment.objects.create(
+            author=self.user,
+            post=hidden_post,
+            text_md='Hidden post comment',
+            text_html='<p>Hidden post comment</p>',
+        )
+        PostLikes.objects.create(user=self.user, post=self.post)
+        PostLikes.objects.create(user=self.user, post=hidden_post)
+
+        response = self.client.get(
+            reverse('user_profile', kwargs={'username': self.user.username})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        activities = response.context['recent_activities']
+        activity_titles = {
+            activity.get('title') or activity.get('postTitle')
+            for activity in activities
+        }
+
+        self.assertIn('Author Test Post', activity_titles)
+        self.assertIn('Public Activity Series', activity_titles)
+        self.assertNotIn('Hidden Activity Post', activity_titles)
+        self.assertNotIn('Draft Activity Post', activity_titles)
+        self.assertNotIn('Future Activity Post', activity_titles)
+        self.assertNotIn('Hidden Activity Series', activity_titles)
+        self.assertNotIn('Empty Activity Series', activity_titles)
+        self.assertNotIn('Draft Only Activity Series', activity_titles)
+        self.assertNotIn('Future Only Activity Series', activity_titles)
+        self.assertNotIn('Hidden Post Only Activity Series', activity_titles)
+
+        self.assertTrue(
+            any(
+                activity['type'] == 'comment'
+                and activity['postTitle'] == 'Author Test Post'
+                for activity in activities
+            )
+        )
+        self.assertTrue(
+            any(
+                activity['type'] == 'like'
+                and activity['postTitle'] == 'Author Test Post'
+                for activity in activities
+            )
+        )
+        self.assertFalse(
+            any(
+                activity['type'] in ['comment', 'like']
+                and activity.get('postTitle') == 'Hidden Activity Post'
+                for activity in activities
+            )
+        )
 
     def test_author_posts_page_exposes_public_posts_and_tags_only(self):
         """작가 글 표면은 숨김, 임시저장, 미래 발행 글과 그 태그를 노출하지 않는다."""

--- a/backend/src/board/views/author.py
+++ b/backend/src/board/views/author.py
@@ -23,7 +23,7 @@ def author_overview(request, username):
     """
     author = get_object_or_404(User.objects.select_related('profile'), username=username)
 
-    recent_activities = UserService.get_user_dashboard_activities(author)[:10]  # Limit to 10 most recent
+    recent_activities = UserService.get_public_author_activities(author)[:10]
 
     about_html = getattr(author.profile, 'about_html', '') if hasattr(author, 'profile') else ''
 


### PR DESCRIPTION
## 🎯 Goal
- Prevent public author overview activity from exposing hidden, draft, scheduled, or otherwise non-public content.
- Separate public author activity policy from dashboard/private activity behavior.

## 🔧 Core Changes
- Add `UserService.get_public_author_activities()` for public-safe activity aggregation.
- Use `PublicPostService` for post, comment, and like activity visibility.
- Use `PublicSeriesService` for public series activity visibility.
- Switch author overview to the public activity service while leaving dashboard activity untouched.
- Add regression coverage for hidden/draft/future posts, non-public series, and hidden-post comment/like activity.

## 🤔 Key Decisions
- Keep dashboard activity behavior separate instead of tightening it implicitly.
- Preserve the existing activity payload shape expected by author templates.
- Keep the existing per-activity-type candidate limit pattern to avoid expanding query scope in this bugfix PR.

## 🧪 Verification Guide
### How to verify
1. Run `npm run server:test -- board.tests.templates.test_author board.tests.services.test_public_post_service board.tests.services.test_public_series_service`.
2. Visit an author overview with hidden/draft/future posts and non-public series activity.
3. Confirm only public post, public series, public comment, and public like activity appears.

### Expected result
- Tests pass.
- Public author overview activity only references public content.
- Dashboard/private activity API behavior is unchanged.

## ✅ Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [x] Tests completed
- [ ] Documentation updated (if needed)
