### PR TITLE
⚡ Optimize author post and interest feeds

### DIFF
--- a/backend/src/board/services/user_service.py
+++ b/backend/src/board/services/user_service.py
@@ -356,21 +356,22 @@ class UserService:
     @staticmethod
     def get_user_interested_posts(user: User) -> QuerySet[Post]:
         """Return public posts the user marked as interesting, newest mark first."""
+        interested_posts = PostLikes.objects.filter(
+            post__id=OuterRef('id'),
+            user=user,
+        )
         return PublicPostService.filter_public_posts(
             Post.objects.select_related(
                 'config', 'series', 'author', 'author__profile'
-            ).filter(likes__user=user)
+            ).filter(
+                Exists(interested_posts)
+            )
         ).annotate(
             author_username=F('author__username'),
             author_image=F('author__profile__avatar'),
             count_likes=Count('likes', distinct=True),
             count_comments=Count('comments', distinct=True),
-            has_liked=Exists(
-                PostLikes.objects.filter(
-                    post__id=OuterRef('id'),
-                    user=user,
-                )
-            ),
+            has_liked=Exists(interested_posts),
             interested_date=Max('likes__created_date', filter=Q(likes__user=user)),
         ).order_by('-interested_date', '-published_date')
 

--- a/backend/src/board/templates/board/author/author_posts.html
+++ b/backend/src/board/templates/board/author/author_posts.html
@@ -24,15 +24,9 @@
                 {% include 'components/search_query_filter.html' with placeholder='포스트 검색' %}
             </div>
 
-            <div class="grid w-full grid-cols-2 gap-3 lg:w-auto">
-                <div class="min-w-0 lg:w-40">
-                    <label class="mb-2 ml-1 block text-xs font-semibold text-content-secondary">정렬</label>
-                    {% include 'components/dropdown_filter.html' with options=sort_options param_name='sort' current_value=request.GET.sort|default:'recent' %}
-                </div>
-                <div class="min-w-0 lg:w-44">
-                    <label class="mb-2 ml-1 block text-xs font-semibold text-content-secondary">태그</label>
-                    {% include 'components/dropdown_filter.html' with options=tag_options param_name='tag' current_value=request.GET.tag|default:'' %}
-                </div>
+            <div class="w-full lg:w-44">
+                <label class="mb-2 ml-1 block text-xs font-semibold text-content-secondary">태그</label>
+                {% include 'components/dropdown_filter.html' with options=tag_options param_name='tag' current_value=request.GET.tag|default:'' %}
             </div>
         </div>
     </div>

--- a/backend/src/board/templates/board/posts/interested_posts.html
+++ b/backend/src/board/templates/board/posts/interested_posts.html
@@ -8,15 +8,11 @@
 
 {% block content %}
 <div class="max-w-7xl mx-auto mt-6 px-4 md:px-6">
-    <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between mb-6">
-        <div class="inline-flex w-fit bg-surface-subtle/80 backdrop-blur-sm p-1 rounded-xl ring-1 ring-line/60">
-            <a href="/" class="px-4 py-1.5 text-content-secondary hover:text-content rounded-lg text-xs font-bold transition-all duration-150">
-                전체
-            </a>
-            <a href="/interests" class="px-4 py-1.5 bg-surface-elevated text-content shadow-sm rounded-lg text-xs font-bold transition-all duration-150">
-                관심
-            </a>
-        </div>
+    <div class="mb-6 flex justify-end">
+        <a href="/" class="inline-flex items-center gap-2 rounded-full bg-surface px-4 py-2 text-sm font-semibold text-content-secondary ring-1 ring-line/60 transition-colors duration-150 hover:bg-surface-subtle hover:text-content">
+            <i class="fas fa-arrow-left text-xs text-content-hint"></i>
+            <span>전체 포스트</span>
+        </a>
     </div>
 
     <div class="mb-8">

--- a/backend/src/board/templates/board/posts/post_list.html
+++ b/backend/src/board/templates/board/posts/post_list.html
@@ -11,15 +11,11 @@
 {% block content %}
 <div class="max-w-7xl mx-auto mt-6 px-4 md:px-6">
     {% if user.is_authenticated %}
