### PR TITLE
🧪 Characterize site setting save hooks

### DIFF
--- a/backend/src/board/tests/models/test_site_setting_save_hooks.py
+++ b/backend/src/board/tests/models/test_site_setting_save_hooks.py
@@ -1,0 +1,74 @@
+from django.db import IntegrityError, transaction
+from django.test import TestCase
+
+from board.models import SiteSetting
+
+
+class SiteSettingSaveHookTestCase(TestCase):
+    """Characterization tests for SiteSetting singleton save behavior."""
+
+    def setUp(self):
+        SiteSetting.objects.all().delete()
+
+    def test_save_forces_primary_key_to_one(self):
+        setting = SiteSetting(header_script='header')
+
+        setting.save()
+
+        self.assertEqual(setting.pk, 1)
+        self.assertEqual(SiteSetting.objects.count(), 1)
+        self.assertEqual(SiteSetting.objects.get(pk=1).header_script, 'header')
+
+    def test_save_with_explicit_primary_key_updates_singleton_key(self):
+        setting = SiteSetting(pk=42, header_script='header')
+
+        setting.save()
+
+        self.assertEqual(setting.pk, 1)
+        self.assertFalse(SiteSetting.objects.filter(pk=42).exists())
+        self.assertEqual(SiteSetting.objects.get(pk=1).header_script, 'header')
+
+    def test_saving_second_instance_updates_existing_singleton(self):
+        SiteSetting.objects.create(header_script='first')
+        setting = SiteSetting(pk=1, header_script='second')
+
+        setting.save()
+
+        self.assertEqual(SiteSetting.objects.count(), 1)
+        self.assertEqual(SiteSetting.objects.get(pk=1).header_script, 'second')
+
+
+    def test_saving_new_unsaved_instance_updates_existing_singleton(self):
+        SiteSetting.objects.create(header_script='first')
+        setting = SiteSetting(header_script='second')
+
+        setting.save()
+
+        self.assertEqual(setting.pk, 1)
+        self.assertEqual(SiteSetting.objects.count(), 1)
+        self.assertEqual(SiteSetting.objects.get(pk=1).header_script, 'second')
+
+    def test_objects_create_second_instance_raises_integrity_error(self):
+        SiteSetting.objects.create(header_script='first')
+
+        with self.assertRaises(IntegrityError):
+            with transaction.atomic():
+                SiteSetting.objects.create(header_script='second')
+
+        self.assertEqual(SiteSetting.objects.count(), 1)
+        self.assertEqual(SiteSetting.objects.get(pk=1).header_script, 'first')
+
+    def test_get_instance_creates_singleton_when_missing(self):
+        setting = SiteSetting.get_instance()
+
+        self.assertEqual(setting.pk, 1)
+        self.assertEqual(SiteSetting.objects.count(), 1)
+
+    def test_get_instance_returns_existing_singleton(self):
+        existing = SiteSetting.objects.create(header_script='existing')
+
+        setting = SiteSetting.get_instance()
+
+        self.assertEqual(setting.pk, existing.pk)
+        self.assertEqual(setting.header_script, 'existing')
+        self.assertEqual(SiteSetting.objects.count(), 1)


### PR DESCRIPTION
## 🎯 Goal

Lock down the current `SiteSetting.save()` singleton behavior and `get_instance()` contract before deciding whether to keep the hook or replace it with a safer service/manager path.

## 🔧 Core Changes

- Added model-level characterization tests for `SiteSetting.save()` forcing `pk = 1`.
- Covered explicit non-1 primary keys being rewritten to the singleton key.
- Covered saving new and existing instances over the singleton row.
- Captured the current `objects.create()` second-row behavior, which raises `IntegrityError` because Django uses force-insert.
- Covered `SiteSetting.get_instance()` create and reuse behavior.

## 🤔 Key Decisions

- This PR intentionally changes tests only; production behavior is unchanged.
- The tests document why replacing the hook is risky: normal `save()` and `objects.create()` currently behave differently once the singleton row exists.

## 🧪 Verification Guide

### How to verify

- `npm run server:test -- board.tests.models.test_site_setting_save_hooks board.tests.api.test_site_setting`
- `npm run server:test`
- Reviewer also ran: `./scripts/manage.sh test board.tests.models.test_site_setting_save_hooks board.tests.api.test_site_setting board.tests.test_agent_content board.tests.templates.test_agent_discovery`

### Expected result

- SiteSetting singleton characterization tests pass.
- SiteSetting API tests pass.
- The full backend test suite passes.

## ✅ Checklist

- [x] Production behavior unchanged
- [x] Focused backend tests pass
- [x] Full backend tests pass
- [x] Subagent review completed
- [x] Reviewer feedback reflected
