### PR TITLE
♻️ Extract post comment list service

### DIFF
--- a/backend/src/board/services/comment_list_service.py
+++ b/backend/src/board/services/comment_list_service.py
@@ -1,0 +1,97 @@
+from django.db.models import Case, Count, Exists, OuterRef, Prefetch, Value, When
+
+from board.models import Comment
+
+
+class CommentListService:
+    """Build and serialize post comment list API responses."""
+
+    @staticmethod
+    def get_post_parent_comments(post_url: str, user_id: int):
+        replies_queryset = CommentListService.annotate_comment_queryset(
+            Comment.objects.select_related('author', 'author__profile'),
+            user_id,
+        ).order_by('created_date')
+
+        return CommentListService.annotate_comment_queryset(
+            Comment.objects.select_related('author', 'author__profile'),
+            user_id,
+        ).prefetch_related(
+            Prefetch('replies', queryset=replies_queryset)
+        ).filter(
+            post__url=post_url,
+            parent__isnull=True,
+        ).order_by('created_date')
+
+    @staticmethod
+    def annotate_comment_queryset(queryset, user_id: int):
+        return queryset.annotate(
+            count_likes=Count('likes', distinct=True),
+            has_liked=Case(
+                When(
+                    Exists(
+                        Comment.objects.filter(
+                            id=OuterRef('id'),
+                            likes__id=user_id,
+                        )
+                    ),
+                    then=Value(True),
+                ),
+                default=Value(False),
+            ),
+        )
+
+    @staticmethod
+    def serialize_post_comments(post_url: str, user) -> dict:
+        user_id = user.id if user.id else -1
+        is_authenticated = user.is_authenticated
+        parent_comments = CommentListService.get_post_parent_comments(post_url, user_id)
+
+        return {
+            'comments': [
+                CommentListService.serialize_comment(
+                    comment,
+                    user_id=user_id,
+                    is_authenticated=is_authenticated,
+                )
+                for comment in parent_comments
+            ]
+        }
+
+    @staticmethod
+    def serialize_comment(comment, user_id: int, is_authenticated: bool) -> dict:
+        return {
+            'id': comment.id,
+            'author': comment.author_username(),
+            'author_image': None if not comment.author else comment.author.profile.get_thumbnail(),
+            'is_mine': is_authenticated and comment.author_id == user_id,
+            'is_edited': comment.edited,
+            'rendered_content': comment.get_text_html(),
+            'created_date': comment.time_since(),
+            'count_likes': comment.count_likes,
+            'is_liked': comment.has_liked,
+            'replies': [
+                CommentListService.serialize_reply(
+                    reply,
+                    parent_id=comment.id,
+                    user_id=user_id,
+                    is_authenticated=is_authenticated,
+                )
+                for reply in comment.replies.all()
+            ],
+        }
+
+    @staticmethod
+    def serialize_reply(reply, parent_id: int, user_id: int, is_authenticated: bool) -> dict:
+        return {
+            'id': reply.id,
+            'author': reply.author_username(),
+            'author_image': None if not reply.author else reply.author.profile.get_thumbnail(),
+            'is_mine': is_authenticated and reply.author_id == user_id,
+            'is_edited': reply.edited,
+            'rendered_content': reply.get_text_html(),
+            'created_date': reply.time_since(),
+            'count_likes': reply.count_likes,
+            'is_liked': reply.has_liked,
+            'parent_id': parent_id,
+        }

--- a/backend/src/board/tests/services/test_comment_list_service.py
+++ b/backend/src/board/tests/services/test_comment_list_service.py
@@ -1,0 +1,52 @@
+from django.test import TestCase
+from django.utils import timezone
+
+from board.models import Comment, Config, Post, PostConfig, PostContent, Profile, User
+from board.services.comment_list_service import CommentListService
+
+
+class CommentListServiceTestCase(TestCase):
+    def setUp(self):
+        self.author = User.objects.create_user(username='comment-author', password='test')
+        self.viewer = User.objects.create_user(username='comment-viewer', password='test')
+        for user in (self.author, self.viewer):
+            Config.objects.create(user=user)
+            Profile.objects.create(user=user)
+        self.post = Post.objects.create(
+            url='comment-list-post',
+            title='Post',
+            author=self.author,
+            published_date=timezone.now(),
+        )
+        PostContent.objects.create(post=self.post, content_html='<p>Post</p>')
+        PostConfig.objects.create(post=self.post, hide=False)
+        self.parent = Comment.objects.create(
+            post=self.post,
+            author=self.viewer,
+            text_md='Parent',
+            text_html='<p>Parent</p>',
+        )
+        self.reply = Comment.objects.create(
+            post=self.post,
+            author=self.author,
+            parent=self.parent,
+            text_md='Reply',
+            text_html='<p>Reply</p>',
+        )
+
+    def test_serialize_post_comments_preserves_parent_and_reply_shape(self):
+        payload = CommentListService.serialize_post_comments(
+            self.post.url,
+            self.viewer,
+        )
+
+        self.assertEqual(len(payload['comments']), 1)
+        comment = payload['comments'][0]
+        self.assertEqual(comment['id'], self.parent.id)
+        self.assertEqual(comment['author'], 'comment-viewer')
+        self.assertTrue(comment['is_mine'])
+        self.assertEqual(comment['count_likes'], 0)
+        self.assertFalse(comment['is_liked'])
+        self.assertEqual(len(comment['replies']), 1)
+        self.assertEqual(comment['replies'][0]['parent_id'], self.parent.id)
+        self.assertFalse(comment['replies'][0]['is_mine'])

