### PR TITLE
♻️ Extract post thumbnail service

### DIFF
--- a/backend/src/board/models.py
+++ b/backend/src/board/models.py
@@ -21,10 +21,10 @@ from modules.hash import get_sha256
 from modules.randomness import randstr
 from modules.sub_task import SubTaskProcessor
 from modules.telegram import TelegramBot
-from modules.thumbnail import make_thumbnail
 from board.constants.config_meta import CONFIG_TYPE, CONFIG_TYPES, CONFIG_MAP
 from board.modules.time import time_since, time_stamp
 from board.modules.read_time import calc_read_time
+from board.services.post_thumbnail_service import PostThumbnailService
 
 
 def get_user_hex(username):
@@ -348,22 +348,10 @@ class Post(models.Model):
         return self.title
 
     def save(self, *args, **kwargs):
-        will_make_thumbnail = False
-        if not getattr(self, '_skip_thumbnail', False):
-            if not self.pk and self.image:
-                will_make_thumbnail = True
-
-            post = Post.objects.filter(id=self.id)
-            if post.exists():
-                post = post.first()
-                if post.image != self.image:
-                    will_make_thumbnail = True
-
+        will_make_thumbnail = PostThumbnailService.should_generate(self)
         super(Post, self).save(*args, **kwargs)
         if will_make_thumbnail:
-            make_thumbnail(self, size=750, quality=50, thumbnail_type='preview')
-            make_thumbnail(self, size=750, quality=85, thumbnail_type='minify')
-            make_thumbnail(self, size=1920, quality=85)
+            PostThumbnailService.generate_thumbnail_set(self)
 
 
 class PostContent(models.Model):

--- a/backend/src/board/models.py
+++ b/backend/src/board/models.py
@@ -21,6 +21,7 @@ from modules.hash import get_sha256
 from modules.randomness import randstr
 from modules.sub_task import SubTaskProcessor
 from modules.telegram import TelegramBot
+from modules.thumbnail import make_thumbnail
 from board.constants.config_meta import CONFIG_TYPE, CONFIG_TYPES, CONFIG_MAP
 from board.modules.time import time_since, time_stamp
 from board.modules.read_time import calc_read_time

