### PR TITLE
♻️ Extract auth login service

### DIFF
--- a/backend/src/board/services/auth_login_service.py
+++ b/backend/src/board/services/auth_login_service.py
@@ -1,0 +1,120 @@
+from django.contrib import auth
+from django.contrib.auth.models import User
+from django.core.cache import cache
+
+from board.modules.response import StatusDone, StatusError, ErrorCode
+from board.services.auth_service import AuthService, OAuthService
+
+
+class AuthLoginService:
+    """Coordinate login, rate limit, and login-time 2FA flows."""
+
+    LOGIN_ATTEMPT_LIMIT = 5
+    LOGIN_ATTEMPT_TTL_SECONDS = 300
+
+    @staticmethod
+    def login_response(user: User, is_first_login=False):
+        data = AuthService.get_user_login_data(user)
+        data['is_first_login'] = is_first_login
+        return StatusDone(data)
+
+    @staticmethod
+    def get_client_ip(request) -> str:
+        return request.META.get('HTTP_X_FORWARDED_FOR', request.META.get('REMOTE_ADDR'))
+
+    @staticmethod
+    def get_attempt_cache_key(request) -> str:
+        return f'login_attempts:{AuthLoginService.get_client_ip(request)}'
+
+    @staticmethod
+    def check_login_rate_limit(request):
+        attempts = cache.get(AuthLoginService.get_attempt_cache_key(request), 0)
+
+        if attempts >= AuthLoginService.LOGIN_ATTEMPT_LIMIT:
+            return StatusError(ErrorCode.REJECT, '너무 많은 실패로 인해 잠시 후 다시 시도해주세요.')
+
+        return None
+
+    @staticmethod
+    def clear_login_attempts(request) -> None:
+        cache.delete(AuthLoginService.get_attempt_cache_key(request))
+
+    @staticmethod
+    def increment_login_attempts(request) -> None:
+        cache_key = AuthLoginService.get_attempt_cache_key(request)
+        cache.set(
+            cache_key,
+            cache.get(cache_key, 0) + 1,
+            AuthLoginService.LOGIN_ATTEMPT_TTL_SECONDS,
+        )
+
+    @staticmethod
+    def common_auth(request, user: User, two_factor_code=None, is_oauth=False):
+        if AuthService.check_two_factor_auth(user):
+            if two_factor_code:
+                if AuthService.verify_totp_token(user, two_factor_code):
+                    AuthLoginService.clear_login_attempts(request)
+                    auth.login(request, user)
+                    return AuthLoginService.login_response(request.user)
+
+                AuthLoginService.increment_login_attempts(request)
+                return StatusError(ErrorCode.REJECT, '2차 인증 코드가 올바르지 않습니다.')
+
+            return StatusDone({
+                'username': user.username,
+                'security': True,
+                'is_oauth': is_oauth,
+            })
+
+        auth.login(request, user)
+        return AuthLoginService.login_response(request.user)
+
+    @staticmethod
+    def handle_oauth_token_login(request, data):
+        oauth_token = data.get('oauth_token', '') or request.POST.get('oauth_token', '')
+        two_factor_code = data.get('code', '') or request.POST.get('code', '')
+
+        oauth_data = OAuthService.get_2fa_data(oauth_token)
+
+        if not oauth_data:
+            return StatusError(ErrorCode.REJECT, '인증 토큰이 만료되었습니다. 다시 로그인해주세요.')
+
+        try:
+            user = User.objects.get(id=oauth_data['user_id'])
+        except User.DoesNotExist:
+            OAuthService.delete_2fa_token(oauth_token)
+            return StatusError(ErrorCode.REJECT)
+
+        if not two_factor_code:
+            return StatusError(ErrorCode.VALIDATE, '2차 인증 코드가 필요합니다.')
+
+        if AuthService.verify_totp_token(user, two_factor_code):
+            AuthLoginService.clear_login_attempts(request)
+            OAuthService.delete_2fa_token(oauth_token)
+            auth.login(request, user)
+            return AuthLoginService.login_response(request.user)
+
+        AuthLoginService.increment_login_attempts(request)
+        return StatusError(ErrorCode.REJECT, '2차 인증 코드가 올바르지 않습니다.')
+
+    @staticmethod
+    def handle_password_login(request, data):
+        username = data.get('username', '') or request.POST.get('username', '')
+        password = data.get('password', '') or request.POST.get('password', '')
+        two_factor_code = data.get('code', '') or request.POST.get('code', '')
+
+        user = auth.authenticate(username=username, password=password)
+
+        if user is not None:
+            if user.is_active:
+                AuthLoginService.clear_login_attempts(request)
+                return AuthLoginService.common_auth(
+                    request,
+                    user,
+                    two_factor_code=two_factor_code,
+                )
+        else:
+            AuthLoginService.increment_login_attempts(request)
+            return StatusError(ErrorCode.AUTHENTICATION)
+
+        return None

