### PR TITLE
♻️ Extract settings heatmap service

### DIFF
--- a/backend/src/board/services/user_heatmap_service.py
+++ b/backend/src/board/services/user_heatmap_service.py
@@ -1,0 +1,71 @@
+from collections import defaultdict
+from datetime import timedelta
+
+from django.contrib.auth.models import User
+from django.core.cache import cache
+from django.db.models import Count
+from django.utils import timezone
+
+from board.models import Comment, Post, PostLikes
+
+
+class UserHeatmapService:
+    """Build and cache private user activity heatmap data for settings."""
+
+    CACHE_KEY_TEMPLATE = 'user_heatmap_{user_id}'
+    CACHE_TTL_SECONDS = 3600
+    WINDOW_DAYS = 365
+
+    @staticmethod
+    def get_settings_heatmap(user: User) -> dict[str, int]:
+        cache_key = UserHeatmapService.CACHE_KEY_TEMPLATE.format(user_id=user.id)
+        heatmap = cache.get(cache_key)
+
+        if heatmap is not None:
+            return heatmap
+
+        heatmap = UserHeatmapService.build_settings_heatmap(user)
+        cache.set(cache_key, heatmap, UserHeatmapService.CACHE_TTL_SECONDS)
+        return heatmap
+
+    @staticmethod
+    def build_settings_heatmap(user: User) -> dict[str, int]:
+        end_date = timezone.now().date()
+        start_date = end_date - timedelta(days=UserHeatmapService.WINDOW_DAYS)
+        heatmap = defaultdict(int)
+
+        UserHeatmapService.add_daily_counts(
+            heatmap,
+            Post.objects.filter(
+                author=user,
+                published_date__date__gte=start_date,
+                published_date__date__lte=end_date,
+            ).values('published_date__date').annotate(count=Count('id')),
+            'published_date__date',
+        )
+        UserHeatmapService.add_daily_counts(
+            heatmap,
+            Comment.objects.filter(
+                author=user,
+                created_date__date__gte=start_date,
+                created_date__date__lte=end_date,
+            ).values('created_date__date').annotate(count=Count('id')),
+            'created_date__date',
+        )
+        UserHeatmapService.add_daily_counts(
+            heatmap,
+            PostLikes.objects.filter(
+                user=user,
+                created_date__date__gte=start_date,
+                created_date__date__lte=end_date,
+            ).values('created_date__date').annotate(count=Count('id')),
+            'created_date__date',
+        )
+
+        return dict(heatmap)
+
+    @staticmethod
+    def add_daily_counts(heatmap, rows, date_field: str) -> None:
+        for row in rows:
+            date_str = row[date_field].strftime('%Y-%m-%d')
+            heatmap[date_str] += row['count']

--- a/backend/src/board/tests/api/test_setting.py
+++ b/backend/src/board/tests/api/test_setting.py
@@ -1,12 +1,14 @@
 import json
 
+from django.core.cache import cache
 from django.test import TestCase
 from django.test.client import Client
 from django.utils import timezone
 
 from board.constants.config_meta import CONFIG_TYPE
 from board.models import (
-    User, Config, Profile, Notify, Post, PostContent, PostConfig
+    Comment, Config, Notify, Post, PostConfig, PostContent,
+    PostLikes, Profile, User
 )
 
 
@@ -39,6 +41,7 @@ class SettingTestCase(TestCase):
 
     def setUp(self):
         self.client = Client(HTTP_USER_AGENT='Mozilla/5.0')
+        cache.clear()
 
     def test_get_setting_notify_not_login(self):
         """비로그인 상태에서 알림 설정 조회 시 에러 테스트"""
@@ -102,6 +105,44 @@ class SettingTestCase(TestCase):
                 CONFIG_TYPE.NOTIFY_MENTION.value,
             }
         )
