### PR TITLE
✨ Add developer API quickstart

### DIFF
--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/DeveloperApiSetting/DeveloperApiSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/DeveloperApiSetting/DeveloperApiSetting.tsx
@@ -221,15 +221,26 @@ const DeveloperApiSetting = () => {
                 description="외부 도구에서 내 글을 읽거나 작성할 수 있는 개인 API 토큰을 발급하고 관리합니다."
                 actionPosition="right"
                 action={(
-                    <a href="/api/developer/v1/docs">
-                        <Button
-                            type="button"
-                            variant="secondary"
-                            size="sm"
-                            leftIcon={<i className="fas fa-book-open" />}>
-                            API 문서
-                        </Button>
-                    </a>
+                    <div className="flex flex-wrap gap-2">
+                        <a href="/docs/developer-api/quickstart">
+                            <Button
+                                type="button"
+                                variant="secondary"
+                                size="sm"
+                                leftIcon={<i className="fas fa-route" />}>
+                                빠른 시작
+                            </Button>
+                        </a>
+                        <a href="/api/developer/v1/docs">
+                            <Button
+                                type="button"
+                                variant="secondary"
+                                size="sm"
+                                leftIcon={<i className="fas fa-book-open" />}>
+                                API 문서
+                            </Button>
+                        </a>
+                    </div>
                 )}
             />
 

--- a/backend/src/board/templates/board/developer_api_quickstart.html
+++ b/backend/src/board/templates/board/developer_api_quickstart.html
@@ -1,0 +1,118 @@
+{% extends 'board/base.html' %}
+
+{% block title %}개발자 API 빠른 시작 | BLEX{% endblock %}
+
+{% block content %}
+<div class="mx-auto max-w-4xl px-4 py-10 md:px-6">
+    <header class="mb-8 rounded-2xl border border-line bg-surface p-6 shadow-subtle">
+        <p class="text-sm font-semibold text-content-hint">BLEX Developer API</p>
+        <h1 class="mt-2 text-3xl font-semibold text-content">개발자 API 빠른 시작</h1>
+        <p class="mt-3 leading-relaxed text-content-secondary">
+            자동 API 문서는 전체 엔드포인트를 보여줍니다. 이 문서는 처음 쓰는 사람이 토큰을 만들고 Markdown 초안을 발행하는 최소 흐름만 설명합니다.
+        </p>
+        <div class="mt-5 flex flex-wrap gap-2">
+            <a class="inline-flex min-h-10 items-center rounded-lg bg-action px-4 py-2 text-sm font-medium text-content-inverted transition-colors duration-150 hover:bg-action-hover active:scale-95" href="/api/developer/v1/docs">
+                자동 API 문서 열기
+            </a>
+            <a class="inline-flex min-h-10 items-center rounded-lg border border-line bg-surface px-4 py-2 text-sm font-medium text-content-secondary transition-colors duration-150 hover:border-line-strong hover:text-content active:scale-95" href="/settings/developer-api">
+                토큰 관리로 이동
+            </a>
+        </div>
+    </header>
+
+    <article class="space-y-8 text-content">
+        <section class="rounded-2xl border border-line bg-surface p-6">
+            <h2 class="text-xl font-semibold">1. 토큰 만들기</h2>
+            <ol class="mt-4 list-decimal space-y-2 pl-5 text-content-secondary">
+                <li>BLEX에 작가 계정으로 로그인합니다.</li>
+                <li><code class="rounded bg-surface-subtle px-1.5 py-0.5 text-content">/settings/developer-api</code>로 이동합니다.</li>
+                <li>글을 만들고 발행하려면 <strong class="text-content">글 읽기</strong>와 <strong class="text-content">글 작성</strong> 권한을 모두 선택합니다.</li>
+                <li>발급 직후 표시되는 전체 토큰을 복사합니다. 이 값은 다시 볼 수 없습니다.</li>
+            </ol>
+            <pre class="mt-4 overflow-x-auto rounded-xl bg-surface-subtle p-4 text-sm"><code>export BLEX_ORIGIN="{{ site_origin }}"
+export BLEX_TOKEN="blex_pat_..."</code></pre>
+        </section>
+
+        <section class="rounded-2xl border border-line bg-surface p-6">
+            <h2 class="text-xl font-semibold">2. 토큰 확인</h2>
+            <pre class="mt-4 overflow-x-auto rounded-xl bg-surface-subtle p-4 text-sm"><code>curl "$BLEX_ORIGIN/api/developer/v1/me" \
+  -H "Authorization: Bearer $BLEX_TOKEN"</code></pre>
+        </section>
+
+        <section class="rounded-2xl border border-line bg-surface p-6">
+            <h2 class="text-xl font-semibold">3. Markdown 초안 만들기</h2>
+            <pre class="mt-4 overflow-x-auto rounded-xl bg-surface-subtle p-4 text-sm"><code>curl -X POST "$BLEX_ORIGIN/api/developer/v1/posts" \
+  -H "Authorization: Bearer $BLEX_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "status": "draft",
+    "title": "API로 만든 첫 글",
+    "markdown": "# Hello BLEX\n\n외부 도구에서 만든 초안입니다.",
+    "tags": ["api", "automation"],
+    "slug": "api-first-draft"
+  }'</code></pre>
+            <p class="mt-4 text-sm leading-relaxed text-content-secondary">
+                응답의 <code class="rounded bg-surface-subtle px-1.5 py-0.5 text-content">data.id</code>와 <code class="rounded bg-surface-subtle px-1.5 py-0.5 text-content">data.updated_at</code>을 기억하세요. 다음 예시의 <code class="rounded bg-surface-subtle px-1.5 py-0.5 text-content">123</code>은 생성 응답의 <code class="rounded bg-surface-subtle px-1.5 py-0.5 text-content">data.id</code>로 바꿔 넣으면 됩니다.
+            </p>
+            <pre class="mt-4 overflow-x-auto rounded-xl bg-surface-subtle p-4 text-sm"><code>{
+  "data": {
+    "id": 123,
+    "updated_at": "2026-05-30T00:00:00+00:00"
+  }
+}</code></pre>
+        </section>
+
+        <section class="rounded-2xl border border-line bg-surface p-6">
+            <h2 class="text-xl font-semibold">4. 이미지 업로드</h2>
+            <pre class="mt-4 overflow-x-auto rounded-xl bg-surface-subtle p-4 text-sm"><code>curl -X POST "$BLEX_ORIGIN/api/developer/v1/images" \
+  -H "Authorization: Bearer $BLEX_TOKEN" \
+  -F "image=@./cover.png"</code></pre>
+            <p class="mt-4 text-sm leading-relaxed text-content-secondary">응답의 <code class="rounded bg-surface-subtle px-1.5 py-0.5 text-content">data.url</code>을 Markdown 이미지 주소로 사용할 수 있습니다.</p>
+        </section>
+
+        <section class="rounded-2xl border border-line bg-surface p-6">
+            <h2 class="text-xl font-semibold">5. 초안 수정하기</h2>
+            <p class="mt-3 text-sm leading-relaxed text-content-secondary">동시 수정 충돌을 줄이려면 상세 조회나 생성 응답의 <code class="rounded bg-surface-subtle px-1.5 py-0.5 text-content">updated_at</code>을 <code class="rounded bg-surface-subtle px-1.5 py-0.5 text-content">expected_updated_at</code>으로 보냅니다.</p>
+            <pre class="mt-4 overflow-x-auto rounded-xl bg-surface-subtle p-4 text-sm"><code>curl -X PATCH "$BLEX_ORIGIN/api/developer/v1/posts/123" \
+  -H "Authorization: Bearer $BLEX_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "expected_updated_at": "2026-05-30T00:00:00+00:00",
+    "description": "외부 도구에서 작성한 BLEX 글입니다.",
+    "tags": ["api", "automation", "blex"]
+  }'</code></pre>
+        </section>
+
+        <section class="rounded-2xl border border-line bg-surface p-6">
+            <h2 class="text-xl font-semibold">6. 초안 발행하기</h2>
+            <pre class="mt-4 overflow-x-auto rounded-xl bg-surface-subtle p-4 text-sm"><code>curl -X POST "$BLEX_ORIGIN/api/developer/v1/posts/123/publish" \
+  -H "Authorization: Bearer $BLEX_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{}'</code></pre>
+        </section>
+
+        <section class="rounded-2xl border border-line bg-surface p-6">
+            <h2 class="text-xl font-semibold">자주 보는 오류</h2>
+            <div class="mt-4 overflow-x-auto">
+                <table class="w-full min-w-[620px] text-left text-sm">
+                    <thead class="border-b border-line text-content-secondary">
+                        <tr><th class="py-2 pr-4">상태</th><th class="py-2 pr-4">코드</th><th class="py-2">의미</th></tr>
+                    </thead>
+                    <tbody class="divide-y divide-line text-content-secondary">
+                        <tr><td class="py-2 pr-4">401</td><td class="py-2 pr-4"><code>auth.missing_token</code></td><td class="py-2">Authorization 헤더가 없습니다.</td></tr>
+                        <tr><td class="py-2 pr-4">401</td><td class="py-2 pr-4"><code>auth.invalid_token</code></td><td class="py-2">토큰이 틀렸거나 폐기되었습니다.</td></tr>
+                        <tr><td class="py-2 pr-4">403</td><td class="py-2 pr-4"><code>auth.insufficient_scope</code></td><td class="py-2">필요한 권한이 없습니다.</td></tr>
+                        <tr><td class="py-2 pr-4">403</td><td class="py-2 pr-4"><code>auth.editor_required</code></td><td class="py-2">글 작성에는 작가 권한이 필요합니다.</td></tr>
+                        <tr><td class="py-2 pr-4">400</td><td class="py-2 pr-4"><code>post.invalid_status</code></td><td class="py-2">지원하지 않는 글 상태입니다.</td></tr>
+                        <tr><td class="py-2 pr-4">400</td><td class="py-2 pr-4"><code>post.missing_published_at</code></td><td class="py-2">예약 발행 시간 없이 예약 글을 만들었습니다.</td></tr>
+                        <tr><td class="py-2 pr-4">400</td><td class="py-2 pr-4"><code>image.too_large</code></td><td class="py-2">이미지 파일이 업로드 제한보다 큽니다.</td></tr>
+                        <tr><td class="py-2 pr-4">409</td><td class="py-2 pr-4"><code>post.version_conflict</code></td><td class="py-2">글이 이미 다른 요청으로 수정되었습니다.</td></tr>
+                        <tr><td class="py-2 pr-4">409</td><td class="py-2 pr-4"><code>post.not_draft</code></td><td class="py-2">이미 발행되었거나 예약된 글을 다시 발행하려고 했습니다.</td></tr>
+                        <tr><td class="py-2 pr-4">422</td><td class="py-2 pr-4"><code>request.invalid_payload</code></td><td class="py-2">필드 타입이나 허용 값이 맞지 않습니다.</td></tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+    </article>
+</div>
+{% endblock %}

