### PR TITLE
🧪 Characterize profile avatar save hook

### DIFF
--- a/backend/src/board/tests/models/test_profile_save_hooks.py
+++ b/backend/src/board/tests/models/test_profile_save_hooks.py
@@ -1,0 +1,75 @@
+from io import BytesIO
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase, override_settings
+from PIL import Image
+
+from board.models import Profile, User
+
+
+class ProfileSaveThumbnailHookTestCase(TestCase):
+    """Characterization tests for Profile.save() avatar thumbnail side effects."""
+
+    @staticmethod
+    def create_test_image(name='avatar.jpg', color='red'):
+        buffer = BytesIO()
+        image = Image.new('RGB', (10, 10), color)
+        image.save(buffer, 'JPEG')
+        buffer.seek(0)
+        return SimpleUploadedFile(name, buffer.read(), content_type='image/jpeg')
+
+    def create_user(self, username='avatar-user'):
+        return User.objects.create_user(
+            username=username,
+            password='test',
+            email=f'{username}@test.com',
+        )
+
+    def test_new_profile_with_avatar_generates_thumbnail(self):
+        user = self.create_user('new-avatar-user')
+
+        with TemporaryDirectory() as media_root:
+            with override_settings(MEDIA_ROOT=media_root):
+                with patch('board.models.make_thumbnail') as mock_make_thumbnail:
+                    profile = Profile.objects.create(
+                        user=user,
+                        avatar=self.create_test_image(),
+                    )
+
+        mock_make_thumbnail.assert_called_once_with(profile, size=500)
+
+    def test_profile_avatar_change_generates_thumbnail(self):
+        user = self.create_user('changed-avatar-user')
+
+        with TemporaryDirectory() as media_root:
+            with override_settings(MEDIA_ROOT=media_root):
+                with patch('board.models.make_thumbnail') as mock_make_thumbnail:
+                    profile = Profile.objects.create(
+                        user=user,
+                        avatar=self.create_test_image('old.jpg', color='blue'),
+                    )
+                    mock_make_thumbnail.reset_mock()
+
+                    profile.avatar = self.create_test_image('new.jpg', color='green')
+                    profile.save()
+
+        mock_make_thumbnail.assert_called_once_with(profile, size=500)
+
+    def test_profile_save_without_avatar_change_does_not_generate_thumbnail(self):
+        user = self.create_user('unchanged-avatar-user')
+
+        with TemporaryDirectory() as media_root:
+            with override_settings(MEDIA_ROOT=media_root):
+                with patch('board.models.make_thumbnail') as mock_make_thumbnail:
+                    profile = Profile.objects.create(
+                        user=user,
+                        avatar=self.create_test_image(),
+                    )
+                    mock_make_thumbnail.reset_mock()
+
+                    profile.bio = 'updated bio'
+                    profile.save()
+
+        mock_make_thumbnail.assert_not_called()


### PR DESCRIPTION
## 🎯 Goal
- Lock the current `Profile.save()` avatar thumbnail side-effect contract before extracting it to a service.
- Make future profile image refactors safer with focused characterization tests.

## 🔧 Core Changes
- Add model tests for `Profile.save()` avatar thumbnail behavior.
- Characterize new profile avatar saves, changed avatar saves, and non-avatar profile saves.
- Mock thumbnail generation to avoid filesystem side effects.

## 🤔 Key Decisions
- Keep this PR test-only; no production behavior changes.
- Patch `board.models.make_thumbnail` because `Profile.save()` currently calls the model-module dependency.
- Use a real profile field update for the no-avatar-change save path.

## 🧪 Verification Guide
### How to verify
1. Run `npm run server:test -- board.tests.models.test_profile_save_hooks`.
2. Confirm three tests pass.

### Expected result
- New profile avatars call `make_thumbnail(profile, size=500)` once.
- Changed avatars call `make_thumbnail(profile, size=500)` once.
- Saving unrelated profile fields does not generate avatar thumbnails.

## ✅ Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [x] Tests completed
- [ ] Documentation updated (if needed)
