### PR TITLE
🐛 Centralize runtime public URL safety

### DIFF
--- a/backend/src/board/apps.py
+++ b/backend/src/board/apps.py
@@ -3,3 +3,6 @@ from django.apps import AppConfig
 
 class BoardConfig(AppConfig):
     name = 'board'
+
+    def ready(self):
+        from board import checks  # noqa: F401

--- a/backend/src/board/checks.py
+++ b/backend/src/board/checks.py
@@ -1,0 +1,53 @@
+from urllib.parse import urlsplit
+
+from django.conf import settings
+from django.core.checks import Tags, Warning, register
+
+from board.services.site_url_service import LOCAL_SITE_HOSTS, SiteUrlService
+
+
+@register(Tags.security)
+def check_public_site_url(app_configs, **kwargs):
+    if settings.DEBUG or getattr(settings, 'TESTING', False):
+        return []
+
+    configured_origin = SiteUrlService.configured_origin()
+    if not configured_origin:
+        return [
+            Warning(
+                'SITE_URL is not configured. Public links in notifications, '
+                'webhooks, and discovery metadata may be relative.',
+                hint=(
+                    'Set SITE_URL to the public HTTPS origin, for example '
+                    'https://blog.example.com.'
+                ),
+                id='board.W001',
+            )
+        ]
+
+    parsed_origin = urlsplit(configured_origin)
+    if parsed_origin.scheme not in {'http', 'https'} or not parsed_origin.netloc:
+        return [
+            Warning(
+                'SITE_URL is not an absolute HTTP(S) origin.',
+                hint=(
+                    'Set SITE_URL to the public HTTPS origin, for example '
+                    'https://blog.example.com.'
+                ),
+                id='board.W002',
+            )
+        ]
+
+    if (parsed_origin.hostname or '').lower() in LOCAL_SITE_HOSTS:
+        return [
+            Warning(
+                'SITE_URL points to a local host in production mode.',
+                hint=(
+                    'Set SITE_URL to the public HTTPS origin before exposing '
+                    'this deployment.'
+                ),
+                id='board.W003',
+            )
+        ]
+
+    return []

--- a/backend/src/board/services/notification_delivery_service.py
+++ b/backend/src/board/services/notification_delivery_service.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 from django.conf import settings
 
+from board.services.site_url_service import SiteUrlService
 from modules.sub_task import SubTaskProcessor
 from modules.telegram import TelegramBot
 
@@ -25,6 +26,6 @@ class NotificationDeliveryService:
 
         bot = TelegramBot(settings.TELEGRAM_BOT_TOKEN)
         SubTaskProcessor.process(lambda: bot.send_messages(telegram_id, [
-            settings.SITE_URL + str(notify.url),
+            SiteUrlService.configured_absolute_url(str(notify.url)),
             notify.content,
         ]))

--- a/backend/src/board/services/site_url_service.py
+++ b/backend/src/board/services/site_url_service.py
@@ -14,8 +14,12 @@ class SiteUrlService:
     """Build public absolute URLs from one origin policy."""
 
     @staticmethod
+    def configured_origin() -> str:
+        return (settings.SITE_URL or '').strip().rstrip('/')
+
+    @staticmethod
     def public_origin(request: HttpRequest) -> str:
-        configured_origin = (settings.SITE_URL or '').strip().rstrip('/')
+        configured_origin = SiteUrlService.configured_origin()
         if configured_origin:
             parsed_origin = urlsplit(configured_origin)
             configured_host = (parsed_origin.hostname or '').lower()
@@ -33,12 +37,28 @@ class SiteUrlService:
         return request.build_absolute_uri('/').rstrip('/')
 
     @staticmethod
+    def normalize_path(path: str) -> str:
+        return path if path.startswith('/') else f'/{path}'
+
+    @staticmethod
     def absolute_url(request: HttpRequest, path: str) -> str:
         if path.startswith(('http://', 'https://')):
             return path
 
-        normalized_path = path if path.startswith('/') else f'/{path}'
+        normalized_path = SiteUrlService.normalize_path(path)
         return f'{SiteUrlService.public_origin(request)}{normalized_path}'
