### PR TITLE
✨ Polish author profile UI

### DIFF
--- a/backend/islands/apps/remotes/src/components/remotes/Author/Heatmap.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/Author/Heatmap.tsx
@@ -181,12 +181,28 @@ const Heatmap = ({ username }: HeatmapProps) => {
                         letter-spacing: 0.015em;
                     }
 
-                    .author-heatmap-chart .graph-svg-tip {
-                        background: var(--color-surface);
-                        color: var(--color-content);
-                        border: 1px solid var(--color-line);
-                        border-radius: 10px;
+                    .author-heatmap-chart .graph-svg-tip,
+                    .author-heatmap-chart .graph-svg-tip.comparison {
+                        background: var(--color-surface-elevated) !important;
+                        color: var(--color-content-secondary) !important;
+                        border: 1px solid var(--color-line) !important;
+                        border-radius: 10px !important;
+                        box-shadow: 0 10px 28px rgba(0, 0, 0, 0.14);
                         backdrop-filter: blur(6px);
+                    }
+
+                    .author-heatmap-chart .graph-svg-tip .title {
+                        color: var(--color-content-secondary) !important;
+                        line-height: 1.25 !important;
+                    }
+
+                    .author-heatmap-chart .graph-svg-tip strong {
+                        color: var(--color-content) !important;
+                        font-weight: 700 !important;
+                    }
+
+                    .author-heatmap-chart .graph-svg-tip .svg-pointer {
+                        border-top-color: var(--color-surface-elevated) !important;
                     }
 
                     .author-heatmap-chart .chart-legend text.subdomain-name {

--- a/backend/src/board/templates/board/author/author_overview.html
+++ b/backend/src/board/templates/board/author/author_overview.html
@@ -31,11 +31,15 @@
             <!-- Featured Posts Section -->
             {% if featured_posts_section.posts or request.user == author %}
             <section>
-                <div class="mb-4 flex items-center justify-between gap-4">
-                    <h2 class="text-2xl font-bold text-content">{{ featured_posts_section.title }}</h2>
-                    {% if featured_posts_section.posts %}
-                    <a href="/@{{ author.username }}/posts" class="text-sm font-semibold text-content-secondary transition-colors hover:text-content">
-                        모든 포스트 보기
+                <div class="mb-4 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+                    <div>
+                        <p class="mb-2 text-xs font-bold uppercase tracking-[0.18em] text-content-hint">Posts</p>
+                        <h2 class="text-2xl font-bold text-content">{{ featured_posts_section.title }}</h2>
+                    </div>
+                    {% if request.user == author %}
+                    <a href="/settings/pinned-posts" class="inline-flex w-fit items-center justify-center rounded-lg bg-surface-subtle px-4 py-2 text-sm font-semibold text-content-secondary transition-colors hover:bg-surface-subtle/80 hover:text-content">
+                        <i class="fas fa-thumbtack mr-2 text-xs"></i>
+                        고정 포스트 설정
                     </a>
                     {% endif %}
                 </div>
@@ -80,8 +84,8 @@
                 </div>
                 {% elif request.user == author %}
                 <div class="rounded-2xl border border-dashed border-line bg-surface px-6 py-8 text-center">
-                    <p class="text-sm font-semibold text-content">아직 보여줄 공개 포스트가 없습니다.</p>
-                    <p class="mt-1 text-sm text-content-secondary">첫 글을 발행하면 이 영역에 최근 포스트가 표시됩니다.</p>
+                    <p class="text-sm font-semibold text-content">아직 공개된 포스트가 없습니다.</p>
+                    <p class="mt-1 text-sm text-content-secondary">첫 글을 발행하면 이 영역에 표시됩니다.</p>
                     <a href="/write" class="mt-4 inline-flex items-center justify-center rounded-lg bg-action px-4 py-2 text-sm font-semibold text-content-inverted transition-colors hover:bg-action-hover">
                         글 작성하기
                     </a>

--- a/backend/src/board/templates/board/author/author_posts.html
+++ b/backend/src/board/templates/board/author/author_posts.html
@@ -35,11 +35,11 @@
         <div class="md:col-span-3">
             {% if not posts %}
                 {% if request.GET.q or request.GET.tag %}
-                    {% with empty_title='검색 결과가 없습니다' empty_message='검색어를 다시 확인해주세요.' %}
+                    {% with empty_title='조건에 맞는 포스트가 없습니다' empty_message='검색어나 태그를 다시 확인해주세요.' %}
                         {% include 'board/author/components/empty_state.html' %}
                     {% endwith %}
                 {% else %}
-                    {% with empty_title='작성된 포스트가 없습니다' empty_message=author.username|add:"님이 포스트를 검토중이에요." %}
+                    {% with empty_title='아직 공개된 포스트가 없습니다' empty_message='새 글이 발행되면 이곳에 표시됩니다.' %}
                         {% include 'board/author/components/empty_state.html' %}
                     {% endwith %}
                 {% endif %}

--- a/backend/src/board/templates/board/author/author_series.html
+++ b/backend/src/board/templates/board/author/author_series.html
@@ -35,11 +35,11 @@
         <div class="md:col-span-3">        
             {% if not series_list %}
                 {% if request.GET.q %}
-                    {% with empty_title='검색 결과가 없습니다' empty_message='검색어를 다시 확인해주세요.' %}
+                    {% with empty_title='조건에 맞는 시리즈가 없습니다' empty_message='검색어를 다시 확인해주세요.' %}
                         {% include 'board/author/components/empty_state.html' %}
                     {% endwith %}
                 {% else %}
-                    {% with empty_title='생성된 시리즈가 없습니다' empty_message=author.username|add:"님이 시리즈를 준비중이에요." %}
+                    {% with empty_title='아직 공개된 시리즈가 없습니다' empty_message='시리즈가 공개되면 이곳에 표시됩니다.' %}
                         {% include 'board/author/components/empty_state.html' %}
                     {% endwith %}
                 {% endif %}

--- a/backend/src/board/templates/board/author/components/activity_section.html
+++ b/backend/src/board/templates/board/author/components/activity_section.html
@@ -1,18 +1,18 @@
 <!-- Activity Section -->
 <section>
     <div class="mb-4">
-        <h2 class="text-2xl font-bold text-content">{% if is_editor_view %}최근 활동{% else %}활동{% endif %}</h2>
-        <p class="mt-1 text-sm text-content-secondary">최근 1년 잔디와 최신 활동 기록입니다.</p>
+        <p class="mb-2 text-xs font-bold uppercase tracking-[0.18em] text-content-hint">Activity</p>
+        <h2 class="text-2xl font-bold text-content">연간 활동</h2>
     </div>
 
     <!-- Heatmap -->
-    <div class="bg-surface rounded-2xl ring-1 ring-line/60 p-6 md:p-7 mb-6" style="min-height: 280px;">
-        <island-component name="Heatmap" props="{{ author_activity_props }}"></island-component>
+    <div class="bg-surface rounded-2xl ring-1 ring-line/60 p-6 md:p-7 mb-6">
+        <island-component name="Heatmap" props="{{ author_activity_props }}" style="display: block; min-height: 218px;"></island-component>
 
         {% if recent_activities %}
             <div class="mt-8 border-t border-line-light pt-6">
                 <div class="mb-3 flex items-center justify-between px-1">
-                    <h3 class="text-sm font-semibold text-content">최근 활동 내역</h3>
+                    <h3 class="text-sm font-semibold text-content">활동 내역</h3>
                     <span class="inline-flex items-center rounded-md bg-surface-subtle px-2 py-0.5 text-[11px] font-medium text-content-secondary">
                         {{ recent_activities|length }}개
                     </span>
@@ -59,7 +59,7 @@
         {% else %}
             <div class="py-12 text-center">
                 <i class="fas fa-wind text-content-hint text-2xl mb-3"></i>
-                <p class="text-sm text-content-hint">기록된 활동이 없습니다</p>
+                <p class="text-sm text-content-hint">표시할 활동이 없습니다</p>
             </div>
         {% endif %}
     </div>

--- a/backend/src/board/templates/board/author/components/readme_section.html
+++ b/backend/src/board/templates/board/author/components/readme_section.html
@@ -1,30 +1,109 @@
 <!-- Introduction Section -->
-<section>
+{% if about_html or user == author %}
+<section
+    {% if user == author %}
+    x-data="{
+        editing: false,
+        saving: false,
+        message: '',
+        initialContent: '{{ about_md|default:''|escapejs }}',
+        content: '{{ about_md|default:''|escapejs }}',
+        startEditing() {
+            this.content = this.initialContent;
+            this.message = '';
+            this.editing = true;
+            this.$nextTick(() => this.$refs.aboutEditor?.focus());
+        },
+        cancelEditing() {
+            this.content = this.initialContent;
+            this.message = '';
+            this.editing = false;
+        },
+        async saveAbout() {
+            if (this.saving) return;
+
+            this.saving = true;
+            this.message = '';
+
+            try {
+                const formData = new FormData();
+                formData.append('about_md', this.content);
+                formData.append('csrfmiddlewaretoken', '{{ csrf_token|escapejs }}');
+
+                const response = await fetch('{% url 'user_about_edit' author.username %}', {
+                    method: 'POST',
+                    body: formData,
+                    headers: {
+                        'X-CSRFToken': '{{ csrf_token|escapejs }}'
+                    }
+                });
+                const data = await response.json().catch(() => ({}));
+
+                if (!response.ok || data.status !== 'success') {
+                    this.message = data.message || '소개글을 저장하지 못했습니다.';
+                    return;
+                }
+
+                window.location.reload();
+            } catch (error) {
+                this.message = '네트워크 오류로 저장하지 못했습니다.';
+            } finally {
+                this.saving = false;
+            }
+        }
+    }"
+    {% endif %}>
     <div>
         <div class="mb-6">
             <p class="mb-2 text-xs font-bold uppercase tracking-[0.18em] text-content-hint">About</p>
             <h2 class="text-2xl font-bold text-content">소개</h2>
         </div>
         {% if about_html %}
-            <div class="prose blog-post-content">
+            <div class="prose blog-post-content" x-show="!editing">
                 {{ about_html|safe }}
             </div>
         {% else %}
-            <div class="text-center py-16">
-                <div class="inline-flex items-center justify-center w-14 h-14 rounded-xl bg-surface-subtle mb-3">
-                    <i class="fas fa-file-alt text-content-hint text-lg"></i>
+            <div class="rounded-2xl border border-dashed border-line bg-surface px-5 py-4" x-show="!editing">
+                <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    <p class="text-sm text-content-secondary">소개글을 작성하면 프로필에 표시됩니다.</p>
+                    <button type="button" @click="startEditing()" class="inline-flex items-center justify-center rounded-lg bg-surface-subtle px-4 py-2 text-sm font-semibold text-content-secondary transition-colors hover:bg-surface-subtle/80 hover:text-content">
+                        <i class="fas fa-edit mr-2"></i>
+                        소개글 작성
+                    </button>
                 </div>
-                <p class="text-content-hint font-medium">아직 소개글이 없습니다</p>
             </div>
         {% endif %}
 
-        {% if user == author %}
-        <div class="mt-6">
-            <a href="{% url 'user_about_edit' author.username %}" class="inline-flex items-center justify-center rounded-lg bg-surface-subtle px-4 py-2 text-sm font-semibold text-content-secondary transition-colors hover:bg-surface-subtle/80 hover:text-content">
+        {% if user == author and about_html %}
+        <div class="mt-6" x-show="!editing">
+            <button type="button" @click="startEditing()" class="inline-flex items-center justify-center rounded-lg bg-surface-subtle px-4 py-2 text-sm font-semibold text-content-secondary transition-colors hover:bg-surface-subtle/80 hover:text-content">
                 <i class="fas fa-edit mr-2"></i>
                 소개글 수정
-            </a>
+            </button>
+        </div>
+        {% endif %}
+
+        {% if user == author %}
+        <div x-show="editing" x-cloak class="rounded-2xl border border-line bg-surface p-4">
+            <textarea
+                x-ref="aboutEditor"
+                x-model="content"
+                class="min-h-64 w-full resize-y rounded-xl border border-line bg-surface-subtle p-4 text-sm leading-relaxed text-content placeholder-content-hint focus:border-line-strong focus:outline-none focus:ring-2 focus:ring-line/10"
+                placeholder="소개글을 작성하세요"></textarea>
+            <div class="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <p x-show="message" x-text="message" class="text-sm text-danger"></p>
+                <div class="flex justify-end gap-2 sm:ml-auto">
+                    <button type="button" @click="cancelEditing()" :disabled="saving" class="inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-semibold text-content-secondary transition-colors hover:bg-surface-subtle hover:text-content disabled:opacity-50">
+                        취소
+                    </button>
+                    <button type="button" @click="saveAbout()" :disabled="saving" class="inline-flex items-center justify-center rounded-lg bg-action px-4 py-2 text-sm font-semibold text-content-inverted transition-colors hover:bg-action-hover disabled:opacity-50">
+                        <span x-show="!saving">저장</span>
+                        <span x-show="saving">저장 중...</span>
+                    </button>
+                </div>
+            </div>
         </div>
         {% endif %}
     </div>
 </section>
+{% endif %}

--- a/backend/src/board/templates/components/notice_carousel.html
+++ b/backend/src/board/templates/components/notice_carousel.html
@@ -14,7 +14,7 @@
     <div class="relative overflow-hidden rounded-2xl">
         {% for notice in notices %}
         <a href="{% if url_prefix %}{{ url_prefix }}{{ notice.author.username }}/{% endif %}{{ notice.url }}"
-           class="group block rounded-2xl border border-line/50 bg-transparent px-5 py-4 transition-colors duration-150 hover:border-line/70 active:bg-surface-subtle/40 {% if forloop.first %}relative{% else %}absolute inset-0{% endif %}"
+           class="group block rounded-2xl border border-line/50 bg-transparent px-5 py-4 transition-colors duration-150 hover:border-line/70 active:bg-surface-subtle/40 {% if forloop.first %}relative z-10 opacity-100{% else %}pointer-events-none absolute inset-0 z-0 opacity-0{% endif %}"
            :style="{
                opacity: currentIndex === {{ forloop.counter0 }} ? 1 : 0,
                zIndex: currentIndex === {{ forloop.counter0 }} ? 10 : 0,
@@ -71,7 +71,7 @@
     <div class="relative overflow-hidden rounded-xl">
         {% for notice in notices %}
         <a href="{% if url_prefix %}{{ url_prefix }}{{ notice.author.username }}/{% endif %}{{ notice.url }}"
-           class="group block rounded-xl border border-line/50 bg-transparent px-4 py-3 transition-colors duration-150 hover:border-line/70 active:bg-surface-subtle/40 {% if forloop.first %}relative{% else %}absolute inset-0{% endif %}"
+           class="group block rounded-xl border border-line/50 bg-transparent px-4 py-3 transition-colors duration-150 hover:border-line/70 active:bg-surface-subtle/40 {% if forloop.first %}relative z-10 opacity-100{% else %}pointer-events-none absolute inset-0 z-0 opacity-0{% endif %}"
            :style="{
                opacity: currentIndex === {{ forloop.counter0 }} ? 1 : 0,
                zIndex: currentIndex === {{ forloop.counter0 }} ? 10 : 0,

--- a/backend/src/board/tests/templates/test_author.py
+++ b/backend/src/board/tests/templates/test_author.py
@@ -122,19 +122,6 @@ class AuthorPostsPageTestCase(TestCase):
         self.assertNotContains(response, 'notice_carousel({')
         self.assertNotContains(response, 'fa-bullhorn')
 
-    def test_author_overview_shows_featured_posts_before_activity(self):
-        """작성자 개요는 소개 다음에 포스트를 먼저 보여주고 활동은 그 뒤에 둔다."""
-        response = self.client.get(
-            reverse('user_profile', kwargs={'username': self.user.username})
-        )
-
-        content = response.content.decode()
-        self.assertContains(response, 'About')
-        self.assertContains(response, '소개')
-        self.assertNotContains(response, 'README')
-        self.assertNotContains(response, 'bg-surface rounded-2xl ring-1 ring-line/60 p-8')
-        self.assertLess(content.index('최근 포스트'), content.index('최근 활동'))
-
     def test_author_overview_featured_posts_have_card_grid_and_posts_link(self):
         """대표 포스트 영역은 좁은 2열 카드 그리드와 전체 포스트 링크를 제공한다."""
         response = self.client.get(
@@ -145,7 +132,6 @@ class AuthorPostsPageTestCase(TestCase):
         self.assertContains(response, 'sm:grid-cols-2')
         self.assertNotContains(response, 'lg:grid-cols-3')
         self.assertContains(response, f'/@{self.user.username}/posts')
-        self.assertContains(response, '모든 포스트 보기')
         self.assertNotContains(response, '먼저 읽어볼 글')
 
     def test_author_overview_featured_posts_limit_keeps_balanced_grid(self):
@@ -177,15 +163,74 @@ class AuthorPostsPageTestCase(TestCase):
             reverse('user_profile', kwargs={'username': empty_author.username})
         )
         self.assertEqual(visitor_response.status_code, 200)
-        self.assertNotContains(visitor_response, '아직 보여줄 공개 포스트가 없습니다.')
+        self.assertNotContains(visitor_response, '아직 공개된 포스트가 없습니다.')
 
         self.client.login(username='emptyauthor', password='testpass123')
         owner_response = self.client.get(
             reverse('user_profile', kwargs={'username': empty_author.username})
         )
         self.assertEqual(owner_response.status_code, 200)
-        self.assertContains(owner_response, '아직 보여줄 공개 포스트가 없습니다.')
+        self.assertContains(owner_response, '아직 공개된 포스트가 없습니다.')
         self.assertContains(owner_response, '글 작성하기')
+
+    def test_author_overview_hides_empty_intro_from_visitors(self):
+        """소개글이 없으면 방문자에게 소개 섹션을 노출하지 않는다."""
+        response = self.client.get(
+            reverse('user_profile', kwargs={'username': self.user.username})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, 'About')
+        self.assertNotContains(response, '소개글을 작성하면 프로필에 표시됩니다.')
+        self.assertNotContains(response, '소개글 작성')
+        self.assertNotContains(response, reverse('user_about_edit', kwargs={'username': self.user.username}))
+        self.assertNotContains(response, '아직 소개글이 없습니다')
+
+    def test_author_overview_shows_empty_intro_prompt_to_owner(self):
+        """소개글이 없으면 작성자 본인에게 작성 진입점을 보여준다."""
+        self.client.login(username='testauthor', password='testpass123')
+        edit_path = reverse('user_about_edit', kwargs={'username': self.user.username})
+
+        response = self.client.get(
+            reverse('user_profile', kwargs={'username': self.user.username})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'About')
+        self.assertContains(response, '소개')
+        self.assertContains(response, '소개글을 작성하면 프로필에 표시됩니다.')
+        self.assertContains(response, '소개글 작성')
+        self.assertNotContains(response, f'href="{edit_path}"')
+        self.assertNotContains(response, '아직 소개글이 없습니다')
+
+    def test_author_overview_renders_intro_content_with_owner_edit_entrypoint(self):
+        """작성된 소개글은 방문자에게 보이고, 수정 진입점은 작성자 본인에게만 보인다."""
+        edit_path = reverse('user_about_edit', kwargs={'username': self.user.username})
+        self.user.profile.about_html = '<p>Visible author intro</p>'
+        self.user.profile.save(update_fields=['about_html'])
+
+        visitor_response = self.client.get(
+            reverse('user_profile', kwargs={'username': self.user.username})
+        )
+
+        self.assertEqual(visitor_response.status_code, 200)
+        self.assertContains(visitor_response, 'About')
+        self.assertContains(visitor_response, '소개')
+        self.assertContains(visitor_response, 'Visible author intro')
+        self.assertNotContains(visitor_response, '소개글 작성')
+        self.assertNotContains(visitor_response, '소개글 수정')
+        self.assertNotContains(visitor_response, edit_path)
+
+        self.client.login(username='testauthor', password='testpass123')
+        owner_response = self.client.get(
+            reverse('user_profile', kwargs={'username': self.user.username})
+        )
+
+        self.assertEqual(owner_response.status_code, 200)
+        self.assertContains(owner_response, 'Visible author intro')
+        self.assertContains(owner_response, '소개글 수정')
+        self.assertNotContains(owner_response, f'href="{edit_path}"')
+        self.assertNotContains(owner_response, '소개글 작성')
 
     def test_author_overview_omits_sidebar_stats_and_quick_links(self):
         """작성자 개요에서는 중복되는 통계와 바로가기 사이드바를 노출하지 않는다."""
@@ -211,6 +256,23 @@ class AuthorPostsPageTestCase(TestCase):
         )
         self.assertEqual(owner_response.status_code, 200)
         self.assertContains(owner_response, '/settings/profile')
