### PR TITLE
🐛 Enforce editor demotion authoring policy

### DIFF
--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/SettingsApp.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/SettingsApp.tsx
@@ -7,7 +7,7 @@ import {
     Navigate,
     useRouter
 } from '@tanstack/react-router';
-import { lazy, Suspense } from 'react';
+import { lazy, Suspense, type ElementType } from 'react';
 import { SettingsLayout } from './components/SettingsLayout';
 import { LoadingState } from '../../shared';
 
@@ -81,6 +81,24 @@ const SettingsIndexRedirect = () => {
     return <Navigate to={settingsMode === 'admin' ? '/site-settings' : '/notify'} replace />;
 };
 
+const editorOnly = (Component: ElementType) => {
+    const EditorOnlyRoute = (props: Record<string, unknown>) => {
+        const router = useRouter();
+        const { isEditor } = router.options.context as SettingsRouterContext;
+
+        if (!isEditor) {
+            return <Navigate to="/notify" replace />;
+        }
+
+        return <Component {...props} />;
+    };
+
+    return EditorOnlyRoute;
+};
+
+const EditorOnlySeriesEditor = editorOnly(SeriesEditor);
+const EditorOnlyBannerEditor = editorOnly(BannerEditor);
+
 // Index route - redirect to the default page for each settings namespace
 const indexRoute = createRoute({
     getParentRoute: () => settingsRoute,
@@ -110,43 +128,43 @@ const profileRoute = createRoute({
 const seriesRoute = createRoute({
     getParentRoute: () => settingsRoute,
     path: '/series',
-    component: SeriesSetting
+    component: editorOnly(SeriesSetting)
 });
 
 const postsRoute = createRoute({
     getParentRoute: () => settingsRoute,
     path: '/posts',
-    component: PostsSetting
+    component: editorOnly(PostsSetting)
 });
 
 const pinnedPostsRoute = createRoute({
     getParentRoute: () => settingsRoute,
     path: '/pinned-posts',
-    component: PinnedPostsSetting
+    component: editorOnly(PinnedPostsSetting)
 });
 
 const draftsRoute = createRoute({
     getParentRoute: () => settingsRoute,
     path: '/drafts',
-    component: DraftsSetting
+    component: editorOnly(DraftsSetting)
 });
 
 const formsRoute = createRoute({
     getParentRoute: () => settingsRoute,
     path: '/forms',
-    component: FormsSetting
+    component: editorOnly(FormsSetting)
 });
 
 const noticesRoute = createRoute({
     getParentRoute: () => settingsRoute,
     path: '/notices',
-    component: NoticeSetting
+    component: editorOnly(NoticeSetting)
 });
 
 const bannersRoute = createRoute({
     getParentRoute: () => settingsRoute,
     path: '/banners',
-    component: BannerSetting
+    component: editorOnly(BannerSetting)
 });
 
 const integrationRoute = createRoute({
@@ -164,13 +182,13 @@ const socialLinksRoute = createRoute({
 const webhookRoute = createRoute({
     getParentRoute: () => settingsRoute,
     path: '/webhook',
-    component: WebhookSetting
+    component: editorOnly(WebhookSetting)
 });
 
 const developerApiRoute = createRoute({
     getParentRoute: () => settingsRoute,
     path: '/developer-api',
-    component: DeveloperApiSetting
+    component: editorOnly(DeveloperApiSetting)
 });
 
 const globalWebhookRoute = createRoute({
@@ -236,7 +254,7 @@ const staticPageEditRoute = createRoute({
 const seriesCreateRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: '/series/create',
-    component: SeriesEditor
+    component: editorOnly(SeriesEditor)
 });
 
 const seriesEditRoute = createRoute({
@@ -245,7 +263,7 @@ const seriesEditRoute = createRoute({
     component: () => {
         const { seriesId } = seriesEditRoute.useParams();
         return (
-            <SeriesEditor seriesId={Number(seriesId)} />
+            <EditorOnlySeriesEditor seriesId={Number(seriesId)} />
         );
     }
 });
@@ -253,7 +271,7 @@ const seriesEditRoute = createRoute({
 const bannerCreateRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: '/banners/create',
-    component: BannerEditor
+    component: editorOnly(BannerEditor)
 });
 
 const bannerEditRoute = createRoute({
@@ -262,7 +280,7 @@ const bannerEditRoute = createRoute({
     component: () => {
         const { bannerId } = bannerEditRoute.useParams();
         return (
-            <BannerEditor bannerId={Number(bannerId)} />
+            <EditorOnlyBannerEditor bannerId={Number(bannerId)} />
         );
     }
 });

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/SettingsNavigation.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/SettingsNavigation.tsx
@@ -135,7 +135,8 @@ const userNavigationSections: NavigationSection[] = [
                 name: '개발자 API',
                 path: '/developer-api',
                 icon: 'fa-code',
-                risk: 'danger'
+                risk: 'danger',
+                requiresEditor: true
             }
         ]
     }

--- a/backend/src/board/admin/user.py
+++ b/backend/src/board/admin/user.py
@@ -16,6 +16,7 @@ from board.models import (
     EmailChange, Profile
 )
 from board.constants.config_meta import CONFIG_TYPES
+from board.services.user_role_service import UserRoleService
 
 from .service import AdminDisplayService, AdminLinkService
 from .constants import COLOR_MUTED, COLOR_INFO, COLOR_BG, COLOR_TEXT
@@ -96,14 +97,12 @@ class CustomUserAdmin(BaseUserAdmin):
     post_count.admin_order_field = 'post_count'
 
     def make_editor(self, request: HttpRequest, queryset: QuerySet[User]) -> None:
-        user_ids = queryset.values_list('id', flat=True)
-        count = Profile.objects.filter(user_id__in=user_ids).update(role=Profile.Role.EDITOR)
+        count = UserRoleService.set_users_role(queryset, Profile.Role.EDITOR)
         self.message_user(request, f'{count}명의 사용자를 편집자로 변경했습니다.')
     make_editor.short_description = '선택한 사용자를 편집자로 변경'
 
     def make_reader(self, request: HttpRequest, queryset: QuerySet[User]) -> None:
-        user_ids = queryset.values_list('id', flat=True)
-        count = Profile.objects.filter(user_id__in=user_ids).update(role=Profile.Role.READER)
+        count = UserRoleService.set_users_role(queryset, Profile.Role.READER)
         self.message_user(request, f'{count}명의 사용자를 독자로 변경했습니다.')
     make_reader.short_description = '선택한 사용자를 독자로 변경'
 
@@ -320,11 +319,11 @@ class ProfileAdmin(admin.ModelAdmin):
     total_posts.short_description = '총 포스트 수'
 
     def set_role_editor(self, request: HttpRequest, queryset: QuerySet[Profile]) -> None:
-        count = queryset.update(role=Profile.Role.EDITOR)
+        count = UserRoleService.set_profiles_role(queryset, Profile.Role.EDITOR)
         self.message_user(request, f'{count}명의 프로필을 편집자로 변경했습니다.')
     set_role_editor.short_description = '역할을 편집자로 변경'
 
     def set_role_reader(self, request: HttpRequest, queryset: QuerySet[Profile]) -> None:
-        count = queryset.update(role=Profile.Role.READER)
+        count = UserRoleService.set_profiles_role(queryset, Profile.Role.READER)
         self.message_user(request, f'{count}명의 프로필을 독자로 변경했습니다.')
     set_role_reader.short_description = '역할을 독자로 변경'

--- a/backend/src/board/decorators.py
+++ b/backend/src/board/decorators.py
@@ -1,6 +1,11 @@
-from django.http import HttpResponseForbidden
 from functools import wraps
+
 from django.conf import settings
+from django.contrib import messages
+from django.shortcuts import redirect
+
+from board.services.api_permission_service import ApiPermissionService
+from board.services.authoring_permission_service import AuthoringPermissionService
 
 def staff_member_required(view_func):
     """
@@ -11,5 +16,45 @@ def staff_member_required(view_func):
     def _wrapped_view(request, *args, **kwargs):
         if settings.DEBUG:
             return view_func(request, *args, **kwargs)
+        return view_func(request, *args, **kwargs)
+    return _wrapped_view
+
+
+def api_editor_required(view_func):
+    @wraps(view_func)
+    def _wrapped_view(request, *args, **kwargs):
+        permission_error = ApiPermissionService.require_editor(request.user)
+        if permission_error:
+            return permission_error
+        return view_func(request, *args, **kwargs)
+    return _wrapped_view
+
+
+def api_editor_required_methods(methods):
+    required_methods = {method.upper() for method in methods}
+
+    def decorator(view_func):
+        @wraps(view_func)
+        def _wrapped_view(request, *args, **kwargs):
+            if request.method.upper() in required_methods:
+                permission_error = ApiPermissionService.require_editor(request.user)
+                if permission_error:
+                    return permission_error
+            return view_func(request, *args, **kwargs)
+        return _wrapped_view
+
+    return decorator
+
+
+def editor_required(view_func):
+    @wraps(view_func)
+    def _wrapped_view(request, *args, **kwargs):
+        if not request.user.is_authenticated:
+            return redirect('login')
+
+        if not AuthoringPermissionService.is_active_editor(request.user):
+            messages.error(request, '편집자 권한이 필요합니다. 관리자에게 문의하세요.')
+            return redirect('index')
+
         return view_func(request, *args, **kwargs)
     return _wrapped_view

--- a/backend/src/board/models.py
+++ b/backend/src/board/models.py
@@ -461,8 +461,24 @@ class Profile(models.Model):
         return self.webhook_subscribers.filter(is_active=True).count()
 
     def save(self, *args, **kwargs):
+        previous_role = None
+        if self.pk:
+            previous_role = Profile.objects.filter(pk=self.pk).values_list('role', flat=True).first()
+
+        is_demoting_to_reader = previous_role == self.Role.EDITOR and self.role == self.Role.READER
         will_make_thumbnail = ProfileImageService.should_generate_avatar_thumbnail(self)
+
         super(Profile, self).save(*args, **kwargs)
+
+        if is_demoting_to_reader:
+            Post.objects.filter(
+                author=self.user,
+                published_date__gt=timezone.now(),
+            ).update(
+                published_date=None,
+                updated_date=timezone.now(),
+            )
+
         if will_make_thumbnail:
             ProfileImageService.generate_avatar_thumbnail(self)
 

--- a/backend/src/board/services/api_permission_service.py
+++ b/backend/src/board/services/api_permission_service.py
@@ -6,6 +6,7 @@ from django.contrib.auth.models import AnonymousUser, User
 from django.http import HttpResponse
 
 from board.modules.response import ErrorCode, StatusError
+from board.services.authoring_permission_service import AuthoringPermissionService
 
 
 class ApiPermissionService:
@@ -23,7 +24,7 @@ class ApiPermissionService:
         if login_error:
             return login_error
 
-        if not hasattr(user, 'profile') or not user.profile.is_editor():
+        if not AuthoringPermissionService.is_active_editor(user):
             return StatusError(ErrorCode.REJECT, '에디터 권한이 필요합니다.')
 
         return None
@@ -46,5 +47,19 @@ class ApiPermissionService:
 
         if user != owner:
             return StatusError(ErrorCode.AUTHENTICATION, '권한이 없습니다.')
+
+        return None
+
+    @staticmethod
+    def require_authoring_owner(user: User | AnonymousUser, owner: User) -> Optional[HttpResponse]:
+        login_error = ApiPermissionService.require_login(user)
+        if login_error:
+            return login_error
+
+        if user != owner:
+            return StatusError(ErrorCode.AUTHENTICATION, '권한이 없습니다.')
+
+        if not AuthoringPermissionService.is_active_editor(user):
+            return StatusError(ErrorCode.REJECT, '에디터 권한이 필요합니다.')
 
         return None

--- a/backend/src/board/services/authoring_permission_service.py
+++ b/backend/src/board/services/authoring_permission_service.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from django.contrib.auth.models import AnonymousUser, User
+
+
+class AuthoringPermissionService:
+    """Shared policy for authoring-only capabilities."""
+
+    @staticmethod
+    def is_active_editor(user: User | AnonymousUser) -> bool:
+        if not user.is_authenticated or not user.is_active:
+            return False
+
+        if not hasattr(user, 'profile'):
+            return False
+
+        return user.profile.is_editor()
+
+    @staticmethod
+    def can_manage_own_content(user: User | AnonymousUser, owner: User) -> bool:
+        if not AuthoringPermissionService.is_active_editor(user):
+            return False
+
+        return user == owner

--- a/backend/src/board/services/developer_token_service.py
+++ b/backend/src/board/services/developer_token_service.py
@@ -6,6 +6,7 @@ from django.contrib.auth.models import User
 from django.utils import timezone
 
 from board.models import DeveloperRequestLog, DeveloperToken
+from board.services.authoring_permission_service import AuthoringPermissionService
 
 
 class DeveloperAuthError(Exception):
@@ -21,7 +22,6 @@ class DeveloperTokenService:
     DEFAULT_EXPIRES_DAYS = 90
     MAX_EXPIRES_DAYS = 365
     VALID_SCOPES = {'posts:read', 'posts:write'}
-    WRITE_SCOPES = {'posts:write'}
 
     @staticmethod
     def hash_token(token):
@@ -64,13 +64,12 @@ class DeveloperTokenService:
         if not user.is_authenticated or not user.is_active:
             raise DeveloperAuthError('auth.need_login', '로그인이 필요합니다.', 401)
 
-        if DeveloperTokenService.WRITE_SCOPES.intersection(scopes):
-            if not hasattr(user, 'profile') or not user.profile.is_editor():
-                raise DeveloperAuthError(
-                    'token.permission_denied',
-                    '글 작성 scope는 편집자 권한이 필요합니다.',
-                    403,
-                )
+        if not AuthoringPermissionService.is_active_editor(user):
+            raise DeveloperAuthError(
+                'token.permission_denied',
+                '개발자 API는 편집자 권한이 필요합니다.',
+                403,
+            )
 
     @staticmethod
     def normalize_expires_at(expires_in_days):
@@ -202,6 +201,13 @@ class DeveloperTokenService:
                 'auth.inactive_user',
                 '비활성 사용자입니다.',
                 401,
+            )
+
+        if not AuthoringPermissionService.is_active_editor(token.user):
+            raise DeveloperAuthError(
+                'auth.editor_required',
+                '개발자 API는 편집자 권한이 필요합니다.',
+                403,
             )
 
         DeveloperToken.objects.filter(id=token.id).update(

--- a/backend/src/board/services/pinned_post_service.py
+++ b/backend/src/board/services/pinned_post_service.py
@@ -13,6 +13,7 @@ from django.db.models import F
 
 from board.models import Post, PinnedPost
 from board.modules.response import ErrorCode
+from board.services.authoring_permission_service import AuthoringPermissionService
 from board.services.public_post_service import PublicPostService
 
 
@@ -33,6 +34,14 @@ class PinnedPostService:
     def _is_published_post(post: Post) -> bool:
         """Return True when the post is published and already visible."""
         return PublicPostService.is_public(post)
+
+    @staticmethod
+    def validate_user_permissions(user: User) -> None:
+        if not AuthoringPermissionService.is_active_editor(user):
+            raise PinnedPostError(
+                ErrorCode.REJECT,
+                '에디터 권한이 필요합니다.',
+            )
 
     @staticmethod
     def get_user_pinned_posts(user: User) -> List[Dict[str, Any]]:
@@ -75,6 +84,8 @@ class PinnedPostService:
         Returns:
             List of pinnable post dictionaries
         """
+        PinnedPostService.validate_user_permissions(user)
+
         pinned_post_ids = PinnedPost.objects.filter(
             user=user
         ).values_list('post_id', flat=True)
@@ -108,6 +119,8 @@ class PinnedPostService:
         Raises:
             PinnedPostError: If validation fails
         """
+        PinnedPostService.validate_user_permissions(user)
+
         # Check if user has reached the limit
         current_count = PinnedPost.objects.filter(
             PublicPostService.build_public_filter('post'),
@@ -178,6 +191,8 @@ class PinnedPostService:
         Raises:
             PinnedPostError: If post is not found or not pinned
         """
+        PinnedPostService.validate_user_permissions(user)
+
         try:
             pinned_post = PinnedPost.objects.select_related('post').get(
                 user=user,
@@ -211,6 +226,8 @@ class PinnedPostService:
         Raises:
             PinnedPostError: If validation fails
         """
+        PinnedPostService.validate_user_permissions(user)
+
         if len(post_urls) > PinnedPostService.MAX_PINNED_POSTS:
             raise PinnedPostError(
                 ErrorCode.REJECT,

--- a/backend/src/board/services/post_service.py
+++ b/backend/src/board/services/post_service.py
@@ -25,6 +25,7 @@ from board.modules.post_description import create_post_description
 from board.services.tag_service import TagService
 from board.modules.response import ErrorCode
 from board.services.post_content_service import PostContentService
+from board.services.authoring_permission_service import AuthoringPermissionService
 from board.services.public_post_service import PublicPostService
 from board.services.webhook_service import WebhookService
 
@@ -51,13 +52,13 @@ class PostService:
         Raises:
             PostValidationError: If user doesn't have permission
         """
-        if not user.is_active:
+        if not user.is_authenticated or not user.is_active:
             raise PostValidationError(
                 ErrorCode.VALIDATE,
                 '활성화되지 않은 사용자입니다.'
             )
 
-        if not user.profile.is_editor():
+        if not AuthoringPermissionService.is_active_editor(user):
             raise PostValidationError(
                 ErrorCode.VALIDATE,
                 '작성 권한이 없습니다.'
@@ -558,9 +559,7 @@ class PostService:
         Returns:
             True if user can edit, False otherwise
         """
-        return user.is_authenticated and (
-            user == post.author or user.is_staff
-        )
+        return AuthoringPermissionService.can_manage_own_content(user, post.author)
 
     @staticmethod
     def can_user_delete_post(user: User, post: Post) -> bool:
@@ -574,9 +573,7 @@ class PostService:
         Returns:
             True if user can delete, False otherwise
         """
-        return user.is_authenticated and (
-            user == post.author or user.is_staff
-        )
+        return AuthoringPermissionService.can_manage_own_content(user, post.author)
 
     @staticmethod
     @transaction.atomic

--- a/backend/src/board/services/series_service.py
+++ b/backend/src/board/services/series_service.py
@@ -11,6 +11,7 @@ from django.db import transaction
 from django.db.models import F
 
 from board.models import Series, Post
+from board.services.authoring_permission_service import AuthoringPermissionService
 from board.services.public_post_service import PublicPostService
 from board.services.public_series_service import PublicSeriesService
 from board.modules.response import ErrorCode
@@ -42,6 +43,12 @@ class SeriesService:
             raise SeriesValidationError(
                 ErrorCode.NEED_LOGIN,
                 '로그인이 필요합니다.'
+            )
+
+        if not AuthoringPermissionService.is_active_editor(user):
+            raise SeriesValidationError(
+                ErrorCode.REJECT,
+                '에디터 권한이 필요합니다.'
             )
 
     @staticmethod
@@ -103,9 +110,7 @@ class SeriesService:
         Returns:
             True if user can edit, False otherwise
         """
-        return user.is_authenticated and (
-            user == series.owner or user.is_staff
-        )
+        return AuthoringPermissionService.can_manage_own_content(user, series.owner)
 
     @staticmethod
     @transaction.atomic

--- a/backend/src/board/services/user_role_service.py
+++ b/backend/src/board/services/user_role_service.py
@@ -13,6 +13,29 @@ class UserRoleService:
 
     @staticmethod
     @transaction.atomic
+    def set_profile_role(profile: Profile, role: str) -> Profile:
+        profile.role = role
+        profile.save(update_fields=['role'])
+        return profile
+
+    @staticmethod
+    @transaction.atomic
+    def set_profiles_role(profiles, role: str) -> int:
+        count = 0
+        for profile in profiles:
+            UserRoleService.set_profile_role(profile, role)
+            count += 1
+        return count
+
+    @staticmethod
+    @transaction.atomic
+    def set_users_role(users, role: str) -> int:
+        user_ids = users.values_list('id', flat=True)
+        profiles = Profile.objects.filter(user_id__in=user_ids)
+        return UserRoleService.set_profiles_role(profiles, role)
+
+    @staticmethod
+    @transaction.atomic
     def set_superuser_status(user: User, is_superuser: bool) -> User:
         """
         Update Django admin access and keep first-admin publishing usable.

--- a/backend/src/board/services/webhook_api_service.py
+++ b/backend/src/board/services/webhook_api_service.py
@@ -1,5 +1,6 @@
 from board.models import Profile, WebhookSubscription, SiteContentScope
 from board.modules.response import StatusError, ErrorCode
+from board.services.authoring_permission_service import AuthoringPermissionService
 
 
 class WebhookApiService:
@@ -12,6 +13,8 @@ class WebhookApiService:
 
         try:
             profile = Profile.objects.get(user=request.user)
+            if not AuthoringPermissionService.is_active_editor(request.user):
+                return None, StatusError(ErrorCode.REJECT, '에디터 권한이 필요합니다.')
             return profile, None
         except Profile.DoesNotExist:
             return None, StatusError(ErrorCode.NOT_FOUND, 'Profile not found')

--- a/backend/src/board/templates/board/posts/post_detail.html
+++ b/backend/src/board/templates/board/posts/post_detail.html
@@ -99,11 +99,13 @@
                                     {% endif %}
                                 </p>
                             </div>
+                            {% if can_edit_post %}
                             <a
                                 href="{% url 'post_edit' post.author_username post.url %}"
                                 class="inline-flex min-h-11 items-center justify-center rounded-lg border border-line px-4 py-2 text-sm font-semibold text-content-secondary transition-all duration-150 hover:bg-surface hover:text-content active:scale-95">
                                 수정하기
                             </a>
+                            {% endif %}
                         </div>
                     </section>
                     {% endif %}
@@ -353,7 +355,7 @@
                         </div>
 
                         <!-- Edit Button -->
-                        {% if user.is_authenticated and user.username == post.author_username %}
+                        {% if can_edit_post %}
                         <a href="{% url 'post_edit' post.author_username post.url %}"
                             class="w-11 h-11 flex items-center justify-center rounded-full text-content-secondary hover:text-content hover:bg-surface-subtle/80 transition-all duration-200 active:scale-95"
                             aria-label="포스트 수정">

--- a/backend/src/board/tests/api/test_developer_auth.py
+++ b/backend/src/board/tests/api/test_developer_auth.py
@@ -26,6 +26,14 @@ class DeveloperAuthAPITestCase(TestCase):
         Profile.objects.create(user=cls.reader, role=Profile.Role.READER)
         Config.objects.create(user=cls.reader)
 
+        cls.other_editor = User.objects.create_user(
+            username='other-developer',
+            password='other-developer',
+            email='other-developer@example.com',
+        )
+        Profile.objects.create(user=cls.other_editor, role=Profile.Role.EDITOR)
+        Config.objects.create(user=cls.other_editor)
+
     def setUp(self):
         self.client.defaults['HTTP_USER_AGENT'] = 'BLEX_TEST'
 
@@ -76,8 +84,8 @@ class DeveloperAuthAPITestCase(TestCase):
             scopes=['posts:read'],
         )
         DeveloperTokenService.create_token(
-            self.reader,
-            name='Reader token',
+            self.other_editor,
+            name='Other editor token',
             scopes=['posts:read'],
         )
         self.client.login(username='developer', password='developer')
@@ -112,8 +120,8 @@ class DeveloperAuthAPITestCase(TestCase):
 
     def test_user_cannot_revoke_other_user_token(self):
         _, token = DeveloperTokenService.create_token(
-            self.reader,
-            name='Reader token',
+            self.other_editor,
+            name='Other editor token',
             scopes=['posts:read'],
         )
         self.client.login(username='developer', password='developer')
@@ -153,14 +161,24 @@ class DeveloperAuthAPITestCase(TestCase):
         self.assertIn('ninja/swagger-ui-bundle.js', body)
         self.assertNotIn('cdn.jsdelivr.net', body)
 
-    def test_reader_cannot_create_write_scope_token(self):
+    def test_reader_cannot_create_developer_token(self):
         self.client.login(username='reader', password='reader')
 
         response = self.client.post(
             '/v1/developer-tokens',
-            json.dumps({'name': 'Writer', 'scopes': ['posts:write']}),
+            json.dumps({'name': 'Reader', 'scopes': ['posts:read']}),
             content_type='application/json',
         )
+
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(body['status'], 'ERROR')
+        self.assertEqual(body['errorCode'], 'error:RJ')
+
+    def test_reader_cannot_list_developer_tokens(self):
+        self.client.login(username='reader', password='reader')
+
+        response = self.client.get('/v1/developer-tokens')
 
         self.assertEqual(response.status_code, 200)
         body = response.json()
@@ -193,6 +211,24 @@ class DeveloperAuthAPITestCase(TestCase):
 
         token.refresh_from_db()
         self.assertIsNotNone(token.last_used_at)
+
+    def test_demoted_editor_token_is_rejected(self):
+        raw_token, _ = DeveloperTokenService.create_token(
+            self.editor,
+            name='MCP',
+            scopes=['posts:read'],
+        )
+        profile = Profile.objects.get(user=self.editor)
+        profile.role = Profile.Role.READER
+        profile.save(update_fields=['role'])
+
+        response = self.client.get(
+            '/api/developer/v1/me',
+            HTTP_AUTHORIZATION=f'Bearer {raw_token}',
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()['error']['code'], 'auth.editor_required')
 
     def test_revoked_token_is_rejected(self):
         raw_token, token = DeveloperTokenService.create_token(

--- a/backend/src/board/tests/api/test_editor_demotion_permissions.py
+++ b/backend/src/board/tests/api/test_editor_demotion_permissions.py
@@ -1,0 +1,204 @@
+import json
+from datetime import timedelta
+
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from board.models import (
+    Config,
+    PinnedPost,
+    Post,
+    PostConfig,
+    PostContent,
+    Profile,
+    Series,
+    User,
+)
+
+
+class EditorDemotionPermissionTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.author = User.objects.create_user(
+            username='author',
+            password='author',
+            email='author@example.com',
+        )
+        Profile.objects.create(user=cls.author, role=Profile.Role.EDITOR)
+        Config.objects.create(user=cls.author)
+
+        cls.public_post = Post.objects.create(
+            author=cls.author,
+            title='Public Post',
+            url='public-post',
+            published_date=timezone.now() - timedelta(days=1),
+        )
+        PostContent.objects.create(post=cls.public_post, content_html='<p>Public content</p>')
+        PostConfig.objects.create(post=cls.public_post, hide=False)
+
+        cls.draft = Post.objects.create(
+            author=cls.author,
+            title='Draft Post',
+            url='draft-post',
+            published_date=None,
+        )
+        PostContent.objects.create(post=cls.draft, content_html='<p>Draft content</p>')
+        PostConfig.objects.create(post=cls.draft, hide=False)
+
+        cls.series = Series.objects.create(
+            owner=cls.author,
+            name='Public Series',
+            url='public-series',
+            text_md='Series',
+            text_html='Series',
+        )
+
+    def setUp(self):
+        self.client.defaults['HTTP_USER_AGENT'] = 'BLEX_TEST'
+        PinnedPost.objects.all().delete()
+
+    def demote_author(self):
+        profile = Profile.objects.get(user=self.author)
+        profile.role = Profile.Role.READER
+        profile.save(update_fields=['role'])
+
+    def test_demoted_author_public_post_remains_visible(self):
+        self.demote_author()
+
+        response = self.client.get('/@author/public-post')
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_demoted_author_does_not_see_post_edit_entrypoint(self):
+        self.demote_author()
+        self.client.login(username='author', password='author')
+
+        response = self.client.get('/@author/public-post')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(
+            response,
+            reverse('post_edit', kwargs={
+                'username': 'author',
+                'post_url': 'public-post',
+            }),
+        )
+
+    def test_demoted_author_cannot_update_existing_post(self):
+        self.demote_author()
+        self.client.login(username='author', password='author')
+
+        response = self.client.post('/v1/users/@author/posts/public-post', {
+            'title': 'Changed',
+            'text_html': '<p>Changed</p>',
+        })
+
+        self.public_post.refresh_from_db()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['status'], 'ERROR')
+        self.assertEqual(response.json()['errorCode'], 'error:RJ')
+        self.assertEqual(self.public_post.title, 'Public Post')
+
+    def test_demoted_author_cannot_manage_drafts(self):
+        self.demote_author()
+        self.client.login(username='author', password='author')
+
+        list_response = self.client.get('/v1/drafts')
+        update_response = self.client.put(
+            '/v1/drafts/draft-post',
+            json.dumps({'title': 'Changed', 'content': '<p>Changed</p>'}),
+            content_type='application/json',
+        )
+
+        self.draft.refresh_from_db()
+        self.assertEqual(list_response.status_code, 200)
+        self.assertEqual(update_response.status_code, 200)
+        self.assertEqual(list_response.json()['status'], 'ERROR')
+        self.assertEqual(list_response.json()['errorCode'], 'error:RJ')
+        self.assertEqual(update_response.json()['status'], 'ERROR')
+        self.assertEqual(update_response.json()['errorCode'], 'error:RJ')
+        self.assertEqual(self.draft.title, 'Draft Post')
+
+    def test_demoted_author_cannot_manage_series(self):
+        self.demote_author()
+        self.client.login(username='author', password='author')
+
+        list_response = self.client.get('/v1/series')
+        update_response = self.client.put(
+            f'/v1/series/{self.series.id}',
+            json.dumps({'name': 'Changed'}),
+            content_type='application/json',
+        )
+
+        self.series.refresh_from_db()
+        self.assertEqual(list_response.status_code, 200)
+        self.assertEqual(update_response.status_code, 200)
+        self.assertEqual(list_response.json()['status'], 'ERROR')
+        self.assertEqual(list_response.json()['errorCode'], 'error:RJ')
+        self.assertEqual(update_response.json()['status'], 'ERROR')
+        self.assertEqual(update_response.json()['errorCode'], 'error:RJ')
+        self.assertEqual(self.series.name, 'Public Series')
+
+    def test_demoted_author_cannot_manage_pinned_posts(self):
+        self.demote_author()
+        self.client.login(username='author', password='author')
+
+        response = self.client.post(
+            '/v1/users/@author/pinned-posts',
+            {'post_url': 'public-post'},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['status'], 'ERROR')
+        self.assertEqual(response.json()['errorCode'], 'error:RJ')
+        self.assertFalse(PinnedPost.objects.exists())
+
+    def test_demoted_author_cannot_access_editor_only_api_surfaces(self):
+        self.demote_author()
+        self.client.login(username='author', password='author')
+
+        cases = [
+            ('get', '/v1/webhook/channels', {}),
+            (
+                'post',
+                '/v1/webhook/test',
+                {
+                    'data': json.dumps({'webhook_url': 'https://example.com/hook'}),
+                    'content_type': 'application/json',
+                },
+            ),
+            ('get', '/v1/forms', {}),
+            ('post', '/v1/image', {}),
+            (
+                'post',
+                '/v1/markdown',
+                {
+                    'data': json.dumps({'text': '# Title'}),
+                    'content_type': 'application/json',
+                },
+            ),
+            ('get', '/v1/setting/posts', {}),
+        ]
+
+        for method, path, kwargs in cases:
+            with self.subTest(path=path):
+                response = getattr(self.client, method)(path, **kwargs)
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.json()['status'], 'ERROR')
+                self.assertEqual(response.json()['errorCode'], 'error:RJ')
+
+    def test_scheduled_post_becomes_draft_when_author_is_demoted(self):
+        scheduled = Post.objects.create(
+            author=self.author,
+            title='Scheduled Post',
+            url='scheduled-post',
+            published_date=timezone.now() + timedelta(days=1),
+        )
+        PostContent.objects.create(post=scheduled, content_html='<p>Scheduled</p>')
+        PostConfig.objects.create(post=scheduled, hide=False)
+
+        self.demote_author()
+
+        scheduled.refresh_from_db()
+        self.assertIsNone(scheduled.published_date)

--- a/backend/src/board/tests/api/test_form.py
+++ b/backend/src/board/tests/api/test_form.py
@@ -1,13 +1,13 @@
 from django.test import Client, TestCase
-from django.urls import reverse
 from django.contrib.auth.models import User
-from board.models import Form
+from board.models import Form, Profile
 
 
 class FormTestCase(TestCase):
     def setUp(self):
         self.user = User.objects.create_user(
             username='testuser', password='testpass')
+        Profile.objects.create(user=self.user, role=Profile.Role.EDITOR)
         self.form = Form.objects.create(
             user=self.user, title='Test Form', content='Test Content')
 
@@ -35,6 +35,7 @@ class FormTestCase(TestCase):
         # 다른 유저로 로그인한 경우
         other_user = User.objects.create_user(
             username='otheruser', password='otherpass')
+        Profile.objects.create(user=other_user, role=Profile.Role.EDITOR)
         self.client.login(username='otheruser', password='otherpass')
         response = self.client.get(f'/v1/forms/{self.form.id}')
         self.assertEqual(response.status_code, 404)

--- a/backend/src/board/tests/api/test_post.py
+++ b/backend/src/board/tests/api/test_post.py
@@ -269,7 +269,7 @@ class PostTestCase(TestCase):
             'description': 'Custom Description'
         })
         content = json.loads(response.content)
-        self.assertEqual(content['errorCode'], 'error:VA')
+        self.assertEqual(content['errorCode'], 'error:RJ')
 
     def test_create_post_markdown_mode(self):
         """마크다운 모드 포스트 생성 테스트"""

--- a/backend/src/board/tests/api/test_series_api.py
+++ b/backend/src/board/tests/api/test_series_api.py
@@ -32,6 +32,15 @@ class SeriesAPITestCase(TestCase):
         Profile.objects.create(user=viewer, role=Profile.Role.READER)
         Config.objects.create(user=viewer)
 
+        other_editor = User.objects.create_user(
+            username='other-editor',
+            password='other-editor',
+            email='other-editor@test.com',
+            first_name='Other Editor',
+        )
+        Profile.objects.create(user=other_editor, role=Profile.Role.EDITOR)
+        Config.objects.create(user=other_editor)
+
         # Create test posts
         for i in range(10):
             post = Post.objects.create(
@@ -335,7 +344,7 @@ class SeriesAPITestCase(TestCase):
 
     def test_get_series_detail_by_id_requires_ownership(self):
         """타인의 시리즈는 상세 API로 조회할 수 없다"""
-        self.client.login(username='viewer', password='viewer')
+        self.client.login(username='other-editor', password='other-editor')
         series = Series.objects.get(url='test-series')
         response = self.client.get(f'/v1/series/{series.id}')
         self.assertEqual(response.status_code, 200)
@@ -672,5 +681,3 @@ class SeriesAPITestCase(TestCase):
         
         series_urls = [s['url'] for s in content['body']['series']]
         self.assertNotIn('hidden-series', series_urls)
-
-

--- a/backend/src/board/tests/api/test_webhook.py
+++ b/backend/src/board/tests/api/test_webhook.py
@@ -29,7 +29,7 @@ class WebhookAPITestCase(TestCase):
             email='test@example.com',
             password='testpass123'
         )
-        cls.profile = Profile.objects.create(user=cls.user)
+        cls.profile = Profile.objects.create(user=cls.user, role=Profile.Role.EDITOR)
 
         cls.other_user = User.objects.create_user(
             username='otheruser',

--- a/backend/src/board/tests/services/test_user_role_service.py
+++ b/backend/src/board/tests/services/test_user_role_service.py
@@ -1,7 +1,10 @@
+from datetime import timedelta
+
 from django.contrib.auth.models import User
 from django.test import TestCase
+from django.utils import timezone
 
-from board.models import Config, Profile
+from board.models import Config, Post, Profile
 from board.services.user_role_service import UserRoleService
 
 
@@ -55,3 +58,22 @@ class UserRoleServiceTestCase(TestCase):
         self.assertFalse(user.is_staff)
         self.assertFalse(user.is_superuser)
         self.assertEqual(user.profile.role, Profile.Role.EDITOR)
+
+    def test_set_users_role_runs_profile_save_policy(self):
+        """역할 일괄 변경도 프로필 저장 정책을 우회하지 않는다."""
+        user = User.objects.create_user(username='scheduled-editor', password='password123')
+        Profile.objects.create(user=user, role=Profile.Role.EDITOR)
+        scheduled = Post.objects.create(
+            author=user,
+            title='Scheduled',
+            url='scheduled',
+            published_date=timezone.now() + timedelta(days=1),
+        )
+
+        count = UserRoleService.set_users_role(User.objects.filter(id=user.id), Profile.Role.READER)
+
+        scheduled.refresh_from_db()
+        user.profile.refresh_from_db()
+        self.assertEqual(count, 1)
+        self.assertEqual(user.profile.role, Profile.Role.READER)
+        self.assertIsNone(scheduled.published_date)

--- a/backend/src/board/tests/templates/test_settings.py
+++ b/backend/src/board/tests/templates/test_settings.py
@@ -67,6 +67,14 @@ class SettingsViewTestCase(TestCase):
 
         self.assertEqual(response.status_code, 404)
 
+    def test_reader_gets_404_for_editor_settings_url(self):
+        client = Client(raise_request_exception=False)
+        client.login(username='settings-reader', password='password123')
+
+        response = client.get('/settings/developer-api')
+
+        self.assertEqual(response.status_code, 404)
+
     def test_legacy_admin_settings_url_redirects_to_admin_namespace(self):
         self.client.login(username='settings-staff', password='password123')
 

--- a/backend/src/board/tests/templates/test_username_redirect.py
+++ b/backend/src/board/tests/templates/test_username_redirect.py
@@ -86,9 +86,9 @@ class UsernameRedirectTestCase(TestCase):
         # Should return 200 OK (no redirect)
         self.assertEqual(response.status_code, 200)
 
-    def test_redirect_only_for_editors(self):
-        """Test redirect only works for users with editor role"""
-        # Create user without editor role
+    def test_redirect_preserves_public_post_for_reader_owner(self):
+        """Old username redirects are based on public post ownership, not current role."""
+        # A demoted editor can have public posts while their current role is reader.
         reader_user = User.objects.create_user(
             username='currentreader',
             email='reader@example.com',
@@ -132,8 +132,12 @@ class UsernameRedirectTestCase(TestCase):
             })
         )
 
-        # Should return 404 (no redirect for non-editors)
-        self.assertEqual(response.status_code, 404)
+        # Public post URLs should keep redirecting after demotion.
+        expected_url = reverse('post_detail', kwargs={
+            'username': 'currentreader',
+            'post_url': 'reader-post'
+        })
+        self.assertRedirects(response, expected_url)
 
     def test_multiple_username_changes(self):
         """Test with multiple username changes (only latest should work)"""

--- a/backend/src/board/views/api/v1/developer_token.py
+++ b/backend/src/board/views/api/v1/developer_token.py
@@ -4,6 +4,7 @@ from django.http import Http404
 from django.shortcuts import get_object_or_404
 
 from board.models import DeveloperToken
+from board.decorators import api_editor_required
 from board.modules.developer_serializers import DeveloperTokenSerializer
 from board.modules.response import ErrorCode, StatusDone, StatusError
 from board.services.developer_token_service import (
@@ -67,10 +68,8 @@ class DeveloperTokenAPI:
         return StatusDone(DeveloperTokenSerializer.serialize(token))
 
 
+@api_editor_required
 def developer_tokens(request, token_id=None):
-    if not request.user.is_authenticated or not request.user.is_active:
-        return StatusError(ErrorCode.NEED_LOGIN)
-
     if token_id is None:
         if request.method == 'GET':
             return DeveloperTokenAPI.list_tokens(request)

--- a/backend/src/board/views/api/v1/draft.py
+++ b/backend/src/board/views/api/v1/draft.py
@@ -5,10 +5,12 @@ from django.http.multipartparser import MultiPartParser
 from django.shortcuts import get_object_or_404
 
 from board.models import Post
+from board.decorators import api_editor_required
 from board.services.post_service import PostService, PostValidationError
 from board.modules.response import StatusDone, StatusError, ErrorCode
 
 
+@api_editor_required
 def drafts_list(request):
     if not request.user.is_active:
         return StatusError(ErrorCode.NEED_LOGIN)
@@ -68,6 +70,7 @@ def drafts_list(request):
     raise Http404
 
 
+@api_editor_required
 def drafts_detail(request, url):
     if not request.user.is_active:
         return StatusError(ErrorCode.NEED_LOGIN)

--- a/backend/src/board/views/api/v1/form.py
+++ b/backend/src/board/views/api/v1/form.py
@@ -3,10 +3,12 @@ from django.shortcuts import get_object_or_404
 from django.http import Http404, QueryDict
 
 from board.models import Form
+from board.decorators import api_editor_required
 from board.modules.time import convert_to_localtime
 from board.modules.response import StatusDone, StatusError, ErrorCode
 
 
+@api_editor_required
 def forms_list(request):
     if not request.user.is_active:
         return StatusError(ErrorCode.NEED_LOGIN)
@@ -44,6 +46,7 @@ def forms_list(request):
             return StatusError(ErrorCode.INVALID_PARAMETER)
 
 
+@api_editor_required
 def forms_detail(request, id):
     if not request.user.is_active:
         return StatusError(ErrorCode.NEED_LOGIN)

--- a/backend/src/board/views/api/v1/image.py
+++ b/backend/src/board/views/api/v1/image.py
@@ -1,6 +1,7 @@
 from django.http import Http404
 
 from board.modules.response import StatusDone, StatusError, ErrorCode
+from board.services.api_permission_service import ApiPermissionService
 from board.services.image_upload_service import ImageUploadError, ImageUploadService
 
 
@@ -8,6 +9,10 @@ def image(request):
     if request.method == 'POST':
         if not request.user.is_active:
             raise Http404
+
+        permission_error = ApiPermissionService.require_editor(request.user)
+        if permission_error:
+            return permission_error
 
         try:
             url = ImageUploadService.upload_content_image(

--- a/backend/src/board/views/api/v1/markdown.py
+++ b/backend/src/board/views/api/v1/markdown.py
@@ -2,9 +2,11 @@ import json
 from django.http import Http404
 
 from modules import markdown
+from board.decorators import api_editor_required_methods
 from board.modules.response import StatusDone, StatusError, ErrorCode
 
 
+@api_editor_required_methods(['POST'])
 def markdown_to_html(request):
     """
     Convert markdown text to HTML.
@@ -15,14 +17,6 @@ def markdown_to_html(request):
     """
     if request.method != 'POST':
         raise Http404
-    
-    if not request.user.is_authenticated:
-        return StatusError(ErrorCode.NEED_LOGIN)
-    
-    # Check if user has editor permission
-    if not hasattr(request.user, 'profile') or not request.user.profile.is_editor():
-        return StatusError(ErrorCode.NEED_LOGIN, '편집자 권한이 필요합니다.')
-
     
     try:
         if request.content_type == 'application/json':

--- a/backend/src/board/views/api/v1/pinned_post.py
+++ b/backend/src/board/views/api/v1/pinned_post.py
@@ -27,7 +27,7 @@ def pinned_posts(request, username):
             'max_count': PinnedPostService.MAX_PINNED_POSTS,
         })
 
-    permission_error = ApiPermissionService.require_owner(request.user, user)
+    permission_error = ApiPermissionService.require_authoring_owner(request.user, user)
     if permission_error:
         return permission_error
 
@@ -65,7 +65,7 @@ def pinned_posts_order(request, username):
     """
     user = get_object_or_404(User, username=username)
 
-    permission_error = ApiPermissionService.require_owner(request.user, user)
+    permission_error = ApiPermissionService.require_authoring_owner(request.user, user)
     if permission_error:
         return permission_error
 
@@ -98,7 +98,7 @@ def pinnable_posts(request, username):
     """
     user = get_object_or_404(User, username=username)
 
-    permission_error = ApiPermissionService.require_owner(request.user, user)
+    permission_error = ApiPermissionService.require_authoring_owner(request.user, user)
     if permission_error:
         return permission_error
 

--- a/backend/src/board/views/api/v1/post.py
+++ b/backend/src/board/views/api/v1/post.py
@@ -6,7 +6,9 @@ from board.models import Post, PinnedPost
 from board.modules.requests import BooleanType
 from board.modules.response import StatusDone, StatusError, ErrorCode
 from board.modules.time import convert_to_localtime, time_since
+from board.decorators import api_editor_required_methods
 from board.services.comment_list_service import CommentListService
+from board.services.api_permission_service import ApiPermissionService
 from board.services.post_service import PostService, PostValidationError
 from board.services.public_post_service import PublicPostService
 
@@ -15,6 +17,10 @@ def post_list(request):
     if request.method == 'POST':
         if not request.user.is_authenticated:
             raise Http404
+
+        permission_error = ApiPermissionService.require_editor(request.user)
+        if permission_error:
+            return permission_error
 
         try:
             image = request.FILES.get('image', None)
@@ -56,13 +62,14 @@ def post_comment_list(request, url):
         return StatusDone(CommentListService.serialize_post_comments(url, request.user))
 
 
+@api_editor_required_methods(['POST', 'PUT', 'DELETE'])
 def user_posts(request, username, url=None):
     if url:
         post = PostService.get_post_detail(username, url, request.user)
 
         if request.method == 'GET':
             if request.GET.get('mode') == 'edit':
-                if not request.user == post.author:
+                if not PostService.can_user_edit_post(request.user, post):
                     raise Http404
 
                 content_html = post.content.content_html if hasattr(post, 'content') else ''

--- a/backend/src/board/views/api/v1/series.py
+++ b/backend/src/board/views/api/v1/series.py
@@ -3,6 +3,7 @@ from django.http import Http404, QueryDict
 from django.shortcuts import get_object_or_404
 
 from board.models import User, Post, Series
+from board.decorators import api_editor_required, api_editor_required_methods
 from board.services import SeriesService
 from board.services.series_service import SeriesValidationError
 from board.services.public_post_service import PublicPostService
@@ -13,6 +14,7 @@ from board.modules.paginator import Paginator
 from board.modules.response import StatusDone, StatusError, ErrorCode
 
 
+@api_editor_required
 def posts_can_add_series(request):
     if request.method == 'GET':
         if not request.user.is_authenticated:
@@ -48,6 +50,7 @@ def posts_can_add_series(request):
     raise Http404
 
 
+@api_editor_required_methods(['POST', 'PUT', 'DELETE'])
 def user_series(request, username, url=None):
     if not url:
         if request.method == 'GET':
@@ -194,6 +197,7 @@ def user_series(request, username, url=None):
         raise Http404
 
 
+@api_editor_required
 def series_order(request):
     """
     Update series order for the current user.
@@ -222,6 +226,7 @@ def series_order(request):
     raise Http404
 
 
+@api_editor_required
 def series_create_update(request):
     """
     Get series list (GET) or Create new series (POST) for the current user.
@@ -281,6 +286,7 @@ def series_create_update(request):
     raise Http404
 
 
+@api_editor_required
 def series_detail(request, series_id):
     """
     Get (GET), update (PUT), or delete (DELETE) a specific series by ID.

--- a/backend/src/board/views/api/v1/setting.py
+++ b/backend/src/board/views/api/v1/setting.py
@@ -13,15 +13,32 @@ from board.modules.paginator import Paginator
 from board.modules.response import StatusDone, StatusError, ErrorCode
 from board.modules.time import convert_to_localtime
 from board.services.auth_service import AuthService, AuthValidationError
+from board.services.api_permission_service import ApiPermissionService
 from board.services.pinned_post_service import PinnedPostService, PinnedPostError
 from board.services.user_heatmap_service import UserHeatmapService
 from board.services.user_notification_service import UserNotificationService
 from board.services.user_social_link_service import UserSocialLinkService
 
 
+EDITOR_SETTING_PARAMETERS = {
+    'posts',
+    'reserved-posts',
+    'tag',
+    'series',
+    'pinned-posts',
+    'pinnable-posts',
+    'pinned-posts/order',
+}
+
+
 def setting(request, parameter):
     if not request.user.is_active:
         return StatusError(ErrorCode.NEED_LOGIN)
+
+    if parameter in EDITOR_SETTING_PARAMETERS:
+        permission_error = ApiPermissionService.require_editor(request.user)
+        if permission_error:
+            return permission_error
 
     user = get_object_or_404(
         User.objects.select_related(

--- a/backend/src/board/views/api/v1/webhook.py
+++ b/backend/src/board/views/api/v1/webhook.py
@@ -9,6 +9,7 @@ When a new post is published, notifications are sent to:
 from django.views.decorators.http import require_http_methods
 
 from board.models import WebhookSubscription, SiteContentScope
+from board.decorators import api_editor_required
 from board.services import WebhookService
 from board.services.api_request_body_service import ApiRequestBodyService
 from board.services.webhook_api_service import WebhookApiService
@@ -49,6 +50,7 @@ def _ensure_staff(request):
 
 
 @require_http_methods(['GET', 'POST'])
+@api_editor_required
 def my_channels(request):
     """
     Manage my notification channels (webhooks).
@@ -85,6 +87,7 @@ def my_channels(request):
 
 
 @require_http_methods(['DELETE'])
+@api_editor_required
 def delete_channel(request, channel_id):
     """
     Delete a notification channel.
@@ -167,6 +170,7 @@ def delete_global_channel(request, channel_id):
 
 
 @require_http_methods(['POST'])
+@api_editor_required
 def test_channel(request):
     """
     Test a webhook URL by sending a test message.

--- a/backend/src/board/views/post.py
+++ b/backend/src/board/views/post.py
@@ -16,15 +16,19 @@ from board.services.discovery_metadata_service import DiscoveryMetadataService
 from board.services.public_post_service import PublicPostService
 from board.services.site_url_service import SiteUrlService
 from board.html_utils import extract_table_of_contents
+from board.decorators import editor_required
 
 def post_detail(request, username, post_url):
     """
     View for the post detail page.
     """
     # Check if this is an old username in the change log
-    username_log = UsernameChangeLog.objects.filter(username=username).select_related('user', 'user__profile').first()
+    username_log = UsernameChangeLog.objects.filter(username=username).select_related('user').first()
     if username_log:
-        if username_log.user.profile.is_editor():
+        if PublicPostService.filter_public_posts(Post.objects).filter(
+            author=username_log.user,
+            url=post_url,
+        ).exists():
             return redirect('post_detail', username=username_log.user.username, post_url=post_url)
 
     author = get_object_or_404(User, username=username)
@@ -74,6 +78,7 @@ def post_detail(request, username, post_url):
         is_owner
         and post_visibility_status in {'hidden', 'scheduled'}
     )
+    can_edit_post = PostService.can_user_edit_post(request.user, post)
 
     show_agent_post_markdown = aeo_enabled and is_public_post
     context = {
@@ -87,6 +92,7 @@ def post_detail(request, username, post_url):
         'post_image_url': post_image_url,
         'logo_url': logo_url,
         'show_post_status_notice': show_post_status_notice,
+        'can_edit_post': can_edit_post,
         'post_visibility_status': post_visibility_status,
         'show_agent_post_markdown': show_agent_post_markdown,
         **DiscoveryMetadataService.build_user_rss_feed_metadata(author, request),
@@ -101,18 +107,12 @@ def post_detail(request, username, post_url):
     return response
 
 
+@editor_required
 def post_editor(request, username=None, post_url=None):
     """
     View for the post editor page.
     Used for both creating new posts and editing existing posts.
     """
-    if not request.user.is_authenticated:
-        return redirect('login')
-
-    if not request.user.profile.is_editor():
-        messages.error(request, '편집자 권한이 필요합니다. 관리자에게 문의하세요.')
-        return redirect('index')
-
     is_edit = username is not None and post_url is not None
     post = None
     draft_post = None

--- a/backend/src/board/views/settings.py
+++ b/backend/src/board/views/settings.py
@@ -3,6 +3,8 @@ from django.contrib.auth.decorators import login_required
 from django.http import Http404
 from django.urls import reverse
 
+from board.services.authoring_permission_service import AuthoringPermissionService
+
 
 ADMIN_SETTINGS_PREFIXES = (
     'site-settings',
@@ -14,6 +16,18 @@ ADMIN_SETTINGS_PREFIXES = (
     'utilities',
 )
 
+EDITOR_SETTINGS_PREFIXES = (
+    'posts',
+    'series',
+    'pinned-posts',
+    'drafts',
+    'forms',
+    'notices',
+    'banners',
+    'webhook',
+    'developer-api',
+)
+
 
 def _is_admin_settings_path(path):
     normalized_path = path.strip('/')
@@ -23,13 +37,21 @@ def _is_admin_settings_path(path):
     )
 
 
+def _is_editor_settings_path(path):
+    normalized_path = path.strip('/')
+    return any(
+        normalized_path == prefix or normalized_path.startswith(f'{prefix}/')
+        for prefix in EDITOR_SETTINGS_PREFIXES
+    )
+
+
 def _build_settings_context(request, settings_mode, base_path):
     admin_url = None
     if request.user.is_staff:
         admin_url = reverse('admin:index')
 
     return {
-        'is_editor': request.user.profile.is_editor(),
+        'is_editor': AuthoringPermissionService.is_active_editor(request.user),
         'is_staff': request.user.is_staff,
         'admin_url': admin_url,
         'settings_mode': settings_mode,
@@ -49,6 +71,9 @@ def settings(request, path=''):
         if not request.user.is_staff:
             raise Http404
         return redirect(f'/admin-settings/{path}')
+
+    if _is_editor_settings_path(path) and not AuthoringPermissionService.is_active_editor(request.user):
+        raise Http404
 
     context = _build_settings_context(request, 'user', '/settings')
 


### PR DESCRIPTION
## 🎯 Goal
- Prevent users demoted from editor to reader from keeping authoring, management, or developer API privileges.
- Keep already public content reachable through existing public surfaces while revoking future publishing and automation access.

## 🔧 Core Changes
- Added shared authoring permission helpers and applied them to post, draft, series, pinned post, form, webhook, image, markdown, settings, and developer-token APIs.
- Reject developer API tokens at authentication time when the token owner is no longer an active editor.
- Convert future scheduled posts back to drafts when an editor is demoted to reader.
- Hide editor-only settings routes and post edit entrypoints for demoted readers.
- Preserve public post access and old-username redirects for already public posts.

## 🤔 Key Decisions
- Reader demotion does not delete or hide already public posts.
- Reader demotion removes authoring and automation capabilities instead of adding API rate limits.
- Existing public discovery remains available through main lists, search, RSS, post sitemap, Markdown endpoints, and direct public URLs.
- Profile-level author archives remain under the existing reader profile policy and are not expanded in this PR.

## 🧪 Verification Guide
### How to verify
1. Demote an editor with public, draft, and scheduled posts to reader.
2. Confirm public post URLs still load, while edit/write/draft/series/pinned/webhook/form/developer API actions return permission errors or hide editor-only UI.
3. Confirm a developer API token created before demotion is rejected after demotion.

### Expected result
- Public posts remain visible on public surfaces.
- Demoted readers cannot create, update, publish, pin, manage drafts/series/forms/webhooks, upload authoring images, or use developer API tokens.
- Future scheduled posts become drafts on demotion.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)

Verification run:
- `npm run server:test` (876 tests)
- `npm run islands:type-check`
- `npm run islands:lint` (existing warnings only)
- `git diff --check`