--- a/backend/src/board/tests/api/test_developer_auth.py
+++ b/backend/src/board/tests/api/test_developer_auth.py
@@ -1,6 +1,6 @@
 import json
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from board.models import Config, DeveloperToken, Profile, User
 from board.services.developer_token_service import DeveloperTokenService
@@ -131,18 +131,37 @@ class DeveloperAuthAPITestCase(TestCase):
         self.assertEqual(response.status_code, 404)
 
     def test_developer_api_docs_redirects_to_generated_docs(self):
+        self.client.login(username='developer', password='developer')
+
         response = self.client.get('/docs/developer-api')
 
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response['Location'], '/api/developer/v1/docs')
 
     def test_developer_api_docs_detail_redirects_to_generated_docs(self):
+        self.client.login(username='developer', password='developer')
+
         response = self.client.get('/docs/developer-api/list-posts')
 
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response['Location'], '/api/developer/v1/docs')
 
+    @override_settings(SITE_URL='https://blex.example')
+    def test_developer_api_quickstart_renders(self):
+        self.client.login(username='developer', password='developer')
+
+        response = self.client.get('/docs/developer-api/quickstart')
+
+        self.assertEqual(response.status_code, 200)
+        body = response.content.decode()
+        self.assertIn('개발자 API 빠른 시작', body)
+        self.assertIn('export BLEX_ORIGIN="https://blex.example"', body)
+        self.assertIn('/api/developer/v1/posts', body)
+        self.assertIn('expected_updated_at', body)
+
     def test_developer_api_openapi_schema_is_available(self):
