### PR TITLE
♻️ Extract user config meta service

### DIFF
--- a/backend/src/board/models.py
+++ b/backend/src/board/models.py
@@ -19,12 +19,13 @@ from cryptography.fernet import InvalidToken
 from modules.cipher import encrypt_value, decrypt_value
 from modules.hash import get_sha256
 from modules.randomness import randstr
-from board.constants.config_meta import CONFIG_TYPE, CONFIG_TYPES, CONFIG_MAP
+from board.constants.config_meta import CONFIG_TYPE
 from board.modules.time import time_since, time_stamp
 from board.services.post_content_service import PostContentService
 from board.services.post_thumbnail_service import PostThumbnailService
 from board.services.profile_image_service import ProfileImageService
 from board.services.notification_delivery_service import NotificationDeliveryService
+from board.services.user_config_meta_service import UserConfigMetaService
 
 
 def get_user_hex(username):
@@ -140,31 +141,10 @@ class Config(models.Model):
     user = models.OneToOneField('auth.User', on_delete=models.CASCADE)
 
     def create_or_update_meta(self, config: CONFIG_TYPE, value):
-        if not config.value in CONFIG_TYPES:
-            return None
-
-        meta = UserConfigMeta.objects.filter(user=self.user, name=config.value)
-        if meta.exists():
-            meta = meta.first()
-
-            if not meta.value == value:
-                meta.value = value
-                meta.save()
-            return True
-
-        UserConfigMeta(user=self.user, name=config.value, value=str(value)).save()
-        return True
+        return UserConfigMetaService.create_or_update_meta(self, config, value)
 
     def get_meta(self, config: CONFIG_TYPE):
-        if not config.value in CONFIG_TYPES:
-            return None
-
-        meta = UserConfigMeta.objects.filter(user=self.user, name=config.value)
-        if not meta.exists():
-            return None
-
-        meta = meta.first()
-        return CONFIG_MAP[meta.name]['type'](meta.value)
+        return UserConfigMetaService.get_meta(self, config)
 
     def has_telegram_id(self):
         if hasattr(self.user, 'telegramsync'):

--- a/backend/src/board/services/__init__.py
+++ b/backend/src/board/services/__init__.py
@@ -12,6 +12,7 @@ _SERVICE_MODULES = {
     'PostThumbnailService': 'post_thumbnail_service',
     'ProfileImageService': 'profile_image_service',
     'NotificationDeliveryService': 'notification_delivery_service',
+    'UserConfigMetaService': 'user_config_meta_service',
     'AuthService': 'auth_service',
     'BannerService': 'banner_service',
     'CommentService': 'comment_service',

--- a/backend/src/board/services/user_config_meta_service.py
+++ b/backend/src/board/services/user_config_meta_service.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from board.constants.config_meta import CONFIG_MAP, CONFIG_TYPE, CONFIG_TYPES
+
+if TYPE_CHECKING:
+    from board.models import Config
+
+
+class UserConfigMetaService:
+    """Manage per-user notification configuration metadata."""
+
+    @staticmethod
+    def create_or_update_meta(
+        config_model: 'Config',
+        config: CONFIG_TYPE,
+        value: object,
+    ) -> bool | None:
+        if config.value not in CONFIG_TYPES:
+            return None
+
+        meta = config_model.user.conf_meta.filter(name=config.value).first()
+        if meta:
+            if meta.value != value:
+                meta.value = value
+                meta.save()
+            return True
+
+        config_model.user.conf_meta.create(name=config.value, value=str(value))
+        return True
+
+    @staticmethod
+    def get_meta(config_model: 'Config', config: CONFIG_TYPE) -> object | None:
+        if config.value not in CONFIG_TYPES:
+            return None
+
+        meta = config_model.user.conf_meta.filter(name=config.value).first()
+        if not meta:
+            return None
+
+        return CONFIG_MAP[meta.name]['type'](meta.value)


### PR DESCRIPTION
## 🎯 Goal
- Move user config meta create/read behavior out of the `Config` model and into a service layer.
- Keep the model methods as compatibility delegates so existing call sites and legacy behavior remain stable.

## 🔧 Core Changes
- Added `UserConfigMetaService` for `create_or_update_meta()` and `get_meta()` behavior.
- Updated `Config` model methods to delegate to the service.
- Exported `UserConfigMetaService` through the lazy service package registry.
- Preserved PR #402 characterization contracts, including the legacy direct bool-input conversion quirk.

## 🤔 Key Decisions
- Used the existing `user.conf_meta` related manager to avoid a runtime `board.models` import from the service and keep circular imports out.
- Kept this as a behavior-preserving extraction only; no call sites were migrated directly to the service in this PR.
- Addressed reviewer feedback by tightening service method type hints without changing runtime behavior.

## 🧪 Verification Guide
### How to verify
1. `npm run server:test -- board.tests.models.test_config_model_methods board.tests.services.test_user_notification_service`
2. `npm run server:test`

### Expected result
- Focused config/user notification tests pass.
- Full backend test suite passes.

## ✅ Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [x] Tests completed
- [ ] Documentation updated (if needed)
