### PR TITLE
🐛 Preserve draft title images during autosave

### DIFF
--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/NewPostEditor.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/NewPostEditor.tsx
@@ -3,7 +3,8 @@ import {
     useState,
     useEffect,
     useMemo,
-    useRef
+    useRef,
+    useCallback
 } from 'react';
 import { toast } from '~/utils/toast';
 import { useConfirm } from '~/hooks/useConfirm';
@@ -70,12 +71,23 @@ const NewPostEditor = ({ draftUrl }: NewPostEditorProps) => {
         url: ''
     });
 
+    type DirtySnapshot = {
+        title: string;
+        subtitle: string;
+        url: string;
+        content: string;
+        metaDescription: string;
+        hide: boolean;
+        advertise: boolean;
+        tags: string[];
+        seriesUrl: string;
+        imagePreview: string;
+        imageFilePending: boolean;
+        imageDeleted: boolean;
+    };
+
     // Track initial state for dirty check
-    const initialDataRef = useRef({
-        title: '',
-        content: '',
-        tags: [] as string[]
-    });
+    const initialDataRef = useRef<DirtySnapshot | null>(null);
     const isIntentionalSubmitRef = useRef(false);
 
     // Custom hooks
@@ -85,8 +97,24 @@ const NewPostEditor = ({ draftUrl }: NewPostEditorProps) => {
         imageDeleted,
         handleImageUpload,
         handleRemoveImage,
-        setImagePreviewUrl
+        setImagePreviewUrl,
+        markImageSaved
     } = useImageUpload();
+
+    const buildDirtySnapshot = useCallback((): DirtySnapshot => ({
+        title: formData.title,
+        subtitle: formData.subtitle,
+        url: formData.url,
+        content: formData.content,
+        metaDescription: formData.metaDescription,
+        hide: formData.hide,
+        advertise: formData.advertise,
+        tags,
+        seriesUrl: selectedSeries.url || '',
+        imagePreview: imagePreview || '',
+        imageFilePending: Boolean(imageFile),
+        imageDeleted
+    }), [formData, tags, selectedSeries.url, imagePreview, imageFile, imageDeleted]);
 
     const handleEditorImageUpload = async (file: File) => {
         try {
@@ -101,15 +129,22 @@ const NewPostEditor = ({ draftUrl }: NewPostEditorProps) => {
     };
 
     const handleAutoSaveSuccess = (url?: string) => {
-        if (!url) return;
+        if (url) {
+            if (url !== currentDraftUrl) {
+                setCurrentDraftUrl(url);
+            }
 
-        if (url !== currentDraftUrl) {
-            setCurrentDraftUrl(url);
+            const newUrl = new URL(window.location.href);
+            newUrl.searchParams.set('draft', url);
+            window.history.replaceState({}, '', newUrl.toString());
         }
 
-        const newUrl = new URL(window.location.href);
-        newUrl.searchParams.set('draft', url);
-        window.history.replaceState({}, '', newUrl.toString());
+        initialDataRef.current = {
+            ...buildDirtySnapshot(),
+            imageFilePending: false,
+            imageDeleted: false
+        };
+        markImageSaved();
     };
 
     const handleAutoSaveError = () => {
@@ -223,12 +258,7 @@ const NewPostEditor = ({ draftUrl }: NewPostEditorProps) => {
                             setImagePreviewUrl(draftData.image);
                         }
 
-                        // Store initial state
-                        initialDataRef.current = {
-                            title: newTitle,
-                            content: newContent,
-                            tags: newTags
-                        };
+                        // Store initial state after React state updates settle below.
                     }
                 }
             } catch {
@@ -239,16 +269,21 @@ const NewPostEditor = ({ draftUrl }: NewPostEditorProps) => {
         };
 
         fetchData();
-    }, [draftUrl]);
+    }, [draftUrl, setImagePreviewUrl]);
+
+    useEffect(() => {
+        if (!isLoading && !initialDataRef.current) {
+            initialDataRef.current = buildDirtySnapshot();
+        }
+    }, [isLoading, buildDirtySnapshot]);
 
     // Check if form has unsaved changes
     const hasUnsavedChanges = () => {
         const initial = initialDataRef.current;
-        return (
-            formData.title !== initial.title ||
-            formData.content !== initial.content ||
-            JSON.stringify(tags) !== JSON.stringify(initial.tags)
-        );
+        if (!initial) return false;
+
+        const current = buildDirtySnapshot();
+        return JSON.stringify(current) !== JSON.stringify(initial);
     };
 
     // Warn on page unload if there are unsaved changes
