### PR TITLE
♻️ Extract webhook API policy service

### DIFF
--- a/backend/src/board/services/webhook_api_service.py
+++ b/backend/src/board/services/webhook_api_service.py
@@ -1,0 +1,64 @@
+from board.models import Profile, WebhookSubscription, SiteContentScope
+from board.modules.response import StatusError, ErrorCode
+
+
+class WebhookApiService:
+    """API-facing policy and serialization helpers for webhook channels."""
+
+    @staticmethod
+    def get_authenticated_profile(request):
+        if not request.user.is_authenticated:
+            return None, StatusError(ErrorCode.NEED_LOGIN, 'Login required')
+
+        try:
+            profile = Profile.objects.get(user=request.user)
+            return profile, None
+        except Profile.DoesNotExist:
+            return None, StatusError(ErrorCode.NOT_FOUND, 'Profile not found')
+
+    @staticmethod
+    def ensure_staff(request):
+        if not request.user.is_authenticated:
+            return StatusError(ErrorCode.NEED_LOGIN, 'Login required')
+        if not request.user.is_staff:
+            return StatusError(ErrorCode.REJECT, '관리자 권한이 필요합니다.')
+        return None
+
+    @staticmethod
+    def get_user_channels(profile: Profile):
+        return WebhookSubscription.objects.filter(
+            scope=SiteContentScope.USER,
+            author=profile,
+        )
+
+    @staticmethod
+    def get_global_channels():
+        return WebhookSubscription.objects.filter(
+            scope=SiteContentScope.GLOBAL,
+        )
+
+    @staticmethod
+    def serialize_channels(channels) -> dict:
+        return {
+            'channels': list(
+                channels.values(
+                    'id',
+                    'name',
+                    'webhook_url',
+                    'is_active',
+                    'failure_count',
+                    'created_date',
+                )
+            )
+        }
+
+    @staticmethod
+    def mutation_success(channel) -> dict:
+        return {
+            'success': True,
+            'channel_id': channel.id,
+        }
+
+    @staticmethod
+    def delete_success() -> dict:
+        return {'success': True}

--- a/backend/src/board/tests/services/test_webhook_api_service.py
+++ b/backend/src/board/tests/services/test_webhook_api_service.py
@@ -1,0 +1,64 @@
+from django.test import RequestFactory, TestCase
+from django.contrib.auth.models import AnonymousUser, User
+
+from board.models import Profile, WebhookSubscription, SiteContentScope
+from board.services.webhook_api_service import WebhookApiService
+
+
+class WebhookApiServiceTestCase(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.user = User.objects.create_user(username='webhook-user', password='test')
+        self.profile = Profile.objects.create(user=self.user)
+
+    def test_get_authenticated_profile_rejects_anonymous_user(self):
+        request = self.factory.get('/v1/webhook/channels')
+        request.user = AnonymousUser()
+
+        profile, error = WebhookApiService.get_authenticated_profile(request)
+
+        self.assertIsNone(profile)
+        self.assertIsNotNone(error)
+
+    def test_ensure_staff_rejects_non_staff_user(self):
+        request = self.factory.get('/v1/webhook/global-channels')
+        request.user = self.user
+
+        self.assertIsNotNone(WebhookApiService.ensure_staff(request))
+
+    def test_serialize_channels_preserves_channel_shape(self):
+        WebhookSubscription.objects.create(
+            scope=SiteContentScope.USER,
+            author=self.profile,
+            webhook_url='https://discord.com/api/webhooks/service/test',
+            name='Service Channel',
+        )
+
+        payload = WebhookApiService.serialize_channels(
+            WebhookApiService.get_user_channels(self.profile)
+        )
+
+        self.assertEqual(len(payload['channels']), 1)
+        channel = payload['channels'][0]
+        self.assertEqual(channel['name'], 'Service Channel')
+        self.assertIn('webhook_url', channel)
+        self.assertIn('is_active', channel)
+        self.assertIn('failure_count', channel)
+        self.assertIn('created_date', channel)
+
+    def test_get_global_channels_excludes_user_channels(self):
+        WebhookSubscription.objects.create(
+            scope=SiteContentScope.USER,
+            author=self.profile,
+            webhook_url='https://discord.com/api/webhooks/user/test',
+        )
+        global_channel = WebhookSubscription.objects.create(
+            scope=SiteContentScope.GLOBAL,
+            author=None,
+            webhook_url='https://discord.com/api/webhooks/global/test',
+        )
+
+        self.assertEqual(
+            list(WebhookApiService.get_global_channels()),
+            [global_channel],
+        )

--- a/backend/src/board/views/api/v1/webhook.py
+++ b/backend/src/board/views/api/v1/webhook.py
@@ -8,22 +8,15 @@ When a new post is published, notifications are sent to:
 """
 from django.views.decorators.http import require_http_methods
 
-from board.models import Profile, WebhookSubscription, SiteContentScope
+from board.models import WebhookSubscription, SiteContentScope
 from board.services import WebhookService
 from board.services.api_request_body_service import ApiRequestBodyService
+from board.services.webhook_api_service import WebhookApiService
 from board.modules.response import StatusDone, StatusError, ErrorCode
 
 
 def _get_authenticated_profile(request):
-    """Get the authenticated user's profile or return error response."""
-    if not request.user.is_authenticated:
-        return None, StatusError(ErrorCode.NEED_LOGIN, 'Login required')
-
-    try:
-        profile = Profile.objects.get(user=request.user)
-        return profile, None
-    except Profile.DoesNotExist:
-        return None, StatusError(ErrorCode.NOT_FOUND, 'Profile not found')
+    return WebhookApiService.get_authenticated_profile(request)
 
 
 def _validate_webhook_payload(request):
@@ -52,11 +45,7 @@ def _validate_webhook_payload(request):
 
 
 def _ensure_staff(request):
-    if not request.user.is_authenticated:
-        return StatusError(ErrorCode.NEED_LOGIN, 'Login required')
-    if not request.user.is_staff:
-        return StatusError(ErrorCode.REJECT, '관리자 권한이 필요합니다.')
-    return None
+    return WebhookApiService.ensure_staff(request)
 
 
 @require_http_methods(['GET', 'POST'])
@@ -76,14 +65,11 @@ def my_channels(request):
         return error
 
     if request.method == 'GET':
-        channels = WebhookSubscription.objects.filter(
-            scope=SiteContentScope.USER,
-            author=profile
-        ).values('id', 'name', 'webhook_url', 'is_active', 'failure_count', 'created_date')
-
-        return StatusDone({
-            'channels': list(channels)
-        })
+        return StatusDone(
+            WebhookApiService.serialize_channels(
+                WebhookApiService.get_user_channels(profile)
+            )
+        )
 
     webhook_url, name, error = _validate_webhook_payload(request)
     if error:
@@ -95,10 +81,7 @@ def my_channels(request):
         name=name
     )
 