-    <div class="mb-6">
-        <div class="inline-flex w-fit bg-surface-subtle/80 backdrop-blur-sm p-1 rounded-xl ring-1 ring-line/60">
-            <a href="/" class="px-4 py-1.5 bg-surface-elevated text-content shadow-sm rounded-lg text-xs font-bold transition-all duration-150">
-                전체
-            </a>
-            <a href="/interests" class="px-4 py-1.5 text-content-secondary hover:text-content rounded-lg text-xs font-bold transition-all duration-150">
-                관심
-            </a>
-        </div>
+    <div class="mb-6 flex justify-end">
+        <a href="/interests" class="inline-flex items-center gap-2 rounded-full bg-surface px-4 py-2 text-sm font-semibold text-content-secondary ring-1 ring-line/60 transition-colors duration-150 hover:bg-surface-subtle hover:text-content">
+            <i class="far fa-heart text-xs text-content-hint"></i>
+            <span>관심 포스트</span>
+        </a>
     </div>
     {% endif %}
 

--- a/backend/src/board/tests/templates/test_author.py
+++ b/backend/src/board/tests/templates/test_author.py
@@ -85,8 +85,8 @@ class AuthorPostsPageTestCase(TestCase):
         self.assertContains(response, '포스트 검색')
         self.assertContains(response, '태그')
         self.assertContains(response, 'masonry-grid')
-        self.assertContains(response, 'min-w-0 lg:w-40')
-        self.assertContains(response, 'min-w-0 lg:w-44')
+        self.assertNotContains(response, '정렬')
+        self.assertContains(response, 'lg:w-44')
         self.assertContains(response, 'relative w-full')
         self.assertContains(response, 'flex w-full items-center justify-between')
         self.assertNotContains(response, 'sm:w-48')
@@ -469,7 +469,7 @@ class AuthorPostsPageTestCase(TestCase):
         required_fields = [
             'author', 'posts', 'post_count', 'series_count',
             'page_number', 'page_count', 'author_tags',
-            'search_query', 'sort_option', 'tag_filter'
+            'search_query', 'tag_filter'
         ]
 
         for field in required_fields:
@@ -492,29 +492,13 @@ class AuthorPostsPageTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context['tag_filter'], 'python')
 
-    def test_author_posts_page_sorting_recent(self):
-        """작가 포스트 페이지 최신순 정렬 테스트"""
-        response = self.client.get(
-            reverse('user_posts', kwargs={'username': self.user.username}) + '?sort=recent'
-        )
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.context['sort_option'], 'recent')
-
-    def test_author_posts_page_sorting_popular(self):
-        """작가 포스트 페이지 인기순 정렬 테스트"""
+    def test_author_posts_page_ignores_legacy_sort_parameter(self):
+        """작가 포스트 페이지는 최신순 고정이며 legacy sort 파라미터를 노출하지 않는다."""
         response = self.client.get(
             reverse('user_posts', kwargs={'username': self.user.username}) + '?sort=popular'
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.context['sort_option'], 'popular')
-
-    def test_author_posts_page_sorting_comments(self):
-        """작가 포스트 페이지 댓글 많은 순 정렬 테스트"""
-        response = self.client.get(
-            reverse('user_posts', kwargs={'username': self.user.username}) + '?sort=comments'
-        )
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.context['sort_option'], 'comments')
+        self.assertNotIn('sort_option', response.context)
 
     def test_nonexistent_author_returns_404(self):
         """존재하지 않는 작가 페이지 접근 시 404 반환"""

--- a/backend/src/board/tests/templates/test_interested_posts.py
+++ b/backend/src/board/tests/templates/test_interested_posts.py
@@ -29,6 +29,13 @@ class InterestedPostsTemplateTestCase(TestCase):
         )
         Profile.objects.create(user=cls.author, role=Profile.Role.EDITOR)
 
