### PR TITLE
♻️ Move post content read time sync to service

### DIFF
--- a/backend/src/board/models.py
+++ b/backend/src/board/models.py
@@ -24,7 +24,7 @@ from modules.telegram import TelegramBot
 from modules.thumbnail import make_thumbnail
 from board.constants.config_meta import CONFIG_TYPE, CONFIG_TYPES, CONFIG_MAP
 from board.modules.time import time_since, time_stamp
-from board.modules.read_time import calc_read_time
+from board.services.post_content_service import PostContentService
 from board.services.post_thumbnail_service import PostThumbnailService
 
 
@@ -360,9 +360,8 @@ class PostContent(models.Model):
     content_html = models.TextField(blank=True)
 
     def save(self, *args, **kwargs):
-        if self.post:
-            self.post.read_time = calc_read_time(self.content_html)
-            self.post.save()
+        if self.post and not getattr(self, '_skip_read_time_sync', False):
+            PostContentService.sync_parent_read_time(self.post, self.content_html)
         super().save(*args, **kwargs)
 
     def __str__(self):

--- a/backend/src/board/services/post_content_service.py
+++ b/backend/src/board/services/post_content_service.py
@@ -1,5 +1,7 @@
 from modules.markdown import parse_post_to_html
 
+from board.modules.read_time import calc_read_time
+
 
 class PostContentService:
     @staticmethod
@@ -21,3 +23,32 @@ class PostContentService:
         if content_type == 'markdown':
             return PostContentService.markdown_input_to_content_html(content)
         return PostContentService.html_input_to_content_html(content)
+
+    @staticmethod
+    def sync_parent_read_time(post, content_html: str) -> None:
+        post.read_time = calc_read_time(content_html)
+        post.save()
+
+    @staticmethod
+    def create_for_post(post, content_html: str):
+        from board.models import PostContent
+
+        PostContentService.sync_parent_read_time(post, content_html)
+        post_content = PostContent(post=post, content_html=content_html)
+        post_content._skip_read_time_sync = True
+        try:
+            post_content.save()
+        finally:
+            delattr(post_content, '_skip_read_time_sync')
+        return post_content
+
+    @staticmethod
+    def update_content(post_content, content_html: str):
+        PostContentService.sync_parent_read_time(post_content.post, content_html)
+        post_content.content_html = content_html
+        post_content._skip_read_time_sync = True
+        try:
+            post_content.save()
+        finally:
+            delattr(post_content, '_skip_read_time_sync')
+        return post_content

--- a/backend/src/board/services/post_service.py
+++ b/backend/src/board/services/post_service.py
@@ -317,7 +317,7 @@ class PostService:
 
         TagService.set_post_tags(post, tag)
 
-        post_content = PostContent.objects.create(
+        post_content = PostContentService.create_for_post(
             post=post,
             content_html=resolved_html,
         )
@@ -502,11 +502,10 @@ class PostService:
             try:
                 post_content = post.content
                 resolved_html = PostService._resolve_content(text_html, content_type)
-                post_content.content_html = resolved_html
-                post_content.save()
+                PostContentService.update_content(post_content, resolved_html)
             except PostContent.DoesNotExist:
                 resolved_html = PostService._resolve_content(text_html, content_type)
-                PostContent.objects.create(
+                PostContentService.create_for_post(
                     post=post,
                     content_html=resolved_html,
                 )
@@ -656,7 +655,7 @@ class PostService:
         if tag:
             TagService.set_post_tags(post, tag)
 
-        PostContent.objects.create(
+        PostContentService.create_for_post(
             post=post,
             content_html=resolved_html,
         )
@@ -698,11 +697,10 @@ class PostService:
             try:
                 post_content = post.content
                 resolved_html = PostService._resolve_content(text_html, content_type)
-                post_content.content_html = resolved_html
-                post_content.save()
+                PostContentService.update_content(post_content, resolved_html)
             except PostContent.DoesNotExist:
                 resolved_html = PostService._resolve_content(text_html, content_type)
-                PostContent.objects.create(
+                PostContentService.create_for_post(
                     post=post,
                     content_html=resolved_html,
                 )
@@ -772,11 +770,10 @@ class PostService:
             try:
                 post_content = post.content
                 resolved_html = PostService._resolve_content(text_html, content_type)
-                post_content.content_html = resolved_html
-                post_content.save()
+                PostContentService.update_content(post_content, resolved_html)
             except PostContent.DoesNotExist:
                 resolved_html = PostService._resolve_content(text_html, content_type)
-                PostContent.objects.create(
+                PostContentService.create_for_post(
                     post=post,
                     content_html=resolved_html,
                 )


### PR DESCRIPTION
## 🎯 Goal
- Move `PostContent.save()` read-time synchronization into the post content service write path.
- Keep the model hook as a compatibility delegate while reducing duplicate sync work in service-managed writes.

## 🔧 Core Changes
- Add `PostContentService.sync_parent_read_time()` for the parent `Post.read_time` update contract.
- Add `PostContentService.create_for_post()` and `update_content()` helpers for service-managed content writes.
- Update `PostService` post/draft/publish write paths to use the new content helpers.
- Keep `PostContent.save()` syncing read time unless a service-managed write explicitly suppresses duplicate sync for that save.

## 🤔 Key Decisions
- Preserve the existing compatibility hook for direct `PostContent.save()` callers.
- Use a temporary `_skip_read_time_sync` flag only around service-managed content saves, then remove it with `finally`.
- Keep behavior locked by the PR #395 read-time characterization tests.

## 🧪 Verification Guide
### How to verify
1. Run `npm run server:test -- board.tests.api.test_post board.tests.api.test_developer_posts board.tests.models.test_post_content_save_hooks board.tests.models.test_post_save_hooks`.
2. Confirm post create/update/draft/publish flows still pass.
3. Confirm model read-time characterization tests still pass.

### Expected result
- Parent `Post.read_time` remains synchronized from `content_html`.
- Service-managed writes avoid duplicate read-time synchronization.
- Direct model saves still keep compatibility behavior.

## ✅ Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [x] Tests completed
- [ ] Documentation updated (if needed)
