### PR TITLE
✨ Add list page SEO policy

### DIFF
--- a/backend/src/board/services/discovery_metadata_service.py
+++ b/backend/src/board/services/discovery_metadata_service.py
@@ -83,6 +83,67 @@ class DiscoveryMetadataService:
         }
 
     @staticmethod
+    def has_unexpected_query_parameters(request: HttpRequest, allowed_keys: set[str]) -> bool:
+        return bool(set(request.GET.keys()) - allowed_keys)
+
+    @staticmethod
+    def build_paginated_page_metadata(
+        request: HttpRequest,
+        path: str,
+        page: int,
+        total_pages: int,
+        query_items: list[tuple[str, str]] | None = None,
+    ) -> dict[str, str]:
+        base_query_items = query_items or []
+        canonical_query_items = [*base_query_items]
+        if page > 1:
+            canonical_query_items.append(('page', str(page)))
+
+        metadata = {
+            'page_canonical_url': SiteUrlService.absolute_url_with_query(
+                request,
+                path,
+                canonical_query_items,
+            ),
+        }
+
+        if page > 1:
+            previous_query_items = [*base_query_items]
+            if page > 2:
+                previous_query_items.append(('page', str(page - 1)))
+            metadata['page_previous_url'] = SiteUrlService.absolute_url_with_query(
+                request,
+                path,
+                previous_query_items,
+            )
+
+        if page < total_pages:
+            next_query_items = [*base_query_items, ('page', str(page + 1))]
+            metadata['page_next_url'] = SiteUrlService.absolute_url_with_query(
+                request,
+                path,
+                next_query_items,
+            )
+
+        return metadata
+
+    @staticmethod
+    def build_noindex_page_metadata(
+        request: HttpRequest,
+        canonical_path: str | None = None,
+        follow_links: bool = True,
+    ) -> dict[str, str | bool]:
+        metadata: dict[str, str | bool] = {
+            'page_noindex': True,
+            'page_robots_content': 'noindex,follow' if follow_links else 'noindex,nofollow',
+        }
+
+        if canonical_path:
+            metadata['page_canonical_url'] = SiteUrlService.absolute_url(request, canonical_path)
+
+        return metadata
+
+    @staticmethod
     def build_meta_description(raw_text: str, fallback: str) -> str:
         clean_text = DiscoveryMetadataService.normalize_text(raw_text)
         source_text = clean_text or fallback

--- a/backend/src/board/templates/board/base.html
+++ b/backend/src/board/templates/board/base.html
@@ -66,6 +66,20 @@
         {% if site_setting and not site_setting.seo_enabled %}
         <meta name="robots" content="noindex,nofollow">
         <meta name="googlebot" content="noindex,nofollow">
+        {% elif page_noindex %}
+        <meta name="robots" content="{{ page_robots_content }}">
+        <meta name="googlebot" content="{{ page_robots_content }}">
+        {% endif %}
+    {% endblock %}
+    {% block page_discovery_meta %}
+        {% if page_canonical_url %}
+        <link rel="canonical" href="{{ page_canonical_url }}">
+        {% endif %}
+        {% if page_previous_url %}
+        <link rel="prev" href="{{ page_previous_url }}">
+        {% endif %}
+        {% if page_next_url %}
+        <link rel="next" href="{{ page_next_url }}">
         {% endif %}
     {% endblock %}
     {% block feed_links %}

