### PR TITLE
🐛 Support LAN dev server Vite URLs

### DIFF
--- a/backend/src/board/templatetags/island.py
+++ b/backend/src/board/templatetags/island.py
@@ -12,25 +12,60 @@ register = template.Library()
 
 # Module-level cache for the Vite manifest
 _manifest_cache = None
+LOOPBACK_DEV_SERVER_HOSTS = {'localhost', '127.0.0.1', '0.0.0.0', '::1'}
 
 
-def get_vite_dev_server_url():
+def format_netloc(hostname, port):
+    if ':' in hostname and not hostname.startswith('['):
+        hostname = f'[{hostname}]'
+    return f'{hostname}:{port}' if port else hostname
+
+
+def rewrite_vite_dev_server_host(url, request=None):
+    if request is None:
+        return url.rstrip('/')
+
+    parsed_url = urllib.parse.urlsplit(url)
+    vite_hostname = (parsed_url.hostname or '').lower()
+    if vite_hostname not in LOOPBACK_DEV_SERVER_HOSTS:
+        return url.rstrip('/')
+
+    request_host = request.get_host()
+    parsed_request_host = urllib.parse.urlsplit(f'//{request_host}')
+    request_hostname = parsed_request_host.hostname
+    if not request_hostname:
+        return url.rstrip('/')
+
+    return urllib.parse.urlunsplit((
+        parsed_url.scheme,
+        format_netloc(request_hostname, parsed_url.port),
+        parsed_url.path,
+        parsed_url.query,
+        parsed_url.fragment,
+    )).rstrip('/')
+
+
+def get_vite_dev_server_url(request=None):
     """
     Resolve the Vite dev server URL from the runtime info file written by Vite.
     Falls back to settings.VITE_DEV_SERVER_URL before the dev server has started.
     """
+    url = None
     info_path = getattr(settings, 'VITE_DEV_SERVER_INFO_PATH', None)
     if info_path and os.path.exists(info_path):
         try:
             with open(info_path, 'r') as f:
                 info = json.load(f)
-            url = info.get('url')
-            if isinstance(url, str) and url:
-                return url.rstrip('/')
+            info_url = info.get('url')
+            if isinstance(info_url, str) and info_url:
+                url = info_url
         except (OSError, json.JSONDecodeError):
             logger.warning("Failed to read Vite dev server info from %s", info_path)
 
-    return getattr(settings, 'VITE_DEV_SERVER_URL', 'http://localhost:8100').rstrip('/')
+    if not url:
+        url = getattr(settings, 'VITE_DEV_SERVER_URL', 'http://localhost:8100')
+
+    return rewrite_vite_dev_server_host(url, request)
 
 
 def get_manifest():
@@ -63,8 +98,7 @@ def get_manifest():
 
     return _manifest_cache
 
-@register.simple_tag
-def island_entry(entry_name):
+def island_entry(entry_name, request=None):
     """
     Get the hashed filename for a Vite entry point.
     
@@ -74,7 +108,7 @@ def island_entry(entry_name):
     """
     # Check if in development mode
     if getattr(settings, 'USE_VITE_DEV_SERVER', settings.DEBUG):
-        return f"{get_vite_dev_server_url()}/{entry_name}"
+        return f"{get_vite_dev_server_url(request)}/{entry_name}"
     
     manifest = get_manifest()
     entry_path = f"{entry_name}"
@@ -87,8 +121,12 @@ def island_entry(entry_name):
     # If not found in manifest (e.g., in development), return the default path
     return static(f"islands/{entry_name}")
 
-@register.simple_tag
-def island_css(entry_name):
+@register.simple_tag(takes_context=True, name='island_entry')
+def island_entry_tag(context, entry_name):
+    return island_entry(entry_name, context.get('request'))
+
+
+def island_css(entry_name, request=None):
     """
     Get the hashed filename for a Vite CSS entry point.
     
@@ -98,7 +136,7 @@ def island_css(entry_name):
     """
     # Check if in development mode
     if getattr(settings, 'USE_VITE_DEV_SERVER', settings.DEBUG):
-        return f"{get_vite_dev_server_url()}/{entry_name}"
+        return f"{get_vite_dev_server_url(request)}/{entry_name}"
     
     manifest = get_manifest()
     entry_path = f"{entry_name}"
@@ -109,6 +147,12 @@ def island_css(entry_name):
             return static(f"islands/{value['file']}")
     
     return static(f"islands/{entry_name}")
+
+
+@register.simple_tag(takes_context=True, name='island_css')
+def island_css_tag(context, entry_name):
+    return island_css(entry_name, context.get('request'))
+
 
 @register.simple_tag
 def island_component(component_name, lazy=False, **props):
@@ -139,13 +183,12 @@ def island_component(component_name, lazy=False, **props):
 
     return mark_safe(html_output)
 
-@register.simple_tag
-def vite_hmr_client():
+def vite_hmr_client(request=None):
     """
     DEBUG 모드일 때만 Vite HMR 클라이언트를 로드
     """
     if getattr(settings, 'USE_VITE_DEV_SERVER', settings.DEBUG):