+
+    @staticmethod
+    def configured_absolute_url(path: str) -> str:
+        if path.startswith(('http://', 'https://')):
+            return path
+
+        normalized_path = SiteUrlService.normalize_path(path)
+        configured_origin = SiteUrlService.configured_origin()
+        if not configured_origin:
+            return normalized_path
+
+        return f'{configured_origin}{normalized_path}'
 
     @staticmethod
     def absolute_url_with_query(

--- a/backend/src/board/services/webhook_service.py
+++ b/backend/src/board/services/webhook_service.py
@@ -9,10 +9,10 @@ import logging
 import time
 import requests
 
-from django.conf import settings
 from django.db.models import Q
 
 from board.models import Post, PostConfig, WebhookSubscription, Profile, SiteContentScope
+from board.services.site_url_service import SiteUrlService
 from board.services.webhook_subscription_state_service import WebhookSubscriptionStateService
 from modules.sub_task import SubTaskProcessor
 
@@ -144,7 +144,7 @@ class WebhookService:
         if not channel_ids:
             return 0
 
-        post_url = settings.SITE_URL + post.get_absolute_url()
+        post_url = SiteUrlService.configured_absolute_url(post.get_absolute_url())
         author_name = post.author.first_name or post.author.username
         content = f'[{author_name}] 새 글이 발행되었어요: [{post.title}]({post_url})'
         delay_seconds = max(0.0, WebhookService.DEFAULT_NOTIFICATION_DELAY_SECONDS)
@@ -243,5 +243,5 @@ class WebhookService:
         return WebhookService.send_webhook(
             url=webhook_url,
             content=test_content,
-            post_url=settings.SITE_URL
+            post_url=SiteUrlService.configured_origin()
         )

--- a/backend/src/board/tests/api/test_webhook.py
+++ b/backend/src/board/tests/api/test_webhook.py
@@ -4,7 +4,7 @@
 import json
 from unittest.mock import patch
 
-from django.test import TestCase, Client
+from django.test import TestCase, Client, override_settings
 from django.contrib.auth.models import User
 from django.utils import timezone
 
@@ -445,6 +445,7 @@ class WebhookNotificationTestCase(TestCase):
 
         mock_process.assert_not_called()
 
+    @override_settings(SITE_URL='https://blex.example')
     @patch.object(WebhookService, 'DEFAULT_NOTIFICATION_DELAY_SECONDS', 0)
     @patch('board.services.webhook_service.WebhookService.send_webhook_with_tracking')
     @patch('board.services.webhook_service.time.sleep')
@@ -484,6 +485,11 @@ class WebhookNotificationTestCase(TestCase):
 
         mock_sleep.assert_not_called()
         self.assertEqual(mock_send_webhook_with_tracking.call_count, 2)
+        for call_args in mock_send_webhook_with_tracking.call_args_list:
+            self.assertEqual(
+                call_args.kwargs['post_url'],
+                'https://blex.example/@author/test-post',
+            )
 
     @patch.object(WebhookService, 'DEFAULT_NOTIFICATION_DELAY_SECONDS', 1.25)
     @patch('board.services.webhook_service.WebhookService.send_webhook_with_tracking')

--- a/backend/src/board/tests/services/test_site_url_service.py
+++ b/backend/src/board/tests/services/test_site_url_service.py
@@ -11,6 +11,10 @@ class SiteUrlServiceTestCase(SimpleTestCase):
     def test_public_origin_uses_configured_site_url_without_trailing_slash(self):
         self.assertEqual(SiteUrlService.public_origin(self.request), 'https://blex.example')
 
+    @override_settings(SITE_URL='https://blex.example/')
+    def test_configured_origin_uses_site_url_without_trailing_slash(self):
+        self.assertEqual(SiteUrlService.configured_origin(), 'https://blex.example')
+
     @override_settings(SITE_URL='')
     def test_public_origin_falls_back_to_request_origin(self):
         self.assertEqual(SiteUrlService.public_origin(self.request), 'http://testserver')
@@ -33,9 +37,24 @@ class SiteUrlServiceTestCase(SimpleTestCase):
         self.assertEqual(SiteUrlService.absolute_url(self.request, '/static/page'), 'https://blex.example/static/page')
 
     @override_settings(SITE_URL='https://blex.example')
+    def test_configured_absolute_url_uses_site_url(self):
+        self.assertEqual(
+            SiteUrlService.configured_absolute_url('settings'),
+            'https://blex.example/settings',
+        )
+
+    @override_settings(SITE_URL='')
+    def test_configured_absolute_url_returns_path_without_site_url(self):
+        self.assertEqual(SiteUrlService.configured_absolute_url('settings'), '/settings')
+
+    @override_settings(SITE_URL='https://blex.example')
     def test_absolute_url_keeps_absolute_input(self):
         self.assertEqual(
             SiteUrlService.absolute_url(self.request, 'https://cdn.example/file.png'),
+            'https://cdn.example/file.png',
+        )
+        self.assertEqual(
+            SiteUrlService.configured_absolute_url('https://cdn.example/file.png'),
             'https://cdn.example/file.png',
         )
 

--- a/backend/src/board/tests/test_runtime_settings.py
+++ b/backend/src/board/tests/test_runtime_settings.py
@@ -3,8 +3,9 @@ import subprocess
 import sys
 from unittest.mock import patch
 
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, override_settings
 
+from board.checks import check_public_site_url
 from main import settings as runtime_settings
 
 
@@ -110,3 +111,27 @@ class RuntimeSettingsTestCase(SimpleTestCase):
                 runtime_settings.get_env_list('BLEX_TEST_ALLOWED_HOSTS', ['*']),
                 ['blog.example.com', 'www.example.com'],
             )