@@ -293,11 +328,6 @@ const NewPostEditor = ({ draftUrl }: NewPostEditorProps) => {
     };
 
     const handleManualSave = async () => {
-        if (!formData.title.trim()) {
-            toast.error('제목을 입력해주세요.');
-            return;
-        }
-
         const success = await manualSave();
         if (success) {
             toast.success('임시저장되었습니다.');
@@ -339,7 +369,8 @@ const NewPostEditor = ({ draftUrl }: NewPostEditorProps) => {
                 url: normalizeUrlForSubmit(formData.url),
                 content: formData.content,
                 tags,
-                seriesId: selectedSeries.id
+                seriesId: selectedSeries.id,
+                imageDeleted
             },
             isDraft,
             false // isEdit

--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/hooks/useAutoSave.ts
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/hooks/useAutoSave.ts
@@ -59,12 +59,29 @@ export const useAutoSave = (data: AutoSaveData, options: UseAutoSaveOptions) => 
     const dataRef = useRef(data);
     const optionsRef = useRef(options);
     const draftUrlRef = useRef<string | undefined>(options.draftUrl);
-    const prevDataStringRef = useRef<string>(JSON.stringify({
-        title: data.title,
-        content: data.content,
-        tags: data.tags,
-        customUrl: data.customUrl
-    }));
+    const getContentSignature = useCallback((value: AutoSaveData) => JSON.stringify({
+        title: value.title,
+        content: value.content,
+        tags: value.tags,
+        subtitle: value.subtitle,
+        description: value.description,
+        seriesUrl: value.seriesUrl,
+        customUrl: value.customUrl
+    }), []);
+
+    const getDataSignature = useCallback((value: AutoSaveData) => JSON.stringify({
+        content: JSON.parse(getContentSignature(value)),
+        imageDeleted: value.imageDeleted,
+        imageFile: value.imageFile ? {
+            name: value.imageFile.name,
+            size: value.imageFile.size,
+            lastModified: value.imageFile.lastModified
+        } : null
+    }), [getContentSignature]);
+
+    const prevDataStringRef = useRef<string>(getDataSignature(data));
+    const prevContentStringRef = useRef<string>(getContentSignature(data));
+    const skipNextImageResetRef = useRef(false);
     const isInitialLoadRef = useRef(true);
 
     dataRef.current = data;
@@ -79,13 +96,8 @@ export const useAutoSave = (data: AutoSaveData, options: UseAutoSaveOptions) => 
 
     const { intervalMs = 3000 } = options;
 
-    // Serialize only the auto-save relevant data
-    const currentDataString = JSON.stringify({
-        title: data.title,
-        content: data.content,
-        tags: data.tags,
-        customUrl: data.customUrl
-    });
+    const currentDataString = getDataSignature(data);
+    const currentContentString = getContentSignature(data);
 
     // Manual save - returns true on success, false on failure
     const manualSave = useCallback(async (): Promise<boolean> => {
@@ -130,12 +142,9 @@ export const useAutoSave = (data: AutoSaveData, options: UseAutoSaveOptions) => 
             setHasSaveError(false);
             setHasPendingChanges(false);
             // Update previous data to prevent auto-save from triggering immediately
-            prevDataStringRef.current = JSON.stringify({
-                title: currentData.title,
-                content: currentData.content,
-                tags: currentData.tags,
-                customUrl: currentData.customUrl
-            });
+            prevDataStringRef.current = getDataSignature(currentData);
+            prevContentStringRef.current = getContentSignature(currentData);
+            skipNextImageResetRef.current = true;
             currentOptions.onSuccess?.();
             return true;
         } catch (error) {
@@ -145,23 +154,32 @@ export const useAutoSave = (data: AutoSaveData, options: UseAutoSaveOptions) => 
         } finally {
             setIsSaving(false);
         }
-    }, [isSaving]);
+    }, [isSaving, getDataSignature, getContentSignature]);
 
