### PR TITLE
♻️ Extract utility cleanup service

### DIFF
--- a/backend/src/board/services/utility_cleanup_service.py
+++ b/backend/src/board/services/utility_cleanup_service.py
@@ -1,0 +1,322 @@
+from django.conf import settings
+from django.contrib.admin.models import LogEntry
+from django.contrib.sessions.models import Session
+
+from board.admin.utilities import (
+    DatabaseStatsService,
+    ImageCleanerService,
+    SessionCleanerService,
+    TagCleanerService,
+)
+from board.modules.response import StatusError, ErrorCode
+
+
+class InvalidImageCleanupTargetError(Exception):
+    """Raised when a utility image cleanup target is not supported."""
+
+
+class UtilityPermissionService:
+    """Permission policy for staff-only utility endpoints."""
+
+    @staticmethod
+    def require_staff(user):
+        if not user.is_active:
+            return StatusError(ErrorCode.NEED_LOGIN)
+
+        if not user.is_staff:
+            return StatusError(ErrorCode.REJECT, '관리자 권한이 필요합니다.')
+
+        return None
+
+
+class UtilityCleanupService:
+    """Build utility stats and cleanup dry-run/execute response contracts."""
+
+    VALID_IMAGE_TARGETS = ('all', 'content', 'title', 'avatar')
+
+    @staticmethod
+    def get_stats() -> dict:
+        stats = DatabaseStatsService.get_statistics()
+        stats['log_count'] = LogEntry.objects.count()
+        return stats
+
+    @staticmethod
+    def clean_tags(body: dict) -> dict:
+        dry_run = body.get('dry_run', True)
+
+        service = TagCleanerService()
+        tag_stats = service.get_tag_statistics()
+        count, tag_names = service.clean_unused_tags(execute=not dry_run)
+
+        return {
+            'total_tags': tag_stats['total_tags'],
+            'used_tags': tag_stats['used_tags'],
+            'unused_tags': tag_stats['unused_tags'],
+            'top_tags': tag_stats['top_tags'],
+            'cleaned_count': count,
+            'cleaned_tags': tag_names[:20],
+            'dry_run': dry_run,
+        }
+
+    @staticmethod
+    def clean_sessions(body: dict) -> dict:
+        dry_run = body.get('dry_run', True)
+        clean_all = body.get('clean_all', False)
+
+        total_sessions = Session.objects.count()
+        expired_sessions = SessionCleanerService.count_expired_sessions()
+        cleaned_count = 0
+
+        if not dry_run:
+            if clean_all:
+                cleaned_count = SessionCleanerService.clean_all_sessions()
+            else:
+                cleaned_count = SessionCleanerService.clean_expired_sessions()
+
+        return {
+            'total_sessions': total_sessions,
+            'expired_sessions': expired_sessions,
+            'cleaned_count': cleaned_count,
+            'clean_all': clean_all,
+            'dry_run': dry_run,
+        }
+
+    @staticmethod
+    def clean_logs(body: dict) -> dict:
+        dry_run = body.get('dry_run', True)
+        log_count = LogEntry.objects.count()
+        cleaned_count = 0
+
+        if not dry_run:
+            LogEntry.objects.all().delete()
+            cleaned_count = log_count
+
+        return {
+            'log_count': log_count,
+            'cleaned_count': cleaned_count,
+            'dry_run': dry_run,
+        }
+
+    @staticmethod
+    def validate_image_target(target: str) -> None:
+        if target not in UtilityCleanupService.VALID_IMAGE_TARGETS:
+            raise InvalidImageCleanupTargetError('유효하지 않은 대상입니다.')
+
+    @staticmethod
+    def clean_images(body: dict) -> dict:
+        dry_run = body.get('dry_run', True)
+        target = body.get('target', 'all')
+        remove_duplicates = body.get('remove_duplicates', False)
+
+        UtilityCleanupService.validate_image_target(target)
+
+        service = ImageCleanerService()
+        messages = []
+
+        used_content = service.scan_content_images()
+        used_title = service.scan_title_images()
+        used_avatar = service.scan_avatar_images()
+
+        total_unused = 0
+        total_size = 0
+        total_duplicates = 0
+        total_duplicate_size = 0
+        unused_files = []
+        duplicate_files = []
+
+        if target in ('all', 'content'):
+            unused_content, unused_size = UtilityCleanupService.collect_unused_files(
+                service,
+                service.content_image_dir,
+                used_content,
+            )
+            total_unused += len(unused_content)
+            total_size += unused_size
+
+            if not dry_run:
+                UtilityCleanupService.clean_files_with_messages(
+                    service,
+                    unused_content,
+                    messages,
+                    '컨텐츠 이미지',
+                )
+            else:
+                unused_files.extend([
+                    UtilityCleanupService.to_file_info(f, 'images/content')
+                    for f in unused_content
+                ])
+
+        if target in ('all', 'title'):
+            unused_title, unused_size = UtilityCleanupService.collect_unused_files(
+                service,
+                service.title_image_dir,
+                used_title,
+            )
+            total_unused += len(unused_title)
+            total_size += unused_size
+
+            if not dry_run:
+                UtilityCleanupService.clean_files_with_messages(
+                    service,
+                    unused_title,
+                    messages,
+                    '타이틀 이미지',
+                )
+            else:
+                unused_files.extend([
+                    UtilityCleanupService.to_file_info(f, 'images/title')
+                    for f in unused_title
+                ])
+
+            if remove_duplicates:
+                duplicate_stats = UtilityCleanupService.handle_title_duplicates(
+                    service,
+                    dry_run,
+                    messages,
+                )
+                total_duplicates += duplicate_stats['count']
+                total_duplicate_size += duplicate_stats['size']
+                duplicate_files.extend(duplicate_stats['files'])
+
+        if target in ('all', 'avatar'):
+            unused_avatar, unused_size = UtilityCleanupService.collect_unused_files(
+                service,
+                service.avatar_image_dir,
+                used_avatar,
+            )
+            total_unused += len(unused_avatar)
+            total_size += unused_size
+
+            if not dry_run:
+                UtilityCleanupService.clean_files_with_messages(
+                    service,
+                    unused_avatar,
+                    messages,
+                    '아바타 이미지',
+                )
+            else:
+                unused_files.extend([
+                    UtilityCleanupService.to_file_info(f, 'images/avatar')
+                    for f in unused_avatar
+                ])
+
+        if target in ('all', 'content'):
+            cache_count, _ = service.clean_image_cache(used_content, not dry_run)
+            if cache_count > 0:
+                messages.append(f'이미지 캐시 {cache_count}개 정리')
+
+        if not dry_run:
+            empty_dirs = UtilityCleanupService.remove_empty_dirs(service, target)
+            if empty_dirs > 0:
+                messages.append(f'빈 디렉토리 {empty_dirs}개 삭제')
+
+        return UtilityCleanupService.build_image_result(
+            total_unused=total_unused,
+            total_size=total_size,
+            total_duplicates=total_duplicates,
+            total_duplicate_size=total_duplicate_size,
+            messages=messages,
+            dry_run=dry_run,
+            unused_files=unused_files,
+            duplicate_files=duplicate_files,
+        )
+
+    @staticmethod
+    def collect_unused_files(service: ImageCleanerService, directory, used_images):
+        files = service.scan_directory(directory, used_images)
+        unused_files = [f for f in files if not f['is_used']]
+        unused_size = sum(f['size'] for f in unused_files)
+        return unused_files, unused_size
+
+    @staticmethod
+    def clean_files_with_messages(
+        service: ImageCleanerService,
+        files: list[dict],
+        messages: list[str],
+        label: str,
+    ) -> None:
+        count, errors = service.clean_files([f['path'] for f in files])
+        messages.append(f'{label} {count}개 삭제 완료')
+        for err in errors:
+            messages.append(f'오류: {err}')
+
+    @staticmethod
+    def handle_title_duplicates(service: ImageCleanerService, dry_run: bool, messages: list[str]) -> dict:
+        dup_count, dup_size, duplicates = service.find_and_remove_duplicates(
+            service.title_image_dir,
+            not dry_run,
+        )
+        if dup_count > 0:
+            messages.append(
+                f'중복 타이틀 이미지 {dup_count}개 '
+                f'({round(dup_size / (1024 * 1024), 2)} MB)'
+            )
+
+        files = []
+        if dry_run:
+            files = [
+                {
+                    'duplicateUrl': d['duplicate_url'],
+                    'duplicateSizeKb': d['duplicate_size_kb'],
+                    'originalUrl': d['original_url'],
+                    'originalSizeKb': d['original_size_kb'],
+                    'hash': d['hash'],
+                }
+                for d in duplicates
+            ]
+
+        return {
+            'count': dup_count,
+            'size': dup_size,
+            'files': files,
+        }
+
+    @staticmethod
+    def remove_empty_dirs(service: ImageCleanerService, target: str) -> int:
+        empty_dirs = 0
+        if target in ('all', 'content'):
+            empty_dirs += service.remove_empty_dirs(service.content_image_dir)
+        if target in ('all', 'title'):
+            empty_dirs += service.remove_empty_dirs(service.title_image_dir)
+        if target in ('all', 'avatar'):
+            empty_dirs += service.remove_empty_dirs(service.avatar_image_dir)
+        return empty_dirs
+
+    @staticmethod
+    def to_file_info(file_dict: dict, media_prefix: str) -> dict:
+        relative = file_dict['relative_path']
+        return {
+            'path': relative,
+            'url': settings.MEDIA_URL + media_prefix + '/' + relative,
+            'size_kb': file_dict['size_kb'],
+        }
+
+    @staticmethod
+    def build_image_result(
+        total_unused: int,
+        total_size: int,
+        total_duplicates: int,
+        total_duplicate_size: int,
+        messages: list[str],
+        dry_run: bool,
+        unused_files: list[dict],
+        duplicate_files: list[dict],
+    ) -> dict:
+        total_saved = total_size + total_duplicate_size
+
+        result = {
+            'total_unused': total_unused,
+            'total_size_mb': round(total_size / (1024 * 1024), 2),
+            'total_duplicates': total_duplicates,
+            'total_duplicate_size_mb': round(total_duplicate_size / (1024 * 1024), 2),
+            'total_saved_mb': round(total_saved / (1024 * 1024), 2),
+            'messages': messages,
+            'dry_run': dry_run,
+        }
+
+        if dry_run:
+            result['unused_files'] = unused_files[:100]
+            if duplicate_files:
+                result['duplicate_files'] = duplicate_files[:100]
+
+        return result