--- a/backend/src/board/tests/templates/test_list_page_seo.py
+++ b/backend/src/board/tests/templates/test_list_page_seo.py
@@ -1,0 +1,229 @@
+"""
+List page canonical and noindex policy tests.
+"""
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from board.models import Post, PostConfig, PostContent, PostLikes, Profile, Series, SiteSetting, Tag
+
+
+class ListPageSEOPolicyTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.author = User.objects.create_user(
+            username='seoauthor',
+            email='seoauthor@example.com',
+            password='testpass123',
+        )
+        Profile.objects.create(user=cls.author, role=Profile.Role.EDITOR)
+        cls.series = Series.objects.create(
+            owner=cls.author,
+            name='SEO Policy Series',
+            url='seo-policy-series',
+            text_md='SEO policy series',
+            text_html='<p>SEO policy series</p>',
+            hide=False,
+        )
+        cls.admin = User.objects.create_user(
+            username='setupadmin',
+            email='setupadmin@example.com',
+            password='testpass123',
+            is_staff=True,
+        )
+        cls.tag = Tag.objects.create(value='python')
+
+        for index in range(26):
+            post = Post.objects.create(
+                title=f'SEO Policy Post {index}',
+                url=f'seo-policy-post-{index}',
+                author=cls.author,
+                series=cls.series if index < 3 else None,
+                created_date=timezone.now(),
+                published_date=timezone.now() - timezone.timedelta(minutes=index),
+            )
+            PostContent.objects.create(
+                post=post,
+                content_html=f'<p>SEO policy content {index}</p>',
+            )
+            PostConfig.objects.create(
+                post=post,
+                hide=False,
+                advertise=False,
+            )
+            post.tags.add(cls.tag)
+
+    def assert_meta_robots(self, response, content: str) -> None:
+        self.assertContains(
+            response,
+            f'<meta name="robots" content="{content}">',
+            html=True,
+        )
+        self.assertContains(
+            response,
+            f'<meta name="googlebot" content="{content}">',
+            html=True,
+        )
+
+    def assert_canonical(self, response, href: str) -> None:
+        self.assertContains(
+            response,
+            f'<link rel="canonical" href="{href}">',
+            html=True,
+        )
+
+    def assert_previous_page(self, response, href: str) -> None:
+        self.assertContains(
+            response,
+            f'<link rel="prev" href="{href}">',
+            html=True,
+        )
+
+    def assert_next_page(self, response, href: str) -> None:
+        self.assertContains(
+            response,
+            f'<link rel="next" href="{href}">',
+            html=True,
+        )
+
+    def test_index_first_page_uses_clean_canonical_and_next_link(self):
+        """메인 목록 첫 페이지는 clean canonical과 다음 페이지 discovery를 제공한다."""
+        response = self.client.get(reverse('index'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assert_canonical(response, 'http://localhost:8000/')
+        self.assert_next_page(response, 'http://localhost:8000/?page=2')
+        self.assertNotContains(response, 'content="noindex,follow"')
+
+    def test_index_page_two_uses_self_canonical_and_previous_link(self):
+        """메인 목록 페이지네이션은 page 쿼리만 보존한 self-canonical을 사용한다."""
+        response = self.client.get(reverse('index') + '?page=2')
+
+        self.assertEqual(response.status_code, 200)
+        self.assert_canonical(response, 'http://localhost:8000/?page=2')
+        self.assert_previous_page(response, 'http://localhost:8000/')
+        self.assertNotContains(response, 'content="noindex,follow"')
+
+    def test_index_unknown_query_is_noindex_and_canonicalizes_to_home(self):
+        """메인 목록의 비표준 쿼리 조합은 색인하지 않고 홈으로 canonical을 모은다."""
+        response = self.client.get(reverse('index') + '?sort=popular&page=2')
+
+        self.assertEqual(response.status_code, 200)
+        self.assert_meta_robots(response, 'noindex,follow')
+        self.assert_canonical(response, 'http://localhost:8000/')
+
+    def test_search_page_is_noindex(self):
+        """검색 화면은 검색어 조합이 색인되지 않도록 noindex로 둔다."""
+        response = self.client.get(reverse('search') + '?q=python')
+
+        self.assertEqual(response.status_code, 200)
+        self.assert_meta_robots(response, 'noindex,follow')
+        self.assert_canonical(response, 'http://localhost:8000/search')
+
+    def test_author_profile_and_posts_use_canonical_policy(self):
+        """작성자 대표 페이지는 canonical을 갖고, 작성자 글 필터는 noindex로 둔다."""
+        profile_response = self.client.get(reverse(
+            'user_profile',
+            kwargs={'username': self.author.username},
+        ))
+        self.assertEqual(profile_response.status_code, 200)
+        self.assert_canonical(profile_response, 'http://localhost:8000/@seoauthor')
+
+        posts_response = self.client.get(
+            reverse('user_posts', kwargs={'username': self.author.username}) + '?tag=python'
+        )
+        self.assertEqual(posts_response.status_code, 200)
+        self.assert_meta_robots(posts_response, 'noindex,follow')
+        self.assert_canonical(posts_response, 'http://localhost:8000/@seoauthor/posts')
+
+    def test_author_series_uses_canonical_policy(self):
+        """작성자 시리즈 기본 목록은 canonical, 정렬 조합은 noindex로 둔다."""
+        series_response = self.client.get(
+            reverse('user_series', kwargs={'username': self.author.username})
+        )
+        self.assertEqual(series_response.status_code, 200)
+        self.assert_canonical(series_response, 'http://localhost:8000/@seoauthor/series')
+
+        sorted_response = self.client.get(
+            reverse('user_series', kwargs={'username': self.author.username}) + '?sort=newest'
+        )
+        self.assertEqual(sorted_response.status_code, 200)
+        self.assert_meta_robots(sorted_response, 'noindex,follow')
+        self.assert_canonical(sorted_response, 'http://localhost:8000/@seoauthor/series')
+
+    def test_author_posts_page_two_uses_paginated_canonical(self):
+        """작성자 글 목록 페이지네이션은 page 쿼리만 canonical에 남긴다."""
+        response = self.client.get(
+            reverse('user_posts', kwargs={'username': self.author.username}) + '?page=2'
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assert_canonical(response, 'http://localhost:8000/@seoauthor/posts?page=2')
+        self.assert_previous_page(response, 'http://localhost:8000/@seoauthor/posts')
+
+    def test_tag_pages_use_noindex_for_sort_and_paginated_canonical_for_detail(self):
+        """태그 정렬 조합은 noindex, 태그 상세 페이지네이션은 self-canonical을 사용한다."""
+        list_response = self.client.get(reverse('tag_list') + '?sort=name')
+        self.assertEqual(list_response.status_code, 200)
+        self.assert_meta_robots(list_response, 'noindex,follow')
+        self.assert_canonical(list_response, 'http://localhost:8000/tags')
+
+        detail_response = self.client.get(
+            reverse('tag_detail', kwargs={'name': self.tag.value}) + '?page=2'
+        )
+        self.assertEqual(detail_response.status_code, 200)
+        self.assert_canonical(detail_response, 'http://localhost:8000/tag/python?page=2')
+        self.assert_previous_page(detail_response, 'http://localhost:8000/tag/python')
+
+    def test_list_pages_noindex_unexpected_query_parameters(self):
+        """목록 화면의 허용되지 않은 쿼리는 색인하지 않고 기본 URL로 모은다."""
+        cases = [
+            (
+                reverse('user_posts', kwargs={'username': self.author.username}) + '?foo=bar',
+                'http://localhost:8000/@seoauthor/posts',
+            ),
+            (
+                reverse('user_series', kwargs={'username': self.author.username}) + '?utm=campaign',
+                'http://localhost:8000/@seoauthor/series',
+            ),
+            (
+                reverse('tag_list') + '?foo=bar',
+                'http://localhost:8000/tags',
+            ),
+            (
+                reverse('tag_detail', kwargs={'name': self.tag.value}) + '?sort=name',
+                'http://localhost:8000/tag/python',
+            ),
+        ]
+
+        for path, canonical_url in cases:
+            with self.subTest(path=path):
+                response = self.client.get(path)
+
+                self.assertEqual(response.status_code, 200)
+                self.assert_meta_robots(response, 'noindex,follow')
+                self.assert_canonical(response, canonical_url)
+
+    def test_private_interested_posts_are_noindex_nofollow(self):
+        """개인화된 관심 목록은 공개 색인 대상이 아니다."""
+        PostLikes.objects.create(user=self.author, post=Post.objects.first())
+        self.client.login(username='seoauthor', password='testpass123')
+
+        response = self.client.get(reverse('interested_posts'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assert_meta_robots(response, 'noindex,nofollow')
+        self.assertNotIn('page_canonical_url', response.context)
+
+    def test_seo_disabled_overrides_page_specific_noindex_policy(self):
+        """SEO OFF는 페이지별 noindex,follow보다 강한 noindex,nofollow를 사용한다."""
+        setting = SiteSetting.get_instance()
+        setting.seo_enabled = False
+        setting.save(update_fields=['seo_enabled'])
+
+        response = self.client.get(reverse('search') + '?q=python')
+
+        self.assertEqual(response.status_code, 200)
+        self.assert_meta_robots(response, 'noindex,nofollow')
+        self.assertEqual(response['X-Robots-Tag'], 'noindex, nofollow')

--- a/backend/src/board/views/author.py
+++ b/backend/src/board/views/author.py
@@ -5,6 +5,7 @@ from django.contrib.auth.decorators import login_required
 from django.db.models import Count, Q
 from django.shortcuts import render, get_object_or_404, redirect
 from django.http import JsonResponse
+from django.urls import reverse
 
 from board.modules.paginator import Paginator
 from board.modules.time import time_since
@@ -30,6 +31,19 @@ def author_overview(request, username):
 
     # Check if author is a reader (not an editor)
     is_reader = not hasattr(author, 'profile') or author.profile.role == Profile.Role.READER
+    author_profile_path = reverse('user_profile', kwargs={'username': author.username})
+    if DiscoveryMetadataService.has_unexpected_query_parameters(request, set()):
+        page_metadata = DiscoveryMetadataService.build_noindex_page_metadata(
+            request,
+            author_profile_path,
+        )
+    else:
+        page_metadata = DiscoveryMetadataService.build_paginated_page_metadata(
+            request,
+            author_profile_path,
+            1,
+            1,
+        )
 
     if is_reader:
         # Reader template - minimal view with just README and activity
@@ -37,6 +51,7 @@ def author_overview(request, username):
             'author': author,
             'recent_activities': recent_activities,
             'about_html': about_html,
+            **page_metadata,
             'author_activity_props': json.dumps({'username': author.username})
         }
         return render(request, 'board/author/author_reader_overview.html', context)
@@ -62,6 +77,7 @@ def author_overview(request, username):
             'series_count': stats['series_count'],
             'user_notices': user_notices,
             **DiscoveryMetadataService.build_user_rss_feed_metadata(author, request),
+            **page_metadata,
             'author_activity_props': json.dumps({'username': author.username})
         }
         return render(request, 'board/author/author_overview.html', context)
@@ -172,6 +188,27 @@ def author_posts(request, username):
         **DiscoveryMetadataService.build_user_rss_feed_metadata(author, request),
         'author_activity_props': json.dumps({'username': author.username}),
     }
+    author_posts_path = reverse('user_posts', kwargs={'username': author.username})
+    if (
+        DiscoveryMetadataService.has_unexpected_query_parameters(request, {'page', 'q', 'tag'})
+        or search_query
+        or tag_filter
+    ):
+        context.update(
+            DiscoveryMetadataService.build_noindex_page_metadata(
+                request,
+                author_posts_path,
+            )
+        )
+    else:
+        context.update(
+            DiscoveryMetadataService.build_paginated_page_metadata(
+                request,
+                author_posts_path,
+                page,
+                paginated_posts.paginator.num_pages,
+            )
+        )
     
     return render(request, 'board/author/author_posts.html', context)
 
@@ -256,6 +293,27 @@ def author_series(request, username):
         'series_sort_options': series_sort_options,
         **DiscoveryMetadataService.build_user_rss_feed_metadata(author, request),
     }
+    author_series_path = reverse('user_series', kwargs={'username': author.username})
+    if (
+        DiscoveryMetadataService.has_unexpected_query_parameters(request, {'page', 'q', 'sort'})
+        or search_query
+        or sort_option != 'custom'
+    ):
+        context.update(
+            DiscoveryMetadataService.build_noindex_page_metadata(
+                request,
+                author_series_path,
+            )
+        )
+    else:
+        context.update(
+            DiscoveryMetadataService.build_paginated_page_metadata(
+                request,
+                author_series_path,
+                page,
+                paginated_series.paginator.num_pages,
+            )
+        )
     
     return render(request, 'board/author/author_series.html', context)
 

--- a/backend/src/board/views/main.py
+++ b/backend/src/board/views/main.py
@@ -1,10 +1,12 @@
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import redirect, render
 from django.db.models import F, Count, Exists, OuterRef
+from django.urls import reverse
 
 from board.models import Post, PostLikes
 from board.modules.paginator import Paginator
 from board.modules.time import time_since
+from board.services.discovery_metadata_service import DiscoveryMetadataService
 from board.services.initial_setup_service import InitialSetupService
 from board.services.public_post_service import PublicPostService
 from board.services.user_service import UserService
@@ -48,6 +50,22 @@ def index(request):
         'page_number': page,
         'page_count': paginated_posts.paginator.num_pages,
     }
