### PR TITLE
♻️ Extract settings notification service

### DIFF
--- a/backend/src/board/services/user_notification_service.py
+++ b/backend/src/board/services/user_notification_service.py
@@ -1,0 +1,92 @@
+import datetime
+
+from django.contrib.auth.models import User
+from django.db.models import Q, QuerySet
+from django.utils import timezone
+
+from board.constants.config_meta import CONFIG_TYPE
+from board.models import Notify
+
+
+class UserNotificationService:
+    """Read and update private notification settings for the settings API."""
+
+    RECENT_NOTIFY_DAYS = 180
+
+    @staticmethod
+    def get_notify_configs_by_role(user: User) -> list[CONFIG_TYPE]:
+        configs = [
+            CONFIG_TYPE.NOTIFY_COMMENT_LIKE,
+            CONFIG_TYPE.NOTIFY_MENTION,
+        ]
+
+        if hasattr(user, 'profile') and user.profile.is_editor():
+            configs = [
+                CONFIG_TYPE.NOTIFY_POSTS_LIKE,
+                CONFIG_TYPE.NOTIFY_POSTS_COMMENT,
+            ] + configs
+
+        return configs
+
+    @staticmethod
+    def get_recent_notifications(user: User) -> QuerySet[Notify]:
+        recent_threshold = timezone.now() - datetime.timedelta(
+            days=UserNotificationService.RECENT_NOTIFY_DAYS,
+        )
+        return Notify.objects.filter(user=user).filter(
+            Q(created_date__gt=recent_threshold) |
+            Q(has_read=False)
+        ).order_by('-created_date')
+
+    @staticmethod
+    def serialize_notification(item: Notify) -> dict:
+        return {
+            'id': item.id,
+            'url': item.url,
+            'is_read': item.has_read,
+            'content': item.content,
+            'created_date': item.time_since(),
+        }
+
+    @staticmethod
+    def get_settings_notify(user: User) -> dict:
+        return {
+            'notify': [
+                UserNotificationService.serialize_notification(item)
+                for item in UserNotificationService.get_recent_notifications(user)
+            ],
+            'is_telegram_sync': user.config.has_telegram_id(),
+        }
+
+    @staticmethod
+    def get_settings_notify_config(user: User) -> dict:
+        return {
+            'config': [
+                {
+                    'name': config.value,
+                    'value': user.config.get_meta(config),
+                }
+                for config in UserNotificationService.get_notify_configs_by_role(user)
+            ]
+        }
+
+    @staticmethod
+    def mark_notification_as_read(user: User, notification_id: str) -> bool:
+        notify = Notify.objects.filter(id=notification_id, user=user)
+        if not notify.exists():
+            return False
+
+        notification = notify.first()
+        notification.has_read = True
+        notification.save()
+        return True
+
+    @staticmethod
+    def update_settings_notify_config(user: User, put) -> None:
+        for config in UserNotificationService.get_notify_configs_by_role(user):
+            value = put.get(config.value)
+            if value in (None, ''):
+                continue
+            if isinstance(value, bool):
+                value = 'true' if value else 'false'
+            user.config.create_or_update_meta(config, value)

--- a/backend/src/board/tests/api/test_setting.py
+++ b/backend/src/board/tests/api/test_setting.py
@@ -60,6 +60,53 @@ class SettingTestCase(TestCase):
         content = json.loads(response.content)
         self.assertEqual(len(content['body']['notify']), 2)
         self.assertEqual(content['body']['isTelegramSync'], False)
+
+    def test_update_setting_notify_marks_as_read(self):
+        """알림 읽음 처리 테스트"""
+        notify = Notify.objects.filter(user__username='test').first()
+        self.client.login(username='test', password='test')
+
+        response = self.client.put(
+            '/v1/setting/notify',
+            json.dumps({'id': notify.id}),
+            content_type='application/json'
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'DONE')
+        notify.refresh_from_db()
+        self.assertTrue(notify.has_read)
+
+    def test_update_setting_notify_rejects_other_user_notification(self):
+        """다른 사용자의 알림 읽음 처리를 막는다."""
+        other_user = User.objects.create_user(
+            username='notify-owner',
+            password='test',
+            email='notify-owner@test.com',
+        )
+        Config.objects.create(user=other_user)
+        Profile.objects.create(user=other_user, role=Profile.Role.READER)
+        notify = Notify.objects.create(
+            user=other_user,
+            content='other notify',
+            url='/other-notify',
+            key='other-notify-key',
+        )
+        self.client.login(username='test', password='test')
+
+        response = self.client.put(
+            '/v1/setting/notify',
+            json.dumps({'id': notify.id}),
+            content_type='application/json'
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'ERROR')
+        self.assertEqual(content['errorCode'], 'error:NF')
+        notify.refresh_from_db()
+        self.assertFalse(notify.has_read)
     
     def test_get_setting_notify_config(self):
         """알림 설정 구성 조회 테스트"""