-        vite_url = get_vite_dev_server_url()
+        vite_url = get_vite_dev_server_url(request)
         preamble = f"""
         <script type="module">
             import RefreshRuntime from '{vite_url}/@react-refresh'
@@ -158,3 +201,8 @@ def vite_hmr_client():
         client = f'<script type="module" src="{vite_url}/@vite/client"></script>'
         return mark_safe(preamble + client)
     return ""
+
+
+@register.simple_tag(takes_context=True, name='vite_hmr_client')
+def vite_hmr_client_tag(context):
+    return vite_hmr_client(context.get('request'))

--- a/backend/src/board/tests/test_island_templatetags.py
+++ b/backend/src/board/tests/test_island_templatetags.py
@@ -2,12 +2,16 @@ import json
 import os
 import tempfile
 
-from django.test import SimpleTestCase, override_settings
+from django.template import Context, Template
+from django.test import RequestFactory, SimpleTestCase, override_settings
 
 from board.templatetags import island
 
 
 class ViteDevServerTemplateTagTestCase(SimpleTestCase):
+    def setUp(self):
+        self.request_factory = RequestFactory()
+
     def test_dev_server_uses_fallback_url_before_info_file_exists(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             info_path = os.path.join(temp_dir, 'dev-server.json')
@@ -28,6 +32,67 @@ class ViteDevServerTemplateTagTestCase(SimpleTestCase):
                 self.assertIn(
                     'http://localhost:8100/@vite/client',
                     str(island.vite_hmr_client()),
+                )
+
+    def test_dev_server_rewrites_loopback_host_to_request_host(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            info_path = os.path.join(temp_dir, 'dev-server.json')
+            with open(info_path, 'w') as f:
+                json.dump({'url': 'http://localhost:8107'}, f)
+
+            request = self.request_factory.get('/', HTTP_HOST='192.168.219.106:8000')
+
+            with override_settings(
+                USE_VITE_DEV_SERVER=True,
+                VITE_DEV_SERVER_URL='http://localhost:8100',
+                VITE_DEV_SERVER_INFO_PATH=info_path,
+                ALLOWED_HOSTS=['*'],
+            ):
+                self.assertEqual(
+                    island.island_entry('src/island.tsx', request=request),
+                    'http://192.168.219.106:8107/src/island.tsx',
+                )
+                self.assertEqual(
+                    island.island_css('styles/main.scss', request=request),
+                    'http://192.168.219.106:8107/styles/main.scss',
+                )
+                self.assertIn(
+                    'http://192.168.219.106:8107/@vite/client',
+                    str(island.vite_hmr_client(request=request)),
+                )
+
+    def test_dev_server_keeps_explicit_non_loopback_host(self):
+        request = self.request_factory.get('/', HTTP_HOST='192.168.219.106:8000')
+
+        with override_settings(
+            USE_VITE_DEV_SERVER=True,
+            VITE_DEV_SERVER_URL='http://devbox.local:8100',
+            VITE_DEV_SERVER_INFO_PATH='',
+            ALLOWED_HOSTS=['*'],
+        ):
+            self.assertEqual(
+                island.island_entry('src/island.tsx', request=request),
+                'http://devbox.local:8100/src/island.tsx',
+            )
+
+    def test_dev_server_template_tag_uses_request_host(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            info_path = os.path.join(temp_dir, 'dev-server.json')
+            with open(info_path, 'w') as f:
+                json.dump({'url': 'http://127.0.0.1:8109'}, f)
+
+            request = self.request_factory.get('/', HTTP_HOST='192.168.219.106:8000')
+            template = Template("{% load island %}{% island_entry 'src/island.tsx' %}")
+
+            with override_settings(
+                USE_VITE_DEV_SERVER=True,
+                VITE_DEV_SERVER_URL='http://localhost:8100',
+                VITE_DEV_SERVER_INFO_PATH=info_path,
+                ALLOWED_HOSTS=['*'],
+            ):
+                self.assertEqual(
+                    template.render(Context({'request': request})),
+                    'http://192.168.219.106:8109/src/island.tsx',
                 )
 
     def test_dev_server_reads_actual_vite_port_from_info_file(self):


### PR DESCRIPTION
## 🎯 Goal
- Opening the Django dev server from a LAN IP still injected Vite assets and HMR clients with loopback hosts like localhost.
- Make LAN device/browser development work without requiring users to manually pin VITE_DEV_SERVER_HOST.

## 🔧 Core Changes
- Vite dev URL helpers now accept the current request from Django template context.
- Loopback Vite hosts are rewritten to the request hostname while preserving the actual Vite port from the dev-server info file.
- Explicit non-loopback dev hosts such as devbox.local are left unchanged.

## 🤔 Key Decisions
- Kept this as runtime behavior instead of adding a guide, because the app can infer the correct host from the request.
- Preserved the existing fallback path when no request is available, so direct helper calls still return localhost URLs.

## 🧪 Verification Guide
### How to verify
1. Run npm run dev.
2. Open Django through a LAN address such as http://192.168.x.x:8000.
3. Inspect injected island script and HMR URLs.

### Expected result
- Island and HMR URLs use the LAN hostname with the Vite dev server port.
- Explicitly configured non-loopback Vite hosts remain unchanged.

## ✅ Checklist
- [ ] Lint completed (not run; no island source changes)
- [ ] Type-check completed (not run; no island source changes)
- [x] Tests completed
- [x] Documentation updated (if needed; no docs change needed)

Verification run:
- node ./scripts/manage.mjs test board.tests.test_island_templatetags -v 2
- npm run server:check-migrations
- npm run server:test
- git diff --check