### PR TITLE
♻️ Extract settings social link service

### DIFF
--- a/backend/src/board/services/user_social_link_service.py
+++ b/backend/src/board/services/user_social_link_service.py
@@ -1,0 +1,55 @@
+from django.contrib.auth.models import User
+
+from board.models import UserLinkMeta
+
+
+class UserSocialLinkService:
+    """Apply settings social link mutations."""
+
+    @staticmethod
+    def update_user_social_links(user: User, put) -> list[dict]:
+        UserSocialLinkService.update_social_links(user, put.get('update', ''))
+        UserSocialLinkService.create_social_links(user, put.get('create', ''))
+        UserSocialLinkService.delete_social_links(user, put.get('delete', ''))
+        return user.profile.collect_social()
+
+    @staticmethod
+    def update_social_links(user: User, update_items: str) -> None:
+        for update_item in UserSocialLinkService.split_items(update_items):
+            link_id, name, value, order = update_item.split(',')
+            UserLinkMeta.objects.update_or_create(
+                user=user,
+                id=link_id,
+                defaults={
+                    'name': name,
+                    'value': value,
+                    'order': order,
+                },
+            )
+
+    @staticmethod
+    def create_social_links(user: User, create_items: str) -> None:
+        for create_item in UserSocialLinkService.split_items(create_items):
+            name, value, order = create_item.split(',')
+            UserLinkMeta.objects.create(
+                user=user,
+                name=name,
+                value=value,
+                order=order,
+            )
+
+    @staticmethod
+    def delete_social_links(user: User, delete_items: str) -> None:
+        for delete_item in UserSocialLinkService.split_items(delete_items):
+            UserLinkMeta.objects.filter(
+                user=user,
+                id=delete_item,
+            ).delete()
+
+    @staticmethod
+    def split_items(items: str) -> list[str]:
+        return [
+            item
+            for item in items.split('&')
+            if item
+        ]

--- a/backend/src/board/tests/api/test_setting.py
+++ b/backend/src/board/tests/api/test_setting.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 from board.constants.config_meta import CONFIG_TYPE
 from board.models import (
     Comment, Config, Notify, Post, PostConfig, PostContent,
-    PostLikes, Profile, User
+    PostLikes, Profile, User, UserLinkMeta
 )
 
 
@@ -374,6 +374,44 @@ class SettingTestCase(TestCase):
         profile = Profile.objects.get(user=User.objects.get(username='test'))
         self.assertEqual(profile.bio, 'Test bio')
         self.assertEqual(profile.homepage, 'https://example.com')
+
+    def test_update_social_links(self):
+        """소셜 링크 생성/수정/삭제 테스트"""
+        user = User.objects.get(username='test')
+        update_link = UserLinkMeta.objects.create(
+            user=user,
+            name='github',
+            value='https://github.com/old',
+            order=1,
+        )
+        delete_link = UserLinkMeta.objects.create(
+            user=user,
+            name='old',
+            value='https://old.example.com',
+            order=2,
+        )
+        self.client.login(username='test', password='test')
+
+        response = self.client.put(
+            '/v1/setting/social',
+            json.dumps({
+                'update': f'{update_link.id},github,https://github.com/new,3',
+                'create': 'homepage,https://example.com,4',
+                'delete': str(delete_link.id),
+            }),
+            content_type='application/json'
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'DONE')
+        update_link.refresh_from_db()
+        self.assertEqual(update_link.value, 'https://github.com/new')
+        self.assertFalse(UserLinkMeta.objects.filter(id=delete_link.id).exists())
+        self.assertEqual(
+            [item['name'] for item in content['body']],
+            ['github', 'homepage'],
+        )
 
     def test_update_account_not_logged_in(self):
         """비로그인 상태에서 계정 수정 시도"""