+        cls.other_reader = User.objects.create_user(
+            username='other_reader',
+            email='other-reader@example.com',
+            password='testpass123',
+        )
+        Profile.objects.create(user=cls.other_reader, role=Profile.Role.READER)
+
         cls.first_post = cls._create_post('First Interested Post', 'first-interested-post')
         cls.second_post = cls._create_post('Second Interested Post', 'second-interested-post')
         cls.hidden_post = cls._create_post('Hidden Interested Post', 'hidden-interested-post', hide=True)
@@ -42,6 +49,11 @@ class InterestedPostsTemplateTestCase(TestCase):
             post=cls.first_post,
             user=cls.reader,
             created_date=timezone.now() - timezone.timedelta(days=1),
+        )
+        PostLikes.objects.create(
+            post=cls.first_post,
+            user=cls.other_reader,
+            created_date=timezone.now() - timezone.timedelta(hours=12),
         )
         PostLikes.objects.create(
             post=cls.second_post,
@@ -82,9 +94,20 @@ class InterestedPostsTemplateTestCase(TestCase):
         self.assertTemplateUsed(response, 'board/posts/interested_posts.html')
         self.assertContains(response, '관심 포스트')
         self.assertContains(response, 'href=/')
-        self.assertContains(response, 'href=/interests')
+        self.assertContains(response, '전체 포스트')
         self.assertContains(response, 'First Interested Post')
         self.assertContains(response, 'Second Interested Post')
+
+
+    def test_interested_posts_keep_total_like_counts(self):
+        self.client.login(username='reader', password='testpass123')
+
+        response = self.client.get(reverse('interested_posts'))
+        posts = {post.url: post for post in response.context['posts']}
+
+        self.assertEqual(posts['first-interested-post'].count_likes, 2)
+        self.assertTrue(posts['first-interested-post'].has_liked)
+        self.assertEqual(posts['second-interested-post'].count_likes, 1)
 
     def test_interested_posts_filters_non_public_posts(self):
         self.client.login(username='reader', password='testpass123')

--- a/backend/src/board/views/author.py
+++ b/backend/src/board/views/author.py
@@ -2,7 +2,7 @@ import json
 
 from django.contrib.auth.models import User
 from django.contrib.auth.decorators import login_required
-from django.db.models import Count, Exists, OuterRef, Q, F
+from django.db.models import Count, Q
 from django.shortcuts import render, get_object_or_404, redirect
 from django.http import JsonResponse
 
@@ -11,7 +11,7 @@ from board.modules.time import time_since
 from board.services.user_service import UserService
 from board.services.public_post_service import PublicPostService
 from board.services.public_series_service import PublicSeriesService
-from board.models import Post, Series, PostLikes, Tag, Profile, SiteNotice, SiteContentScope
+from board.models import Comment, Post, Series, PostLikes, Tag, Profile, SiteNotice, SiteContentScope
 from modules import markdown
 
 
@@ -84,64 +84,37 @@ def author_posts(request, username):
     
     # Get search query and filters
     search_query = request.GET.get('q', '')
-    sort_option = request.GET.get('sort', 'recent')
     tag_filter = request.GET.get('tag', '')
 
     posts = PublicPostService.filter_public_posts(
         Post.objects.select_related(
-            'config', 'series', 'author', 'author__profile', 'content'
+            'config', 'series', 'author', 'author__profile'
         )
     ).filter(
         author=author,
     )
-    
+
     if search_query:
         posts = posts.filter(
-            Q(title__icontains=search_query) | 
-            Q(content__content_html__icontains=search_query) | 
+            Q(title__icontains=search_query) |
             Q(content__content_html__icontains=search_query)
         )
-    
+
     if tag_filter:
-        posts = posts.filter(tags__value=tag_filter)
-    
-    posts = posts.annotate(
-        author_username=F('author__username'),
-        author_image=F('author__profile__avatar'),
-        count_likes=Count('likes', distinct=True),
-        count_comments=Count('comments', distinct=True),
-        has_liked=Exists(
-            PostLikes.objects.filter(
-                post__id=OuterRef('id'),
-                user__id=request.user.id if request.user.id else -1
-            )
-        ),
-    )
-    
-    if sort_option == 'popular':
-        posts = posts.order_by('-count_likes', '-published_date')
-    elif sort_option == 'comments':
-        posts = posts.order_by('-count_comments', '-published_date')
-    else:  # default to 'recent'
-        posts = posts.order_by('-published_date')
-    
-    series = PublicSeriesService.filter_public_series(
-        Series.objects.filter(owner__username=username),
-        'count_posts',
-    ).order_by('-updated_date')
-    
+        posts = posts.filter(tags__value=tag_filter).distinct()
+
+    posts = posts.order_by('-published_date')
+
     public_author_tag_filter = PublicPostService.build_public_filter('posts') & Q(
         posts__author=author,
     )
     author_tags = Tag.objects.filter(
         public_author_tag_filter
-    ).annotate(
-        count=Count('posts', filter=public_author_tag_filter, distinct=True)
-    ).order_by('-count', 'value')
+    ).distinct().order_by('value')
 