-    // Auto-save effect (JSON only, no image)
+    // Auto-save effect
     useEffect(() => {
         if (!options.enabled) return;
 
         // Check if data has actually changed
         if (prevDataStringRef.current === currentDataString) return;
 
+        if (skipNextImageResetRef.current && prevContentStringRef.current === currentContentString) {
+            skipNextImageResetRef.current = false;
+            prevDataStringRef.current = currentDataString;
+            return;
+        }
+
+        skipNextImageResetRef.current = false;
+
         // Skip initial load trigger - when data changes from empty to loaded
         if (isInitialLoadRef.current) {
-            const prevData = JSON.parse(prevDataStringRef.current);
+            const prevData = JSON.parse(prevContentStringRef.current);
             const wasEmpty = !prevData.title && !prevData.content && !prevData.tags && !prevData.customUrl;
 
             if (wasEmpty) {
                 isInitialLoadRef.current = false;
                 prevDataStringRef.current = currentDataString;
+                prevContentStringRef.current = currentContentString;
                 return;
             }
         }
@@ -169,6 +187,7 @@ export const useAutoSave = (data: AutoSaveData, options: UseAutoSaveOptions) => 
         isInitialLoadRef.current = false;
 
         prevDataStringRef.current = currentDataString;
+        prevContentStringRef.current = currentContentString;
         setHasPendingChanges(true);
 
         if (autoSaveRef.current) clearTimeout(autoSaveRef.current);
@@ -190,21 +209,7 @@ export const useAutoSave = (data: AutoSaveData, options: UseAutoSaveOptions) => 
 
             const currentData = dataRef.current;
             if (currentData.title || currentData.content) {
-                // Auto-save uses JSON (no image), so temporarily clear image fields
-                const savedImageFile = dataRef.current.imageFile;
-                const savedImageDeleted = dataRef.current.imageDeleted;
-                dataRef.current = {
-                    ...dataRef.current,
-                    imageFile: null,
-                    imageDeleted: false
-                };
-                manualSave().finally(() => {
-                    dataRef.current = {
-                        ...dataRef.current,
-                        imageFile: savedImageFile,
-                        imageDeleted: savedImageDeleted
-                    };
-                });
+                manualSave();
             }
         }, intervalMs);
 
@@ -212,7 +217,7 @@ export const useAutoSave = (data: AutoSaveData, options: UseAutoSaveOptions) => 
             if (autoSaveRef.current) clearTimeout(autoSaveRef.current);
             if (countdownRef.current) clearInterval(countdownRef.current);
         };