--- a/backend/src/board/tests/services/test_user_social_link_service.py
+++ b/backend/src/board/tests/services/test_user_social_link_service.py
@@ -1,0 +1,72 @@
+from django.test import TestCase
+
+from board.models import Config, Profile, User, UserLinkMeta
+from board.services.user_social_link_service import UserSocialLinkService
+
+
+class UserSocialLinkServiceTestCase(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username='social-user', password='test')
+        Config.objects.create(user=self.user)
+        Profile.objects.create(user=self.user)
+
+    def test_split_items_ignores_empty_segments(self):
+        self.assertEqual(
+            UserSocialLinkService.split_items('github,url,1&&site,url,2&'),
+            ['github,url,1', 'site,url,2'],
+        )
+
+    def test_update_user_social_links_creates_updates_and_deletes_links(self):
+        update_link = UserLinkMeta.objects.create(
+            user=self.user,
+            name='github',
+            value='https://github.com/old',
+            order=1,
+        )
+        delete_link = UserLinkMeta.objects.create(
+            user=self.user,
+            name='old',
+            value='https://old.example.com',
+            order=2,
+        )
+        put = type('QueryDict', (), {
+            'get': lambda self, key, default='': {
+                'update': f'{update_link.id},github,https://github.com/new,3',
+                'create': 'homepage,https://example.com,4',
+                'delete': str(delete_link.id),
+            }.get(key, default)
+        })()
+
+        social_links = UserSocialLinkService.update_user_social_links(self.user, put)
+
+        update_link.refresh_from_db()
+        self.assertEqual(update_link.value, 'https://github.com/new')
+        self.assertEqual(update_link.order, 3)
+        self.assertFalse(UserLinkMeta.objects.filter(id=delete_link.id).exists())
+        self.assertTrue(
+            UserLinkMeta.objects.filter(
+                user=self.user,
+                name='homepage',
+                value='https://example.com',
+                order=4,
+            ).exists()
+        )
+        self.assertEqual(
+            [item['name'] for item in social_links],
+            ['github', 'homepage'],
+        )
+
+    def test_delete_social_links_keeps_other_user_links(self):
+        other_user = User.objects.create_user(username='other-social-user', password='test')
+        Config.objects.create(user=other_user)
+        Profile.objects.create(user=other_user)
+        other_link = UserLinkMeta.objects.create(
+            user=other_user,
+            name='github',
+            value='https://github.com/other',
+            order=1,
+        )
+
+        UserSocialLinkService.delete_social_links(self.user, str(other_link.id))
+
+        self.assertTrue(UserLinkMeta.objects.filter(id=other_link.id).exists())

--- a/backend/src/board/views/api/v1/setting.py
+++ b/backend/src/board/views/api/v1/setting.py
@@ -7,7 +7,7 @@ from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 from board.models import (
-    User, Series, Post, UserLinkMeta, SiteSetting,
+    User, Series, Post, SiteSetting,
     Profile, Notify)
 from board.modules.paginator import Paginator
 from board.modules.response import StatusDone, StatusError, ErrorCode
@@ -16,6 +16,7 @@ from board.services.auth_service import AuthService, AuthValidationError
 from board.services.pinned_post_service import PinnedPostService, PinnedPostError
 from board.services.user_heatmap_service import UserHeatmapService
 from board.services.user_notification_service import UserNotificationService
+from board.services.user_social_link_service import UserSocialLinkService
 
 
 def setting(request, parameter):
@@ -355,46 +356,7 @@ def setting(request, parameter):
             return StatusDone()
     
         if parameter == 'social':
-            update_items = put.get('update', '')
-            for update_item in update_items.split('&'):
-                if not update_item:
-                    continue
-
-                [id, name, value, order] = update_item.split(',')
-                UserLinkMeta.objects.update_or_create(
-                    user=user,
-                    id=id,
-                    defaults={
-                        'name': name,
-                        'value': value,
-                        'order': order,
-                    }
-                )                
-            
-            create_items = put.get('create', '')
-            for create_item in create_items.split('&'):
-                if not create_item:
-                    continue
-
-                [name, value, order] = create_item.split(',')
-                UserLinkMeta.objects.create(
-                    user=user,
-                    name=name,
-                    value=value,
-                    order=order,
-                )
-
-            delete_items = put.get('delete', '')
-            for delete_item in delete_items.split('&'):
-                if not delete_item:
-                    continue
-
-                UserLinkMeta.objects.filter(
-                    user=user,
-                    id=delete_item,
-                ).delete()
-            
-            return StatusDone(user.profile.collect_social())
+            return StatusDone(UserSocialLinkService.update_user_social_links(user, put))
 
         if parameter == 'pinned-posts/order':
             post_urls_str = put.get('post_urls', '[]')


### PR DESCRIPTION
## 🎯 Goal
- Reduce `setting.py` social link mutation logic.
- Preserve the existing settings social link string contract while making it independently testable.

## 🔧 Core Changes
- Add `UserSocialLinkService` for social link update/create/delete mutation handling.
- Replace inline `PUT /v1/setting/social` parsing and mutation loops with a service call.
- Add endpoint and service tests for valid update/create/delete flows and ownership-preserving delete behavior.

## 🤔 Key Decisions
- Keep the legacy valid-input parser contract unchanged: items split by `&`, fields split by `,`.
- Keep malformed input behavior unchanged for this extraction PR.
- Keep response shape unchanged by returning `user.profile.collect_social()` after mutations.

## 🧪 Verification Guide
### How to verify
1. Run `npm run server:test -- board.tests.api.test_setting board.tests.services.test_user_social_link_service`.
2. Log in and call `PUT /v1/setting/social` with update/create/delete payload strings.
3. Confirm returned social links match `collect_social()` ordering.

### Expected result
- Tests pass.
- Existing social link update/create/delete behavior is preserved.
- `setting.py` no longer owns social link mutation loops.

## ✅ Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [x] Tests completed
- [ ] Documentation updated (if needed)
