### PR TITLE
♻️ Clarify legacy JSON body fallback

### DIFF
--- a/backend/src/board/services/api_request_body_service.py
+++ b/backend/src/board/services/api_request_body_service.py
@@ -46,12 +46,17 @@ class ApiRequestBodyService:
             )
 
     @staticmethod
-    def parse_json_or_default(request, default=None):
-        """Parse JSON, falling back to default when the body is invalid."""
+    def parse_json_or_empty_for_legacy_only(request):
+        """Parse JSON, swallowing invalid bodies only for legacy update endpoints.
+
+        Prefer parse_json_or_error() for all new mutation endpoints. This helper
+        exists to preserve old partial-update behavior where invalid JSON is
+        treated as an empty payload and existing fields remain unchanged.
+        """
         try:
-            return ApiRequestBodyService.parse_json(request, default=default)
+            return ApiRequestBodyService.parse_json(request)
         except (json.JSONDecodeError, UnicodeDecodeError):
-            return {} if default is None else default
+            return {}
 
     @staticmethod
     def parse_json_or_querydict(request):

--- a/backend/src/board/tests/services/test_api_request_body_service.py
+++ b/backend/src/board/tests/services/test_api_request_body_service.py
@@ -75,7 +75,7 @@ class ApiRequestBodyServiceTestCase(TestCase):
         self.assertEqual(data.get('title'), 'Form Title')
         self.assertEqual(data.get('post_ids'), '1,2')
 
-    def test_parse_json_or_default_returns_default_for_invalid_json(self):
+    def test_parse_json_or_empty_for_legacy_only_returns_default_for_invalid_json(self):
         request = self.factory.put('/v1/example/1', data=b'{invalid', content_type='application/json')
 
-        self.assertEqual(ApiRequestBodyService.parse_json_or_default(request), {})
+        self.assertEqual(ApiRequestBodyService.parse_json_or_empty_for_legacy_only(request), {})

--- a/backend/src/board/views/api/v1/banner.py
+++ b/backend/src/board/views/api/v1/banner.py
@@ -124,7 +124,7 @@ def banner(request, banner_id=None):
             user=user,
         )
 
-        put_data = ApiRequestBodyService.parse_json_or_default(request)
+        put_data = ApiRequestBodyService.parse_json_or_empty_for_legacy_only(request)
 
         # Update fields if provided
         if 'title' in put_data:

--- a/backend/src/board/views/api/v1/global_banner.py
+++ b/backend/src/board/views/api/v1/global_banner.py
@@ -96,7 +96,7 @@ def global_banners(request, banner_id=None):
     if request.method == 'PUT' and banner_id:
         banner = get_object_or_404(qs.select_related('user'), id=banner_id)
 
-        put_data = ApiRequestBodyService.parse_json_or_default(request)
+        put_data = ApiRequestBodyService.parse_json_or_empty_for_legacy_only(request)
 
         if 'title' in put_data:
             banner.title = put_data['title']

--- a/backend/src/board/views/api/v1/global_notice.py
+++ b/backend/src/board/views/api/v1/global_notice.py
@@ -88,7 +88,7 @@ def global_notices(request, notice_id=None):
     if request.method == 'PUT' and notice_id:
         notice = get_object_or_404(qs, id=notice_id)
 
-        put_data = ApiRequestBodyService.parse_json_or_default(request)
+        put_data = ApiRequestBodyService.parse_json_or_empty_for_legacy_only(request)
 
         if 'title' in put_data:
             notice.title = put_data['title']

--- a/backend/src/board/views/api/v1/notice.py
+++ b/backend/src/board/views/api/v1/notice.py
@@ -92,7 +92,7 @@ def notices(request, notice_id=None):
     if request.method == 'PUT' and notice_id:
         notice = get_object_or_404(qs, id=notice_id)
 
-        put_data = ApiRequestBodyService.parse_json_or_default(request)
+        put_data = ApiRequestBodyService.parse_json_or_empty_for_legacy_only(request)
 
         if 'title' in put_data:
             notice.title = put_data['title']

--- a/backend/src/board/views/api/v1/site_setting.py
+++ b/backend/src/board/views/api/v1/site_setting.py
@@ -38,7 +38,7 @@ def site_settings(request):
         return StatusDone(serialize_site_setting(request, setting))
 
     if request.method == 'PUT':
-        put_data = ApiRequestBodyService.parse_json_or_default(request)
+        put_data = ApiRequestBodyService.parse_json_or_empty_for_legacy_only(request)
 
         if 'header_script' in put_data:
             setting.header_script = put_data['header_script']

--- a/backend/src/board/views/api/v1/static_page.py
+++ b/backend/src/board/views/api/v1/static_page.py
@@ -108,7 +108,7 @@ def static_pages(request, page_id=None):
     if request.method == 'PUT' and page_id:
         page = get_object_or_404(StaticPage, id=page_id)
 
-        put_data = ApiRequestBodyService.parse_json_or_default(request)
+        put_data = ApiRequestBodyService.parse_json_or_empty_for_legacy_only(request)
 
         if 'title' in put_data:
             page.title = put_data['title']


### PR DESCRIPTION
## 🎯 Goal
- Make the invalid-JSON silent fallback helper explicitly legacy-only.
- Reduce the chance that new mutation APIs accidentally swallow invalid request bodies.

## 🔧 Core Changes
- Rename `parse_json_or_default()` to `parse_json_or_empty_for_legacy_only()`.
- Remove the unused default override so the helper always falls back to `{}`.
- Update only legacy partial-update endpoints that already preserve invalid JSON as empty payload behavior.
- Keep strict create/reorder endpoints on `parse_json_or_error()`.

## 🤔 Key Decisions
- Preserve existing legacy update behavior to avoid client-facing regressions.
- Prefer a loud method name over a behavior change in this PR.
- Do not keep an alias for the old helper to avoid dead code and future misuse.

## 🧪 Verification Guide
### How to verify
1. Run `npm run server:test -- board.tests.services.test_api_request_body_service board.tests.api.test_banner board.tests.api.test_global_banner_api board.tests.api.test_notice board.tests.api.test_global_notice board.tests.api.test_static_page board.tests.api.test_site_setting`.
2. Send invalid JSON to legacy update endpoints; existing fields should remain unchanged.
3. Send invalid JSON to create/reorder endpoints; they should still return validation errors.

### Expected result
- Tests pass.
- Legacy invalid JSON fallback behavior is unchanged.
- New code reads as legacy-only and discourages accidental reuse.

## ✅ Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [x] Tests completed
- [ ] Documentation updated (if needed)
