### PR TITLE
🧪 Characterize webhook subscription transitions

### DIFF
--- a/backend/src/board/tests/api/test_webhook.py
+++ b/backend/src/board/tests/api/test_webhook.py
@@ -560,3 +560,23 @@ class WebhookFailureTrackingTestCase(TestCase):
         self.channel.refresh_from_db()
         self.assertEqual(self.channel.failure_count, 0)
         self.assertIsNotNone(self.channel.last_success_date)
+
+
+    @patch('board.services.webhook_service.WebhookService.send_webhook')
+    def test_success_does_not_reactivate_inactive_channel(self, mock_send):
+        """성공 기록은 비활성화된 채널을 재활성화하지 않음"""
+        self.channel.failure_count = 3
+        self.channel.is_active = False
+        self.channel.save(update_fields=['failure_count', 'is_active'])
+        mock_send.return_value = True
+
+        WebhookService.send_webhook_with_tracking(
+            channel=self.channel,
+            content='Test',
+            post_url='https://example.com'
+        )
+
+        self.channel.refresh_from_db()
+        self.assertEqual(self.channel.failure_count, 0)
+        self.assertFalse(self.channel.is_active)
+        self.assertIsNotNone(self.channel.last_success_date)

--- a/backend/src/board/tests/models/test_webhook_subscription_model_methods.py
+++ b/backend/src/board/tests/models/test_webhook_subscription_model_methods.py
@@ -1,0 +1,79 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+from django.utils import timezone
+
+from board.models import Profile, User, WebhookSubscription
+
+
+class WebhookSubscriptionModelMethodsTestCase(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username='webhook-transition-user',
+            password='test',
+            email='webhook-transition-user@test.com',
+        )
+        self.profile = Profile.objects.create(user=self.user)
+        self.channel = WebhookSubscription.objects.create(
+            author=self.profile,
+            webhook_url='https://discord.com/api/webhooks/transition/test',
+        )
+
+    def test_record_success_resets_failures_and_sets_last_success_date(self):
+        now = timezone.now()
+        self.channel.failure_count = 2
+        self.channel.save(update_fields=['failure_count'])
+
+        with patch('board.models.timezone.now', return_value=now):
+            self.channel.record_success()
+
+        self.channel.refresh_from_db()
+        self.assertEqual(self.channel.failure_count, 0)
+        self.assertEqual(self.channel.last_success_date, now)
+        self.assertTrue(self.channel.is_active)
+
+    def test_record_success_does_not_reactivate_inactive_channel(self):
+        self.channel.failure_count = WebhookSubscription.MAX_FAILURES
+        self.channel.is_active = False
+        self.channel.save(update_fields=['failure_count', 'is_active'])
+
+        self.channel.record_success()
+
+        self.channel.refresh_from_db()
+        self.assertEqual(self.channel.failure_count, 0)
+        self.assertFalse(self.channel.is_active)
+        self.assertIsNotNone(self.channel.last_success_date)
+
+    def test_record_failure_increments_failure_count_without_deactivation_before_limit(self):
+        self.channel.failure_count = WebhookSubscription.MAX_FAILURES - 2
+        self.channel.save(update_fields=['failure_count'])
+
+        self.channel.record_failure()
+
+        self.channel.refresh_from_db()
+        self.assertEqual(
+            self.channel.failure_count,
+            WebhookSubscription.MAX_FAILURES - 1,
+        )
+        self.assertTrue(self.channel.is_active)
+
+    def test_record_failure_deactivates_at_max_failures(self):
+        self.channel.failure_count = WebhookSubscription.MAX_FAILURES - 1
+        self.channel.save(update_fields=['failure_count'])
+
+        self.channel.record_failure()
+
+        self.channel.refresh_from_db()
+        self.assertEqual(self.channel.failure_count, WebhookSubscription.MAX_FAILURES)
+        self.assertFalse(self.channel.is_active)
+
+    def test_record_failure_preserves_last_success_date(self):
+        last_success_date = timezone.now()
+        self.channel.last_success_date = last_success_date
+        self.channel.save(update_fields=['last_success_date'])
+
+        self.channel.record_failure()
+
+        self.channel.refresh_from_db()
+        self.assertEqual(self.channel.failure_count, 1)
+        self.assertEqual(self.channel.last_success_date, last_success_date)


### PR DESCRIPTION
## 🎯 Goal
- Characterize `WebhookSubscription.record_success()` / `record_failure()` state transitions before any service extraction.
- Lock the webhook delivery tracking behavior that controls failure counters, last success timestamps, and automatic deactivation.

## 🔧 Core Changes
- Added focused model tests for webhook success/failure transitions.
- Added a service-path regression test ensuring a successful webhook send does not reactivate an inactive channel.
- No production behavior changed.

## 🤔 Key Decisions
- Kept this PR characterization-only to avoid mixing state-transition extraction with behavior changes.
- Asserted database-visible outcomes instead of mocking internal `save(update_fields=...)` calls.
- Added the reviewer-suggested service-path inactive-channel success case because it is easy to lose during extraction.

## 🧪 Verification Guide
### How to verify
1. `npm run server:test -- board.tests.models.test_webhook_subscription_model_methods board.tests.api.test_webhook.WebhookFailureTrackingTestCase`
2. `npm run server:test`

### Expected result
- Focused webhook transition tests pass.
- Full backend test suite passes.

## ✅ Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [x] Tests completed
- [ ] Documentation updated (if needed)