--- a/backend/src/board/tests/services/test_user_notification_service.py
+++ b/backend/src/board/tests/services/test_user_notification_service.py
@@ -1,0 +1,128 @@
+from datetime import timedelta
+
+from django.test import TestCase
+from django.utils import timezone
+
+from board.constants.config_meta import CONFIG_TYPE
+from board.models import Config, Notify, Profile, User
+from board.services.user_notification_service import UserNotificationService
+
+
+class UserNotificationServiceTestCase(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username='notify-user', password='test')
+        Config.objects.create(user=self.user)
+        Profile.objects.create(user=self.user, role=Profile.Role.EDITOR)
+
+    def create_notify(self, key, has_read=False, created_date=None):
+        return Notify.objects.create(
+            user=self.user,
+            content=key,
+            url=f'/{key}',
+            key=key,
+            has_read=has_read,
+            created_date=created_date or timezone.now(),
+        )
+
+    def test_get_notify_configs_by_role_keeps_editor_and_reader_visibility(self):
+        reader = User.objects.create_user(username='notify-reader', password='test')
+        Config.objects.create(user=reader)
+        Profile.objects.create(user=reader, role=Profile.Role.READER)
+
+        editor_configs = UserNotificationService.get_notify_configs_by_role(self.user)
+        reader_configs = UserNotificationService.get_notify_configs_by_role(reader)
+
+        self.assertEqual(
+            editor_configs,
+            [
+                CONFIG_TYPE.NOTIFY_POSTS_LIKE,
+                CONFIG_TYPE.NOTIFY_POSTS_COMMENT,
+                CONFIG_TYPE.NOTIFY_COMMENT_LIKE,
+                CONFIG_TYPE.NOTIFY_MENTION,
+            ],
+        )
+        self.assertEqual(
+            reader_configs,
+            [
+                CONFIG_TYPE.NOTIFY_COMMENT_LIKE,
+                CONFIG_TYPE.NOTIFY_MENTION,
+            ],
+        )
+
+    def test_get_recent_notifications_keeps_recent_or_unread_policy(self):
+        recent_read = self.create_notify('recent-read', has_read=True)
+        old_unread = self.create_notify(
+            'old-unread',
+            has_read=False,
+            created_date=timezone.now() - timedelta(days=181),
+        )
+        self.create_notify(
+            'old-read',
+            has_read=True,
+            created_date=timezone.now() - timedelta(days=181),
+        )
+
+        notifications = list(UserNotificationService.get_recent_notifications(self.user))
+
+        self.assertEqual(
+            {item.id for item in notifications},
+            {recent_read.id, old_unread.id},
+        )
+
+    def test_get_settings_notify_config_serializes_current_values(self):
+        self.user.config.create_or_update_meta(
+            CONFIG_TYPE.NOTIFY_COMMENT_LIKE,
+            'true',
+        )
+
+        payload = UserNotificationService.get_settings_notify_config(self.user)
+
+        config_map = {
+            item['name']: item['value']
+            for item in payload['config']
+        }
+        self.assertEqual(config_map[CONFIG_TYPE.NOTIFY_COMMENT_LIKE.value], True)
+
+    def test_update_settings_notify_config_skips_empty_and_converts_bool(self):
+        put = type('QueryDict', (), {
+            'get': lambda self, key, default='': {
+                CONFIG_TYPE.NOTIFY_POSTS_LIKE.value: True,
+                CONFIG_TYPE.NOTIFY_POSTS_COMMENT.value: '',
+            }.get(key, default)
+        })()
+
+        UserNotificationService.update_settings_notify_config(self.user, put)
+
+        self.assertEqual(self.user.config.get_meta(CONFIG_TYPE.NOTIFY_POSTS_LIKE), True)
+        self.assertIsNone(self.user.config.get_meta(CONFIG_TYPE.NOTIFY_POSTS_COMMENT))
+
+    def test_mark_notification_as_read_returns_false_when_missing(self):
+        self.assertFalse(
+            UserNotificationService.mark_notification_as_read(self.user, '999999')
+        )
+
+    def test_mark_notification_as_read_updates_existing_notification(self):
+        notification = self.create_notify('mark-read', has_read=False)
+
+        result = UserNotificationService.mark_notification_as_read(
+            self.user,
+            str(notification.id),
+        )
+
+        notification.refresh_from_db()
+        self.assertTrue(result)
+        self.assertTrue(notification.has_read)
+
+    def test_mark_notification_as_read_returns_false_for_other_user_notification(self):
+        other_user = User.objects.create_user(username='notify-other', password='test')
+        Config.objects.create(user=other_user)
+        notification = self.create_notify('other-user-notify', has_read=False)
+
+        result = UserNotificationService.mark_notification_as_read(
+            other_user,
+            str(notification.id),
+        )
+
+        notification.refresh_from_db()
+        self.assertFalse(result)
+        self.assertFalse(notification.has_read)

--- a/backend/src/board/views/api/v1/setting.py
+++ b/backend/src/board/views/api/v1/setting.py
@@ -1,13 +1,11 @@
-import datetime
 import json
 
 from django.contrib import auth