-    }, [currentDataString, options.enabled, intervalMs, manualSave]);
+    }, [currentDataString, currentContentString, options.enabled, intervalMs, manualSave]);
 
     return {
         lastSaved,

--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/hooks/useFormSubmit.ts
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/hooks/useFormSubmit.ts
@@ -8,6 +8,7 @@ interface FormSubmitData {
     content: string;
     tags: string[];
     seriesId: string;
+    imageDeleted?: boolean;
 }
 
 interface UseFormSubmitOptions {
@@ -84,6 +85,11 @@ export const useFormSubmit = (options: UseFormSubmitOptions) => {
 
             if (isDraft) {
                 addHiddenField(form, 'is_draft', 'true');
+            }
+
+            if (data.imageDeleted) {
+                addHiddenField(form, 'image_delete', 'true');
+                addHiddenField(form, 'remove_image', 'true');
             }
 
             // Handle draft URL

--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/hooks/useImageUpload.ts
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/hooks/useImageUpload.ts
@@ -1,11 +1,11 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 
 export const useImageUpload = () => {
     const [imagePreview, setImagePreview] = useState<string | null>(null);
     const [imageFile, setImageFile] = useState<File | null>(null);
     const [imageDeleted, setImageDeleted] = useState(false);
 
-    const handleImageUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const handleImageUpload = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
         const file = event.target.files?.[0];
         if (file) {
             setImageFile(file);
@@ -16,17 +16,24 @@ export const useImageUpload = () => {
             };
             reader.readAsDataURL(file);
         }
-    };
+    }, []);
 
-    const handleRemoveImage = () => {
+    const handleRemoveImage = useCallback(() => {
         setImagePreview(null);
         setImageFile(null);
         setImageDeleted(true);
-    };
+    }, []);
 
-    const setImagePreviewUrl = (url: string | null) => {
+    const setImagePreviewUrl = useCallback((url: string | null) => {
         setImagePreview(url);
-    };
+        setImageFile(null);
+        setImageDeleted(false);
+    }, []);
+
+    const markImageSaved = useCallback(() => {
+        setImageFile(null);
+        setImageDeleted(false);
+    }, []);
 
     return {
         imagePreview,
@@ -34,6 +41,7 @@ export const useImageUpload = () => {
         imageDeleted,
         handleImageUpload,
         handleRemoveImage,
-        setImagePreviewUrl
+        setImagePreviewUrl,
+        markImageSaved
     };
 };

--- a/backend/src/board/services/post_service.py
+++ b/backend/src/board/services/post_service.py
@@ -743,6 +743,7 @@ class PostService:
         custom_url: Optional[str] = None,
         tag: Optional[str] = None,
         image: Optional[Any] = None,
+        image_delete: bool = False,
         is_hide: bool = False,
         is_advertise: bool = False,
         reserved_date_str: str = '',
@@ -797,7 +798,7 @@ class PostService:
         if tag is not None:
             TagService.set_post_tags(post, tag)
 
-        PostService._set_image_with_dedup(post, image)
+        PostService._set_image_with_dedup(post, image, image_delete)
 
         reserved_date = PostService.validate_reserved_date(reserved_date_str)
         if reserved_date:

--- a/backend/src/board/tests/api/test_draft.py
+++ b/backend/src/board/tests/api/test_draft.py
@@ -1,11 +1,16 @@
 import json
 from datetime import timedelta
+from io import BytesIO
 
+from PIL import Image
+
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 from django.contrib.auth.models import User
 from django.utils import timezone
 
 from board.models import Post, PostContent, PostConfig, Profile
+from board.services.post_service import PostService
 
 
 class DraftTestCase(TestCase):
@@ -34,6 +39,13 @@ class DraftTestCase(TestCase):
 
     def setUp(self):
         self.client.defaults['HTTP_USER_AGENT'] = 'BLEX_TEST'
+
+    def _create_test_image(self, name='test.jpg'):
+        image = Image.new('RGB', (10, 10), color='red')
+        buffer = BytesIO()
+        image.save(buffer, format='JPEG')
+        buffer.seek(0)
+        return SimpleUploadedFile(name, buffer.getvalue(), content_type='image/jpeg')
 
     def _create_draft(self, title='Test Draft', content='<p>Draft content</p>', tags='test'):
         """Helper to create a draft and return its URL."""
@@ -170,6 +182,62 @@ class DraftTestCase(TestCase):
         self.assertEqual(post.title, 'Updated Title')
         self.assertEqual(post.subtitle, 'My subtitle')
         self.assertIsNone(post.published_date)
+
+    def test_create_draft_with_image(self):
+        """이미지를 포함한 임시저장이 타이틀 이미지를 유지한다."""
+        self.client.login(username='test', password='test')
+
+        response = self.client.post('/v1/drafts', {
+            'title': 'Image Draft',
+            'content': '<p>content</p>',
+            'image': self._create_test_image('draft-title.jpg'),
+        })
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'DONE')
+
+        post = Post.objects.get(url=content['body']['url'])
+        self.assertTrue(post.image)
+        self.assertIn('images/title/', post.image.name)
+
+    def test_update_draft_delete_image(self):
+        """임시글 이미지 삭제 플래그가 타이틀 이미지를 제거한다."""
+        url = self._create_draft(title='Delete Image Draft')
+        post = Post.objects.get(url=url)
+        post.image = self._create_test_image('draft-delete.jpg')
+        post.save()
+        self.assertTrue(post.image)
+
+        response = self.client.put(
+            f'/v1/drafts/{url}',
+            json.dumps({'image_delete': 'true'}),
+            content_type='application/json'
+        )
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'DONE')
+
+        post.refresh_from_db()
+        self.assertFalse(post.image)
+
+    def test_publish_draft_delete_image(self):
+        """이미지 삭제 상태로 임시글을 발행하면 기존 타이틀 이미지를 제거한다."""
+        url = self._create_draft(title='Publish Delete Image Draft')
+        post = Post.objects.get(url=url)
+        post.image = self._create_test_image('draft-publish-delete.jpg')
+        post.save()
+        self.assertTrue(post.image)
+
+        PostService.publish_draft(
+            post=post,
+            title=post.title,
+            text_html=post.content.content_html,
+            image_delete=True,
+        )
+
+        post.refresh_from_db()
+        self.assertTrue(post.is_published())
+        self.assertFalse(post.image)
 
     def test_update_draft_custom_url_changes_lookup_key(self):
         """드래프트 URL 변경 시 식별 URL이 갱신되어야 함"""