-    tag_options = [{'value': '', 'label': '전체 태그'}] # Default option
+    tag_options = [{'value': '', 'label': '전체 태그'}]
     for tag in author_tags:
-        tag_options.append({'value': tag.value, 'label': f'{tag.value} ({tag.count})'})
+        tag_options.append({'value': tag.value, 'label': tag.value})
 
     page = int(request.GET.get('page', 1))
     paginated_posts = Paginator(
@@ -150,17 +123,37 @@ def author_posts(request, username):
         page=page
     )
 
-    # paginator에서 total count 가져오기 (별도 쿼리 불필요)
     post_count = paginated_posts.paginator.count
-    series_count = series.count()
-    
-    sort_options = [
-        {'value': 'recent', 'label': '최신순'},
-        {'value': 'popular', 'label': '인기순'},
-        {'value': 'comments', 'label': '댓글 많은 순'}
-    ]
+    series_count = PublicSeriesService.filter_public_series(
+        Series.objects.filter(owner=author),
+        'count_posts',
+    ).count()
 
-    for post in paginated_posts:
+    page_posts = list(paginated_posts)
+    post_ids = [post.id for post in page_posts]
+    like_counts = {
+        item['post_id']: item['count']
+        for item in PostLikes.objects.filter(post_id__in=post_ids)
+        .values('post_id')
+        .annotate(count=Count('id'))
+    }
+    comment_counts = {
+        item['post_id']: item['count']
+        for item in Comment.objects.filter(post_id__in=post_ids)
+        .values('post_id')
+        .annotate(count=Count('id'))
+    }
+    liked_post_ids = set()
+    if request.user.is_authenticated:
+        liked_post_ids = set(
+            PostLikes.objects.filter(post_id__in=post_ids, user=request.user)
+            .values_list('post_id', flat=True)
+        )
+
+    for post in page_posts:
+        post.count_likes = like_counts.get(post.id, 0)
+        post.count_comments = comment_counts.get(post.id, 0)
+        post.has_liked = post.id in liked_post_ids
         post.time_display = time_since(post.published_date)
 
     context = {
@@ -172,10 +165,8 @@ def author_posts(request, username):
         'page_count': paginated_posts.paginator.num_pages,
         'author_tags': author_tags,
         'search_query': search_query,
-        'sort_option': sort_option,
         'tag_filter': tag_filter,
         'tag_options': tag_options,
-        'sort_options': sort_options,
         'author_activity_props': json.dumps({'username': author.username}),
     }
     


### PR DESCRIPTION
## Summary
- Optimize the author posts page by removing the legacy sort selector and heavy pre-pagination like/comment aggregations.
- Count likes and comments only for posts on the current author-posts page.
- Remove the always-on post content join from author post lists unless search needs it.
- Fix interested-post like counts so they show total likes, not just the current user's like.
- Replace the main feed `All / Interest` segment with a smaller interest-posts link, and add a back link from the interest page.

## Tests
- `npm run server:test -- board.tests.templates.test_interested_posts board.tests.templates.test_author.AuthorPostsPageTestCase`