+        self.client.login(username='developer', password='developer')
+
         response = self.client.get('/api/developer/v1/openapi.json')
 
         self.assertEqual(response.status_code, 200)
@@ -154,12 +173,41 @@ class DeveloperAuthAPITestCase(TestCase):
         self.assertEqual(security_schemes['DeveloperBearerAuth']['scheme'], 'bearer')
 
     def test_developer_api_docs_use_local_swagger_assets(self):
+        self.client.login(username='developer', password='developer')
+
         response = self.client.get('/api/developer/v1/docs')
 
         self.assertEqual(response.status_code, 200)
         body = response.content.decode()
         self.assertIn('ninja/swagger-ui-bundle.js', body)
         self.assertNotIn('cdn.jsdelivr.net', body)
+
+    def test_developer_api_docs_require_login(self):
+        paths = (
+            '/docs/developer-api/quickstart',
+            '/api/developer/v1/docs',
+            '/api/developer/v1/openapi.json',
+        )
+
+        for path in paths:
+            with self.subTest(path=path):
+                response = self.client.get(path)
+                self.assertEqual(response.status_code, 302)
+                self.assertIn('/login', response['Location'])
+
+    def test_developer_api_docs_require_editor_role(self):
+        self.client.login(username='reader', password='reader')
+        paths = (
+            '/docs/developer-api/quickstart',
+            '/api/developer/v1/docs',
+            '/api/developer/v1/openapi.json',
+        )
+
+        for path in paths:
+            with self.subTest(path=path):
+                response = self.client.get(path)
+                self.assertEqual(response.status_code, 302)
+                self.assertEqual(response['Location'], '/')
 
     def test_reader_cannot_create_developer_token(self):
         self.client.login(username='reader', password='reader')

