### PR TITLE
🐛 Use local date for settings heatmap

### DIFF
--- a/backend/src/board/services/user_heatmap_service.py
+++ b/backend/src/board/services/user_heatmap_service.py
@@ -30,7 +30,7 @@ class UserHeatmapService:
 
     @staticmethod
     def build_settings_heatmap(user: User) -> dict[str, int]:
-        end_date = timezone.now().date()
+        end_date = timezone.localdate()
         start_date = end_date - timedelta(days=UserHeatmapService.WINDOW_DAYS)
         heatmap = defaultdict(int)
 

--- a/backend/src/board/tests/services/test_user_heatmap_service.py
+++ b/backend/src/board/tests/services/test_user_heatmap_service.py
@@ -35,7 +35,7 @@ class UserHeatmapServiceTestCase(TestCase):
             text_html='<p>comment</p>',
         )
         PostLikes.objects.create(post=post, user=self.user)
-        date_key = timezone.now().date().strftime('%Y-%m-%d')
+        date_key = timezone.localdate().strftime('%Y-%m-%d')
 
         heatmap = UserHeatmapService.get_settings_heatmap(self.user)
 
@@ -47,7 +47,7 @@ class UserHeatmapServiceTestCase(TestCase):
 
     def test_settings_heatmap_uses_cache(self):
         post = self.create_post('cached-heatmap-post')
-        date_key = timezone.now().date().strftime('%Y-%m-%d')
+        date_key = timezone.localdate().strftime('%Y-%m-%d')
 
         first_heatmap = UserHeatmapService.get_settings_heatmap(self.user)
         PostLikes.objects.create(post=post, user=self.user)


### PR DESCRIPTION
## 🎯 Goal
- Fix settings heatmap activity disappearing around UTC/local-date boundaries.
- Keep the private settings heatmap window aligned with the configured local timezone.

## 🔧 Core Changes
- Use `timezone.localdate()` for the settings heatmap end date.
- Update heatmap service tests to assert local-date keys.

## 🤔 Key Decisions
- Keep cache policy unchanged.
- Scope this fix to the settings heatmap failure exposed by CI.
- Preserve existing query shape and response format.

## 🧪 Verification Guide
### How to verify
1. Run `npm run server:test -- board.tests.services.test_user_heatmap_service board.tests.api.test_setting.SettingTestCase.test_get_setting_heatmap_counts_private_user_activity_and_uses_cache`.
2. Confirm heatmap entries for current local-day activity are included.

### Expected result
- Settings heatmap includes current local-day posts, comments, and likes.
- Existing 1-hour cache behavior remains unchanged.

## ✅ Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [x] Tests completed
- [ ] Documentation updated (if needed)
