### PR TITLE
✨ Add first post publishing flow

### DIFF
--- a/backend/islands/apps/remotes/package.json
+++ b/backend/islands/apps/remotes/package.json
@@ -29,6 +29,7 @@
         "@tanstack/react-router": "^1.162.4",
         "alpinejs": "^3.15.8",
         "axios": "^1.16.0",
+        "driver.js": "^1.4.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-hook-form": "^7.71.2",

--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/NewPostEditor.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/NewPostEditor.tsx
@@ -17,6 +17,8 @@ import PublishChecklist from './components/PublishChecklist';
 import { useAutoSave } from './hooks/useAutoSave';
 import { useImageUpload } from './hooks/useImageUpload';
 import { useFormSubmit } from './hooks/useFormSubmit';
+import { Info } from '@blex/ui/icons';
+import { startFirstPublishTour as startFirstPublishTourDriver } from './utils/firstPublishTour';
 import { getPublishChecklist } from './utils/publishChecklist';
 import { getSeries } from '~/lib/api/settings';
 import { getDraft } from '~/lib/api/posts';
@@ -25,6 +27,7 @@ import type { Series } from './types';
 
 interface NewPostEditorProps {
     draftUrl?: string;
+    showFirstPublishGuide?: boolean;
 }
 
 const normalizeUrlInput = (value: string) => {
@@ -44,7 +47,10 @@ const generateUrlFromTitle = (title: string) => {
     return normalizeUrlForSubmit(title);
 };
 
-const NewPostEditor = ({ draftUrl }: NewPostEditorProps) => {
+const NewPostEditor = ({
+    draftUrl,
+    showFirstPublishGuide = false
+}: NewPostEditorProps) => {
     const { confirm } = useConfirm();
     const [isLoading, setIsLoading] = useState(true);
     const [seriesList, setSeriesList] = useState<Series[]>([]);
@@ -89,6 +95,7 @@ const NewPostEditor = ({ draftUrl }: NewPostEditorProps) => {
     // Track initial state for dirty check
     const initialDataRef = useRef<DirtySnapshot | null>(null);
     const isIntentionalSubmitRef = useRef(false);
+    const firstPublishGuideButtonRef = useRef<HTMLButtonElement>(null);
 
     // Custom hooks
     const {
@@ -200,8 +207,11 @@ const NewPostEditor = ({ draftUrl }: NewPostEditorProps) => {
         content: formData.content,
         description: formData.metaDescription,
         tags,
-        hasCoverImage: Boolean(imagePreview)
-    }), [formData.title, formData.content, formData.metaDescription, tags, imagePreview]);
+        hasCoverImage: Boolean(imagePreview),
+        isHidden: formData.hide
+    }), [formData.title, formData.content, formData.metaDescription, formData.hide, tags, imagePreview]);
+
+    const shouldShowFirstPublishGuide = !isLoading && showFirstPublishGuide;
 
     // Fetch series list and draft data if draftUrl exists
     useEffect(() => {
@@ -336,6 +346,14 @@ const NewPostEditor = ({ draftUrl }: NewPostEditorProps) => {
         }
     };
 
+    const handleStartFirstPublishGuide = async () => {
+        try {
+            await startFirstPublishTourDriver({ returnFocusTo: firstPublishGuideButtonRef.current });
+        } catch {
+            toast.error('가이드를 불러오는데 실패했습니다.');
+        }
+    };
+
     const handleTitleChange = (title: string) => {
         setFormData(prev => ({
             ...prev,
@@ -402,6 +420,21 @@ const NewPostEditor = ({ draftUrl }: NewPostEditorProps) => {
 
     return (
         <PostEditorWrapper>
+            {shouldShowFirstPublishGuide && (
+                <div className="mb-4 flex justify-end">
+                    <button
+                        ref={firstPublishGuideButtonRef}
+                        type="button"
+                        onClick={handleStartFirstPublishGuide}
+                        className="inline-flex min-h-11 items-center justify-center gap-2 rounded-full border border-line bg-surface px-3.5 py-2 text-sm font-medium text-content-secondary shadow-subtle transition-all duration-150 hover:bg-surface-elevated hover:text-content active:scale-95"
+                        aria-label="첫 발행 가이드 열기"
+                        title="첫 발행 가이드 열기">
+                        <Info className="h-4 w-4 shrink-0" />
+                        <span>첫 발행 가이드</span>
+                    </button>
+                </div>
+            )}
+
             <PostForm
                 formRef={formRef}
                 isLoading={isLoading}

--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/PostEditor.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/PostEditor.tsx
@@ -8,13 +8,15 @@ interface PostEditorProps {
     username?: string;
     postUrl?: string;
     draftUrl?: string;
+    showFirstPublishGuide?: boolean;
 }
 
 const PostEditor = ({
     mode,
     username,
     postUrl,
-    draftUrl
+    draftUrl,
+    showFirstPublishGuide = false
 }: PostEditorProps) => {
     if (mode === 'edit' && (!username || !postUrl)) {
         return (
@@ -61,7 +63,7 @@ const PostEditor = ({
     switch (mode) {
         case 'new':
         case 'draft':
-            return <NewPostEditor draftUrl={draftUrl} />;
+            return <NewPostEditor draftUrl={draftUrl} showFirstPublishGuide={showFirstPublishGuide} />;
 
         case 'edit':
             return <EditPostEditor username={username!} postUrl={postUrl!} />;

--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/components/PostActions.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/components/PostActions.tsx
@@ -41,6 +41,7 @@ const PostActions = ({
     onOpenSettings
 }: PostActionsProps) => {
     const isEdit = mode === 'edit';
+    const submitLabel = isEdit ? '수정' : '발행';
     const [, setTick] = useState(0);
 
     // Update time display every 30 seconds
@@ -69,7 +70,8 @@ const PostActions = ({
                     onClick={onOpenSettings}
                     rounded="full"
                     aria-label="게시 설정"
-                    title="게시 설정">
+                    title="게시 설정"
+                    data-tour="post-settings">
                     <SlidersHorizontal className="w-5 h-5" />
                 </IconButton>
             )}
@@ -80,7 +82,10 @@ const PostActions = ({
                     <div className="w-px h-8 bg-line/50 mx-1" />
 
                     {/* Autosave Status */}
-                    <div className="flex items-center gap-1.5 px-1 text-xs text-content-hint" aria-live="polite">
+                    <div
+                        className="flex items-center gap-1.5 px-1 text-xs text-content-hint"
+                        aria-live="polite"
+                        data-tour="post-autosave">
                         {isSaving ? (
                             <>
                                 <div className="w-1.5 h-1.5 rounded-full bg-line-strong animate-pulse" />
@@ -109,7 +114,7 @@ const PostActions = ({
                         ) : (
                             <>
                                 <div className="w-1.5 h-1.5 rounded-full bg-line-strong" />
-                                <span>변경 사항 없음</span>
+                                <span>자동 저장 켜짐</span>
                             </>
                         )}
                     </div>
@@ -132,8 +137,9 @@ const PostActions = ({
                 disabled={isSubmitting || isSaving}
                 variant="primary"
                 className="!rounded-full"
-                leftIcon={<Send className="w-4 h-4" />}>
-                {isEdit ? '수정' : '게시'}
+                leftIcon={<Send className="w-4 h-4" />}
+                data-tour="post-publish">
+                {submitLabel}
             </Button>
         </FloatingBottomBar>
     );

--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/components/PublishChecklist.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/components/PublishChecklist.tsx
@@ -61,6 +61,13 @@ const PublishChecklist = ({
                     <p className="text-sm leading-relaxed text-content-secondary">{description}</p>
                 </div>
 
+                <div className="rounded-xl border border-line bg-surface-subtle px-4 py-3">
+                    <p className="text-sm font-semibold text-content">{result.visibilityTitle}</p>
+                    <p className="mt-1 text-xs leading-relaxed text-content-secondary">
+                        {result.visibilityDescription}
+                    </p>
+                </div>
+
                 <div className="space-y-2" aria-live="polite">
                     {result.items.map(item => (
                         <div

--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/utils/firstPublishTour.css
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/utils/firstPublishTour.css
@@ -1,0 +1,110 @@
+.driver-popover.blex-first-publish-tour {
+    width: min(320px, calc(100vw - 32px));
+    max-width: min(320px, calc(100vw - 32px));
+    border: 1px solid var(--color-line);
+    border-radius: 12px;
+    background: var(--color-surface);
+    color: var(--color-content);
+    box-shadow: 0 24px 64px rgba(0, 0, 0, 0.22);
+    padding: 16px;
+}
+
+.driver-popover.blex-first-publish-tour * {
+    font-family: inherit;
+}
+
+.driver-popover.blex-first-publish-tour .driver-popover-title {
+    color: var(--color-content);
+    font-size: 15px;
+    font-weight: 650;
+    line-height: 1.45;
+    padding-right: 36px;
+}
+
+.driver-popover.blex-first-publish-tour .driver-popover-description {
+    color: var(--color-content-secondary);
+    font-size: 13px;
+    line-height: 1.65;
+    margin-top: 6px;
+}
+
+.driver-popover.blex-first-publish-tour .driver-popover-close-btn {
+    color: var(--color-content-hint);
+    min-height: 44px;
+    min-width: 44px;
+    border-radius: 8px;
+    line-height: 44px;
+    transition: color 150ms ease, background-color 150ms ease;
+}
+
+.driver-popover.blex-first-publish-tour .driver-popover-close-btn:hover,
+.driver-popover.blex-first-publish-tour .driver-popover-close-btn:focus {
+    background: var(--color-surface-subtle);
+    color: var(--color-content);
+}
+
+.driver-popover.blex-first-publish-tour .driver-popover-footer {
+    gap: 12px;
+    margin-top: 16px;
+}
+
+.driver-popover.blex-first-publish-tour .driver-popover-progress-text {
+    color: var(--color-content-hint);
+    font-size: 12px;
+}
+
+.driver-popover.blex-first-publish-tour .driver-popover-navigation-btns {
+    gap: 6px;
+}
+
+.driver-popover.blex-first-publish-tour .driver-popover-footer button {
+    min-height: 44px;
+    border: 1px solid var(--color-line);
+    border-radius: 8px;
+    background: var(--color-surface);
+    color: var(--color-content-secondary);
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 1;
+    padding: 0 14px;
+    text-shadow: none;
+    transition: transform 150ms ease, background-color 150ms ease, color 150ms ease;
+}
+
+.driver-popover.blex-first-publish-tour .driver-popover-footer button:hover,
+.driver-popover.blex-first-publish-tour .driver-popover-footer button:focus {
+    background: var(--color-surface-subtle);
+    color: var(--color-content);
+}
+
+.driver-popover.blex-first-publish-tour .driver-popover-footer button:active {
+    transform: scale(0.96);
+}
+
+.driver-popover.blex-first-publish-tour .driver-popover-navigation-btns button:last-child {
+    border-color: var(--color-action);
+    background: var(--color-action);
+    color: var(--color-content-inverted);
+}
+
+.driver-popover.blex-first-publish-tour .driver-popover-navigation-btns button:last-child:hover,
+.driver-popover.blex-first-publish-tour .driver-popover-navigation-btns button:last-child:focus {
+    background: var(--color-action-hover);
+    color: var(--color-content-inverted);
+}
+
+.driver-popover.blex-first-publish-tour .driver-popover-arrow-side-left {
+    border-left-color: var(--color-surface);
+}
+
+.driver-popover.blex-first-publish-tour .driver-popover-arrow-side-right {
+    border-right-color: var(--color-surface);
+}
+
+.driver-popover.blex-first-publish-tour .driver-popover-arrow-side-top {
+    border-top-color: var(--color-surface);
+}
+
+.driver-popover.blex-first-publish-tour .driver-popover-arrow-side-bottom {
+    border-bottom-color: var(--color-surface);
+}

--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/utils/firstPublishTour.ts
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/utils/firstPublishTour.ts
@@ -1,0 +1,102 @@
+import type { DriveStep } from 'driver.js';
+
+const tourTargets = {
+    settings: '[data-tour="post-settings"]',
+    autosave: '[data-tour="post-autosave"]',
+    publish: '[data-tour="post-publish"]'
+};
+
+const hasTarget = (selector: string) => Boolean(document.querySelector(selector));
+
+interface StartFirstPublishTourOptions {
+    returnFocusTo?: HTMLElement | null;
+}
+
+const getOverlayColor = () => {
+    const color = getComputedStyle(document.documentElement)
+        .getPropertyValue('--color-content')
+        .trim();
+
+    return color || '#020617';
+};
+
+const getSteps = (): DriveStep[] => {
+    const steps: DriveStep[] = [
+        {
+            element: tourTargets.autosave,
+            popover: {
+                title: '작성 내용은 자동으로 저장됩니다',
+                description: '잠시 멈춰도 임시 글로 남습니다. 바로 저장하고 싶을 때만 임시 저장을 누르세요.',
+                side: 'top',
+                align: 'center'
+            }
+        },
+        {
+            element: tourTargets.settings,
+            popover: {
+                title: '선택 항목은 나중에 정해도 됩니다',
+                description: 'URL, 설명, 시리즈, 비공개 여부는 여기에서 바꿉니다. 설명, 태그, 커버 이미지는 비워도 발행할 수 있습니다.',
+                side: 'top',
+                align: 'center'
+            }
+        },
+        {
+            element: tourTargets.publish,
+            popover: {
+                title: '발행 전 한 번 더 확인합니다',
+                description: '제목과 본문 같은 필수 항목만 막습니다. 권장 항목은 나중에 보완해도 됩니다.',
+                side: 'top',
+                align: 'end'
+            }
+        }
+    ];
+
+    return steps.filter(step => typeof step.element !== 'string' || hasTarget(step.element));
+};
+
+export const startFirstPublishTour = async (options: StartFirstPublishTourOptions = {}) => {
+    const steps = getSteps();
+
+    if (steps.length === 0) {
+        return;
+    }
+
+    const [{ driver }] = await Promise.all([
+        import('driver.js'),
+        import('driver.js/dist/driver.css'),
+        import('./firstPublishTour.css')
+    ]);
+
+    const firstPublishTour = driver({
+        steps,
+        animate: true,
+        allowClose: true,
+        allowKeyboardControl: true,
+        disableActiveInteraction: true,
+        overlayClickBehavior: 'close',
+        overlayColor: getOverlayColor(),
+        overlayOpacity: 0.58,
+        popoverClass: 'blex-first-publish-tour',
+        popoverOffset: 12,
+        progressText: '{{current}} / {{total}}',
+        showButtons: ['previous', 'next', 'close'],
+        showProgress: true,
+        smoothScroll: true,
+        stagePadding: 8,
+        stageRadius: 10,
+        nextBtnText: '다음',
+        prevBtnText: '이전',
+        doneBtnText: '끝내기',
+        onPopoverRender: (popover) => {
+            popover.closeButton.setAttribute('aria-label', '가이드 닫기');
+        },
+        onNextClick: (_, __, { driver: activeDriver }) => {
+            activeDriver.moveNext();
+        },
+        onDestroyed: () => {
+            options.returnFocusTo?.focus({ preventScroll: true });
+        }
+    });
+
+    firstPublishTour.drive();
+};

--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/utils/publishChecklist.ts
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/utils/publishChecklist.ts
@@ -15,6 +15,7 @@ export interface PublishChecklistInput {
     description: string;
     tags: string[];
     hasCoverImage: boolean;
+    isHidden: boolean;
 }
 
 export interface PublishChecklistResult {
@@ -22,6 +23,8 @@ export interface PublishChecklistResult {
     missingRequired: PublishChecklistItem[];
     missingRecommended: PublishChecklistItem[];
     canPublish: boolean;
+    visibilityTitle: string;
+    visibilityDescription: string;
 }
 
 const hasText = (value: string) => value.trim().length > 0;
@@ -58,21 +61,21 @@ export const getPublishChecklist = (input: PublishChecklistInput): PublishCheckl
         {
             id: 'description',
             label: '설명',
-            description: '검색과 공유 화면에서 글을 설명합니다.',
+            description: '검색 결과와 공유 화면에서 글을 설명합니다. 비워도 발행은 가능합니다.',
             severity: 'recommended',
             status: hasText(input.description) ? 'pass' : 'missing'
         },
         {
             id: 'tags',
             label: '태그',
-            description: '관련 글을 찾기 쉽게 만듭니다.',
+            description: '관련 글을 묶고 독자가 비슷한 글을 찾기 쉽게 만듭니다.',
             severity: 'recommended',
             status: input.tags.length > 0 ? 'pass' : 'missing'
         },
         {
             id: 'coverImage',
             label: '커버 이미지',
-            description: '목록과 공유 카드에서 글의 첫인상을 만듭니다.',
+            description: '목록과 공유 카드에서 글의 첫인상을 만듭니다. 본문 이미지를 대신 쓰지는 않습니다.',
             severity: 'recommended',
             status: input.hasCoverImage ? 'pass' : 'missing'
         }
@@ -80,11 +83,17 @@ export const getPublishChecklist = (input: PublishChecklistInput): PublishCheckl
 
     const missingRequired = items.filter(item => item.severity === 'required' && item.status === 'missing');
     const missingRecommended = items.filter(item => item.severity === 'recommended' && item.status === 'missing');
+    const visibilityTitle = input.isHidden ? '비공개로 발행됩니다' : '공개로 발행됩니다';
+    const visibilityDescription = input.isHidden
+        ? '작성자만 볼 수 있으며 공개 URL, RSS, Sitemap, Markdown 노출에서 제외됩니다.'
+        : '발행 후 공개 URL에서 바로 확인할 수 있고 RSS와 Sitemap에 반영됩니다.';
 
     return {
         items,
         missingRequired,
         missingRecommended,
-        canPublish: missingRequired.length === 0
+        canPublish: missingRequired.length === 0,
+        visibilityTitle,
+        visibilityDescription
     };
 };

--- a/backend/islands/pnpm-lock.yaml
+++ b/backend/islands/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       axios:
         specifier: ^1.16.0
         version: 1.16.0
+      driver.js:
+        specifier: ^1.4.0
+        version: 1.4.0
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -820,36 +823,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.6':
     resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
@@ -1449,24 +1458,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.1':
     resolution: {integrity: sha512-WZA0CHRL/SP1TRbA5mp9htsppSEkWuQ4KsSUumYQnyl8ZdT39ntwqmz4IUHGN6p4XdSlYfJwM4rRzZLShHsGAQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.1':
     resolution: {integrity: sha512-qMFzxI2YlBOLW5PhblzuSWlWfwLHaneBE0xHzLrBgNtqN6mWfs+qYbhryGSXQjFYB1Dzf5w+LN5qbUTPhW7Y5g==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.1':
     resolution: {integrity: sha512-5r1X2FKnCMUPlXTWRYpHdPYUY6a1Ar/t7P24OuiEdEOmms5lyqjDRvVY1yy9Rmioh+AunQ0rWiOTPE8F9A3v5g==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.1':
     resolution: {integrity: sha512-MGFB5cVPvshR85MTJkEvqDUnuNoysrsRxd6vnk1Lf2tbiqNlXpHYZqkqOQalydienEWOHHFyyuTSYRsLfxFJ2Q==}
@@ -2210,6 +2223,9 @@ packages:
   dompurify@3.4.2:
     resolution: {integrity: sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==}
 
+  driver.js@1.4.0:
+    resolution: {integrity: sha512-Gm64jm6PmcU+si21sQhBrTAM1JvUrR0QhNmjkprNLxohOBzul9+pNHXgQaT9lW84gwg9GMLB3NZGuGolsz5uew==}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -2758,24 +2774,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.31.1:
     resolution: {integrity: sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.31.1:
     resolution: {integrity: sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.31.1:
     resolution: {integrity: sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.31.1:
     resolution: {integrity: sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==}
@@ -5483,6 +5503,8 @@ snapshots:
   dompurify@3.4.2:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
+
+  driver.js@1.4.0: {}
 
   dunder-proto@1.0.1:
     dependencies:

--- a/backend/src/board/services/user_role_service.py
+++ b/backend/src/board/services/user_role_service.py
@@ -1,0 +1,35 @@
+"""
+User role service.
+"""
+
+from django.contrib.auth.models import User
+from django.db import transaction
+
+from board.models import Config, Profile
+
+
+class UserRoleService:
+    """Business logic for user role changes."""
+
+    @staticmethod
+    @transaction.atomic
+    def set_superuser_status(user: User, is_superuser: bool) -> User:
+        """
+        Update Django admin access and keep first-admin publishing usable.
+
+        Superusers should be able to open the admin area and publish the first
+        post. Demoting admin access does not remove the editor role because
+        writing permission is intentionally separate from staff access.
+        """
+        user.is_superuser = is_superuser
+        user.is_staff = is_superuser
+        user.save(update_fields=['is_superuser', 'is_staff'])
+
+        if is_superuser:
+            Config.objects.get_or_create(user=user)
+            profile, _ = Profile.objects.get_or_create(user=user)
+            if profile.role != Profile.Role.EDITOR:
+                profile.role = Profile.Role.EDITOR
+                profile.save(update_fields=['role'])
+
+        return user

--- a/backend/src/board/templates/board/posts/post_detail.html
+++ b/backend/src/board/templates/board/posts/post_detail.html
@@ -30,7 +30,7 @@
 
 <!-- Canonical URL -->
 <link rel="canonical" href="{{ canonical_url }}">
-{% if aeo_enabled %}
+{% if show_agent_post_markdown %}
 <link rel="alternate" type="text/markdown" href="{{ post_markdown_url }}">
 {% endif %}
 {% endblock %}
@@ -75,7 +75,80 @@
                     {% if post.image %}
                     <meta itemprop="image" content="{{ post_image_url }}">
                     {% endif %}
-                    
+
+                    {% if show_publish_success %}
+                    <section
+                        data-publish-success-guide
+                        data-publish-success-visibility="{{ publish_success_visibility }}"
+                        class="mb-8 rounded-lg border border-line bg-surface-subtle px-4 py-4 sm:px-5 sm:py-5">
+                        <div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                            <div class="min-w-0">
+                                <p class="text-xs font-semibold uppercase text-content-hint">발행 완료</p>
+                                <h2 class="mt-1 text-lg font-semibold text-content">
+                                    {% if publish_success_visibility == 'hidden' %}
+                                    비공개 글로 저장되었습니다
+                                    {% elif publish_success_visibility == 'scheduled' %}
+                                    예약 발행으로 저장되었습니다
+                                    {% else %}
+                                    글이 공개되었습니다
+                                    {% endif %}
+                                </h2>
+                                <p class="mt-1 text-sm leading-relaxed text-content-secondary">
+                                    {% if publish_success_visibility == 'hidden' %}
+                                    비공개 상태라 작성자만 볼 수 있습니다. 공개하려면 글 설정에서 비공개를 해제하세요.
+                                    {% elif publish_success_visibility == 'scheduled' %}
+                                    예약 시각이 되면 공개 URL, RSS, Sitemap, Markdown URL에 반영됩니다.
+                                    {% else %}
+                                    아래 링크로 공개 화면과 피드 노출 상태를 바로 확인할 수 있습니다.
+                                    {% endif %}
+                                </p>
+                            </div>
+                            <a
+                                href="{% url 'post_edit' post.author_username post.url %}"
+                                class="inline-flex min-h-11 items-center justify-center rounded-lg border border-line px-4 py-2 text-sm font-semibold text-content-secondary transition-all duration-150 hover:bg-surface hover:text-content active:scale-95">
+                                수정하기
+                            </a>
+                        </div>
+
+                        <div class="mt-4 grid gap-2 sm:grid-cols-2">
+                            <a
+                                data-publish-success-link="post"
+                                href="{{ publish_success_links.post }}"
+                                class="group rounded-lg border border-line bg-surface px-3 py-3 transition-colors duration-150 hover:bg-surface-elevated">
+                                <span class="block text-sm font-semibold text-content">{% if publish_success_visibility == 'public' %}공개 URL{% else %}작성자 미리보기{% endif %}</span>
+                                <span class="mt-1 block truncate text-xs text-content-hint group-hover:text-content-secondary">{{ publish_success_links.post }}</span>
+                            </a>
+                            {% if publish_success_links.markdown %}
+                            <a
+                                data-publish-success-link="markdown"
+                                href="{{ publish_success_links.markdown }}"
+                                class="group rounded-lg border border-line bg-surface px-3 py-3 transition-colors duration-150 hover:bg-surface-elevated">
+                                <span class="block text-sm font-semibold text-content">Markdown URL</span>
+                                <span class="mt-1 block truncate text-xs text-content-hint group-hover:text-content-secondary">{{ publish_success_links.markdown }}</span>
+                            </a>
+                            {% endif %}
+                            {% if publish_success_links.rss %}
+                            <a
+                                data-publish-success-link="rss"
+                                href="{{ publish_success_links.rss }}"
+                                class="group rounded-lg border border-line bg-surface px-3 py-3 transition-colors duration-150 hover:bg-surface-elevated">
+                                <span class="block text-sm font-semibold text-content">RSS</span>
+                                <span class="mt-1 block truncate text-xs text-content-hint group-hover:text-content-secondary">{{ publish_success_links.rss }}</span>
+                            </a>
+                            {% endif %}
+                            {% if publish_success_links.sitemap %}
+                            <a
+                                data-publish-success-link="sitemap"
+                                href="{{ publish_success_links.sitemap }}"
+                                class="group rounded-lg border border-line bg-surface px-3 py-3 transition-colors duration-150 hover:bg-surface-elevated">
+                                <span class="block text-sm font-semibold text-content">Sitemap</span>
+                                <span class="mt-1 block truncate text-xs text-content-hint group-hover:text-content-secondary">{{ publish_success_links.sitemap }}</span>
+                            </a>
+                            {% endif %}
+                        </div>
+                    </section>
+                    {% endif %}
+
                     <!-- Article Header -->
                     <div class="mb-12 sm:mb-16">
                         {% if post.series %}
@@ -248,7 +321,7 @@
                         await this.copyToClipboard(decodedUrl);
                     }
                 }"
-                {% if aeo_enabled %}data-agent-copy-url="{{ post_markdown_url }}"{% endif %}
+                {% if show_agent_post_markdown %}data-agent-copy-url="{{ post_markdown_url }}"{% endif %}
                 class="fixed sm:sticky bottom-6 left-0 right-0 z-30 flex justify-center pointer-events-none">
                     <div class="pointer-events-auto floating-glass-surface rounded-full px-3 py-3 flex items-center gap-2 transform transition-all motion-interaction">
 

--- a/backend/src/board/templates/board/posts/post_editor.html
+++ b/backend/src/board/templates/board/posts/post_editor.html
@@ -15,8 +15,8 @@
 {% if is_edit %}
     {% island_component 'PostEditor' mode="edit" username=post.author.username postUrl=post.url %}
 {% elif draft_post %}
-    {% island_component 'PostEditor' mode="draft" username=request.user.username draftUrl=draft_post.url %}
+    {% island_component 'PostEditor' mode="draft" username=request.user.username draftUrl=draft_post.url showFirstPublishGuide=show_first_publish_guide %}
 {% else %}
-    {% island_component 'PostEditor' mode="new" username=request.user.username %}
+    {% island_component 'PostEditor' mode="new" username=request.user.username showFirstPublishGuide=show_first_publish_guide %}
 {% endif %}
 {% endblock %}

--- a/backend/src/board/tests/services/test_user_role_service.py
+++ b/backend/src/board/tests/services/test_user_role_service.py
@@ -1,0 +1,57 @@
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from board.models import Config, Profile
+from board.services.user_role_service import UserRoleService
+
+
+class UserRoleServiceTestCase(TestCase):
+    def test_set_superuser_status_grants_editor_role(self):
+        """관리자 승격 시 첫 글을 쓸 수 있도록 편집자 권한도 부여한다."""
+        user = User.objects.create_user(username='first-admin', password='password123')
+        Profile.objects.create(user=user, role=Profile.Role.READER)
+
+        UserRoleService.set_superuser_status(user, True)
+
+        user.refresh_from_db()
+        user.profile.refresh_from_db()
+        self.assertTrue(user.is_staff)
+        self.assertTrue(user.is_superuser)
+        self.assertEqual(user.profile.role, Profile.Role.EDITOR)
+
+    def test_set_superuser_status_creates_missing_profile(self):
+        """Django 기본 관리자 생성 계정도 편집자 프로필을 갖게 한다."""
+        user = User.objects.create_user(username='django-admin', password='password123')
+
+        UserRoleService.set_superuser_status(user, True)
+
+        user.refresh_from_db()
+        self.assertTrue(user.is_staff)
+        self.assertTrue(user.is_superuser)
+        self.assertEqual(user.profile.role, Profile.Role.EDITOR)
+
+    def test_set_superuser_status_creates_missing_config(self):
+        """Django 기본 관리자 생성 계정도 사용자 설정을 갖게 한다."""
+        user = User.objects.create_user(username='configless-admin', password='password123')
+
+        UserRoleService.set_superuser_status(user, True)
+
+        self.assertTrue(Config.objects.filter(user=user).exists())
+
+    def test_set_superuser_status_does_not_remove_editor_role_on_demote(self):
+        """관리자 권한 해제는 글쓰기 권한을 임의로 빼앗지 않는다."""
+        user = User.objects.create_user(
+            username='editor-admin',
+            password='password123',
+            is_staff=True,
+            is_superuser=True,
+        )
+        Profile.objects.create(user=user, role=Profile.Role.EDITOR)
+
+        UserRoleService.set_superuser_status(user, False)
+
+        user.refresh_from_db()
+        user.profile.refresh_from_db()
+        self.assertFalse(user.is_staff)
+        self.assertFalse(user.is_superuser)
+        self.assertEqual(user.profile.role, Profile.Role.EDITOR)

--- a/backend/src/board/tests/templates/test_post_detail.py
+++ b/backend/src/board/tests/templates/test_post_detail.py
@@ -2,13 +2,18 @@
 Tests for Post Detail View and ToC structure
 """
 import datetime
+import html
+import json
+import re
+import urllib.parse
 
 from django.test import TestCase, Client, override_settings
 from django.contrib.auth.models import User
 from django.urls import reverse
 from django.utils import timezone
 
-from board.models import Post, PostContent, PostConfig, Series, SiteSetting
+from board.models import Config, Post, PostContent, PostConfig, Profile, Series, SiteSetting
+from board.services.post_service import PostService
 
 class PostDetailViewTestCase(TestCase):
     def setUp(self):
@@ -282,3 +287,217 @@ class PostDetailViewTestCase(TestCase):
             response['Link']
         )
         self.assertEqual(response['X-Llms-Txt'], llms_txt_url)
+
+    @override_settings(SITE_URL='https://blex.example')
+    def test_post_detail_shows_publish_success_guide_for_author(self):
+        """작성자가 발행 직후 접근하면 공개 링크 확인 가이드를 보여준다."""
+        self.enable_aeo()
+        self.client.login(username='testauthor', password='password123')
+        url = reverse('post_detail', kwargs={
+            'username': 'testauthor',
+            'post_url': 'test-post'
+        })
+        response = self.client.get(f'{url}?published=1')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.context['show_publish_success'])
+
+        content = response.content.decode()
+        self.assertIn('data-publish-success-guide', content)
+        self.assertIn('data-publish-success-visibility=public', content)
+        self.assertIn('data-publish-success-link=post', content)
+        self.assertIn('data-publish-success-link=markdown', content)
+        self.assertIn('data-publish-success-link=rss', content)
+        self.assertIn('data-publish-success-link=sitemap', content)
+        self.assertIn('https://blex.example/@testauthor/test-post', content)
+        self.assertIn('https://blex.example/@testauthor/test-post.md', content)
+        self.assertIn('https://blex.example/rss', content)
+        self.assertIn('https://blex.example/posts/sitemap.xml', content)
+
+    def test_post_detail_hides_publish_success_guide_for_anonymous_user(self):
+        """published 쿼리가 있어도 작성자가 아니면 발행 완료 가이드를 숨긴다."""
+        url = reverse('post_detail', kwargs={
+            'username': 'testauthor',
+            'post_url': 'test-post'
+        })
+        response = self.client.get(f'{url}?published=1')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.context['show_publish_success'])
+        self.assertNotContains(response, 'data-publish-success-guide')
+
+    def test_post_detail_publish_success_guide_marks_hidden_posts(self):
+        """비공개 발행 글은 공개 링크 대신 작성자 미리보기 상태로 안내한다."""
+        self.enable_aeo()
+        self.post.config.hide = True
+        self.post.config.save(update_fields=['hide'])
+        self.client.login(username='testauthor', password='password123')
+        url = reverse('post_detail', kwargs={
+            'username': 'testauthor',
+            'post_url': 'test-post'
+        })
+        response = self.client.get(f'{url}?published=1')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'data-publish-success-visibility=hidden')
+        self.assertNotContains(response, 'data-publish-success-link=markdown')
+        self.assertNotContains(response, 'data-publish-success-link=rss')
+        self.assertNotContains(response, 'data-publish-success-link=sitemap')
+        self.assertNotContains(response, 'rel="alternate" type="text/markdown"')
+        self.assertNotContains(response, 'data-agent-copy-url=')
+        self.assertNotIn('Link', response)
+        self.assertNotIn('X-Llms-Txt', response)
+
+    def test_post_detail_publish_success_guide_marks_scheduled_posts(self):
+        """예약 발행 글은 아직 공개 피드 링크를 확인 링크로 보여주지 않는다."""
+        self.enable_aeo()
+        self.post.published_date = timezone.now() + datetime.timedelta(days=1)
+        self.post.save(update_fields=['published_date'])
+        self.client.login(username='testauthor', password='password123')
+        url = reverse('post_detail', kwargs={
+            'username': 'testauthor',
+            'post_url': 'test-post'
+        })
+        response = self.client.get(f'{url}?published=1')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'data-publish-success-visibility=scheduled')
+        self.assertNotContains(response, 'data-publish-success-link=markdown')
+        self.assertNotContains(response, 'data-publish-success-link=rss')
+        self.assertNotContains(response, 'data-publish-success-link=sitemap')
+        self.assertNotContains(response, 'rel="alternate" type="text/markdown"')
+        self.assertNotContains(response, 'data-agent-copy-url=')
+        self.assertNotIn('Link', response)
+        self.assertNotIn('X-Llms-Txt', response)
+
+
+class PostEditorPublishRedirectTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user(
+            username='editor',
+            email='editor@example.com',
+            password='password123'
+        )
+        Profile.objects.create(user=cls.user, role=Profile.Role.EDITOR)
+        Config.objects.create(user=cls.user)
+
+    def get_post_editor_props(self, response):
+        content = response.content.decode()
+        match = re.search(
+            r'<island-component[^>]*\bdata-island-name="?PostEditor"?[^>]*\bprops="?([^"\s>]+)"?',
+            content,
+        )
+        self.assertIsNotNone(match)
+        return json.loads(urllib.parse.unquote(html.unescape(match.group(1))))
+
+    def test_post_editor_shows_first_publish_guide_for_author_without_posts(self):
+        """발행한 글이 없는 작성자에게 첫 발행 가이드를 노출한다."""
+        self.client.login(username='editor', password='password123')
+
+        response = self.client.get('/write')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.context['show_first_publish_guide'])
+        props = self.get_post_editor_props(response)
+        self.assertTrue(props['showFirstPublishGuide'])
+
+    def test_post_editor_shows_first_publish_guide_for_first_draft(self):
+        """발행한 글 없이 임시 글만 있는 작성자에게 첫 발행 가이드를 노출한다."""
+        draft = PostService.create_draft(
+            user=self.user,
+            title='First Draft',
+            text_html='<p>Draft body</p>',
+            custom_url='first-draft',
+        )
+        self.client.login(username='editor', password='password123')
+
+        response = self.client.get(f'/write?draft={draft.url}')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.context['show_first_publish_guide'])
+        props = self.get_post_editor_props(response)
+        self.assertTrue(props['showFirstPublishGuide'])
+
+    def test_post_editor_hides_first_publish_guide_after_first_publish(self):
+        """이미 발행한 글이 있는 작성자에게 첫 발행 가이드를 숨긴다."""
+        PostService.create_post(
+            user=self.user,
+            title='Existing Post',
+            text_html='<p>Published body</p>',
+            custom_url='existing-post',
+        )
+        self.client.login(username='editor', password='password123')
+
+        response = self.client.get('/write')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.context['show_first_publish_guide'])
+        props = self.get_post_editor_props(response)
+        self.assertFalse(props['showFirstPublishGuide'])
+
+    def test_post_editor_redirects_new_publish_to_success_guide(self):
+        """새 글 발행 후 공개 상세 화면의 발행 완료 가이드로 이동한다."""
+        self.client.login(username='editor', password='password123')
+
+        response = self.client.post('/write', {
+            'title': 'First Published Post',
+            'url': 'first-published-post',
+            'content_html': '<p>Hello BLEX</p>',
+        })
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response['Location'], '/@editor/first-published-post?published=1')
+        self.assertTrue(Post.objects.filter(
+            author=self.user,
+            url='first-published-post',
+            published_date__isnull=False,
+        ).exists())
+
+    def test_post_editor_redirects_draft_publish_to_success_guide(self):
+        """초안 발행은 기존 초안을 공개 글로 바꾸고 발행 완료 가이드로 이동한다."""
+        draft = PostService.create_draft(
+            user=self.user,
+            title='Draft Title',
+            text_html='<p>Draft body</p>',
+            custom_url='draft-title',
+        )
+        self.client.login(username='editor', password='password123')
+
+        response = self.client.post('/write', {
+            'draft_url': draft.url,
+            'title': 'Published Draft Title',
+            'url': 'published-draft-title',
+            'content_html': '<p>Published draft body</p>',
+        })
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response['Location'], '/@editor/published-draft-title?published=1')
+
+        draft.refresh_from_db()
+        self.assertEqual(draft.url, 'published-draft-title')
+        self.assertIsNotNone(draft.published_date)
+        self.assertEqual(Post.objects.filter(author=self.user).count(), 1)
+
+    def test_post_editor_returns_to_draft_when_draft_publish_fails(self):
+        """초안 발행 검증 실패 시 작성 맥락을 잃지 않고 기존 초안으로 돌아간다."""
+        draft = PostService.create_draft(
+            user=self.user,
+            title='Recoverable Draft',
+            text_html='',
+            custom_url='recoverable-draft',
+        )
+        self.client.login(username='editor', password='password123')
+
+        response = self.client.post('/write', {
+            'draft_url': draft.url,
+            'title': 'Recoverable Draft',
+            'url': 'recoverable-draft',
+            'content_html': '',
+        })
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response['Location'], '/write?draft=recoverable-draft')
+
+        draft.refresh_from_db()
+        self.assertIsNone(draft.published_date)

--- a/backend/src/board/views/post.py
+++ b/backend/src/board/views/post.py
@@ -62,6 +62,33 @@ def post_detail(request, username, post_url):
     logo_url = SiteUrlService.absolute_url(request, f'{settings.RESOURCE_URL}logo.png')
 
     aeo_enabled = AgentContentService.is_aeo_enabled()
+    is_public_post = PublicPostService.is_public(post)
+    publish_success_visibility = 'public'
+    if post.config.hide:
+        publish_success_visibility = 'hidden'
+    elif not is_public_post:
+        publish_success_visibility = 'scheduled'
+
+    show_publish_success = (
+        request.GET.get('published') == '1'
+        and is_owner
+        and post.published_date is not None
+    )
+    publish_success_links = {}
+    if show_publish_success:
+        publish_success_links = {
+            'post': canonical_url,
+        }
+        if is_public_post:
+            publish_success_links.update({
+                'rss': SiteUrlService.absolute_url(request, '/rss'),
+                'sitemap': SiteUrlService.absolute_url(
+                    request,
+                    reverse('sitemap_section', kwargs={'section': 'posts'})
+                ),
+            })
+
+    show_agent_post_markdown = aeo_enabled and is_public_post
     context = {
         'post': post,
         'banners': banners,
@@ -72,12 +99,18 @@ def post_detail(request, username, post_url):
         'author_url': author_url,
         'post_image_url': post_image_url,
         'logo_url': logo_url,
+        'show_publish_success': show_publish_success,
+        'publish_success_visibility': publish_success_visibility,
+        'publish_success_links': publish_success_links,
+        'show_agent_post_markdown': show_agent_post_markdown,
     }
-    if aeo_enabled:
+    if show_agent_post_markdown:
         context['post_markdown_url'] = AgentContentService.build_post_markdown_url(post, request)
+        if show_publish_success:
+            publish_success_links['markdown'] = context['post_markdown_url']
 
     response = render(request, 'board/posts/post_detail.html', context)
-    if aeo_enabled:
+    if show_agent_post_markdown:
         response['Link'] = AgentContentService.build_agent_link_header(post, request)
         response['X-Llms-Txt'] = AgentContentService.build_llms_txt_url(request)
     return response
@@ -99,6 +132,11 @@ def post_editor(request, username=None, post_url=None):
     post = None
     draft_post = None
     series_list = []
+    has_published_posts = Post.objects.filter(
+        author=request.user,
+        published_date__isnull=False,
+    ).exists()
+    show_first_publish_guide = not is_edit and not has_published_posts
 
     draft_url = request.GET.get('draft')
     if draft_url and not is_edit:
@@ -218,7 +256,7 @@ def post_editor(request, username=None, post_url=None):
                     post_draft_url = ''
                 except PostValidationError as e:
                     messages.error(request, e.message)
-                    return redirect('post_write')
+                    return redirect(f"{reverse('post_write')}?draft={post_draft_url}")
 
             if not post_draft_url:
                 try:
@@ -245,7 +283,13 @@ def post_editor(request, username=None, post_url=None):
             messages.success(request, '포스트가 임시저장되었습니다.')
             return redirect('post_edit', username=request.user.username, post_url=post.url)
 
-        return redirect('post_detail', username=request.user.username, post_url=post.url)
+        post_detail_url = reverse('post_detail', kwargs={
+            'username': request.user.username,
+            'post_url': post.url,
+        })
+        if not is_edit:
+            post_detail_url = f'{post_detail_url}?published=1'
+        return redirect(post_detail_url)
 
     context = {
         'is_edit': is_edit,
@@ -253,6 +297,7 @@ def post_editor(request, username=None, post_url=None):
         'draft_post': draft_post,
         'series_list': series_list,
         'is_editor_page': True,
+        'show_first_publish_guide': show_first_publish_guide,
     }
 
     return render(request, 'board/posts/post_editor.html', context)

--- a/backend/src/utility/make_superuser.py
+++ b/backend/src/utility/make_superuser.py
@@ -9,6 +9,7 @@ os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'main.settings')
 django.setup()
 
 from django.contrib.auth.models import User
+from board.services.user_role_service import UserRoleService
 
 if __name__ == '__main__':
     username = ''
@@ -22,13 +23,9 @@ if __name__ == '__main__':
     answer = input(f"make a superuser {user.first_name}? (Y/N) ").upper()
     
     if answer == 'Y':
-        user.is_superuser = True
-        user.is_staff = True
-        user.save()
+        UserRoleService.set_superuser_status(user, True)
     if answer == 'N':
-        user.is_superuser = False
-        user.is_staff = False
-        user.save()
+        UserRoleService.set_superuser_status(user, False)
     
     superusers = User.objects.filter(is_superuser=True)
     print(f"Now superuser is {superusers.count()}")


### PR DESCRIPTION
## 🎯 Goal
- Help first-time editors understand the minimal path from writing to publishing.
- Reduce confusion after first publish by showing public link guidance only when it is actually valid.
- Ensure admin-created users can enter the writing flow without missing profile/config records.

## 🔧 Core Changes
- Added a first publish guide for editors with no published posts, including a focused 3-step tour for autosave, post settings, and publish confirmation.
- Added publish success guidance on post detail pages and limited agent-readable Markdown/RSS/sitemap links to public posts.
- Updated publish checklist copy and visibility handling for hidden/scheduled posts.
- Added user role service handling so superuser promotion creates missing editor profile/config records.

## 🤔 Key Decisions
- The first publish guide is shown only until the author has at least one published post; draft-only authors still see it.
- The guide entry stays in the editor flow instead of the floating action bar to avoid mobile overlap and keep the action bar focused.
- Title/body tour steps were removed because they describe obvious fields; the tour now focuses on decisions that can create uncertainty.
- Markdown alternate links and agent copy URLs are exposed only for public posts to keep the public surface consistent.

## 🧪 Verification Guide
### How to verify
1. Log in as an editor with no published posts and open `/write`; confirm `첫 발행 가이드` appears and starts the 3-step tour.
2. Publish a first post and confirm the detail page opens with `?published=1` and shows the publish success guide.
3. Open `/write` again after publishing one post; confirm the first publish guide is hidden.
4. Publish hidden or scheduled posts and confirm public Markdown/RSS/sitemap links are not shown.

### Expected result
- First-time authors get clear onboarding before their first published post.
- Experienced authors are not shown the first-publish prompt by default.
- Public agent-readable links are advertised only for posts that are actually public.

## ✅ Checklist
- [x] Lint completed for changed PostEditor files
- [x] Type-check completed
- [x] Tests completed
- [ ] Documentation updated (if needed)