### PR TITLE
🧪 Characterize post thumbnail save hook

### DIFF
--- a/backend/src/board/tests/models/test_post_save_hooks.py
+++ b/backend/src/board/tests/models/test_post_save_hooks.py
@@ -1,0 +1,117 @@
+from io import BytesIO
+from tempfile import TemporaryDirectory
+from unittest.mock import call, patch
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase, override_settings
+from PIL import Image
+
+from board.models import Post, User
+
+
+class PostSaveThumbnailHookTestCase(TestCase):
+    """Characterization tests for Post.save() thumbnail side effects."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user(
+            username='thumbnail-author',
+            password='test',
+            email='thumbnail@test.com',
+        )
+
+    @staticmethod
+    def create_test_image(name='cover.jpg', color='red'):
+        buffer = BytesIO()
+        image = Image.new('RGB', (10, 10), color)
+        image.save(buffer, 'JPEG')
+        buffer.seek(0)
+        return SimpleUploadedFile(name, buffer.read(), content_type='image/jpeg')
+
+    def assert_thumbnail_set_created(self, mock_make_thumbnail, post):
+        self.assertEqual(mock_make_thumbnail.call_count, 3)
+        mock_make_thumbnail.assert_has_calls([
+            call(post, size=750, quality=50, thumbnail_type='preview'),
+            call(post, size=750, quality=85, thumbnail_type='minify'),
+            call(post, size=1920, quality=85),
+        ])
+
+    def test_new_post_with_image_generates_thumbnail_set(self):
+        with TemporaryDirectory() as media_root:
+            with override_settings(MEDIA_ROOT=media_root):
+                with patch('board.models.make_thumbnail') as mock_make_thumbnail:
+                    post = Post.objects.create(
+                        author=self.user,
+                        title='New image post',
+                        url='new-image-post',
+                        image=self.create_test_image(),
+                    )
+
+        self.assert_thumbnail_set_created(mock_make_thumbnail, post)
+
+    def test_post_image_change_generates_thumbnail_set(self):
+        with TemporaryDirectory() as media_root:
+            with override_settings(MEDIA_ROOT=media_root):
+                with patch('board.models.make_thumbnail') as mock_make_thumbnail:
+                    post = Post.objects.create(
+                        author=self.user,
+                        title='Changed image post',
+                        url='changed-image-post',
+                        image=self.create_test_image('old.jpg', color='blue'),
+                    )
+                    mock_make_thumbnail.reset_mock()
+
+                    post.image = self.create_test_image('new.jpg', color='green')
+                    post.save()
+
+        self.assert_thumbnail_set_created(mock_make_thumbnail, post)
+
+    def test_post_save_without_image_change_does_not_generate_thumbnails(self):
+        with TemporaryDirectory() as media_root:
+            with override_settings(MEDIA_ROOT=media_root):
+                with patch('board.models.make_thumbnail') as mock_make_thumbnail:
+                    post = Post.objects.create(
+                        author=self.user,
+                        title='Unchanged image post',
+                        url='unchanged-image-post',
+                        image=self.create_test_image(),
+                    )
+                    mock_make_thumbnail.reset_mock()
+
+                    post.title = 'Unchanged image post updated'
+                    post.save()
+
+        mock_make_thumbnail.assert_not_called()
+
+    def test_skip_thumbnail_flag_disables_thumbnail_generation(self):
+        with TemporaryDirectory() as media_root:
+            with override_settings(MEDIA_ROOT=media_root):
+                with patch('board.models.make_thumbnail') as mock_make_thumbnail:
+                    post = Post(
+                        author=self.user,
+                        title='Skip thumbnail post',
+                        url='skip-thumbnail-post',
+                        image=self.create_test_image(),
+                    )
+                    post._skip_thumbnail = True
+                    post.save()
+
+        mock_make_thumbnail.assert_not_called()
+
+    def test_skip_thumbnail_flag_disables_changed_image_thumbnail_generation(self):
+        with TemporaryDirectory() as media_root:
+            with override_settings(MEDIA_ROOT=media_root):
+                with patch('board.models.make_thumbnail') as mock_make_thumbnail:
+                    post = Post.objects.create(
+                        author=self.user,
+                        title='Skip changed thumbnail post',
+                        url='skip-changed-thumbnail-post',
+                        image=self.create_test_image('old.jpg', color='blue'),
+                    )
+                    mock_make_thumbnail.reset_mock()
+
+                    post.image = self.create_test_image('new.jpg', color='green')
+                    post._skip_thumbnail = True
+                    post.save()
+
+        mock_make_thumbnail.assert_not_called()


### PR DESCRIPTION
## 🎯 Goal
- Lock the current `Post.save()` thumbnail side-effect contract before extracting it to a service.
- Make future thumbnail refactors safer by documenting when filesystem thumbnail work is expected or suppressed.

## 🔧 Core Changes
- Add focused model tests for `Post.save()` thumbnail behavior.
- Characterize new image saves, changed image saves, unchanged image saves, and `_skip_thumbnail` behavior.
- Assert the current preview, minify, and original thumbnail call sequence while mocking filesystem thumbnail generation.

## 🤔 Key Decisions
- Keep this PR test-only; no production behavior changes.
- Patch `board.models.make_thumbnail` directly because `Post.save()` imports the function at model module load time.
- Use temporary media roots to avoid test media leakage.

## 🧪 Verification Guide
### How to verify
1. Run `npm run server:test -- board.tests.models.test_post_save_hooks`.
2. Confirm five tests pass.

### Expected result
- New or changed post images trigger three thumbnail calls.
- Unchanged images do not trigger thumbnail work.
- `_skip_thumbnail` suppresses thumbnail work for both new and changed image saves.

## ✅ Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [x] Tests completed
- [ ] Documentation updated (if needed)