--- a/backend/src/board/tests/services/test_auth_login_service.py
+++ b/backend/src/board/tests/services/test_auth_login_service.py
@@ -1,0 +1,46 @@
+from django.core.cache import cache
+from django.test import RequestFactory, TestCase
+
+from board.services.auth_login_service import AuthLoginService
+
+
+class AuthLoginServiceTestCase(TestCase):
+    def setUp(self):
+        cache.clear()
+        self.factory = RequestFactory()
+
+    def test_get_client_ip_prefers_forwarded_for(self):
+        request = self.factory.post(
+            '/v1/login',
+            HTTP_X_FORWARDED_FOR='203.0.113.1',
+            REMOTE_ADDR='127.0.0.1',
+        )
+
+        self.assertEqual(AuthLoginService.get_client_ip(request), '203.0.113.1')
+
+    def test_login_rate_limit_allows_under_limit(self):
+        request = self.factory.post('/v1/login', REMOTE_ADDR='127.0.0.1')
+        for _ in range(AuthLoginService.LOGIN_ATTEMPT_LIMIT - 1):
+            AuthLoginService.increment_login_attempts(request)
+
+        self.assertIsNone(AuthLoginService.check_login_rate_limit(request))
+
+    def test_login_rate_limit_rejects_at_limit(self):
+        request = self.factory.post('/v1/login', REMOTE_ADDR='127.0.0.1')
+        for _ in range(AuthLoginService.LOGIN_ATTEMPT_LIMIT):
+            AuthLoginService.increment_login_attempts(request)
+
+        response = AuthLoginService.check_login_rate_limit(request)
+
+        self.assertIsNotNone(response)
+
+    def test_clear_login_attempts_removes_attempt_count(self):
+        request = self.factory.post('/v1/login', REMOTE_ADDR='127.0.0.1')
+        AuthLoginService.increment_login_attempts(request)
+
+        AuthLoginService.clear_login_attempts(request)
+
+        self.assertEqual(
+            cache.get(AuthLoginService.get_attempt_cache_key(request), 0),
+            0,
+        )

--- a/backend/src/board/views/api/v1/auth.py
+++ b/backend/src/board/views/api/v1/auth.py
@@ -8,7 +8,6 @@ import base64
 
 from django.conf import settings
 from django.contrib import auth
-from django.core.cache import cache
 from django.contrib.auth.models import User
 from django.http import Http404, QueryDict
 from django.shortcuts import get_object_or_404
@@ -19,6 +18,7 @@ from board.models import (
     UserLinkMeta, UsernameChangeLog, TelegramSync, SocialAuthProvider, SiteSetting)
 from board.modules.notify import create_notify
 from board.modules.response import StatusDone, StatusError, ErrorCode
+from board.services.auth_login_service import AuthLoginService
 from board.services.auth_request_parser import AuthRequestParser
 from board.services.auth_service import AuthService, OAuthService, AuthValidationError
 from modules import oauth
@@ -28,128 +28,14 @@ from modules.telegram import TelegramBot
 from modules.randomness import randnum, randstr
 
 