+
+    def test_author_overview_pinned_posts_setting_entrypoint_is_owner_only(self):
+        """고정 포스트 설정 진입점은 작성자 본인에게만 노출한다."""
+        visitor_response = self.client.get(
+            reverse('user_profile', kwargs={'username': self.user.username})
+        )
+        self.assertEqual(visitor_response.status_code, 200)
+        self.assertNotContains(visitor_response, '/settings/pinned-posts')
+        self.assertNotContains(visitor_response, '고정 포스트 설정')
+
+        self.client.login(username='testauthor', password='testpass123')
+        owner_response = self.client.get(
+            reverse('user_profile', kwargs={'username': self.user.username})
+        )
+        self.assertEqual(owner_response.status_code, 200)
+        self.assertContains(owner_response, '/settings/pinned-posts')
+        self.assertContains(owner_response, '고정 포스트 설정')
 
     def test_author_overview_social_link_add_entrypoint_uses_existing_empty_state(self):
         """소셜 링크가 없을 때는 기존 빈 상태 추가 링크만 노출한다."""

--- a/backend/src/board/views/author.py
+++ b/backend/src/board/views/author.py
@@ -10,6 +10,7 @@ from django.urls import reverse
 from board.modules.paginator import Paginator
 from board.modules.time import time_since
 from board.services.user_service import UserService