-    return StatusDone({
-        'success': True,
-        'channel_id': channel.id
-    })
+    return StatusDone(WebhookApiService.mutation_success(channel))
 
 
 @require_http_methods(['DELETE'])
@@ -120,7 +103,7 @@ def delete_channel(request, channel_id):
             author=profile
         )
         channel.delete()
-        return StatusDone({'success': True})
+        return StatusDone(WebhookApiService.delete_success())
     except WebhookSubscription.DoesNotExist:
         return StatusError(ErrorCode.NOT_FOUND, 'Channel not found')
 
@@ -142,13 +125,11 @@ def global_channels(request):
         return staff_error
 
     if request.method == 'GET':
-        channels = WebhookSubscription.objects.filter(
-            scope=SiteContentScope.GLOBAL
-        ).values('id', 'name', 'webhook_url', 'is_active', 'failure_count', 'created_date')
-
-        return StatusDone({
-            'channels': list(channels)
-        })
+        return StatusDone(
+            WebhookApiService.serialize_channels(
+                WebhookApiService.get_global_channels()
+            )
+        )
 
     webhook_url, name, error = _validate_webhook_payload(request)
     if error:
@@ -159,10 +140,7 @@ def global_channels(request):
         name=name
     )
 
-    return StatusDone({
-        'success': True,
-        'channel_id': channel.id
-    })
+    return StatusDone(WebhookApiService.mutation_success(channel))
 
 
 @require_http_methods(['DELETE'])
@@ -183,7 +161,7 @@ def delete_global_channel(request, channel_id):
             scope=SiteContentScope.GLOBAL
         )
         channel.delete()
-        return StatusDone({'success': True})
+        return StatusDone(WebhookApiService.delete_success())
     except WebhookSubscription.DoesNotExist:
         return StatusError(ErrorCode.NOT_FOUND, 'Channel not found')
 


### PR DESCRIPTION
## 🎯 Goal
- Reduce inline webhook API policy and serialization logic.
- Keep webhook channel behavior stable while naming user/global scope helpers explicitly.

## 🔧 Core Changes
- Add `WebhookApiService` for authenticated profile lookup, staff policy, user/global channel query helpers, and response serialization.
- Delegate existing view helper wrappers to the service.
- Move channel list, mutation success, and delete success response construction into the service.
- Add service tests for policy rejection, channel scope filtering, and channel response shape.

## 🤔 Key Decisions
- Keep webhook payload validation and test dispatch in the view for this PR.
- Preserve user channel scope: `scope=USER` and `author=profile`.
- Preserve global channel scope: `scope=GLOBAL`.
- Preserve existing `StatusDone` camelization behavior for `webhook_url`, `is_active`, `failure_count`, and `channel_id`.

## 🧪 Verification Guide
### How to verify
1. Run `npm run server:test -- board.tests.api.test_webhook board.tests.services.test_webhook_api_service`.
2. Request user webhook channels as an authenticated author.
3. Request global webhook channels as staff and non-staff.
4. Create/delete user and global webhook channels.

### Expected result
- Tests pass.
- User/global channel scopes do not leak into each other.
- Response shapes remain unchanged.

## ✅ Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [x] Tests completed
- [ ] Documentation updated (if needed)