--- a/backend/src/board/tests/api/test_utility.py
+++ b/backend/src/board/tests/api/test_utility.py
@@ -342,6 +342,7 @@ class UtilityAPITestCase(TestCase):
         )
         content = json.loads(response.content)
         self.assertEqual(content['status'], 'ERROR')
+        self.assertEqual(content['errorCode'], 'error:VA')
 
     def test_clean_images_specific_target(self):
         for target in ('content', 'title', 'avatar'):

--- a/backend/src/board/tests/services/test_utility_cleanup_service.py
+++ b/backend/src/board/tests/services/test_utility_cleanup_service.py
@@ -1,0 +1,97 @@
+from django.contrib.admin.models import LogEntry
+from django.contrib.contenttypes.models import ContentType
+from django.contrib.sessions.models import Session
+from django.test import TestCase
+from django.utils import timezone
+
+from board.models import Profile, Tag, User
+from board.services.utility_cleanup_service import (
+    InvalidImageCleanupTargetError,
+    UtilityCleanupService,
+    UtilityPermissionService,
+)
+
+
+class UtilityCleanupServiceTestCase(TestCase):
+    def setUp(self):
+        self.staff_user = User.objects.create_user(
+            username='utility-staff',
+            password='test',
+            is_staff=True,
+        )
+        Profile.objects.create(user=self.staff_user)
+        self.normal_user = User.objects.create_user(
+            username='utility-normal',
+            password='test',
+        )
+        Profile.objects.create(user=self.normal_user)
+
+    def test_require_staff_rejects_non_staff_user(self):
+        self.assertIsNotNone(UtilityPermissionService.require_staff(self.normal_user))
+
+    def test_require_staff_allows_staff_user(self):
+        self.assertIsNone(UtilityPermissionService.require_staff(self.staff_user))
+
+    def test_clean_tags_dry_run_preserves_unused_tags(self):
+        Tag.objects.create(value='service-unused-tag')
+
+        payload = UtilityCleanupService.clean_tags({'dry_run': True})
+
+        self.assertTrue(payload['dry_run'])
+        self.assertGreaterEqual(payload['unused_tags'], 1)
+        self.assertTrue(Tag.objects.filter(value='service-unused-tag').exists())
+
+    def test_clean_sessions_dry_run_preserves_sessions(self):
+        Session.objects.create(
+            session_key='service_expired_session',
+            session_data='data',
+            expire_date=timezone.now() - timezone.timedelta(days=1),
+        )
+
+        payload = UtilityCleanupService.clean_sessions({'dry_run': True})
+
+        self.assertTrue(payload['dry_run'])
+        self.assertGreaterEqual(payload['expired_sessions'], 1)
+        self.assertEqual(payload['cleaned_count'], 0)
+        self.assertTrue(
+            Session.objects.filter(session_key='service_expired_session').exists()
+        )
+
+    def test_clean_logs_execute_removes_logs(self):
+        content_type = ContentType.objects.get_for_model(User)
+        LogEntry.objects.create(
+            user=self.staff_user,
+            content_type=content_type,
+            object_id='1',
+            object_repr='test',
+            action_flag=1,
+        )
+
+        payload = UtilityCleanupService.clean_logs({'dry_run': False})
+
+        self.assertFalse(payload['dry_run'])
+        self.assertGreaterEqual(payload['cleaned_count'], 1)
+        self.assertEqual(LogEntry.objects.count(), 0)
+
+    def test_clean_images_rejects_invalid_target(self):
+        with self.assertRaises(InvalidImageCleanupTargetError):
+            UtilityCleanupService.clean_images({
+                'dry_run': True,
+                'target': 'invalid',
+            })
+
+    def test_build_image_result_preserves_dry_run_contract(self):
+        payload = UtilityCleanupService.build_image_result(
+            total_unused=1,
+            total_size=1024,
+            total_duplicates=0,
+            total_duplicate_size=0,
+            messages=[],
+            dry_run=True,
+            unused_files=[{'path': 'a.png'}],
+            duplicate_files=[],
+        )
+
+        self.assertTrue(payload['dry_run'])
+        self.assertEqual(payload['total_unused'], 1)
+        self.assertIn('unused_files', payload)

