### PR TITLE
♻️ Extract telegram sync encryption service

### DIFF
--- a/backend/src/board/models.py
+++ b/backend/src/board/models.py
@@ -14,9 +14,6 @@ from django.utils.text import slugify
 from django.utils.html import strip_tags
 
 from dateutil import parser as dateutil_parser
-from cryptography.fernet import InvalidToken
-
-from modules.cipher import encrypt_value, decrypt_value
 from modules.hash import get_sha256
 from modules.randomness import randstr
 from board.constants.config_meta import CONFIG_TYPE
@@ -28,6 +25,7 @@ from board.services.notification_delivery_service import NotificationDeliverySer
 from board.services.webhook_subscription_state_service import WebhookSubscriptionStateService
 from board.services.user_config_meta_service import UserConfigMetaService
 from board.services.series_save_service import SeriesSaveService
+from board.services.telegram_sync_encryption_service import TelegramSyncEncryptionService
 
 
 def get_user_hex(username):
@@ -517,10 +515,7 @@ class TelegramSync(models.Model):
     created_date = models.DateTimeField(default=timezone.now)
 
     def get_decrypted_tid(self):
-        try:
-            return decrypt_value(self.tid)
-        except (InvalidToken, Exception):
-            return ''
+        return TelegramSyncEncryptionService.get_decrypted_tid(self)
 
     def is_token_expire(self):
         one_day_ago = timezone.now() - datetime.timedelta(days=1)
@@ -532,16 +527,11 @@ class TelegramSync(models.Model):
         return self.user.username
     
     def save(self, *args, **kwargs):
-        if self.tid and not self._is_encrypted(self.tid):
-            self.tid = encrypt_value(self.tid).decode()
+        TelegramSyncEncryptionService.prepare_for_save(self)
         super().save(*args, **kwargs)
     
     def _is_encrypted(self, value):
-        try:
-            decrypt_value(value)
-            return True
-        except:
-            return False
+        return TelegramSyncEncryptionService.is_encrypted(value)
 
 
 

--- a/backend/src/board/services/telegram_sync_encryption_service.py
+++ b/backend/src/board/services/telegram_sync_encryption_service.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from cryptography.fernet import InvalidToken
+
+from modules.cipher import decrypt_value, encrypt_value
+
+if TYPE_CHECKING:
+    from board.models import TelegramSync
+
+
+class TelegramSyncEncryptionService:
+    """Encapsulates TelegramSync encrypted ID persistence behavior."""
+
+    @staticmethod
+    def get_decrypted_tid(telegram_sync: 'TelegramSync') -> str:
+        try:
+            return decrypt_value(telegram_sync.tid)
+        except (InvalidToken, Exception):
+            return ''
+
+    @staticmethod
+    def is_encrypted(value: str) -> bool:
+        try:
+            decrypt_value(value)
+            return True
+        except Exception:
+            return False
+
+    @staticmethod
+    def prepare_for_save(telegram_sync: 'TelegramSync') -> None:
+        if (
+            telegram_sync.tid
+            and not TelegramSyncEncryptionService.is_encrypted(telegram_sync.tid)
+        ):
+            telegram_sync.tid = encrypt_value(telegram_sync.tid).decode()

--- a/docs/MODEL_SAVE_HOOK_INVENTORY.md
+++ b/docs/MODEL_SAVE_HOOK_INVENTORY.md
@@ -18,7 +18,7 @@ This document records model-layer side effects that should be reduced in small, 
 | P2 | `PostContent.save()` | Recalculates `post.read_time` and calls `post.save()` before saving content. | Cross-model write from content model; content save can trigger `Post.save()` side effects unless the post object is clean enough; parent write can survive if content save later fails. | Characterize read-time update and ensure no unexpected thumbnail generation, then move read-time synchronization into a transaction-aware post content service/write path. |
 | P2 | `Profile.save()` | Detects changed avatar and generates thumbnail after saving. | Filesystem image work hidden behind profile saves; expensive for unrelated profile updates. | Add tests for new avatar, changed avatar, and unchanged avatar, then extract avatar thumbnail behavior into a profile image service. |
 | P3 | `Series.save()` | Generates URL when empty and refreshes `updated_date` on every save. Compatibility delegate now routes slug/timestamp policy through `SeriesSaveService`. | Save hook remains for backward compatibility; bulk updates still bypass model save as before. | Keep characterization coverage around URL generation/collision and timestamp refresh; avoid adding new slug policy outside `SeriesSaveService`. |