+
+    def test_get_setting_heatmap_counts_private_user_activity_and_uses_cache(self):
+        """설정 heatmap은 기존 private activity 집계와 1시간 캐시 정책을 유지한다."""
+        user = User.objects.get(username='test')
+        post = Post.objects.create(
+            url='heatmap-post',
+            title='Heatmap Post',
+            author=user,
+            published_date=timezone.now(),
+        )
+        PostContent.objects.create(
+            post=post,
+            content_html='<h1>Heatmap</h1>'
+        )
+        PostConfig.objects.create(
+            post=post,
+            hide=True,
+        )
+        Comment.objects.create(
+            post=post,
+            author=user,
+            text_md='Heatmap comment',
+            text_html='<p>Heatmap comment</p>',
+        )
+        PostLikes.objects.create(post=post, user=user)
+        self.client.login(username='test', password='test')
+
+        response = self.client.get('/v1/setting/heatmap')
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(sum(content['body'].values()), 3)
+
+        PostLikes.objects.create(post=post, user=user)
+        cached_response = self.client.get('/v1/setting/heatmap')
+        cached_content = json.loads(cached_response.content)
+
+        self.assertEqual(sum(cached_content['body'].values()), 3)
 
     def test_update_notify_config_without_posts(self):
         """포스트가 없는 사용자의 알림 설정 업데이트 테스트"""

--- a/backend/src/board/tests/services/test_user_heatmap_service.py
+++ b/backend/src/board/tests/services/test_user_heatmap_service.py
@@ -1,0 +1,57 @@
+from django.core.cache import cache
+from django.test import TestCase
+from django.utils import timezone
+
+from board.models import (
+    Comment, Config, Post, PostConfig, PostContent, PostLikes, Profile, User
+)
+from board.services.user_heatmap_service import UserHeatmapService
+
+
+class UserHeatmapServiceTestCase(TestCase):
+    def setUp(self):
+        cache.clear()
+        self.user = User.objects.create_user(username='heatmap-user', password='test')
+        Config.objects.create(user=self.user)
+        Profile.objects.create(user=self.user, role=Profile.Role.EDITOR)
+
+    def create_post(self, url, published_date=None, hide=False):
+        post = Post.objects.create(
+            url=url,
+            title=url,
+            author=self.user,
+            published_date=published_date or timezone.now(),
+        )
+        PostContent.objects.create(post=post, content_html='<p>content</p>')
+        PostConfig.objects.create(post=post, hide=hide)
+        return post
+
+    def test_settings_heatmap_counts_posts_comments_and_likes(self):
+        post = self.create_post('heatmap-post', hide=True)
+        Comment.objects.create(
+            post=post,
+            author=self.user,
+            text_md='comment',
+            text_html='<p>comment</p>',
+        )
+        PostLikes.objects.create(post=post, user=self.user)
+        date_key = timezone.now().date().strftime('%Y-%m-%d')
+
+        heatmap = UserHeatmapService.get_settings_heatmap(self.user)
+
+        self.assertEqual(heatmap[date_key], 3)
+        self.assertEqual(
+            cache.get(f'user_heatmap_{self.user.id}'),
+            heatmap,
+        )
+
+    def test_settings_heatmap_uses_cache(self):
+        post = self.create_post('cached-heatmap-post')
+        date_key = timezone.now().date().strftime('%Y-%m-%d')
+
+        first_heatmap = UserHeatmapService.get_settings_heatmap(self.user)
+        PostLikes.objects.create(post=post, user=self.user)
+        second_heatmap = UserHeatmapService.get_settings_heatmap(self.user)
+
+        self.assertEqual(first_heatmap[date_key], 1)
+        self.assertEqual(second_heatmap[date_key], 1)

--- a/backend/src/board/views/api/v1/setting.py
+++ b/backend/src/board/views/api/v1/setting.py
@@ -1,12 +1,8 @@
 import datetime
 import json
-from collections import defaultdict
-from datetime import timedelta
 
 from django.contrib import auth