--- a/backend/src/board/views/api/v1/utility.py
+++ b/backend/src/board/views/api/v1/utility.py
@@ -1,16 +1,9 @@
-import os
-
-from django.conf import settings
-from django.contrib.admin.models import LogEntry
-from django.contrib.sessions.models import Session
-
 from board.modules.response import StatusDone, StatusError, ErrorCode
 from board.services.api_request_body_service import ApiRequestBodyService
-from board.admin.utilities import (
-    DatabaseStatsService,
-    SessionCleanerService,
-    TagCleanerService,
-    ImageCleanerService,
+from board.services.utility_cleanup_service import (
+    InvalidImageCleanupTargetError,
+    UtilityCleanupService,
+    UtilityPermissionService,
 )
 
 
@@ -18,19 +11,14 @@ def utility_stats(request):
     """
     GET /v1/utilities/stats - DB 통계 + 로그 수 반환
     """
-    if not request.user.is_active:
-        return StatusError(ErrorCode.NEED_LOGIN)
-
-    if not request.user.is_staff:
-        return StatusError(ErrorCode.REJECT, '관리자 권한이 필요합니다.')
+    permission_error = UtilityPermissionService.require_staff(request.user)
+    if permission_error:
+        return permission_error
 
     if request.method != 'GET':
         return StatusError(ErrorCode.REJECT)
 
-    stats = DatabaseStatsService.get_statistics()
-    stats['log_count'] = LogEntry.objects.count()
-
-    return StatusDone(stats)
+    return StatusDone(UtilityCleanupService.get_stats())
 
 
 def utility_clean_tags(request):
@@ -38,11 +26,9 @@ def utility_clean_tags(request):
     POST /v1/utilities/clean-tags - 태그 정리
     Body: { dry_run: bool }
     """
-    if not request.user.is_active:
-        return StatusError(ErrorCode.NEED_LOGIN)
-
-    if not request.user.is_staff:
-        return StatusError(ErrorCode.REJECT, '관리자 권한이 필요합니다.')
+    permission_error = UtilityPermissionService.require_staff(request.user)
+    if permission_error:
+        return permission_error
 
     if request.method != 'POST':
         return StatusError(ErrorCode.REJECT)
@@ -51,21 +37,7 @@ def utility_clean_tags(request):
     if body_error:
         return body_error
 
-    dry_run = body.get('dry_run', True)
-
-    service = TagCleanerService()
-    tag_stats = service.get_tag_statistics()
-    count, tag_names = service.clean_unused_tags(execute=not dry_run)
-
-    return StatusDone({
-        'total_tags': tag_stats['total_tags'],
-        'used_tags': tag_stats['used_tags'],
-        'unused_tags': tag_stats['unused_tags'],
-        'top_tags': tag_stats['top_tags'],
-        'cleaned_count': count,
-        'cleaned_tags': tag_names[:20],
-        'dry_run': dry_run,
-    })
+    return StatusDone(UtilityCleanupService.clean_tags(body))
 
 
 def utility_clean_sessions(request):
@@ -73,11 +45,9 @@ def utility_clean_sessions(request):
     POST /v1/utilities/clean-sessions - 세션 정리
     Body: { dry_run: bool, clean_all: bool }
     """
-    if not request.user.is_active:
-        return StatusError(ErrorCode.NEED_LOGIN)
-
-    if not request.user.is_staff:
-        return StatusError(ErrorCode.REJECT, '관리자 권한이 필요합니다.')
+    permission_error = UtilityPermissionService.require_staff(request.user)
+    if permission_error:
+        return permission_error
 
     if request.method != 'POST':
         return StatusError(ErrorCode.REJECT)
@@ -86,26 +56,7 @@ def utility_clean_sessions(request):
     if body_error:
         return body_error
 
-    dry_run = body.get('dry_run', True)
-    clean_all = body.get('clean_all', False)
-
-    total_sessions = Session.objects.count()
-    expired_sessions = SessionCleanerService.count_expired_sessions()
-    cleaned_count = 0
-
-    if not dry_run:
-        if clean_all:
-            cleaned_count = SessionCleanerService.clean_all_sessions()
-        else:
-            cleaned_count = SessionCleanerService.clean_expired_sessions()
-
-    return StatusDone({
-        'total_sessions': total_sessions,
-        'expired_sessions': expired_sessions,
-        'cleaned_count': cleaned_count,
-        'clean_all': clean_all,
-        'dry_run': dry_run,
-    })
+    return StatusDone(UtilityCleanupService.clean_sessions(body))
 
 
 def utility_clean_logs(request):
@@ -113,11 +64,9 @@ def utility_clean_logs(request):
     POST /v1/utilities/clean-logs - 로그 정리
     Body: { dry_run: bool }
     """
-    if not request.user.is_active:
-        return StatusError(ErrorCode.NEED_LOGIN)
-
-    if not request.user.is_staff:
-        return StatusError(ErrorCode.REJECT, '관리자 권한이 필요합니다.')
+    permission_error = UtilityPermissionService.require_staff(request.user)
+    if permission_error:
+        return permission_error
 
     if request.method != 'POST':
         return StatusError(ErrorCode.REJECT)
@@ -126,19 +75,7 @@ def utility_clean_logs(request):
     if body_error:
         return body_error
 
-    dry_run = body.get('dry_run', True)
-    log_count = LogEntry.objects.count()
-    cleaned_count = 0
-
-    if not dry_run:
-        LogEntry.objects.all().delete()
-        cleaned_count = log_count
-
-    return StatusDone({
-        'log_count': log_count,
-        'cleaned_count': cleaned_count,
-        'dry_run': dry_run,
-    })
+    return StatusDone(UtilityCleanupService.clean_logs(body))
 
 
 def utility_clean_images(request):
@@ -146,11 +83,9 @@ def utility_clean_images(request):
     POST /v1/utilities/clean-images - 이미지 정리
     Body: { dry_run: bool, target: str, remove_duplicates: bool }
     """
-    if not request.user.is_active:
-        return StatusError(ErrorCode.NEED_LOGIN)
-
-    if not request.user.is_staff:
-        return StatusError(ErrorCode.REJECT, '관리자 권한이 필요합니다.')
+    permission_error = UtilityPermissionService.require_staff(request.user)
+    if permission_error:
+        return permission_error
 
     if request.method != 'POST':
         return StatusError(ErrorCode.REJECT)
@@ -159,143 +94,7 @@ def utility_clean_images(request):
     if body_error:
         return body_error
 
-    dry_run = body.get('dry_run', True)
-    target = body.get('target', 'all')
-    remove_duplicates = body.get('remove_duplicates', False)
-
-    if target not in ('all', 'content', 'title', 'avatar'):
+    try:
+        return StatusDone(UtilityCleanupService.clean_images(body))
+    except InvalidImageCleanupTargetError:
         return StatusError(ErrorCode.VALIDATE, '유효하지 않은 대상입니다.')
-
-    service = ImageCleanerService()
-    messages = []
-
-    used_content = service.scan_content_images()
-    used_title = service.scan_title_images()
-    used_avatar = service.scan_avatar_images()
-
-    total_unused = 0
-    total_size = 0
-    total_duplicates = 0
-    total_duplicate_size = 0
-    unused_files = []
-    duplicate_files = []
-
-    def to_file_info(file_dict, media_prefix):
-        """파일 정보를 미디어 URL 포함 dict로 변환"""
-        relative = file_dict['relative_path']
-        return {
-            'path': relative,
-            'url': settings.MEDIA_URL + media_prefix + '/' + relative,
-            'size_kb': file_dict['size_kb'],
-        }
-
-    # 컨텐츠 이미지
-    if target in ('all', 'content'):
-        content_files = service.scan_directory(service.content_image_dir, used_content)
-        unused_content = [f for f in content_files if not f['is_used']]
-        total_unused += len(unused_content)
-        total_size += sum(f['size'] for f in unused_content)
-
-        if not dry_run:
-            count, errors = service.clean_files([f['path'] for f in unused_content])
-            messages.append(f'컨텐츠 이미지 {count}개 삭제 완료')
-            for err in errors:
-                messages.append(f'오류: {err}')
-        else:
-            unused_files.extend([
-                to_file_info(f, 'images/content') for f in unused_content
-            ])
-
-    # 타이틀 이미지
-    if target in ('all', 'title'):
-        title_files = service.scan_directory(service.title_image_dir, used_title)
-        unused_title = [f for f in title_files if not f['is_used']]
-        total_unused += len(unused_title)
-        total_size += sum(f['size'] for f in unused_title)
-
-        if not dry_run:
-            count, errors = service.clean_files([f['path'] for f in unused_title])
-            messages.append(f'타이틀 이미지 {count}개 삭제 완료')
-            for err in errors:
-                messages.append(f'오류: {err}')
-        else:
-            unused_files.extend([
-                to_file_info(f, 'images/title') for f in unused_title
-            ])
-
-        if remove_duplicates:
-            dup_count, dup_size, duplicates = service.find_and_remove_duplicates(
-                service.title_image_dir, not dry_run
-            )
-            total_duplicates += dup_count
-            total_duplicate_size += dup_size
-            if dup_count > 0:
-                messages.append(
-                    f'중복 타이틀 이미지 {dup_count}개 '
-                    f'({round(dup_size / (1024 * 1024), 2)} MB)'
-                )
-            if dry_run:
-                duplicate_files.extend([
-                    {
-                        'duplicateUrl': d['duplicate_url'],
-                        'duplicateSizeKb': d['duplicate_size_kb'],
-                        'originalUrl': d['original_url'],
-                        'originalSizeKb': d['original_size_kb'],
-                        'hash': d['hash'],
-                    }
-                    for d in duplicates
-                ])
-
-    # 아바타 이미지
-    if target in ('all', 'avatar'):
-        avatar_files = service.scan_directory(service.avatar_image_dir, used_avatar)
-        unused_avatar = [f for f in avatar_files if not f['is_used']]
-        total_unused += len(unused_avatar)
-        total_size += sum(f['size'] for f in unused_avatar)
-
-        if not dry_run:
-            count, errors = service.clean_files([f['path'] for f in unused_avatar])
-            messages.append(f'아바타 이미지 {count}개 삭제 완료')
-            for err in errors:
-                messages.append(f'오류: {err}')
-        else:
-            unused_files.extend([
-                to_file_info(f, 'images/avatar') for f in unused_avatar
-            ])
-
-    # 이미지 캐시 정리
-    if target in ('all', 'content'):
-        cache_count, _ = service.clean_image_cache(used_content, not dry_run)
-        if cache_count > 0:
-            messages.append(f'이미지 캐시 {cache_count}개 정리')
-
-    # 빈 디렉토리 정리
-    if not dry_run:
-        empty_dirs = 0
-        if target in ('all', 'content'):
-            empty_dirs += service.remove_empty_dirs(service.content_image_dir)
-        if target in ('all', 'title'):
-            empty_dirs += service.remove_empty_dirs(service.title_image_dir)
-        if target in ('all', 'avatar'):
-            empty_dirs += service.remove_empty_dirs(service.avatar_image_dir)
-        if empty_dirs > 0:
-            messages.append(f'빈 디렉토리 {empty_dirs}개 삭제')
-
-    total_saved = total_size + total_duplicate_size
-
-    result = {
-        'total_unused': total_unused,
-        'total_size_mb': round(total_size / (1024 * 1024), 2),
-        'total_duplicates': total_duplicates,
-        'total_duplicate_size_mb': round(total_duplicate_size / (1024 * 1024), 2),
-        'total_saved_mb': round(total_saved / (1024 * 1024), 2),
-        'messages': messages,
-        'dry_run': dry_run,
-    }
-
-    if dry_run:
-        result['unused_files'] = unused_files[:100]
-        if duplicate_files:
-            result['duplicate_files'] = duplicate_files[:100]
-
-    return StatusDone(result)


### PR DESCRIPTION
## 🎯 Goal
- Reduce inline staff-only utility cleanup orchestration in `utility.py`.
- Preserve destructive cleanup dry-run/execute contracts while making cleanup behavior easier to test.

## 🔧 Core Changes
- Add `UtilityPermissionService` for staff-only utility guard reuse.
- Add `UtilityCleanupService` for stats, tag/session/log/image cleanup response contracts.
- Move image cleanup orchestration helpers, dry-run file previews, duplicate previews, cache cleanup, and empty-dir cleanup into the service.
- Add service tests for staff guard, dry-run behavior, destructive log cleanup, invalid image target, and image result contracts.

## 🤔 Key Decisions
- Preserve default `dry_run=True` behavior for cleanup endpoints.
- Preserve invalid JSON behavior through `ApiRequestBodyService.parse_json_or_error()`.
- Preserve image target validation and use a dedicated `InvalidImageCleanupTargetError` so unrelated `ValueError`s are not swallowed.
- Keep request body parsing and HTTP response mapping in the view.

## 🧪 Verification Guide
### How to verify
1. Run `npm run server:test -- board.tests.api.test_utility board.tests.services.test_utility_cleanup_service`.
2. Call cleanup endpoints with empty JSON bodies and confirm they dry-run by default.
3. Call cleanup endpoints with `dry_run=false` only in a safe local/dev environment.
4. Call image cleanup with an invalid target and confirm validation error response.

### Expected result
- Tests pass.
- Dry-run endpoints do not delete data/files.
- Execute mode behavior remains unchanged.
- `utility.py` delegates cleanup orchestration to `UtilityCleanupService`.

## ✅ Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [x] Tests completed
- [ ] Documentation updated (if needed)
