### PR TITLE
♻️ Extract notification delivery service

### DIFF
--- a/backend/src/board/models.py
+++ b/backend/src/board/models.py
@@ -19,13 +19,12 @@ from cryptography.fernet import InvalidToken
 from modules.cipher import encrypt_value, decrypt_value
 from modules.hash import get_sha256
 from modules.randomness import randstr
-from modules.sub_task import SubTaskProcessor
-from modules.telegram import TelegramBot
 from board.constants.config_meta import CONFIG_TYPE, CONFIG_TYPES, CONFIG_MAP
 from board.modules.time import time_since, time_stamp
 from board.services.post_content_service import PostContentService
 from board.services.post_thumbnail_service import PostThumbnailService
 from board.services.profile_image_service import ProfileImageService
+from board.services.notification_delivery_service import NotificationDeliveryService
 
 
 def get_user_hex(username):
@@ -218,14 +217,7 @@ class Notify(models.Model):
         return get_sha256(user.username + url + content + (hidden_key if hidden_key else ''))
 
     def send_notify(self):
-        if hasattr(self.user, 'telegramsync'):
-            tid = self.user.telegramsync.get_decrypted_tid()
-            if not tid == '':
-                bot = TelegramBot(settings.TELEGRAM_BOT_TOKEN)
-                SubTaskProcessor.process(lambda: bot.send_messages(tid, [
-                    settings.SITE_URL + str(self.url),
-                    self.content
-                ]))
+        NotificationDeliveryService.send_telegram_notification(self)
 
     def to_dict(self):
         return {

--- a/backend/src/board/services/__init__.py
+++ b/backend/src/board/services/__init__.py
@@ -11,6 +11,7 @@ _SERVICE_MODULES = {
     'PostService': 'post_service',
     'PostThumbnailService': 'post_thumbnail_service',
     'ProfileImageService': 'profile_image_service',
+    'NotificationDeliveryService': 'notification_delivery_service',
     'AuthService': 'auth_service',
     'BannerService': 'banner_service',
     'CommentService': 'comment_service',

--- a/backend/src/board/services/notification_delivery_service.py
+++ b/backend/src/board/services/notification_delivery_service.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from django.conf import settings
+
+from modules.sub_task import SubTaskProcessor
+from modules.telegram import TelegramBot
+
+if TYPE_CHECKING:
+    from board.models import Notify
+
+
+class NotificationDeliveryService:
+    """Encapsulates external notification delivery side effects."""
+
+    @staticmethod
+    def send_telegram_notification(notify: 'Notify') -> None:
+        if not hasattr(notify.user, 'telegramsync'):
+            return
+
+        telegram_id = notify.user.telegramsync.get_decrypted_tid()
+        if telegram_id == '':
+            return
+
+        bot = TelegramBot(settings.TELEGRAM_BOT_TOKEN)
+        SubTaskProcessor.process(lambda: bot.send_messages(telegram_id, [
+            settings.SITE_URL + str(notify.url),
+            notify.content,
+        ]))

--- a/backend/src/board/tests/models/test_notify_model_methods.py
+++ b/backend/src/board/tests/models/test_notify_model_methods.py
@@ -24,8 +24,8 @@ class NotifySendNotifyTestCase(TestCase):
             content='Hello notify',
         )
 
-    @patch('board.models.SubTaskProcessor.process')
-    @patch('board.models.TelegramBot')
+    @patch('board.services.notification_delivery_service.SubTaskProcessor.process')
+    @patch('board.services.notification_delivery_service.TelegramBot')
     def test_send_notify_without_telegram_sync_is_noop(self, mock_bot, mock_process):
         notify = self.create_notify()
 
@@ -34,8 +34,8 @@ class NotifySendNotifyTestCase(TestCase):
         mock_bot.assert_not_called()
         mock_process.assert_not_called()
 
-    @patch('board.models.SubTaskProcessor.process')
-    @patch('board.models.TelegramBot')
+    @patch('board.services.notification_delivery_service.SubTaskProcessor.process')
+    @patch('board.services.notification_delivery_service.TelegramBot')
     def test_send_notify_with_blank_telegram_id_is_noop(self, mock_bot, mock_process):
         TelegramSync.objects.create(user=self.user, tid='')
         notify = self.create_notify()
@@ -46,8 +46,8 @@ class NotifySendNotifyTestCase(TestCase):
         mock_process.assert_not_called()
 
     @override_settings(SITE_URL='https://example.test', TELEGRAM_BOT_TOKEN='token')
-    @patch('board.models.SubTaskProcessor.process')
-    @patch('board.models.TelegramBot')
+    @patch('board.services.notification_delivery_service.SubTaskProcessor.process')
+    @patch('board.services.notification_delivery_service.TelegramBot')
     def test_send_notify_dispatches_telegram_message(self, mock_bot, mock_process):
         TelegramSync.objects.create(user=self.user, tid='123456')
         notify = self.create_notify()


### PR DESCRIPTION
## 🎯 Goal
- Move `Notify.send_notify()` Telegram delivery side effects out of the model body.
- Keep the model method as a compatibility delegate while isolating external notification delivery in a service.

## 🔧 Core Changes
- Add `NotificationDeliveryService.send_telegram_notification()`.
- Update `Notify.send_notify()` to delegate delivery behavior to the service.
- Remove Telegram/SubTaskProcessor imports from `models.py`.
- Add `NotificationDeliveryService` to lazy `board.services` package exports.
- Update notify delivery characterization tests to patch service-level dependencies.

## 🤔 Key Decisions
- Preserve existing behavior for missing Telegram sync, blank decrypted Telegram id, and valid Telegram delivery.
- Keep async dispatch through `SubTaskProcessor.process()` unchanged.
- Keep `Notify.send_notify()` as a compatibility delegate for existing callers.

## 🧪 Verification Guide
### How to verify
1. Run `npm run server:test -- board.tests.models.test_notify_model_methods board.tests.api.test_setting board.tests.services.test_user_notification_service`.
2. Confirm notify delivery characterization tests pass.
3. Confirm settings notification flows still pass.

### Expected result
- Missing/blank Telegram sync does not dispatch.
- Valid Telegram sync dispatches the same `[SITE_URL + url, content]` payload through `SubTaskProcessor`.
- Notification delivery side effects live in `NotificationDeliveryService`.

## ✅ Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [x] Tests completed
- [ ] Documentation updated (if needed)