+from board.services.authoring_permission_service import AuthoringPermissionService
 from board.services.discovery_metadata_service import DiscoveryMetadataService
 from board.services.public_post_service import PublicPostService
 from board.services.public_series_service import PublicSeriesService
@@ -24,13 +25,15 @@ def author_overview(request, username):
     Readers and editors see different templates.
     """
     author = get_object_or_404(User.objects.select_related('profile'), username=username)
+    profile = getattr(author, 'profile', None)
 
     recent_activities = UserService.get_public_author_activities(author)[:10]
 
-    about_html = getattr(author.profile, 'about_html', '') if hasattr(author, 'profile') else ''
+    about_md = profile.about_md if profile else ''
+    about_html = profile.about_html if profile else ''
 
     # Check if author is a reader (not an editor)
-    is_reader = not hasattr(author, 'profile') or author.profile.role == Profile.Role.READER
+    is_reader = not AuthoringPermissionService.is_active_editor(author)
     author_profile_path = reverse('user_profile', kwargs={'username': author.username})
     if DiscoveryMetadataService.has_unexpected_query_parameters(request, set()):
         page_metadata = DiscoveryMetadataService.build_noindex_page_metadata(
@@ -50,6 +53,7 @@ def author_overview(request, username):
         context = {
             'author': author,
             'recent_activities': recent_activities,
+            'about_md': about_md,
             'about_html': about_html,
             **page_metadata,
             'author_activity_props': json.dumps({'username': author.username})
@@ -72,6 +76,7 @@ def author_overview(request, username):
             'featured_posts_section': featured_posts_section,
             'pinned_posts': featured_posts_section['posts'],
             'recent_activities': recent_activities,
+            'about_md': about_md,
             'about_html': about_html,
             'post_count': stats['post_count'],
             'series_count': stats['series_count'],
@@ -97,7 +102,7 @@ def author_posts(request, username):
     """
     author = get_object_or_404(User.objects.select_related('profile'), username=username)
 