-| P3 | `TelegramSync.save()` | Encrypts `tid` when non-empty and not already encrypted. | Encryption policy is hidden in persistence; broad exception in `_is_encrypted()` can mask malformed state. | Characterize plaintext save, encrypted save idempotence, and blank value behavior; then extract encryption/idempotence to auth/telegram service. |
+| P3 | `TelegramSync.save()` | Encrypts `tid` when non-empty and not already encrypted. Compatibility delegate now routes encryption/idempotence through `TelegramSyncEncryptionService`. | Save hook remains for backward compatibility; broad malformed-value behavior is preserved by characterization tests. | Keep encryption/idempotence policy in `TelegramSyncEncryptionService`; avoid adding new encryption logic to model/view code. |
 | P3 | `SiteSetting.save()` | Forces `pk = 1` before every save to maintain singleton behavior. | Singleton policy is hidden in save and can surprise callers trying to create test rows. | Characterize singleton behavior and `get_instance()`; keep hook unless replacing with a manager/service and migration-safe admin path. |
 
 ## Related model-layer write methods
@@ -50,7 +50,7 @@ These are not `save()` overrides, but they perform writes or side effects from m
 7. `Config.create_or_update_meta()` characterization and extraction to a user config service.
 8. `WebhookSubscription` success/failure transition characterization before optional service extraction.
 9. `Series.save()` slug/timestamp characterization and service extraction completed; keep compatibility delegate covered by tests.
-10. `TelegramSync.save()` encryption idempotence characterization before extracting encryption policy.
+10. `TelegramSync.save()` encryption idempotence characterization and service extraction completed; keep compatibility delegate covered by tests.
 11. `SiteSetting.save()` singleton characterization; keep the hook unless a safer manager/service replacement is proven.
 
 ## Test strategy


### PR DESCRIPTION
## 🎯 Goal

Move `TelegramSync.save()` encryption/idempotence policy out of the model body while preserving the existing compatibility behavior.

## 🔧 Core Changes

- Added `TelegramSyncEncryptionService` for encrypted Telegram ID handling.
- Kept `TelegramSync.get_decrypted_tid()`, `save()`, and `_is_encrypted()` as compatibility delegates.
- Preserved the legacy behavior covered by the prior characterization tests, including malformed non-empty values being treated as plaintext on save.
- Updated the model save-hook inventory to record the completed extraction.

## 🤔 Key Decisions

- The model hook remains as a compatibility guard because existing callers may still assign plaintext `tid` and call `save()`.
- The service avoids runtime imports from `board.models` by using `TYPE_CHECKING` only.
- `_is_encrypted()` now delegates to a service method with the same practical decrypt-failure semantics for persistence flows.

## 🧪 Verification Guide

### How to verify

- `npm run server:test -- board.tests.models.test_telegram_sync_save_hooks board.tests.api.test_telegram_api board.tests.models.test_notify_model_methods`
- `npm run server:test`
- Reviewer also ran: `./scripts/manage.sh test board.tests.models.test_telegram_sync_save_hooks board.tests.api.test_telegram_api board.tests.models.test_notify_model_methods`

### Expected result

- TelegramSync save-hook characterization tests pass.
- Telegram API and notification delivery tests pass.
- The full backend test suite passes.

## ✅ Checklist

- [x] Behavior preserved by characterization tests
- [x] Focused backend tests pass
- [x] Full backend tests pass
- [x] Subagent review completed
- [x] Refactor inventory updated
