### PR TITLE
♻️ Extract series API serializer

### DIFF
--- a/backend/src/board/services/series_serializer.py
+++ b/backend/src/board/services/series_serializer.py
@@ -1,0 +1,123 @@
+from board.modules.time import convert_to_localtime
+
+
+class SeriesSerializer:
+    """Serialize series API response contracts."""
+
+    @staticmethod
+    def available_post(post) -> dict:
+        return {
+            'id': post.id,
+            'title': post.title,
+            'publishedDate': (
+                convert_to_localtime(post.published_date).strftime('%Y-%m-%d')
+                if post.published_date else None
+            ),
+        }
+
+    @staticmethod
+    def public_series_list_item(series) -> dict:
+        return {
+            'url': series.url,
+            'name': series.name,
+            'image': series.thumbnail(),
+            'total_posts': series.total_posts,
+            'created_date': convert_to_localtime(series.created_date).strftime('%Y년 %m월 %d일'),
+            'owner': series.owner_username,
+        }
+
+    @staticmethod
+    def owner_series_order_item(series) -> dict:
+        return {
+            'url': series.url,
+            'title': series.name,
+            'total_posts': series.total_posts,
+        }
+
+    @staticmethod
+    def public_continue_detail(series, posts) -> dict:
+        return {
+            'name': series.name,
+            'url': series.url,
+            'owner': series.owner_username,
+            'owner_image': series.owner_avatar,
+            'description': series.text_md,
+            'total_posts': series.total_posts,
+            'posts': [
+                {
+                    'title': post[0],
+                    'url': post[1],
+                }
+                for post in posts
+            ],
+        }
+
+    @staticmethod
+    def public_detail_post(post, number: int) -> dict:
+        return {
+            'url': post.url,
+            'number': number,
+            'title': post.title,
+            'image': str(post.image),
+            'read_time': post.read_time,
+            'description': post.meta_description,
+            'created_date': convert_to_localtime(post.published_date).strftime('%Y년 %m월 %d일'),
+        }
+
+    @staticmethod
+    def public_detail(series, posts, page: int, order: str) -> dict:
+        start_number = series.total_posts - (
+            posts.paginator.per_page * (page - 1)
+        )
+        return {
+            'name': series.name,
+            'url': series.url,
+            'owner': series.owner_username,
+            'owner_image': series.owner_avatar,
+            'description': series.text_md,
+            'total_posts': series.total_posts,
+            'posts': [
+                SeriesSerializer.public_detail_post(
+                    post,
+                    (
+                        start_number - posts.index(post)
+                        if order == 'latest'
+                        else posts.index(post) + 1 + (page - 1) * posts.paginator.per_page
+                    ),
+                )
+                for post in posts
+            ],
+            'last_page': posts.paginator.num_pages,
+        }
+
+    @staticmethod
+    def owner_series_list_item(series) -> dict:
+        return {
+            'id': str(series.id),
+            'name': series.name,
+            'url': series.url,
+            'total_posts': series.total_posts,
+            'created_date': convert_to_localtime(series.created_date).strftime('%Y년 %m월 %d일'),
+        }
+
+    @staticmethod
+    def owner_detail(series, post_ids: list[int]) -> dict:
+        return {
+            'id': series.id,
+            'name': series.name,
+            'url': series.url,
+            'description': series.text_md,
+            'post_ids': post_ids,
+            'post_count': len(post_ids),
+        }
+
+    @staticmethod
+    def mutation_detail(series, thumbnail: str = '') -> dict:
+        return {
+            'id': series.id,
+            'name': series.name,
+            'url': series.url,
+            'description': series.text_md,
+            'thumbnail': thumbnail,
+            'postCount': series.posts.count(),
+        }