-def login_response(user: User, is_first_login=False):
-    data = AuthService.get_user_login_data(user)
-    data['is_first_login'] = is_first_login
-    return StatusDone(data)
-
-
-def common_auth(request, user, two_factor_code=None, is_oauth=False):
-    """
-    Handle authentication with optional 2FA code.
-
-    Args:
-        request: HTTP request
-        user: Authenticated user
-        two_factor_code: Optional 2FA code from client
-        is_oauth: Whether this is OAuth authentication
-
-    Returns:
-        StatusDone with login data or security requirement
-    """
-    if AuthService.check_two_factor_auth(user):
-        if two_factor_code:
-            client_ip = get_client_ip(request)
-            cache_key = f'login_attempts:{client_ip}'
-
-            if AuthService.verify_totp_token(user, two_factor_code):
-                cache.delete(cache_key)
-                auth.login(request, user)
-                return login_response(request.user)
-            else:
-                cache.set(cache_key, cache.get(cache_key, 0) + 1, 300)
-                return StatusError(ErrorCode.REJECT, '2차 인증 코드가 올바르지 않습니다.')
-        else:
-            return StatusDone({
-                'username': user.username,
-                'security': True,
-                'is_oauth': is_oauth,
-            })
-
-    auth.login(request, user)
-    return login_response(request.user)
-
-
-def get_client_ip(request):
-    """Get client IP address from request"""
-    return request.META.get('HTTP_X_FORWARDED_FOR', request.META.get('REMOTE_ADDR'))
-
-
-def check_login_rate_limit(request):
-    """
-    Check login rate limiting for the client IP.
-    Returns StatusError if blocked, None otherwise.
-    """
-    client_ip = get_client_ip(request)
-    cache_key = f'login_attempts:{client_ip}'
-    attempts = cache.get(cache_key, 0)
-
-    if attempts >= 5:
-        return StatusError(ErrorCode.REJECT, '너무 많은 실패로 인해 잠시 후 다시 시도해주세요.')
-
-    return None
-
-
-def handle_oauth_token_login(request, data):
-    """Handle OAuth token-based login with 2FA"""
-    client_ip = get_client_ip(request)
-    oauth_token = data.get('oauth_token', '') or request.POST.get('oauth_token', '')
-    two_factor_code = data.get('code', '') or request.POST.get('code', '')
-
-    oauth_data = OAuthService.get_2fa_data(oauth_token)
-
-    if not oauth_data:
-        return StatusError(ErrorCode.REJECT, '인증 토큰이 만료되었습니다. 다시 로그인해주세요.')
-
-    try:
-        user = User.objects.get(id=oauth_data['user_id'])
-    except User.DoesNotExist:
-        OAuthService.delete_2fa_token(oauth_token)
-        return StatusError(ErrorCode.REJECT)
-
-    if not two_factor_code:
-        return StatusError(ErrorCode.VALIDATE, '2차 인증 코드가 필요합니다.')
-
-    cache_key = f'login_attempts:{client_ip}'
-
-    if AuthService.verify_totp_token(user, two_factor_code):
-        cache.delete(cache_key)
-        OAuthService.delete_2fa_token(oauth_token)
-        auth.login(request, user)
-        return login_response(request.user)
-    else:
-        cache.set(cache_key, cache.get(cache_key, 0) + 1, 300)
-        return StatusError(ErrorCode.REJECT, '2차 인증 코드가 올바르지 않습니다.')
-
-
-def handle_password_login(request, data):
-    """Handle username/password-based login with optional 2FA"""
-    client_ip = get_client_ip(request)
-    cache_key = f'login_attempts:{client_ip}'
-
-    username = data.get('username', '') or request.POST.get('username', '')
-    password = data.get('password', '') or request.POST.get('password', '')
-    two_factor_code = data.get('code', '') or request.POST.get('code', '')
-
-    user = auth.authenticate(username=username, password=password)
-
-    if user is not None:
-        if user.is_active:
-            cache.delete(cache_key)
-            return common_auth(request, user, two_factor_code=two_factor_code)
-    else:
-        cache.set(cache_key, cache.get(cache_key, 0) + 1, 300)
-        return StatusError(ErrorCode.AUTHENTICATION)
-
-
 def login(request):
     if request.method == 'GET':
         if request.user.is_active:
-            return login_response(request.user)
+            return AuthLoginService.login_response(request.user)
         return StatusError(ErrorCode.NEED_LOGIN)
 
     if request.method == 'POST':
-        rate_limit_error = check_login_rate_limit(request)
+        rate_limit_error = AuthLoginService.check_login_rate_limit(request)
         if rate_limit_error:
             return rate_limit_error
 
@@ -157,9 +43,9 @@ def login(request):
 
         oauth_token = data.get('oauth_token', '') or request.POST.get('oauth_token', '')
         if oauth_token:
-            return handle_oauth_token_login(request, data)
+            return AuthLoginService.handle_oauth_token_login(request, data)
         else:
-            return handle_password_login(request, data)
+            return AuthLoginService.handle_password_login(request, data)
 
     raise Http404
 
@@ -214,7 +100,7 @@ def sign(request):
         )
 
         auth.login(request, new_user)
-        return login_response(request.user, is_first_login=True)
+        return AuthLoginService.login_response(request.user, is_first_login=True)
 
     if request.method == 'PATCH':
         user = request.user
@@ -268,7 +154,7 @@ def sign_social(request, social):
 
                 users = User.objects.filter(last_name=token)
                 if users.exists():
-                    return common_auth(request, users.first(), is_oauth=True)
+                    return AuthLoginService.common_auth(request, users.first(), is_oauth=True)
 
                 user, profile, config = AuthService.create_user(
                     username=user_id,
@@ -285,7 +171,7 @@ def sign_social(request, social):
                 )
 
                 auth.login(request, user)
-                return login_response(request.user, is_first_login=True)
+                return AuthLoginService.login_response(request.user, is_first_login=True)
 
         if social == 'google':
             if request.POST.get('code'):
@@ -302,7 +188,7 @@ def sign_social(request, social):
 
                 users = User.objects.filter(last_name=token)
                 if users.exists():
-                    return common_auth(request, users.first(), is_oauth=True)
+                    return AuthLoginService.common_auth(request, users.first(), is_oauth=True)
 
                 user, profile, config = AuthService.create_user(
                     username=user_id,
@@ -313,7 +199,7 @@ def sign_social(request, social):
                 )
 
                 auth.login(request, user)
-                return login_response(request.user, is_first_login=True)
+                return AuthLoginService.login_response(request.user, is_first_login=True)
 
     raise Http404
 


### PR DESCRIPTION
## 🎯 Goal
- Reduce login-time orchestration in `auth.py`.
- Move rate limiting, password login, OAuth-token 2FA login, and login-time 2FA handling into a focused service.

## 🔧 Core Changes
- Add `AuthLoginService` for login response serialization, client IP cache keys, login attempt rate limiting, password login, OAuth-token 2FA login, and common login-time 2FA flow.
- Update `/v1/login` and existing social OAuth sign-in paths to delegate login orchestration to the service.
- Add service tests for login attempt cache behavior and client IP resolution.

## 🤔 Key Decisions
- Preserve cache key format `login_attempts:{ip}`, attempt limit `5`, and TTL `300` seconds.
- Preserve 2FA response shapes, DEBUG bypass through `AuthService.check_two_factor_auth()`, and inactive-user behavior.
- Keep this PR scoped to login orchestration only; 2FA setup/verify endpoints remain unchanged.

## 🧪 Verification Guide
### How to verify
1. Run `npm run server:test -- board.tests.api.test_auth board.tests.api.test_two_factor_auth board.tests.services.test_auth_login_service`.
2. Test form and JSON login.
3. Test invalid password rate limiting.
4. Test 2FA-required, invalid-code, and valid-code login flows.

### Expected result
- Tests pass.
- Login and 2FA login behavior remain unchanged.
- `auth.py` delegates login-time orchestration to `AuthLoginService`.

## ✅ Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [x] Tests completed
- [ ] Documentation updated (if needed)
