### PR TITLE
✨ Expand llms discovery entrypoint

### DIFF
--- a/backend/src/board/services/agent_content_service.py
+++ b/backend/src/board/services/agent_content_service.py
@@ -118,10 +118,38 @@ class AgentContentService:
 
     @staticmethod
     def build_llms_txt(request: HttpRequest) -> str:
+        public_origin = SiteUrlService.public_origin(request)
         lines = [
             '# BLEX',
             '',
             '> BLEX is a publishing site.',
+            '',
+            '## Discovery',
+            '',
+            AgentContentService.build_llms_link_line(
+                'Sitemap index',
+                AgentContentService.build_sitemap_url(request),
+                'Find public sitemap sections.',
+            ),
+            AgentContentService.build_llms_link_line(
+                'Posts sitemap',
+                SiteUrlService.absolute_url(
+                    request,
+                    reverse('sitemap_section', kwargs={'section': 'posts'}),
+                ),
+                'Find public posts without listing them here.',
+            ),
+            AgentContentService.build_llms_link_line(
+                'RSS feed',
+                SiteUrlService.absolute_url(request, '/rss'),
+                'Read recent public posts.',
+            ),
+            '',
+            '## Markdown',
+            '',
+            f'- Public post Markdown: `{public_origin}/@{{username}}/{{post_url}}.md`',
+            f'- Public series Markdown: `{public_origin}/@{{username}}/series/{{series_url}}.md`',
+            f'- Static page Markdown: `{public_origin}/static/{{slug}}.md`',
         ]
 
         return '\n'.join(lines).strip() + '\n'

--- a/backend/src/board/tests/test_agent_content.py
+++ b/backend/src/board/tests/test_agent_content.py
@@ -437,35 +437,53 @@ class AgentContentTestCase(TestCase):
         body = response.content.decode()
         self.assertIn('Source: https://blex.example/static/about-ai', body)
 
-    def test_llms_txt_returns_minimal_site_summary(self):
-        """/llms.txt는 최소한의 사이트 요약만 제공한다."""
+    def test_llms_txt_returns_discovery_entrypoint(self):
+        """/llms.txt는 공개 콘텐츠 discovery endpoint와 Markdown 규칙을 안내한다."""
         response = self.client.get('/llms.txt')
 
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response['Content-Type'].startswith('text/plain'))
 
         body = response.content.decode()
-        self.assertEqual(
-            body,
-            '# BLEX\n\n> BLEX is a publishing site.\n',
-        )
+        self.assertIn('# BLEX', body)
+        self.assertIn('## Discovery', body)
+        self.assertIn('[Sitemap index](http://localhost:8000/sitemap.xml)', body)
+        self.assertIn('[Posts sitemap](http://localhost:8000/posts/sitemap.xml)', body)
+        self.assertIn('[RSS feed](http://localhost:8000/rss)', body)
+        self.assertIn('## Markdown', body)
+        self.assertIn('`http://localhost:8000/@{username}/{post_url}.md`', body)
+        self.assertIn('`http://localhost:8000/@{username}/series/{series_url}.md`', body)
+        self.assertIn('`http://localhost:8000/static/{slug}.md`', body)
 
-    def test_llms_txt_does_not_expose_content_indexes_or_markdown_links(self):
-        """llms.txt는 sitemap, RSS, Markdown 목록을 노출하지 않는다."""
+    @override_settings(SITE_URL='https://blex.example')
+    def test_llms_txt_uses_configured_site_url(self):
+        """/llms.txt는 configured SITE_URL origin으로 discovery URL을 만든다."""
+        response = self.client.get('/llms.txt')
+
+        self.assertEqual(response.status_code, 200)
+
+        body = response.content.decode()
+        self.assertIn('[Sitemap index](https://blex.example/sitemap.xml)', body)
+        self.assertIn('[Posts sitemap](https://blex.example/posts/sitemap.xml)', body)
+        self.assertIn('[RSS feed](https://blex.example/rss)', body)
+        self.assertIn('`https://blex.example/@{username}/{post_url}.md`', body)
+
+    def test_llms_txt_does_not_enumerate_public_or_non_public_content(self):
+        """llms.txt는 discovery 규칙만 제공하고 개별 콘텐츠를 열거하지 않는다."""
         response = self.client.get('/llms.txt')
 
         self.assertEqual(response.status_code, 200)
 
         body = response.content.decode()
 
-        self.assertRegex(
-            body,
-            r'^# BLEX\n\n> .+\n$',
-        )
-        self.assertNotIn('/sitemap.xml', body)
-        self.assertNotIn('/rss', body)
-        self.assertNotIn('.md', body)
-        self.assertNotIn('## ', body)
+        self.assertNotIn('Agent Ready Post', body)
+        self.assertNotIn('/@aeo-author/agent-ready-post.md', body)
+        self.assertNotIn('Hidden Agent Post', body)
+        self.assertNotIn('/@aeo-author/hidden-agent-post.md', body)
+        self.assertNotIn('Draft Agent Post', body)
+        self.assertNotIn('/@aeo-author/draft-agent-post.md', body)
+        self.assertNotIn('Future Agent Post', body)
+        self.assertNotIn('/@aeo-author/future-agent-post.md', body)
 
     def test_post_markdown_endpoint_returns_clean_markdown(self):
         """공개 포스트는 Markdown endpoint로 AI용 본문을 제공한다."""


### PR DESCRIPTION
## 🎯 Goal
- Make `/llms.txt` useful as an AI agent discovery entrypoint.
- Keep the response small by linking stable discovery endpoints and URL patterns instead of enumerating all content.

## 🔧 Core Changes
- Added sitemap index, posts sitemap, and RSS feed links to `/llms.txt`.
- Added Markdown URL patterns for public posts, series, and static pages.
- Kept `/llms.txt` gated behind AEO and avoided listing individual posts or non-public content.
- Updated agent content tests for configured `SITE_URL`, discovery links, and non-enumeration behavior.

## 🤔 Key Decisions
- Did not list every post in `/llms.txt` to avoid growth and duplicate sitemap/RSS responsibilities.
- Used sitemap pagination as the scalable content index path.
- Kept the first expansion focused on stable discovery, leaving latest content snippets/metrics for later.

## 🧪 Verification Guide
### How to verify
1. Run `node ./scripts/manage.mjs test board.tests.test_agent_content -v 2`.
2. Run `npm run server:test`.
3. Enable AEO and request `/llms.txt`.

### Expected result
- `/llms.txt` includes sitemap, posts sitemap, RSS, and Markdown URL patterns.
- `/llms.txt` stays small and does not enumerate individual public/non-public posts.
- AEO-disabled sites still return 404 for `/llms.txt`.

## ✅ Checklist
- [x] Lint completed (not applicable: no Islands changes)
- [x] Type-check completed (not applicable: no Islands changes)
- [x] Tests completed
- [x] Documentation updated (if needed)