+    if DiscoveryMetadataService.has_unexpected_query_parameters(request, {'page'}):
+        context.update(
+            DiscoveryMetadataService.build_noindex_page_metadata(
+                request,
+                reverse('index'),
+            )
+        )
+    else:
+        context.update(
+            DiscoveryMetadataService.build_paginated_page_metadata(
+                request,
+                reverse('index'),
+                page,
+                paginated_posts.paginator.num_pages,
+            )
+        )
 
     return render(request, 'board/posts/post_list.html', context)
 
@@ -71,5 +89,11 @@ def interested_posts(request):
         'page_number': page,
         'page_count': paginated_posts.paginator.num_pages,
     }
+    context.update(
+        DiscoveryMetadataService.build_noindex_page_metadata(
+            request,
+            follow_links=False,
+        )
+    )
 
     return render(request, 'board/posts/interested_posts.html', context)

--- a/backend/src/board/views/search.py
+++ b/backend/src/board/views/search.py
@@ -1,6 +1,9 @@
 import json
 
 from django.shortcuts import render
+from django.urls import reverse
+
+from board.services.discovery_metadata_service import DiscoveryMetadataService
 
 
 def search_page(request):
@@ -14,4 +17,10 @@ def search_page(request):
         'search_page_props': json.dumps(props),
         'is_search_page': True,
     }