-from django.db.models import Q, Count
+from django.db.models import Count
 from django.http import Http404, QueryDict
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
-from board.constants.config_meta import CONFIG_TYPE
 from board.models import (
     User, Series, Post, UserLinkMeta, SiteSetting,
     Profile, Notify)
@@ -17,22 +15,7 @@ from board.modules.time import convert_to_localtime
 from board.services.auth_service import AuthService, AuthValidationError
 from board.services.pinned_post_service import PinnedPostService, PinnedPostError
 from board.services.user_heatmap_service import UserHeatmapService
-
-
-def _get_notify_configs_by_role(user):
-    configs = [
-        CONFIG_TYPE.NOTIFY_COMMENT_LIKE,
-        CONFIG_TYPE.NOTIFY_MENTION,
-    ]
-
-    # 작성자(EDITOR)는 포스트 관련 알림 옵션을 추가로 노출
-    if hasattr(user, 'profile') and user.profile.is_editor():
-        configs = [
-            CONFIG_TYPE.NOTIFY_POSTS_LIKE,
-            CONFIG_TYPE.NOTIFY_POSTS_COMMENT,
-        ] + configs
-
-    return configs
+from board.services.user_notification_service import UserNotificationService
 
 
 def setting(request, parameter):
@@ -49,22 +32,7 @@ def setting(request, parameter):
 
     if request.method == 'GET':
         if parameter == 'notify':
-            six_months_ago = timezone.now() - datetime.timedelta(days=180)
-            notify = Notify.objects.filter(user=user).filter(
-                Q(created_date__gt=six_months_ago) |
-                Q(has_read=False)
-            ).order_by('-created_date')
-
-            return StatusDone({
-                'notify': list(map(lambda item: {
-                    'id': item.id,
-                    'url': item.url,
-                    'is_read': item.has_read,
-                    'content': item.content,
-                    'created_date': item.time_since()
-                }, notify)),
-                'is_telegram_sync': request.user.config.has_telegram_id()
-            })
+            return StatusDone(UserNotificationService.get_settings_notify(user))
 
         if parameter == 'unread-notify':
             unread_count = Notify.objects.filter(
@@ -77,14 +45,7 @@ def setting(request, parameter):
             })
 
         if parameter == 'notify-config':
-            configs = _get_notify_configs_by_role(user)
-
-            return StatusDone({
-                'config': list(map(lambda config: {
-                    'name': config.value,
-                    'value': user.config.get_meta(config)
-                }, configs))
-            })
+            return StatusDone(UserNotificationService.get_settings_notify_config(user))
 
         if parameter == 'account':
             try:
@@ -327,26 +288,13 @@ def setting(request, parameter):
         if parameter == 'notify':
             id = put.get('id')
 
-            notify = Notify.objects.filter(id=id)
-            if not notify.exists():
+            if not UserNotificationService.mark_notification_as_read(user, id):
                 return StatusError(ErrorCode.NOT_FOUND, '알림을 찾을 수 없습니다.')
 
-            notify = notify.first()
-            notify.has_read = True
-            notify.save()
             return StatusDone()
 
         if parameter == 'notify-config':
-            configs = _get_notify_configs_by_role(user)
-
-            for config in configs:
-                value = put.get(config.value)
-                if value in (None, ''):
-                    continue
-                if isinstance(value, bool):
-                    value = 'true' if value else 'false'
-                user.config.create_or_update_meta(config, value)
-
+            UserNotificationService.update_settings_notify_config(user, put)
             return StatusDone()
 
         if parameter == 'account':


### PR DESCRIPTION
## 🎯 Goal
- Reduce `setting.py` notification and notification-config controller logic.
- Keep settings notification response contracts stable while making notification policy independently testable.

## 🔧 Core Changes
- Add `UserNotificationService` for settings notification retrieval, config serialization, config updates, and read marking.
- Move role-specific notification config visibility out of the view.
- Preserve recent notification policy: last 180 days or unread, ordered by newest first.
- Harden notification read updates so users can only mark their own notifications as read.
- Add service and endpoint regression tests for role visibility, update behavior, and notification ownership.

## 🤔 Key Decisions
- Keep GET response shapes unchanged for `notify` and `notify-config`.
- Keep legacy bool conversion and empty-value skip behavior for notification config updates.
- Treat cross-user notification read marking as a permission bug and return the existing not-found contract.

## 🧪 Verification Guide
### How to verify
1. Run `npm run server:test -- board.tests.api.test_setting board.tests.services.test_user_notification_service`.
2. Log in and request `/v1/setting/notify` and `/v1/setting/notify-config`.
3. Update notification config and mark one of the logged-in user's notifications as read.

### Expected result
- Tests pass.
- Notification payloads and config visibility remain unchanged.
- A user cannot mark another user's notification as read.

## ✅ Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [x] Tests completed
- [ ] Documentation updated (if needed)
