### PR TITLE
♻️ Extract profile avatar image service

### DIFF
--- a/backend/src/board/models.py
+++ b/backend/src/board/models.py
@@ -21,11 +21,11 @@ from modules.hash import get_sha256
 from modules.randomness import randstr
 from modules.sub_task import SubTaskProcessor
 from modules.telegram import TelegramBot
-from modules.thumbnail import make_thumbnail
 from board.constants.config_meta import CONFIG_TYPE, CONFIG_TYPES, CONFIG_MAP
 from board.modules.time import time_since, time_stamp
 from board.services.post_content_service import PostContentService
 from board.services.post_thumbnail_service import PostThumbnailService
+from board.services.profile_image_service import ProfileImageService
 
 
 def get_user_hex(username):
@@ -477,19 +477,10 @@ class Profile(models.Model):
         return self.webhook_subscribers.filter(is_active=True).count()
 
     def save(self, *args, **kwargs):
-        will_make_thumbnail = False
-        if not self.pk and self.avatar:
-            will_make_thumbnail = True
-
-        profile = Profile.objects.filter(id=self.id)
-        if profile.exists():
-            profile = profile.first()
-            if profile.avatar != self.avatar:
-                will_make_thumbnail = True
-
+        will_make_thumbnail = ProfileImageService.should_generate_avatar_thumbnail(self)
         super(Profile, self).save(*args, **kwargs)
         if will_make_thumbnail:
-            make_thumbnail(self, size=500)
+            ProfileImageService.generate_avatar_thumbnail(self)
 
     def get_absolute_url(self):
         return reverse('user_profile', args=[self.user.username])

--- a/backend/src/board/services/__init__.py
+++ b/backend/src/board/services/__init__.py
@@ -10,6 +10,7 @@ from importlib import import_module
 _SERVICE_MODULES = {
     'PostService': 'post_service',
     'PostThumbnailService': 'post_thumbnail_service',
+    'ProfileImageService': 'profile_image_service',
     'AuthService': 'auth_service',
     'BannerService': 'banner_service',
     'CommentService': 'comment_service',

--- a/backend/src/board/services/profile_image_service.py
+++ b/backend/src/board/services/profile_image_service.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from modules.thumbnail import make_thumbnail
+
+if TYPE_CHECKING:
+    from board.models import Profile
+
+
+class ProfileImageService:
+    """Encapsulates Profile avatar image side effects."""
+
+    @staticmethod
+    def should_generate_avatar_thumbnail(profile: 'Profile') -> bool:
+        if not profile.pk:
+            return bool(profile.avatar)
+
+        saved_profile = profile.__class__.objects.filter(id=profile.id).first()
+        if not saved_profile:
+            return False
+
+        return saved_profile.avatar != profile.avatar
+
+    @staticmethod
+    def generate_avatar_thumbnail(profile: 'Profile') -> None:
+        make_thumbnail(profile, size=500)

--- a/backend/src/board/tests/models/test_profile_save_hooks.py
+++ b/backend/src/board/tests/models/test_profile_save_hooks.py
@@ -32,7 +32,7 @@ class ProfileSaveThumbnailHookTestCase(TestCase):
 
         with TemporaryDirectory() as media_root:
             with override_settings(MEDIA_ROOT=media_root):
-                with patch('board.models.make_thumbnail') as mock_make_thumbnail:
+                with patch('board.services.profile_image_service.make_thumbnail') as mock_make_thumbnail:
                     profile = Profile.objects.create(
                         user=user,
                         avatar=self.create_test_image(),
@@ -45,7 +45,7 @@ class ProfileSaveThumbnailHookTestCase(TestCase):
 
         with TemporaryDirectory() as media_root:
             with override_settings(MEDIA_ROOT=media_root):
-                with patch('board.models.make_thumbnail') as mock_make_thumbnail:
+                with patch('board.services.profile_image_service.make_thumbnail') as mock_make_thumbnail:
                     profile = Profile.objects.create(
                         user=user,
                         avatar=self.create_test_image('old.jpg', color='blue'),
@@ -62,7 +62,7 @@ class ProfileSaveThumbnailHookTestCase(TestCase):
 
         with TemporaryDirectory() as media_root:
             with override_settings(MEDIA_ROOT=media_root):
-                with patch('board.models.make_thumbnail') as mock_make_thumbnail:
+                with patch('board.services.profile_image_service.make_thumbnail') as mock_make_thumbnail:
                     profile = Profile.objects.create(
                         user=user,
                         avatar=self.create_test_image(),


### PR DESCRIPTION
## 🎯 Goal
- Move `Profile.save()` avatar thumbnail decision and execution out of the model body while preserving the compatibility hook.
- Keep avatar thumbnail behavior locked by the characterization tests from PR #397.

## 🔧 Core Changes
- Add `ProfileImageService` for avatar thumbnail decision and execution.
- Update `Profile.save()` to delegate avatar thumbnail behavior to the service.
- Add `ProfileImageService` to lazy `board.services` package exports.
- Update profile save-hook tests to patch the service-level `make_thumbnail` dependency.

## 🤔 Key Decisions
- Preserve existing behavior for new avatar, changed avatar, unchanged avatar, and no-avatar saves.
- Preserve the previous edge behavior for manually assigned unsaved primary keys by not generating thumbnails when no saved row exists.
- Keep `Profile.save()` as a compatibility delegate for now; removing the hook is a later, higher-risk migration.

## 🧪 Verification Guide
### How to verify
1. Run `npm run server:test -- board.tests.models.test_profile_save_hooks board.tests.api.test_setting.SettingTestCase.test_upload_avatar board.tests.models.test_post_save_hooks board.tests.api.test_webhook`.
2. Confirm profile avatar characterization tests still pass.
3. Confirm settings avatar upload still passes.
4. Confirm existing lazy service exports remain compatible through webhook tests.

### Expected result
- Avatar thumbnail behavior remains unchanged for covered contracts.
- Existing package-level service imports continue to work.
- Profile avatar image logic is isolated behind `ProfileImageService`.

## ✅ Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [x] Tests completed
- [ ] Documentation updated (if needed)