+    context.update(
+        DiscoveryMetadataService.build_noindex_page_metadata(
+            request,
+            reverse('search'),
+        )
+    )
     return render(request, 'board/search/search.html', context)

--- a/backend/src/board/views/tag.py
+++ b/backend/src/board/views/tag.py
@@ -1,7 +1,10 @@
 from django.http import Http404
 from django.shortcuts import render
+from django.urls import reverse
+
 from board.modules.paginator import Paginator
 
+from board.services.discovery_metadata_service import DiscoveryMetadataService
 from board.services import TagService
 
 
@@ -56,6 +59,27 @@ def tag_list_view(request):
         'last_page': paginated_tags.paginator.num_pages,
         'sort_options': sort_options,
     }
+    tags_path = reverse('tag_list')
+    if (
+        DiscoveryMetadataService.has_unexpected_query_parameters(request, {'page', 'q', 'sort'})
+        or search_query
+        or sort != 'popular'
+    ):
+        context.update(
+            DiscoveryMetadataService.build_noindex_page_metadata(
+                request,
+                tags_path,
+            )
+        )
+    else:
+        context.update(
+            DiscoveryMetadataService.build_paginated_page_metadata(
+                request,
+                tags_path,
+                page,
+                paginated_tags.paginator.num_pages,
+            )
+        )
 
     return render(request, 'board/tags/tag_list.html', context)
 