--- a/backend/src/board/tests/services/test_series_serializer.py
+++ b/backend/src/board/tests/services/test_series_serializer.py
@@ -1,0 +1,63 @@
+from django.test import TestCase
+from django.utils import timezone
+
+from board.models import Config, Post, PostConfig, PostContent, Profile, Series, User
+from board.services.series_serializer import SeriesSerializer
+
+
+class SeriesSerializerTestCase(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username='series-user', password='test')
+        Config.objects.create(user=self.user)
+        Profile.objects.create(user=self.user)
+        self.series = Series.objects.create(
+            owner=self.user,
+            name='Serializer Series',
+            url='serializer-series',
+            text_md='Description',
+        )
+        self.series.owner_username = self.user.username
+        self.series.owner_avatar = ''
+        self.series.total_posts = 1
+        self.post = Post.objects.create(
+            author=self.user,
+            title='Serializer Post',
+            url='serializer-post',
+            series=self.series,
+            published_date=timezone.now(),
+        )
+        PostContent.objects.create(post=self.post, content_html='<p>content</p>')
+        PostConfig.objects.create(post=self.post, hide=False)
+
+    def test_available_post_preserves_contract(self):
+        payload = SeriesSerializer.available_post(self.post)
+
+        self.assertEqual(payload['id'], self.post.id)
+        self.assertEqual(payload['title'], 'Serializer Post')
+        self.assertIn('publishedDate', payload)
+
+    def test_public_continue_detail_preserves_contract(self):
+        payload = SeriesSerializer.public_continue_detail(
+            self.series,
+            [('Serializer Post', 'serializer-post')],
+        )
+
+        self.assertEqual(payload['name'], 'Serializer Series')
+        self.assertEqual(payload['total_posts'], 1)
+        self.assertEqual(
+            payload['posts'],
+            [{'title': 'Serializer Post', 'url': 'serializer-post'}],
+        )
+
+    def test_owner_detail_preserves_post_id_contract(self):
+        payload = SeriesSerializer.owner_detail(self.series, [self.post.id])
+
+        self.assertEqual(payload['id'], self.series.id)
+        self.assertEqual(payload['post_ids'], [self.post.id])
+        self.assertEqual(payload['post_count'], 1)
+
+    def test_mutation_detail_preserves_post_count_contract(self):
+        payload = SeriesSerializer.mutation_detail(self.series)
+
+        self.assertEqual(payload['id'], self.series.id)
+        self.assertEqual(payload['postCount'], 1)

--- a/backend/src/board/views/api/v1/series.py
+++ b/backend/src/board/views/api/v1/series.py
@@ -8,9 +8,9 @@ from board.services.series_service import SeriesValidationError
 from board.services.public_post_service import PublicPostService
 from board.services.public_series_service import PublicSeriesService
 from board.services.api_request_body_service import ApiRequestBodyService
+from board.services.series_serializer import SeriesSerializer
 from board.modules.paginator import Paginator
 from board.modules.response import StatusDone, StatusError, ErrorCode
-from board.modules.time import convert_to_localtime
 
 
 def posts_can_add_series(request):
@@ -40,11 +40,10 @@ def posts_can_add_series(request):
         else:
             posts = SeriesService.get_posts_available_for_series(request.user)
 
-        return StatusDone(list(map(lambda post: {
-            'id': post.id,
-            'title': post.title,
-            'publishedDate': convert_to_localtime(post.published_date).strftime('%Y-%m-%d') if post.published_date else None,
-        }, posts)))
+        return StatusDone([
+            SeriesSerializer.available_post(post)
+            for post in posts
+        ])
 
     raise Http404
 
@@ -59,14 +58,10 @@ def user_series(request, username, url=None):
                 page=request.GET.get('page', 1)
             )
             return StatusDone({
-                'series': list(map(lambda item: {
-                    'url': item.url,
-                    'name': item.name,
-                    'image': item.thumbnail(),
-                    'total_posts': item.total_posts,
-                    'created_date': convert_to_localtime(item.created_date).strftime('%Y년 %m월 %d일'),
-                    'owner': item.owner_username,
-                }, series)),
+                'series': [
+                    SeriesSerializer.public_series_list_item(item)
+                    for item in series
+                ],
                 'last_page': series.paginator.num_pages
             })
 
@@ -91,11 +86,10 @@ def user_series(request, username, url=None):
 
                     series = SeriesService.get_user_series_list(request.user)
                     return StatusDone({
-                        'series': list(map(lambda item: {
-                            'url': item.url,
-                            'title': item.name,
-                            'total_posts': item.total_posts
-                        }, series))
+                        'series': [
+                            SeriesSerializer.owner_series_order_item(item)
+                            for item in series
+                        ]
                     })
                 except SeriesValidationError as e:
                     return StatusError(e.code, e.message)
@@ -142,18 +136,7 @@ def user_series(request, username, url=None):
                 posts = PublicPostService.filter_public_posts(Post.objects).filter(
                     series=series,
                 ).values_list('title', 'url')
-                return StatusDone({
-                    'name': series.name,
-                    'url': series.url,
-                    'owner': series.owner_username,
-                    'owner_image': series.owner_avatar,
-                    'description': series.text_md,
-                    'total_posts': series.total_posts,
-                    'posts': list(map(lambda post: {
-                        'title': post[0],
-                        'url': post[1],
-                    }, posts)),
-                })
+                return StatusDone(SeriesSerializer.public_continue_detail(series, posts))
 
             page = request.GET.get('page', 1)
             order = request.GET.get('order', 'latest')
@@ -167,26 +150,9 @@ def user_series(request, username, url=None):
                 offset=12,
                 page=page
             )