--- a/backend/src/board/urls.py
+++ b/backend/src/board/urls.py
@@ -19,7 +19,7 @@ from board.views.sitemap import sitemap_index_view, sitemap_section_view
 from board.views.tag import tag_list_view, tag_detail_view
 from board.views.static_pages import static_page_view
 from board.views.settings import settings, admin_settings
-from board.views.developer_api_docs import developer_api_docs
+from board.views.developer_api_docs import developer_api_docs, developer_api_quickstart
 from board.decorators import staff_member_required
 
 def empty():
@@ -48,6 +48,7 @@ urlpatterns = [
 
     # Developer API docs compatibility redirect
     path('docs/developer-api', developer_api_docs, name='developer_api_docs'),
+    path('docs/developer-api/quickstart', developer_api_quickstart, name='developer_api_quickstart'),
     path('docs/developer-api/<slug:operation_id>', developer_api_docs, name='developer_api_docs_detail'),
 
     # Post actions

--- a/backend/src/board/views/api/developer/v1/api.py
+++ b/backend/src/board/views/api/developer/v1/api.py
@@ -4,6 +4,7 @@ from ninja import Body, File, NinjaAPI, Query, Status, UploadedFile
 from ninja.errors import HttpError, ValidationError
 from ninja.security import HttpBearer
 
+from board.decorators import editor_required
 from board.models import Series, Tag
 from board.modules.developer_serializers import (
     DeveloperPostSerializer,
@@ -58,6 +59,7 @@ api = NinjaAPI(
     description='Personal token API for managing BLEX posts from external tools.',
     auth=DeveloperBearerAuth(),
     urls_namespace='developer_api_v1',
+    docs_decorator=editor_required,
 )
 
 

--- a/backend/src/board/views/developer_api_docs.py
+++ b/backend/src/board/views/developer_api_docs.py
@@ -1,5 +1,21 @@
-from django.shortcuts import redirect
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import redirect, render
+
+from board.decorators import editor_required
+from board.services.site_url_service import SiteUrlService
 
 
-def developer_api_docs(request, operation_id=''):
+@editor_required
+def developer_api_docs(request: HttpRequest, operation_id: str = '') -> HttpResponse:
     return redirect('/api/developer/v1/docs')
+
+
+@editor_required
+def developer_api_quickstart(request: HttpRequest) -> HttpResponse:
+    return render(
+        request,
+        'board/developer_api_quickstart.html',
+        {
+            'site_origin': SiteUrlService.public_origin(request),
+        },
+    )


### PR DESCRIPTION
## 🎯 Goal
- Help writers start using the Developer API without reading the full generated Swagger docs first.
- Keep Developer API docs surfaces visible only to signed-in writers, matching the token management feature scope.

## 🔧 Core Changes
- Added `/docs/developer-api/quickstart` with a guided curl flow for token checks, Markdown draft creation, image upload, update, and publish.
- Linked the quickstart from the Developer API settings page next to the generated API docs.
- Restricted quickstart, Swagger, and OpenAPI JSON docs to authenticated writers.
- Added tests for quickstart rendering and docs access control.

## 🤔 Key Decisions
- Kept the quickstart as a single rendered service page instead of a duplicate markdown doc to avoid drift.
- Used the existing `SiteUrlService.public_origin(request)` so examples follow the configured public site origin.
- Left actual Developer API endpoints on Bearer token authentication; only the human-facing docs surfaces require writer login.

## 🧪 Verification Guide
### How to verify
1. Log in as a writer and open `/settings/developer-api`.
2. Click `빠른 시작`, then confirm `/docs/developer-api/quickstart` renders curl examples with the configured origin.
3. Open `/api/developer/v1/docs` and `/api/developer/v1/openapi.json` as a writer.
4. Log out or use a reader account and confirm those docs pages are not accessible.

### Expected result
- Writers can access the quickstart, Swagger, and OpenAPI JSON docs.
- Non-authenticated users are redirected to login.
- Readers are redirected away from Developer API docs surfaces.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)