-from django.core.cache import cache
-from django.db.models import (
-    Q, F, Count, Case, When, Sum, Subquery, OuterRef)
+from django.db.models import Q, Count
 from django.http import Http404, QueryDict
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
@@ -14,12 +10,13 @@ from django.utils.dateparse import parse_datetime
 from board.constants.config_meta import CONFIG_TYPE
 from board.models import (
     User, Series, Post, UserLinkMeta, SiteSetting,
-    Profile, Notify, Comment, PostLikes, UsernameChangeLog, PinnedPost)
+    Profile, Notify)
 from board.modules.paginator import Paginator
 from board.modules.response import StatusDone, StatusError, ErrorCode
 from board.modules.time import convert_to_localtime
 from board.services.auth_service import AuthService, AuthValidationError
 from board.services.pinned_post_service import PinnedPostService, PinnedPostError
+from board.services.user_heatmap_service import UserHeatmapService
 
 
 def _get_notify_configs_by_role(user):
@@ -106,57 +103,7 @@ def setting(request, parameter):
             })
 
         if parameter == 'heatmap':
-            # Try to get heatmap from cache first (cache for 1 hour)
-            cache_key = f'user_heatmap_{user.id}'
-            heatmap = cache.get(cache_key)
-
-            if heatmap is None:
-                # Generate heatmap data for the last year
-                # Calculate date range (last 365 days)
-                end_date = timezone.now().date()
-                start_date = end_date - timedelta(days=365)
-
-                # Initialize heatmap with all dates
-                heatmap = defaultdict(int)
-
-                # Fetch posts within the date range
-                posts = Post.objects.filter(
-                    author=user,
-                    published_date__date__gte=start_date,
-                    published_date__date__lte=end_date,
-                ).values('published_date__date').annotate(count=Count('id'))
-
-                for post in posts:
-                    date_str = post['published_date__date'].strftime('%Y-%m-%d')
-                    heatmap[date_str] += post['count']
-
-                # Fetch comments within the date range
-                comments = Comment.objects.filter(
-                    author=user,
-                    created_date__date__gte=start_date,
-                    created_date__date__lte=end_date,
-                ).values('created_date__date').annotate(count=Count('id'))
-
-                for comment in comments:
-                    date_str = comment['created_date__date'].strftime('%Y-%m-%d')
-                    heatmap[date_str] += comment['count']
-
-                # Fetch likes within the date range
-                likes = PostLikes.objects.filter(
-                    user=user,
-                    created_date__date__gte=start_date,
-                    created_date__date__lte=end_date,
-                ).values('created_date__date').annotate(count=Count('id'))
-
-                for like in likes:
-                    date_str = like['created_date__date'].strftime('%Y-%m-%d')
-                    heatmap[date_str] += like['count']
-
-                # Convert to regular dict and cache for 1 hour (3600 seconds)
-                heatmap = dict(heatmap)
-                cache.set(cache_key, heatmap, 3600)
-
-            return StatusDone(heatmap)
+            return StatusDone(UserHeatmapService.get_settings_heatmap(user))
 
         if parameter == 'profile':
             return StatusDone({


### PR DESCRIPTION
## 🎯 Goal
- Reduce `setting.py` fat-controller logic by extracting the settings heatmap generation and cache policy.
- Preserve the existing private settings heatmap contract while making the behavior independently testable.

## 🔧 Core Changes
- Add `UserHeatmapService` for settings heatmap building and caching.
- Keep cache key `user_heatmap_{user_id}`, TTL `3600`, and 365-day activity window.
- Replace inline heatmap query/caching code in `setting.py` with a service call.
- Add service and endpoint regression tests for activity counts and cache behavior.

## 🤔 Key Decisions
- Keep settings heatmap private semantics unchanged: it counts the user’s own posts, comments, and likes without public visibility filtering.
- Extract only heatmap logic in this PR; notification/profile/social settings remain untouched.

## 🧪 Verification Guide
### How to verify
1. Run `npm run server:test -- board.tests.api.test_setting board.tests.services.test_user_heatmap_service`.
2. Log in and request `/v1/setting/heatmap`.
3. Confirm repeated requests use the cached heatmap until cache expiry.

### Expected result
- Tests pass.
- Settings heatmap response shape and counts remain unchanged.
- `setting.py` loses the inline heatmap query/caching block.

## ✅ Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [x] Tests completed
- [ ] Documentation updated (if needed)
