### PR TITLE
✨ Add RSS alternate discovery links

### DIFF
--- a/backend/src/board/context_processors.py
+++ b/backend/src/board/context_processors.py
@@ -1,5 +1,8 @@
 from django.conf import settings
+from django.urls import reverse
+
 from board.models import SiteSetting, SiteNotice, SiteContentScope, StaticPage
+from board.services.site_url_service import SiteUrlService
 
 
 def oauth_settings(request):
@@ -18,6 +21,7 @@ def site_settings(request):
     """
     return {
         'site_setting': SiteSetting.get_instance(),
+        'site_rss_feed_url': SiteUrlService.absolute_url(request, reverse('site_rss_feed')),
     }
 
 

--- a/backend/src/board/services/discovery_metadata_service.py
+++ b/backend/src/board/services/discovery_metadata_service.py
@@ -73,6 +73,16 @@ class DiscoveryMetadataService:
         }
 
     @staticmethod
+    def build_user_rss_feed_metadata(author: User, request: HttpRequest) -> dict[str, str]:
+        return {
+            'author_rss_feed_title': f'{author.username} RSS',
+            'author_rss_feed_url': SiteUrlService.absolute_url(
+                request,
+                reverse('user_rss_feed', kwargs={'username': author.username}),
+            ),
+        }
+
+    @staticmethod
     def build_meta_description(raw_text: str, fallback: str) -> str:
         clean_text = DiscoveryMetadataService.normalize_text(raw_text)
         source_text = clean_text or fallback

--- a/backend/src/board/templates/board/base.html
+++ b/backend/src/board/templates/board/base.html
@@ -68,6 +68,14 @@
         <meta name="googlebot" content="noindex,nofollow">
         {% endif %}
     {% endblock %}
+    {% block feed_links %}
+        {% if site_setting and site_setting.seo_enabled %}
+        <link rel="alternate" type="application/rss+xml" title="BLEX RSS" href="{{ site_rss_feed_url }}">
+        {% if author_rss_feed_url and author_rss_feed_title %}
+        <link rel="alternate" type="application/rss+xml" title="{{ author_rss_feed_title }}" href="{{ author_rss_feed_url }}">
+        {% endif %}
+        {% endif %}
+    {% endblock %}
     <link rel="stylesheet" href="{% island_css 'styles/tailwind.css' %}">
     <link rel="stylesheet" href="{% island_css 'styles/main.scss' %}">
     <link rel="icon" href="{% resource 'favicon.ico' %}" />

--- a/backend/src/board/tests/templates/test_rss_discovery.py
+++ b/backend/src/board/tests/templates/test_rss_discovery.py
@@ -1,0 +1,125 @@
+"""
+RSS auto-discovery template tests.
+"""
+from django.contrib.auth.models import User
+from django.test import TestCase, override_settings
+from django.urls import reverse
+from django.utils import timezone
+
+from board.models import Post, PostConfig, PostContent, Profile, SiteSetting
+
+
+class RSSDiscoveryTemplateTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.author = User.objects.create_user(
+            username='rssauthor',
+            email='rssauthor@example.com',
+            password='testpass123',
+        )
+        User.objects.create_user(
+            username='setupadmin',
+            email='setupadmin@example.com',
+            password='testpass123',
+            is_staff=True,
+        )
+        Profile.objects.create(user=cls.author, role=Profile.Role.EDITOR)
+        cls.post = Post.objects.create(
+            title='RSS Discovery Post',
+            url='rss-discovery-post',
+            author=cls.author,
+            created_date=timezone.now(),
+            published_date=timezone.now(),
+        )
+        PostContent.objects.create(
+            post=cls.post,
+            content_html='<p>RSS discovery content</p>',
+        )
+        PostConfig.objects.create(
+            post=cls.post,
+            hide=False,
+        )
+
+    def assert_rss_alternate(self, response, title: str, href: str) -> None:
+        self.assertContains(
+            response,
+            f'<link rel="alternate" type="application/rss+xml" title="{title}" href="{href}">',
+            html=True,
+        )
+
+    def test_index_advertises_site_rss_alternate(self):
+        """메인 페이지는 사이트 RSS feed를 자동 발견 링크로 노출한다."""
+        response = self.client.get(reverse('index'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assert_rss_alternate(response, 'BLEX RSS', 'http://localhost:8000/rss')
+        self.assertEqual(response.content.decode().count('application/rss+xml'), 1)
+
+    def test_public_author_pages_advertise_author_rss_alternate(self):
+        """공개 작성자 페이지는 사이트 RSS와 작성자 RSS를 함께 노출한다."""
+        urls = [
+            reverse('user_profile', kwargs={'username': self.author.username}),
+            reverse('user_posts', kwargs={'username': self.author.username}),
+            reverse('user_series', kwargs={'username': self.author.username}),
+        ]
+
+        for url in urls:
+            with self.subTest(url=url):
+                response = self.client.get(url)
+
+                self.assertEqual(response.status_code, 200)
+                self.assert_rss_alternate(response, 'BLEX RSS', 'http://localhost:8000/rss')
+                self.assert_rss_alternate(
+                    response,
+                    'rssauthor RSS',
+                    'http://localhost:8000/rss/@rssauthor',
+                )
+                self.assertEqual(response.content.decode().count('application/rss+xml'), 2)
+
+    def test_post_detail_advertises_author_rss_alternate(self):
+        """글 상세 페이지는 사이트 RSS와 글 작성자 RSS를 함께 노출한다."""
+        response = self.client.get(reverse(
+            'post_detail',
+            kwargs={
+                'username': self.author.username,
+                'post_url': self.post.url,
+            },
+        ))
+
+        self.assertEqual(response.status_code, 200)
+        self.assert_rss_alternate(response, 'BLEX RSS', 'http://localhost:8000/rss')
+        self.assert_rss_alternate(
+            response,
+            'rssauthor RSS',
+            'http://localhost:8000/rss/@rssauthor',
+        )
+
+    @override_settings(SITE_URL='https://blex.example')
+    def test_rss_alternate_links_use_configured_site_url(self):
+        """RSS 자동 발견 링크는 configured SITE_URL origin을 사용한다."""
+        response = self.client.get(reverse(
+            'post_detail',
+            kwargs={
+                'username': self.author.username,
+                'post_url': self.post.url,
+            },
+        ))
+
+        self.assertEqual(response.status_code, 200)
+        self.assert_rss_alternate(response, 'BLEX RSS', 'https://blex.example/rss')
+        self.assert_rss_alternate(
+            response,
+            'rssauthor RSS',
+            'https://blex.example/rss/@rssauthor',
+        )
+
+    def test_rss_alternate_links_are_omitted_when_seo_disabled(self):
+        """SEO가 꺼져 있으면 HTML에서 RSS 자동 발견 링크를 숨긴다."""
+        setting = SiteSetting.get_instance()
+        setting.seo_enabled = False
+        setting.save(update_fields=['seo_enabled'])
+
+        response = self.client.get(reverse('index'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, 'application/rss+xml')

--- a/backend/src/board/urls.py
+++ b/backend/src/board/urls.py
@@ -83,7 +83,7 @@ urlpatterns = [
     ),
 
     # RSS and Etc
-    path('rss', SitePostsFeed()),
+    path('rss', SitePostsFeed(), name='site_rss_feed'),
     path('rss/@<username>', UserPostsFeed(), name='user_rss_feed'),
     path('robots.txt', agent.robots_txt, name='robots_txt'),
 

--- a/backend/src/board/views/author.py
+++ b/backend/src/board/views/author.py
@@ -9,6 +9,7 @@ from django.http import JsonResponse
 from board.modules.paginator import Paginator
 from board.modules.time import time_since
 from board.services.user_service import UserService
+from board.services.discovery_metadata_service import DiscoveryMetadataService
 from board.services.public_post_service import PublicPostService
 from board.services.public_series_service import PublicSeriesService
 from board.models import Comment, Post, Series, PostLikes, Tag, Profile, SiteNotice, SiteContentScope
@@ -60,6 +61,7 @@ def author_overview(request, username):
             'post_count': stats['post_count'],
             'series_count': stats['series_count'],
             'user_notices': user_notices,
+            **DiscoveryMetadataService.build_user_rss_feed_metadata(author, request),
             'author_activity_props': json.dumps({'username': author.username})
         }
         return render(request, 'board/author/author_overview.html', context)
@@ -167,6 +169,7 @@ def author_posts(request, username):
         'search_query': search_query,
         'tag_filter': tag_filter,
         'tag_options': tag_options,
+        **DiscoveryMetadataService.build_user_rss_feed_metadata(author, request),
         'author_activity_props': json.dumps({'username': author.username}),
     }
     
@@ -251,6 +254,7 @@ def author_series(request, username):
         'page_number': page,
         'page_count': paginated_series.paginator.num_pages,
         'series_sort_options': series_sort_options,
+        **DiscoveryMetadataService.build_user_rss_feed_metadata(author, request),
     }
     
     return render(request, 'board/author/author_series.html', context)

--- a/backend/src/board/views/post.py
+++ b/backend/src/board/views/post.py
@@ -12,6 +12,7 @@ from board.models import Post, Series, PostLikes, UsernameChangeLog
 from board.services.post_service import PostService, PostValidationError
 from board.services.banner_service import BannerService
 from board.services.agent_content_service import AgentContentService
+from board.services.discovery_metadata_service import DiscoveryMetadataService
 from board.services.public_post_service import PublicPostService
 from board.services.site_url_service import SiteUrlService
 from board.html_utils import extract_table_of_contents
@@ -88,6 +89,7 @@ def post_detail(request, username, post_url):
         'show_post_status_notice': show_post_status_notice,
         'post_visibility_status': post_visibility_status,
         'show_agent_post_markdown': show_agent_post_markdown,
+        **DiscoveryMetadataService.build_user_rss_feed_metadata(author, request),
     }
     if show_agent_post_markdown:
         context['post_markdown_url'] = AgentContentService.build_post_markdown_url(post, request)

--- a/backend/src/board/views/series.py
+++ b/backend/src/board/views/series.py
@@ -97,6 +97,7 @@ def series_detail(request, username, series_url):
         'request': request,
         'aeo_enabled': aeo_enabled,
         'series_updated_date_display': series.updated_date.strftime('%Y-%m-%d'),
+        **DiscoveryMetadataService.build_user_rss_feed_metadata(author, request),
         **metadata,
     }
     if aeo_enabled:


### PR DESCRIPTION
## 🎯 Goal
- Let RSS readers and crawlers discover BLEX feeds directly from public HTML pages.
- Continue the public discovery work after sitemap and `/llms.txt` without adding visible UI.

## 🔧 Core Changes
- Added a named site RSS route and global RSS alternate link in the base HTML head.
- Added author RSS alternate metadata to public author, post detail, and series detail pages.
- Reused the existing public URL policy so RSS alternate URLs respect configured `SITE_URL`.
- Omitted RSS auto-discovery links when SEO is disabled, matching the existing sitemap/noindex behavior.
- Added focused template tests for site feed, author feed, configured `SITE_URL`, and SEO-disabled behavior.

## 🤔 Key Decisions
- Kept RSS discovery in `<head>` only; no visible page UI was added.
- Used the base template to emit feed links from context metadata instead of duplicating `<link>` blocks across templates.
- Kept feed discovery separate from `/llms.txt`; `/llms.txt` points to RSS, while HTML pages advertise RSS to feed readers.

## 🧪 Verification Guide
### How to verify
1. Run `node ./scripts/manage.mjs test board.tests.templates.test_rss_discovery -v 2`.
2. Run `node ./scripts/manage.mjs test board.tests.templates.test_rss_discovery board.tests.templates.test_main board.tests.templates.test_author board.tests.templates.test_post_detail board.tests.test_agent_content -v 2`.
3. Run `npm run server:test`.

### Expected result
- Main/public pages include a site RSS alternate link when SEO is enabled.
- Author, post detail, and series detail pages include both site RSS and author RSS alternate links.
- RSS alternate links use configured `SITE_URL` and are omitted from HTML when SEO is disabled.

## ✅ Checklist
- [x] Lint completed (not applicable: no Islands changes)
- [x] Type-check completed (not applicable: no Islands changes)
- [x] Tests completed
- [x] Documentation updated (if needed)