--- a/backend/src/board/services/__init__.py
+++ b/backend/src/board/services/__init__.py
@@ -5,24 +5,30 @@ This package contains business logic extracted from views.
 Services handle complex business operations and can be reused across views.
 """
 
-from .post_service import PostService
-from .auth_service import AuthService
-from .banner_service import BannerService
-from .comment_service import CommentService
-from .pinned_post_service import PinnedPostService
-from .series_service import SeriesService
-from .tag_service import TagService
-from .user_service import UserService
-from .webhook_service import WebhookService
+from importlib import import_module
 
-__all__ = [
-    'PostService',
-    'AuthService',
-    'BannerService',
-    'CommentService',
-    'PinnedPostService',
-    'SeriesService',
-    'TagService',
-    'UserService',
-    'WebhookService',
-]
+_SERVICE_MODULES = {
+    'PostService': 'post_service',
+    'PostThumbnailService': 'post_thumbnail_service',
+    'AuthService': 'auth_service',
+    'BannerService': 'banner_service',
+    'CommentService': 'comment_service',
+    'PinnedPostService': 'pinned_post_service',
+    'SeriesService': 'series_service',
+    'TagService': 'tag_service',
+    'UserService': 'user_service',
+    'WebhookService': 'webhook_service',
+}
+
+__all__ = list(_SERVICE_MODULES)
+
+
+def __getattr__(name):
+    module_name = _SERVICE_MODULES.get(name)
+    if module_name is None:
+        raise AttributeError(f'module {__name__!r} has no attribute {name!r}')
+
+    module = import_module(f'{__name__}.{module_name}')
+    service = getattr(module, name)
+    globals()[name] = service
+    return service

--- a/backend/src/board/services/post_thumbnail_service.py
+++ b/backend/src/board/services/post_thumbnail_service.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from modules.thumbnail import make_thumbnail
+
+if TYPE_CHECKING:
+    from board.models import Post
+
+
+class PostThumbnailService:
+    """Encapsulates Post title image thumbnail side effects."""
+
+    @staticmethod
+    def should_generate(post: 'Post') -> bool:
+        if getattr(post, '_skip_thumbnail', False):
+            return False
+
+        if not post.pk:
+            return bool(post.image)
+
+        saved_post = post.__class__.objects.filter(id=post.id).first()
+        if not saved_post:
+            return False
+
+        return saved_post.image != post.image
+
+    @staticmethod
+    def generate_thumbnail_set(post: 'Post') -> None:
+        make_thumbnail(post, size=750, quality=50, thumbnail_type='preview')
+        make_thumbnail(post, size=750, quality=85, thumbnail_type='minify')
+        make_thumbnail(post, size=1920, quality=85)

--- a/backend/src/board/tests/models/test_post_save_hooks.py
+++ b/backend/src/board/tests/models/test_post_save_hooks.py
@@ -39,7 +39,7 @@ class PostSaveThumbnailHookTestCase(TestCase):
     def test_new_post_with_image_generates_thumbnail_set(self):
         with TemporaryDirectory() as media_root:
             with override_settings(MEDIA_ROOT=media_root):
-                with patch('board.models.make_thumbnail') as mock_make_thumbnail:
+                with patch('board.services.post_thumbnail_service.make_thumbnail') as mock_make_thumbnail:
                     post = Post.objects.create(
                         author=self.user,
                         title='New image post',
@@ -52,7 +52,7 @@ class PostSaveThumbnailHookTestCase(TestCase):
     def test_post_image_change_generates_thumbnail_set(self):
         with TemporaryDirectory() as media_root:
             with override_settings(MEDIA_ROOT=media_root):
-                with patch('board.models.make_thumbnail') as mock_make_thumbnail:
+                with patch('board.services.post_thumbnail_service.make_thumbnail') as mock_make_thumbnail:
                     post = Post.objects.create(
                         author=self.user,
                         title='Changed image post',
@@ -69,7 +69,7 @@ class PostSaveThumbnailHookTestCase(TestCase):
     def test_post_save_without_image_change_does_not_generate_thumbnails(self):
         with TemporaryDirectory() as media_root:
             with override_settings(MEDIA_ROOT=media_root):
-                with patch('board.models.make_thumbnail') as mock_make_thumbnail:
+                with patch('board.services.post_thumbnail_service.make_thumbnail') as mock_make_thumbnail:
                     post = Post.objects.create(
                         author=self.user,
                         title='Unchanged image post',
@@ -86,7 +86,7 @@ class PostSaveThumbnailHookTestCase(TestCase):
     def test_skip_thumbnail_flag_disables_thumbnail_generation(self):
         with TemporaryDirectory() as media_root:
             with override_settings(MEDIA_ROOT=media_root):
-                with patch('board.models.make_thumbnail') as mock_make_thumbnail:
+                with patch('board.services.post_thumbnail_service.make_thumbnail') as mock_make_thumbnail:
                     post = Post(
                         author=self.user,
                         title='Skip thumbnail post',
@@ -101,7 +101,7 @@ class PostSaveThumbnailHookTestCase(TestCase):
     def test_skip_thumbnail_flag_disables_changed_image_thumbnail_generation(self):
         with TemporaryDirectory() as media_root:
             with override_settings(MEDIA_ROOT=media_root):
-                with patch('board.models.make_thumbnail') as mock_make_thumbnail:
+                with patch('board.services.post_thumbnail_service.make_thumbnail') as mock_make_thumbnail:
                     post = Post.objects.create(
                         author=self.user,
                         title='Skip changed thumbnail post',


### PR DESCRIPTION
## 🎯 Goal
- Move `Post.save()` thumbnail decision and execution out of the model body while preserving the existing compatibility hook.
- Keep the thumbnail side-effect contract locked by the characterization tests from PR #393.

## 🔧 Core Changes
- Add `PostThumbnailService` for thumbnail generation decision and preview/minify/original execution.
- Update `Post.save()` to delegate to `PostThumbnailService` while preserving the save-hook behavior.
- Make `board.services` package exports lazy so models can import a focused service without eager circular imports.
- Update thumbnail save-hook tests to patch the service-level `make_thumbnail` dependency.

## 🤔 Key Decisions
- Preserve the existing behavior for regular new posts, changed images, unchanged images, and `_skip_thumbnail`.
- Preserve the previous edge behavior for manually assigned unsaved primary keys by not generating thumbnails when no saved row exists.
- Keep `Post.save()` as a compatibility delegate for now; removing the hook is a later, higher-risk migration.

## 🧪 Verification Guide
### How to verify
1. Run `npm run server:test -- board.tests.models.test_post_save_hooks board.tests.api.test_webhook`.
2. Confirm `Post.save()` thumbnail characterization tests still pass.
3. Confirm `board.services` lazy exports remain compatible through webhook API tests.

### Expected result
- Thumbnail behavior remains unchanged for covered contracts.
- Existing package-level service imports continue to work.
- Model thumbnail logic is isolated behind `PostThumbnailService`.

## ✅ Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [x] Tests completed
- [ ] Documentation updated (if needed)