-    if not hasattr(author, 'profile') or not author.profile.is_editor():
+    if not AuthoringPermissionService.is_active_editor(author):
         return redirect('user_about', username=username)
     
     # Get search query and filters
@@ -220,9 +225,7 @@ def author_series(request, username):
     """
     author = get_object_or_404(User.objects.select_related('profile'), username=username)
 
-    # If author is a reader (not an editor), redirect to about page
-    # If profile doesn't exist, treat as reader
-    if not hasattr(author, 'profile') or not author.profile.is_editor():
+    if not AuthoringPermissionService.is_active_editor(author):
         return redirect('user_about', username=username)
     
     # Get search query and filters


### PR DESCRIPTION
## 🎯 Goal
- Improve the author profile page so owner-only editing affordances are available in place without changing the public reader experience.
- Reduce layout flicker and unclear copy in author profile sections.

## 🔧 Core Changes
- Add inline author intro editing on the profile page while preserving the existing save endpoint.
- Add an owner-only entry point for pinned post settings near the profile posts section.
- Rename and simplify author profile section copy, empty states, and activity labels.
- Reserve the author activity island height before mount and fix heatmap tooltip contrast.
- Prevent the global notice carousel from briefly stacking notices before Alpine initializes.
- Route author role checks through AuthoringPermissionService instead of direct role comparisons.

## 🤔 Key Decisions
- Kept intro editing as a small Alpine interaction because the requested flow is textarea editing plus reload, not a full rich editor migration.
- Kept pinned post management in the existing settings page instead of moving the modal into the profile page.
- Left post detail comments and related posts loading height out of scope for this PR.

## 🧪 Verification Guide
### How to verify
1. Open an author profile as a visitor and confirm empty intro controls are hidden.
2. Open the same profile as the owner and confirm intro write/edit switches to an inline textarea.
3. Save intro text and confirm the profile reloads with rendered intro content.
4. Hover the activity heatmap in light theme and confirm the tooltip remains readable.
5. Open a page with global notices and confirm notices do not overlap before the carousel initializes.

### Expected result
- Visitors only see published profile content.
- Owners can edit intro content directly from the profile page.
- Author profile empty states and labels are consistent.
- Activity heatmap and notice carousel render without the reported visual glitches.

## ✅ Checklist
- [ ] Lint completed (not applicable: no island lint changes)
- [x] Type-check completed
- [x] Tests completed
- [ ] Documentation updated (not applicable)

Verification run:
- `git diff --check`
- `npm run server:test -- board.tests.templates.test_author`
- `npm run server:test -- board.tests.templates.test_main.MainPageTemplateTestCase.test_index_page_renders_global_notice_label`
- `npm run islands:type-check`