--- a/backend/src/board/views/post.py
+++ b/backend/src/board/views/post.py
@@ -151,6 +151,7 @@ def post_editor(request, username=None, post_url=None):
         hide = request.POST.get('hide') in ['on', 'true']
         advertise = request.POST.get('advertise') in ['on', 'true']
         is_draft = request.POST.get('is_draft') == 'true'
+        image_delete = request.POST.get('image_delete') == 'true' or request.POST.get('remove_image') == 'true'
 
         series = None
         if series_id:
@@ -163,8 +164,8 @@ def post_editor(request, username=None, post_url=None):
             image = None
             if 'image' in request.FILES:
                 image = request.FILES['image']
-            elif request.POST.get('remove_image') == 'true':
-                image = None  # This will be handled separately
+            elif image_delete:
+                image = None
 
             PostService.update_post(
                 post=post,
@@ -175,14 +176,11 @@ def post_editor(request, username=None, post_url=None):
                 series_url=series.url if series else None,
                 tag=','.join(tags) if tags else None,
                 image=image,
+                image_delete=image_delete,
                 is_hide=hide,
                 is_advertise=advertise,
                 content_type=content_type,
             )
-
-            if request.POST.get('remove_image') == 'true':
-                post.image = None
-                post.save()
 
             messages.success(request, 'Post has been updated successfully.')
         else:
@@ -209,6 +207,7 @@ def post_editor(request, username=None, post_url=None):
                         custom_url=url,
                         tag=','.join(tags) if tags else '',
                         image=image,
+                        image_delete=image_delete,
                         is_hide=hide,
                         is_advertise=advertise,
                         content_type=content_type,


### PR DESCRIPTION
## 🎯 Goal
- Fix post editor draft flows where title image changes could be lost or ignored during autosave/manual save/publish.
- Keep draft save behavior consistent so users do not lose cover/title image state while editing.

## 🔧 Core Changes
- Include title image upload and delete state in the draft autosave payload.
- Track the full editor dirty snapshot instead of only title/content/tags.
- Preserve image delete intent when publishing a draft or submitting the editor form.
- Add draft API coverage for creating drafts with images, deleting draft images, and publishing drafts after image deletion.

## 🤔 Key Decisions
- Reused the existing draft payload builder so autosave can send FormData only when file/delete state is present.
- Moved delete-image handling through `PostService` rather than patching the model directly in the view.
- Aligned manual draft save with autosave by allowing the backend/default payload behavior to handle empty titles.

## 🧪 Verification Guide
### How to verify
1. Create or edit a draft, set a title image, and wait for autosave.
2. Reload the editor and confirm the title image remains visible.
3. Remove the title image from a draft, save/publish it, and confirm the image stays removed.

### Expected result
- Draft title images are preserved after autosave/manual save, and explicit image deletion is respected through publish.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)