+
+    @override_settings(DEBUG=True, TESTING=False, SITE_URL='http://localhost:8000')
+    def test_public_site_url_check_skips_debug_mode(self):
+        """개발 모드에서는 로컬 SITE_URL을 허용한다."""
+        self.assertEqual(check_public_site_url(None), [])
+
+    @override_settings(DEBUG=False, TESTING=False, SITE_URL='')
+    def test_public_site_url_check_warns_when_missing_in_production(self):
+        """운영 모드에서 SITE_URL이 없으면 공개 URL 정책 경고를 낸다."""
+        warnings = check_public_site_url(None)
+
+        self.assertEqual([warning.id for warning in warnings], ['board.W001'])
+
+    @override_settings(DEBUG=False, TESTING=False, SITE_URL='http://localhost:8000')
+    def test_public_site_url_check_warns_for_local_origin_in_production(self):
+        """운영 모드에서 로컬 SITE_URL은 공개 표면 경고를 낸다."""
+        warnings = check_public_site_url(None)
+
+        self.assertEqual([warning.id for warning in warnings], ['board.W003'])
+
+    @override_settings(DEBUG=False, TESTING=False, SITE_URL='https://blex.example')
+    def test_public_site_url_check_accepts_public_origin(self):
+        """운영 모드의 실제 공개 origin은 경고하지 않는다."""
+        self.assertEqual(check_public_site_url(None), [])

--- a/backend/src/board/views/api/v1/telegram.py
+++ b/backend/src/board/views/api/v1/telegram.py
@@ -6,6 +6,7 @@ from django.utils import timezone
 
 from board.models import TelegramSync
 from board.modules.response import StatusDone, StatusError, ErrorCode
+from board.services.site_url_service import SiteUrlService
 from modules.sub_task import SubTaskProcessor
 from modules.telegram import TelegramBot
 from modules.randomness import randstr
@@ -38,7 +39,7 @@ def telegram(request, parameter):
 
             except:
                 if req_userid:
-                    message = '블렉스 다양한 정보를 살펴보세요!\n\n' + settings.SITE_URL + '/notion'
+                    message = '블렉스 다양한 정보를 살펴보세요!\n\n' + SiteUrlService.configured_absolute_url('/notion')
                     SubTaskProcessor.process(
                         lambda: bot.send_message(req_userid, message))
             return StatusDone()

