### PR TITLE
🧪 Characterize telegram sync save hooks

### DIFF
--- a/backend/src/board/tests/models/test_telegram_sync_save_hooks.py
+++ b/backend/src/board/tests/models/test_telegram_sync_save_hooks.py
@@ -1,0 +1,76 @@
+from django.test import TestCase
+
+from board.models import TelegramSync, User
+from modules.cipher import encrypt_value
+
+
+class TelegramSyncSaveHookTestCase(TestCase):
+    """Characterization tests for TelegramSync.save() encryption behavior."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username='telegram-sync-user',
+            password='test',
+            email='telegram-sync-user@test.com',
+        )
+
+    def test_save_encrypts_plaintext_tid(self):
+        sync = TelegramSync.objects.create(user=self.user, tid='123456')
+
+        self.assertNotEqual(sync.tid, '123456')
+        self.assertEqual(sync.get_decrypted_tid(), '123456')
+
+        sync.refresh_from_db()
+        self.assertNotEqual(sync.tid, '123456')
+        self.assertEqual(sync.get_decrypted_tid(), '123456')
+
+    def test_save_leaves_blank_tid_unchanged(self):
+        sync = TelegramSync.objects.create(user=self.user, tid='')
+
+        self.assertEqual(sync.tid, '')
+        self.assertEqual(sync.get_decrypted_tid(), '')
+
+        sync.refresh_from_db()
+        self.assertEqual(sync.tid, '')
+        self.assertEqual(sync.get_decrypted_tid(), '')
+
+    def test_save_preserves_already_encrypted_tid(self):
+        encrypted_tid = encrypt_value('123456').decode()
+
+        sync = TelegramSync.objects.create(user=self.user, tid=encrypted_tid)
+
+        self.assertEqual(sync.tid, encrypted_tid)
+        self.assertEqual(sync.get_decrypted_tid(), '123456')
+
+        sync.refresh_from_db()
+        self.assertEqual(sync.tid, encrypted_tid)
+        self.assertEqual(sync.get_decrypted_tid(), '123456')
+
+    def test_resave_preserves_encrypted_tid(self):
+        sync = TelegramSync.objects.create(user=self.user, tid='123456')
+        encrypted_tid = sync.tid
+
+        sync.auth_token = 'ABC123'
+        sync.save()
+
+        self.assertEqual(sync.tid, encrypted_tid)
+        self.assertEqual(sync.get_decrypted_tid(), '123456')
+
+        sync.refresh_from_db()
+        self.assertEqual(sync.tid, encrypted_tid)
+        self.assertEqual(sync.get_decrypted_tid(), '123456')
+
+    def test_save_encrypts_invalid_ciphertext_as_plaintext(self):
+        sync = TelegramSync.objects.create(user=self.user, tid='not-a-fernet-token')
+
+        self.assertNotEqual(sync.tid, 'not-a-fernet-token')
+        self.assertEqual(sync.get_decrypted_tid(), 'not-a-fernet-token')
+
+        sync.refresh_from_db()
+        self.assertNotEqual(sync.tid, 'not-a-fernet-token')
+        self.assertEqual(sync.get_decrypted_tid(), 'not-a-fernet-token')
+
+    def test_get_decrypted_tid_returns_empty_for_invalid_ciphertext(self):
+        sync = TelegramSync(user=self.user, tid='not-a-fernet-token')
+
+        self.assertEqual(sync.get_decrypted_tid(), '')


### PR DESCRIPTION
## 🎯 Goal

Lock down the current `TelegramSync.save()` encryption and idempotence behavior before extracting the encryption policy into a service.

## 🔧 Core Changes

- Added characterization coverage for encrypting plaintext Telegram IDs on save.
- Covered blank `tid` preservation.
- Covered already-encrypted `tid` preservation and unrelated resave idempotence.
- Captured the legacy malformed-ciphertext behavior: invalid non-empty values are treated as plaintext on save.
- Captured `get_decrypted_tid()` fallback behavior for invalid ciphertext.

## 🤔 Key Decisions

- This PR intentionally changes tests only; production behavior is unchanged.
- Tests avoid asserting exact ciphertext for newly encrypted plaintext because Fernet encryption is intentionally non-deterministic.
- Exact ciphertext equality is asserted only for idempotence cases where the current behavior must not re-encrypt.

## 🧪 Verification Guide

### How to verify

- `npm run server:test -- board.tests.models.test_telegram_sync_save_hooks`
- `npm run server:test`
- Reviewer also ran: `./scripts/manage.sh test board.tests.models.test_telegram_sync_save_hooks board.tests.api.test_telegram_api board.tests.models.test_notify_model_methods`

### Expected result

- TelegramSync save-hook characterization tests pass.
- The full backend test suite passes.

## ✅ Checklist

- [x] Production behavior unchanged
- [x] Focused backend tests pass
- [x] Full backend tests pass
- [x] Subagent review completed
- [x] Reviewer feedback reflected
