### PR TITLE
♻️ Extract webhook subscription state service

### DIFF
--- a/backend/src/board/models.py
+++ b/backend/src/board/models.py
@@ -25,6 +25,7 @@ from board.services.post_content_service import PostContentService
 from board.services.post_thumbnail_service import PostThumbnailService
 from board.services.profile_image_service import ProfileImageService
 from board.services.notification_delivery_service import NotificationDeliveryService
+from board.services.webhook_subscription_state_service import WebhookSubscriptionStateService
 from board.services.user_config_meta_service import UserConfigMetaService
 
 
@@ -734,19 +735,14 @@ class WebhookSubscription(models.Model):
 
     def record_success(self):
         """Record a successful webhook delivery"""
-        self.failure_count = 0
-        self.last_success_date = timezone.now()
-        self.save(update_fields=['failure_count', 'last_success_date'])
+        WebhookSubscriptionStateService.record_success(self)
 
     def record_failure(self):
         """
         Record a failed webhook delivery.
         Auto-deactivates after MAX_FAILURES consecutive failures.
         """
-        self.failure_count += 1
-        if self.failure_count >= self.MAX_FAILURES:
-            self.is_active = False
-        self.save(update_fields=['failure_count', 'is_active'])
+        WebhookSubscriptionStateService.record_failure(self)
 
 
 class UsernameChangeLog(models.Model):

--- a/backend/src/board/services/__init__.py
+++ b/backend/src/board/services/__init__.py
@@ -21,6 +21,7 @@ _SERVICE_MODULES = {
     'TagService': 'tag_service',
     'UserService': 'user_service',
     'WebhookService': 'webhook_service',
+    'WebhookSubscriptionStateService': 'webhook_subscription_state_service',
 }
 
 __all__ = list(_SERVICE_MODULES)

--- a/backend/src/board/services/webhook_service.py
+++ b/backend/src/board/services/webhook_service.py
@@ -13,6 +13,7 @@ from django.conf import settings
 from django.db.models import Q
 
 from board.models import Post, PostConfig, WebhookSubscription, Profile, SiteContentScope
+from board.services.webhook_subscription_state_service import WebhookSubscriptionStateService
 from modules.sub_task import SubTaskProcessor
 
 
@@ -93,9 +94,9 @@ class WebhookService:
         )
 
         if success:
-            channel.record_success()
+            WebhookSubscriptionStateService.record_success(channel)
         else:
-            channel.record_failure()
+            WebhookSubscriptionStateService.record_failure(channel)
             if not channel.is_active:
                 logger.info(
                     f'Webhook channel {channel.id} deactivated '

--- a/backend/src/board/services/webhook_subscription_state_service.py
+++ b/backend/src/board/services/webhook_subscription_state_service.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from django.utils import timezone
+
+if TYPE_CHECKING:
+    from board.models import WebhookSubscription
+
+
+class WebhookSubscriptionStateService:
+    """Manage webhook subscription delivery state transitions."""
+
+    @staticmethod
+    def record_success(channel: 'WebhookSubscription') -> None:
+        channel.failure_count = 0
+        channel.last_success_date = timezone.now()
+        channel.save(update_fields=['failure_count', 'last_success_date'])
+
+    @staticmethod
+    def record_failure(channel: 'WebhookSubscription') -> None:
+        channel.failure_count += 1
+        if channel.failure_count >= channel.MAX_FAILURES:
+            channel.is_active = False
+        channel.save(update_fields=['failure_count', 'is_active'])

--- a/backend/src/board/tests/services/test_webhook_subscription_state_service.py
+++ b/backend/src/board/tests/services/test_webhook_subscription_state_service.py
@@ -1,0 +1,47 @@
+from django.test import TestCase
+
+from board.models import Profile, User, WebhookSubscription
+from board.services.webhook_subscription_state_service import WebhookSubscriptionStateService
+
+
+class WebhookSubscriptionStateServiceTestCase(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username='webhook-state-service-user',
+            password='test',
+            email='webhook-state-service-user@test.com',
+        )
+        self.profile = Profile.objects.create(user=self.user)
+        self.channel = WebhookSubscription.objects.create(
+            author=self.profile,
+            webhook_url='https://discord.com/api/webhooks/state-service/test',
+        )
+
+    def test_record_success_resets_failures_without_reactivating_channel(self):
+        self.channel.failure_count = WebhookSubscription.MAX_FAILURES
+        self.channel.is_active = False
+        self.channel.save(update_fields=['failure_count', 'is_active'])
+
+        WebhookSubscriptionStateService.record_success(self.channel)
+
+        self.channel.refresh_from_db()
+        self.assertEqual(self.channel.failure_count, 0)
+        self.assertFalse(self.channel.is_active)
+        self.assertIsNotNone(self.channel.last_success_date)
+
+    def test_record_failure_increments_failure_count_before_limit(self):
+        WebhookSubscriptionStateService.record_failure(self.channel)
+
+        self.channel.refresh_from_db()
+        self.assertEqual(self.channel.failure_count, 1)
+        self.assertTrue(self.channel.is_active)
+
+    def test_record_failure_deactivates_at_max_failures(self):
+        self.channel.failure_count = WebhookSubscription.MAX_FAILURES - 1
+        self.channel.save(update_fields=['failure_count'])
+
+        WebhookSubscriptionStateService.record_failure(self.channel)
+
+        self.channel.refresh_from_db()
+        self.assertEqual(self.channel.failure_count, WebhookSubscription.MAX_FAILURES)
+        self.assertFalse(self.channel.is_active)


### PR DESCRIPTION
## 🎯 Goal
- Move webhook subscription success/failure state transitions into a service layer.
- Keep `WebhookSubscription.record_success()` / `record_failure()` as compatibility delegates while making `WebhookService` use the service directly.

## 🔧 Core Changes
- Added `WebhookSubscriptionStateService` for webhook delivery state transitions.
- Updated `WebhookSubscription` model methods to delegate to the service.
- Updated `WebhookService.send_webhook_with_tracking()` to call the state service directly.
- Added direct service tests for success, failure before limit, and failure at limit.

## 🤔 Key Decisions
- Kept model methods as thin compatibility delegates to avoid breaking existing callers.
- Kept behavior identical to PR #404 characterization, including not reactivating inactive channels on success.
- Used a separate state service to avoid circular imports between `models.py` and `webhook_service.py`.

## 🧪 Verification Guide
### How to verify
1. `npm run server:test -- board.tests.services.test_webhook_subscription_state_service board.tests.models.test_webhook_subscription_model_methods board.tests.api.test_webhook.WebhookFailureTrackingTestCase`
2. `npm run server:test`

### Expected result
- Focused webhook state tests pass.
- Full backend test suite passes.

## ✅ Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [x] Tests completed
- [ ] Documentation updated (if needed)