--- a/backend/src/modules/oauth.py
+++ b/backend/src/modules/oauth.py
@@ -2,6 +2,8 @@ import requests
 
 from django.conf import settings
 
+from board.services.site_url_service import SiteUrlService
+
 
 class State:
     def __init__(self, success, user):
@@ -14,7 +16,7 @@ def auth_google(code) -> State:
         'code': code,
         'client_id': settings.GOOGLE_OAUTH_CLIENT_ID,
         'client_secret': settings.GOOGLE_OAUTH_CLIENT_SECRET,
-        'redirect_uri': settings.SITE_URL + '/login/callback/google',
+        'redirect_uri': SiteUrlService.configured_absolute_url('/login/callback/google'),
         'grant_type': 'authorization_code',
     }
     response = requests.post(

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -25,6 +25,8 @@ touch backend/src/db.sqlite3
 
 로컬 Docker 확인만 할 때는 `SITE_URL=http://localhost:20002`, `ALLOWED_HOSTS=localhost,127.0.0.1`, `CSRF_TRUSTED_ORIGINS=http://localhost:20002`처럼 맞춥니다.
 
+`ALLOWED_HOSTS`를 비워 두면 하위 호환을 위해 기존처럼 `*`로 동작합니다. 새 운영 배포에서는 명시적인 호스트 목록을 설정하세요. `DEBUG=FALSE`에서 `SITE_URL`이 비어 있거나 `localhost` 같은 로컬 주소면 Django system check가 경고합니다.
+
 임의 문자열은 아래처럼 만들 수 있습니다.
 
 ```bash

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -25,7 +25,7 @@ touch backend/src/db.sqlite3
 
 로컬 Docker 확인만 할 때는 `SITE_URL=http://localhost:20002`, `ALLOWED_HOSTS=localhost,127.0.0.1`, `CSRF_TRUSTED_ORIGINS=http://localhost:20002`처럼 맞춥니다.
 
-`ALLOWED_HOSTS`를 비워 두면 하위 호환을 위해 기존처럼 `*`로 동작합니다. 새 운영 배포에서는 명시적인 호스트 목록을 설정하세요. `DEBUG=FALSE`에서 `SITE_URL`이 비어 있거나 `localhost` 같은 로컬 주소면 Django system check가 경고합니다.
+`ALLOWED_HOSTS`를 비워 두면 기존처럼 `*`로 동작합니다. 운영 배포에서는 명시적인 호스트 목록을 설정하세요.
 
 임의 문자열은 아래처럼 만들 수 있습니다.
 


### PR DESCRIPTION
## 🎯 Goal
- Keep requestless external URLs from bypassing the shared public URL policy.
- Warn operators when production `SITE_URL` would leak missing or local origins.
- Preserve the legacy `ALLOWED_HOSTS=*` fallback for backward compatibility.

## 🔧 Core Changes
- Added requestless configured origin and absolute URL helpers to `SiteUrlService`.
- Replaced direct `settings.SITE_URL` concatenation in OAuth, notifications, webhooks, and Telegram fallback messaging.
- Added Django security system checks for missing, invalid, or local `SITE_URL` in production.
- Documented the `ALLOWED_HOSTS` compatibility fallback and `SITE_URL` warning behavior.

## 🤔 Key Decisions
- Kept the `ALLOWED_HOSTS` default wildcard for backward compatibility.
- Used warnings instead of hard failures for `SITE_URL` so existing deployments are not blocked immediately.
- Skipped `SITE_URL` warnings during `DEBUG` and `TESTING` so local development and test output stay clean.

## 🧪 Verification Guide
### How to verify
1. Run `node ./scripts/manage.mjs check`.
2. Run `npm run server:test`.
3. In production-like settings, set `DEBUG=FALSE` with blank or localhost `SITE_URL` and run Django check.

### Expected result
- Runtime check passes for normal local/test settings.
- Full backend tests pass.
- Production-like local/missing `SITE_URL` emits `board.W001` or `board.W003`.

## ✅ Checklist
- [x] Lint completed (not applicable: no Islands changes)
- [x] Type-check completed (not applicable: no Islands changes)
- [x] Tests completed
- [x] Documentation updated (if needed)