### PR TITLE
🐛 Harden public comment creation policy

### DIFF
--- a/backend/src/board/services/comment_service.py
+++ b/backend/src/board/services/comment_service.py
@@ -48,6 +48,41 @@ class CommentService:
             )
 
     @staticmethod
+    def validate_post_allows_public_comment(post: Post) -> None:
+        """
+        Validate if a post can receive comments from the public comment API.
+
+        Args:
+            post: Post instance
+
+        Raises:
+            CommentValidationError: If comments are blocked
+        """
+        if hasattr(post, 'config') and post.config.block_comment:
+            raise CommentValidationError(
+                ErrorCode.REJECT,
+                '댓글이 차단된 글입니다.'
+            )
+
+    @staticmethod
+    def validate_parent_belongs_to_post(parent: Optional[Comment], post: Post) -> None:
+        """
+        Validate if the parent comment belongs to the post being commented on.
+
+        Args:
+            parent: Optional parent comment
+            post: Post instance
+
+        Raises:
+            CommentValidationError: If parent belongs to another post
+        """
+        if parent and parent.post_id != post.id:
+            raise CommentValidationError(
+                ErrorCode.REJECT,
+                '부모 댓글이 대상 글에 속하지 않습니다.'
+            )
+
+    @staticmethod
     def validate_user_can_edit(user: User, comment: Comment) -> None:
         """
         Validate if user can edit the comment.
@@ -294,6 +329,8 @@ class CommentService:
             CommentValidationError: If validation fails
         """
         CommentService.validate_user_can_comment(user)
+        CommentService.validate_post_allows_public_comment(post)
+        CommentService.validate_parent_belongs_to_post(parent, post)
 
         # 1레벨 제한: 대댓글의 대댓글 방지
         if parent and parent.parent:

--- a/backend/src/board/tests/api/test_comment.py
+++ b/backend/src/board/tests/api/test_comment.py
@@ -80,6 +80,105 @@ class CommentTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(Comment.objects.last().text_md, '# New Comment')
 
+    def test_create_comment_on_hidden_post_returns_404(self):
+        """숨김 글에는 공개 댓글 API로 댓글을 생성할 수 없다."""
+        post = Post.objects.get(url='test-post')
+        post.config.hide = True
+        post.config.save()
+        initial_count = Comment.objects.count()
+        self.client.login(username='viewer', password='test')
+
+        response = self.client.post('/v1/comments?url=test-post', {
+            'comment_md': '# Hidden Post Comment',
+        })
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(Comment.objects.count(), initial_count)
+
+    def test_create_comment_on_draft_post_returns_404(self):
+        """임시저장 글에는 공개 댓글 API로 댓글을 생성할 수 없다."""
+        post = Post.objects.get(url='test-post')
+        post.published_date = None
+        post.save(update_fields=['published_date'])
+        initial_count = Comment.objects.count()
+        self.client.login(username='viewer', password='test')
+
+        response = self.client.post('/v1/comments?url=test-post', {
+            'comment_md': '# Draft Post Comment',
+        })
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(Comment.objects.count(), initial_count)
+
+    def test_create_comment_on_scheduled_post_returns_404(self):
+        """미래 발행 글에는 공개 댓글 API로 댓글을 생성할 수 없다."""
+        post = Post.objects.get(url='test-post')
+        post.published_date = timezone.now() + timezone.timedelta(days=1)
+        post.save(update_fields=['published_date'])
+        initial_count = Comment.objects.count()
+        self.client.login(username='viewer', password='test')
+
+        response = self.client.post('/v1/comments?url=test-post', {
+            'comment_md': '# Scheduled Post Comment',
+        })
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(Comment.objects.count(), initial_count)
+
+    def test_create_comment_on_blocked_post_returns_error(self):
+        """댓글 차단 글에는 댓글을 생성할 수 없다."""
+        post = Post.objects.get(url='test-post')
+        post.config.block_comment = True
+        post.config.save()
+        initial_count = Comment.objects.count()
+        self.client.login(username='viewer', password='test')
+
+        response = self.client.post('/v1/comments?url=test-post', {
+            'comment_md': '# Blocked Comment',
+        })
+
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'ERROR')
+        self.assertIn('댓글이 차단된 글입니다', content['errorMessage'])
+        self.assertEqual(Comment.objects.count(), initial_count)
+
+    def test_create_reply_rejects_parent_from_other_post(self):
+        """대댓글 parent는 같은 글의 댓글이어야 한다."""
+        author = User.objects.get(username='author')
+        other_post = Post.objects.create(
+            url='other-post',
+            title='Other Post',
+            author=author,
+            published_date=timezone.now(),
+        )
+        PostContent.objects.create(
+            post=other_post,
+            content_html='<h1>Other Post</h1>',
+        )
+        PostConfig.objects.create(
+            post=other_post,
+            hide=False,
+            advertise=False,
+        )
+        other_parent = Comment.objects.create(
+            post=other_post,
+            author=User.objects.get(username='viewer'),
+            text_md='Other post comment',
+            text_html='<p>Other post comment</p>',
+        )
+        initial_count = Comment.objects.count()
+        self.client.login(username='author', password='test')
+
+        response = self.client.post('/v1/comments?url=test-post', {
+            'comment_md': 'Cross-post reply',
+            'parent_id': other_parent.id,
+        })
+
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'ERROR')
+        self.assertIn('부모 댓글이 대상 글에 속하지 않습니다', content['errorMessage'])
+        self.assertEqual(Comment.objects.count(), initial_count)
+
     def test_create_nested_comment(self):
         """대댓글 생성 테스트"""
         parent_comment = Comment.objects.last()