@@ -86,5 +110,22 @@ def tag_detail_view(request, name):
         'page': page,
         'last_page': paginated_posts.paginator.num_pages,
     }
+    tag_detail_path = reverse('tag_detail', kwargs={'name': name})
+    if DiscoveryMetadataService.has_unexpected_query_parameters(request, {'page'}):
+        context.update(
+            DiscoveryMetadataService.build_noindex_page_metadata(
+                request,
+                tag_detail_path,
+            )
+        )
+    else:
+        context.update(
+            DiscoveryMetadataService.build_paginated_page_metadata(
+                request,
+                tag_detail_path,
+                page,
+                paginated_posts.paginator.num_pages,
+            )
+        )
 
     return render(request, 'board/tags/tag_detail.html', context)


### PR DESCRIPTION
## 🎯 Goal
- Reduce duplicate indexing risk across list, search, tag, and author pages.
- Make canonical/noindex behavior explicit for paginated and query-driven public surfaces.

## 🔧 Core Changes
- Added shared metadata helpers for paginated canonical URLs, prev/next discovery links, and page-specific robots meta.
- Added canonical and noindex policies to home, search, author profile/posts/series, tag list/detail, and interested-posts pages.
- Treat unexpected list-page query parameters as `noindex,follow` with canonical URLs normalized to the base page.
- Added focused template tests for the resulting HTML meta/link behavior.

## 🤔 Key Decisions
- Keep clean list pages and page-only pagination indexable with self-canonical URLs.
- Keep search, filters, non-default sorting, unknown query combinations, and private interested posts out of the index.
- Let SEO OFF continue to override page-specific policy with `noindex,nofollow`.
- Keep tests at the rendered HTML boundary instead of testing private helper implementation details.

## 🧪 Verification Guide
### How to verify
1. View source for `/`, `/?page=2`, `/search?q=python`, `/@seoauthor/posts?tag=python`, `/@seoauthor/series?sort=newest`, `/tags?sort=name`, and `/tag/python?sort=name`.
2. Confirm canonical, prev/next, and robots meta match the intended list-page policy.
3. Confirm SEO OFF still emits `noindex,nofollow` and `X-Robots-Tag` for page-specific noindex surfaces.

### Expected result
- Clean list and page-only pagination URLs expose canonical/prev/next discovery links.
- Search/filter/sort/unknown query combinations emit `noindex,follow` and canonicalize to their base list URL.
- `/interests` emits `noindex,nofollow` without a canonical URL.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)

Validation run:
- `node ./scripts/manage.mjs check`
- `git diff --check`
- `node ./scripts/manage.mjs test board.tests.templates.test_list_page_seo -v 2`
- `node ./scripts/manage.mjs test board.tests.templates.test_list_page_seo board.tests.templates.test_main board.tests.templates.test_author board.tests.templates.test_tag board.tests.templates.test_post_detail board.tests.templates.test_agent_discovery board.tests.templates.test_series_static_seo board.tests.test_agent_content -v 2`
- `npm run server:test`