-            start_number = series.total_posts - \
-                (posts.paginator.per_page * (int(page) - 1))
-            return StatusDone({
-                'name': series.name,
-                'url': series.url,
-                'owner': series.owner_username,
-                'owner_image': series.owner_avatar,
-                'description': series.text_md,
-                'total_posts': series.total_posts,
-                'posts': list(map(lambda post: {
-                    'url': post.url,
-                    'number': start_number - posts.index(post) if order == 'latest' else posts.index(post) + 1 + (int(page) - 1) * posts.paginator.per_page,
-                    'title': post.title,
-                    'image': str(post.image),
-                    'read_time': post.read_time,
-                    'description': post.meta_description,
-                    'created_date': convert_to_localtime(post.published_date).strftime('%Y년 %m월 %d일')
-                }, posts)),
-                'last_page': posts.paginator.num_pages
-            })
+            return StatusDone(
+                SeriesSerializer.public_detail(series, posts, int(page), order)
+            )
 
         series = get_object_or_404(
             PublicSeriesService.with_public_post_count(series_queryset, 'total_posts'),
@@ -269,13 +235,10 @@ def series_create_update(request):
         series = SeriesService.get_user_series_list(request.user)
 
         return StatusDone({
-            'series': list(map(lambda item: {
-                'id': str(item.id),
-                'name': item.name,
-                'url': item.url,
-                'total_posts': item.total_posts,
-                'created_date': convert_to_localtime(item.created_date).strftime('%Y년 %m월 %d일'),
-            }, series))
+            'series': [
+                SeriesSerializer.owner_series_list_item(item)
+                for item in series
+            ]
         })
 
     elif request.method == 'POST':
@@ -306,14 +269,12 @@ def series_create_update(request):
                 post_ids=post_ids
             )
 
-            return StatusDone({
-                'id': series.id,
-                'name': series.name,
-                'url': series.url,
-                'description': series.text_md,
-                'thumbnail': body.get('thumbnail', ''),
-                'postCount': series.posts.count()
-            })
+            return StatusDone(
+                SeriesSerializer.mutation_detail(
+                    series,
+                    thumbnail=body.get('thumbnail', ''),
+                )
+            )
         except SeriesValidationError as e:
             return StatusError(e.code, e.message)
 
@@ -342,14 +303,7 @@ def series_detail(request, series_id):
             ).values_list('id', flat=True)
         )
 
-        return StatusDone({
-            'id': series.id,
-            'name': series.name,
-            'url': series.url,
-            'description': series.text_md,
-            'post_ids': post_ids,
-            'post_count': len(post_ids)
-        })
+        return StatusDone(SeriesSerializer.owner_detail(series, post_ids))
 
     if request.method == 'PUT':
         body, body_error = ApiRequestBodyService.parse_json_or_error(
@@ -379,14 +333,12 @@ def series_detail(request, series_id):
                 post_ids=post_ids
             )
 
-            return StatusDone({
-                'id': series.id,
-                'name': series.name,
-                'url': series.url,
-                'description': series.text_md,
-                'thumbnail': body.get('thumbnail', ''),
-                'postCount': series.posts.count()
-            })
+            return StatusDone(
+                SeriesSerializer.mutation_detail(
+                    series,
+                    thumbnail=body.get('thumbnail', ''),
+                )
+            )
         except SeriesValidationError as e:
             return StatusError(e.code, e.message)
 


### PR DESCRIPTION
## 🎯 Goal
- Reduce inline response serialization in `series.py` API views.
- Preserve series API contracts while making response shapes easier to test independently.

## 🔧 Core Changes
- Add `SeriesSerializer` for series API response dictionaries.
- Move valid-post, public series list/detail, owner list/detail, mutation, and order response serialization out of the view.
- Add serializer characterization tests for key response shapes.

## 🤔 Key Decisions
- Keep query construction, public visibility policy, permissions, and mutation behavior unchanged.
- Keep existing snake_case keys in Python payloads so `StatusDone` continues to apply the existing camelCase wire conversion.
- Preserve existing public detail numbering behavior for latest and oldest order.

## 🧪 Verification Guide
### How to verify
1. Run `npm run server:test -- board.tests.api.test_series_api board.tests.services.test_series_serializer`.
2. Request `/v1/users/@author/series` and `/v1/users/@author/series/test-series`.
3. Request `/v1/series`, `/v1/series/<id>`, and mutation endpoints.

### Expected result
- Tests pass.
- Response shapes remain unchanged.
- `series.py` delegates response construction to `SeriesSerializer`.

## ✅ Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [x] Tests completed
- [ ] Documentation updated (if needed)