--- a/backend/src/board/views/api/v1/post.py
+++ b/backend/src/board/views/api/v1/post.py
@@ -1,25 +1,12 @@
-import random
-import datetime
-
-from django.conf import settings
-from django.db.models import (
-    Q, F, Case, Exists, When, Subquery,
-    Value, OuterRef, Count, IntegerField, Prefetch)
 from django.http import Http404, QueryDict
 from django.shortcuts import get_object_or_404
-from django.utils import timezone
 from django.utils.dateparse import parse_datetime
-from django.utils.text import slugify
 
-from board.models import (
-    Comment, Series, Post, PostContent,
-    PostConfig, PinnedPost, PostLikes)
-from board.modules.notify import create_notify
-from board.modules.paginator import Paginator
-from board.modules.post_description import create_post_description
+from board.models import Post, PinnedPost
 from board.modules.requests import BooleanType
 from board.modules.response import StatusDone, StatusError, ErrorCode
 from board.modules.time import convert_to_localtime, time_since
+from board.services.comment_list_service import CommentListService
 from board.services.post_service import PostService, PostValidationError
 
 
@@ -65,80 +52,7 @@ def post_list(request):
 
 def post_comment_list(request, url):
     if request.method == 'GET':
-        user_id = request.user.id if request.user.id else -1
-        is_authenticated = request.user.is_authenticated
-
-        # 대댓글용 queryset (미리 annotate 적용)
-        replies_queryset = Comment.objects.select_related(
-            'author',
-            'author__profile'
-        ).annotate(
-            count_likes=Count('likes', distinct=True),
-            has_liked=Case(
-                When(
-                    Exists(
-                        Comment.objects.filter(
-                            id=OuterRef('id'),
-                            likes__id=user_id
-                        )
-                    ),
-                    then=Value(True)
-                ),
-                default=Value(False),
-            )
-        ).order_by('created_date')
-
-        # 부모 댓글만 조회 (parent__isnull=True)
-        parent_comments = Comment.objects.select_related(
-            'author',
-            'author__profile'
-        ).prefetch_related(
-            Prefetch('replies', queryset=replies_queryset)
-        ).annotate(
-            count_likes=Count('likes', distinct=True),
-            has_liked=Case(
-                When(
-                    Exists(
-                        Comment.objects.filter(
-                            id=OuterRef('id'),
-                            likes__id=user_id
-                        )
-                    ),
-                    then=Value(True)
-                ),
-                default=Value(False),
-            )
-        ).filter(post__url=url, parent__isnull=True).order_by('created_date')
-
-        def serialize_comment(comment):
-            # prefetch된 replies 사용 (추가 쿼리 없음)
-            return {
-                'id': comment.id,
-                'author': comment.author_username(),
-                'author_image': None if not comment.author else comment.author.profile.get_thumbnail(),
-                'is_mine': is_authenticated and comment.author_id == user_id,
-                'is_edited': comment.edited,
-                'rendered_content': comment.get_text_html(),
-                'created_date': comment.time_since(),
-                'count_likes': comment.count_likes,
-                'is_liked': comment.has_liked,
-                'replies': list(map(lambda reply: {
-                    'id': reply.id,
-                    'author': reply.author_username(),
-                    'author_image': None if not reply.author else reply.author.profile.get_thumbnail(),
-                    'is_mine': is_authenticated and reply.author_id == user_id,
-                    'is_edited': reply.edited,
-                    'rendered_content': reply.get_text_html(),
-                    'created_date': reply.time_since(),
-                    'count_likes': reply.count_likes,
-                    'is_liked': reply.has_liked,
-                    'parent_id': comment.id,
-                }, comment.replies.all()))
-            }
-
-        return StatusDone({
-            'comments': list(map(serialize_comment, parent_comments))
-        })
+        return StatusDone(CommentListService.serialize_post_comments(url, request.user))
 
 
 def user_posts(request, username, url=None):


### PR DESCRIPTION
## 🎯 Goal
- Reduce inline comment-list query/serialization logic in `post.py`.
- Preserve the existing comment list response contract while making parent/reply serialization testable.

## 🔧 Core Changes
- Add `CommentListService` for post comment list query annotation, reply prefetching, and response serialization.
- Replace inline `GET /v1/posts/{url}/comments` query/serializer code with a service call.
- Add service tests covering parent/reply response shape and authenticated ownership flags.

## 🤔 Key Decisions
- Keep public comment-list policy unchanged in this extraction PR.
- Preserve `select_related`, reply `Prefetch`, likes count annotation, liked-state annotation, and `created_date` ordering.
- Preserve existing parent/reply field shapes, including `parent_id` only on replies.

## 🧪 Verification Guide
### How to verify
1. Run `npm run server:test -- board.tests.api.test_comment board.tests.services.test_comment_list_service`.
2. Request `GET /v1/posts/{url}/comments` as anonymous and authenticated users.
3. Confirm parent/reply fields and like/mine flags match existing behavior.

### Expected result
- Tests pass.
- Comment list response shape remains unchanged.
- `post.py` delegates comment list query/serialization to `CommentListService`.

## ✅ Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [x] Tests completed
- [ ] Documentation updated (if needed)