--- a/backend/src/board/views/api/v1/comment.py
+++ b/backend/src/board/views/api/v1/comment.py
@@ -12,6 +12,7 @@ from board.modules.notify import create_notify
 from board.modules.response import StatusDone, StatusError, ErrorCode
 from board.modules.paginator import Paginator
 from board.services.comment_service import CommentService, CommentValidationError
+from board.services.public_post_service import PublicPostService
 from modules import markdown
 
 
@@ -19,7 +20,12 @@ def comment_list(request):
     """Create a new comment using CommentService"""
     if request.method == 'POST':
         try:
-            post = get_object_or_404(Post, url=request.GET.get('url'))
+            post = get_object_or_404(
+                PublicPostService.filter_public_posts(
+                    Post.objects.select_related('config')
+                ),
+                url=request.GET.get('url')
+            )
             text_md = request.POST.get('comment_md', '')
             parent_id = request.POST.get('parent_id')
 


### PR DESCRIPTION
## 🎯 Goal
- Prevent public comment creation on hidden, draft, scheduled, or comment-blocked posts.
- Prevent replies from using a parent comment that belongs to a different post.

## 🔧 Core Changes
- Use `PublicPostService.filter_public_posts()` for public comment creation post lookup.
- Add comment creation validation for `block_comment` posts.
- Add parent-comment ownership validation inside `CommentService.create_comment()`.
- Add regression tests for hidden/draft/scheduled posts, blocked comments, and cross-post parent replies.

## 🤔 Key Decisions
- Treat non-public post comment creation as a 404 to avoid revealing hidden/draft/scheduled post existence.
- Return `StatusError` for visible posts that reject comments or invalid parent payloads.
- Keep parent lookup behavior unchanged and enforce the post invariant in the service layer.

## 🧪 Verification Guide
### How to verify
1. Run `npm run server:test -- board.tests.api.test_comment board.tests.services.test_public_post_service`.
2. Try creating comments on hidden, draft, scheduled, and comment-blocked posts.
3. Try creating a reply using a parent comment from another post.

### Expected result
- Tests pass.
- Public comment creation only works for public posts that allow comments.
- Normal comment, reply, mention, and notification behavior remains unchanged.

## ✅ Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [x] Tests completed
- [ ] Documentation updated (if needed)
