### PR TITLE
♻️ Extract auth request parser

### DIFF
--- a/backend/src/board/services/auth_request_parser.py
+++ b/backend/src/board/services/auth_request_parser.py
@@ -1,0 +1,12 @@
+import json
+
+
+class AuthRequestParser:
+    """Parse legacy auth request bodies without changing fallback behavior."""
+
+    @staticmethod
+    def parse_login_request(request) -> dict:
+        try:
+            return json.loads(request.body.decode('utf-8')) if request.body else {}
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return {}

--- a/backend/src/board/tests/api/test_auth.py
+++ b/backend/src/board/tests/api/test_auth.py
@@ -47,6 +47,35 @@ class AuthTestCase(TestCase):
         self.assertEqual(content['status'], 'DONE')
         self.assertEqual(content['body']['username'], 'test')
 
+    def test_login_with_json_body(self):
+        """JSON body 로그인 테스트"""
+        response = self.client.post(
+            '/v1/login',
+            json.dumps({
+                'username': 'test',
+                'password': 'test',
+            }),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'DONE')
+        self.assertEqual(content['body']['username'], 'test')
+
+    def test_login_with_invalid_json_body_keeps_legacy_fallback(self):
+        """invalid JSON body는 기존처럼 빈 dict fallback 후 인증 실패한다."""
+        response = self.client.post(
+            '/v1/login',
+            '{"username":',
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'ERROR')
+        self.assertEqual(content['errorCode'], 'error:AT')
+
     def test_logout(self):
         """로그아웃 테스트"""
         self.client.login(username='test', password='test')

--- a/backend/src/board/tests/services/test_auth_request_parser.py
+++ b/backend/src/board/tests/services/test_auth_request_parser.py
@@ -1,0 +1,34 @@
+from django.test import RequestFactory, TestCase
+
+from board.services.auth_request_parser import AuthRequestParser
+
+
+class AuthRequestParserTestCase(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_parse_login_request_reads_json_body(self):
+        request = self.factory.post(
+            '/v1/login',
+            '{"username":"test","password":"secret"}',
+            content_type='application/json',
+        )
+
+        data = AuthRequestParser.parse_login_request(request)
+
+        self.assertEqual(data['username'], 'test')
+        self.assertEqual(data['password'], 'secret')
+
+    def test_parse_login_request_returns_empty_dict_for_invalid_json(self):
+        request = self.factory.post(
+            '/v1/login',
+            '{"username":',
+            content_type='application/json',
+        )
+
+        self.assertEqual(AuthRequestParser.parse_login_request(request), {})
+
+    def test_parse_login_request_returns_empty_dict_for_empty_body(self):
+        request = self.factory.post('/v1/login')
+
+        self.assertEqual(AuthRequestParser.parse_login_request(request), {})

--- a/backend/src/board/views/api/v1/auth.py
+++ b/backend/src/board/views/api/v1/auth.py
@@ -19,6 +19,7 @@ from board.models import (
     UserLinkMeta, UsernameChangeLog, TelegramSync, SocialAuthProvider, SiteSetting)
 from board.modules.notify import create_notify
 from board.modules.response import StatusDone, StatusError, ErrorCode
+from board.services.auth_request_parser import AuthRequestParser
 from board.services.auth_service import AuthService, OAuthService, AuthValidationError
 from modules import oauth
 from modules.challenge import auth_hcaptcha
@@ -67,14 +68,6 @@ def common_auth(request, user, two_factor_code=None, is_oauth=False):
 
     auth.login(request, user)
     return login_response(request.user)
-
-
-def parse_login_request(request):
-    """Parse login request data from JSON or POST"""
-    try:
-        return json.loads(request.body.decode('utf-8')) if request.body else {}
-    except (json.JSONDecodeError, UnicodeDecodeError):
-        return {}
 
 
 def get_client_ip(request):
@@ -160,7 +153,7 @@ def login(request):
         if rate_limit_error:
             return rate_limit_error
 
-        data = parse_login_request(request)
+        data = AuthRequestParser.parse_login_request(request)
 
         oauth_token = data.get('oauth_token', '') or request.POST.get('oauth_token', '')
         if oauth_token:


### PR DESCRIPTION
## 🎯 Goal
- Start reducing `auth.py` parser responsibility with a small behavior-preserving extraction.
- Characterize login request parsing before larger auth orchestration refactors.

## 🔧 Core Changes
- Add `AuthRequestParser.parse_login_request()` for legacy login body parsing.
- Replace the inline login parser in `auth.py` with the parser class.
- Add tests for JSON login, invalid JSON legacy fallback, empty body fallback, and parser behavior.

## 🤔 Key Decisions
- Preserve invalid JSON behavior: parser returns `{}` and login falls back to POST/form data before failing authentication.
- Do not touch rate limiting, OAuth token dispatch, or 2FA orchestration in this PR.

## 🧪 Verification Guide
### How to verify
1. Run `npm run server:test -- board.tests.api.test_auth board.tests.services.test_auth_request_parser`.
2. Login with form data.
3. Login with JSON body.
4. Send invalid JSON and confirm it follows the existing authentication-failure path.

### Expected result
- Tests pass.
- Form and JSON login behavior stays unchanged.
- Invalid JSON still uses the legacy empty-dict fallback.

## ✅ Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [x] Tests completed
- [ ] Documentation updated (if needed)
