### PR TITLE
🐛 Prevent post detail layout shift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 test-results/
 playwright-report/
 blob-report/
+/.turbo/
 
 DockerfileDev
 

--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/PostEditorWrapper.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/PostEditorWrapper.tsx
@@ -7,12 +7,12 @@ interface PostEditorWrapperProps {
 const PostEditorWrapper = ({ children }: PostEditorWrapperProps) => {
     return (
         <div className="pt-8 pb-16 px-4 md:px-6">
-            <div className="flex justify-center gap-6">
-                <aside className="hidden xl:block w-64 flex-shrink-0" aria-hidden="true" />
-                <main className="max-w-4xl w-full">
+            <div className="post-detail-layout">
+                <aside className="post-detail-sidebar" aria-hidden="true" />
+                <main className="post-detail-main">
                     {children}
                 </main>
-                <aside className="hidden xl:block w-64 flex-shrink-0" aria-hidden="true" />
+                <aside className="post-detail-sidebar" aria-hidden="true" />
             </div>
         </div>
     );

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/shared/BannerPreviewFrame.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/shared/BannerPreviewFrame.tsx
@@ -88,14 +88,14 @@ const BannerPreviewFrame = ({
 
     return (
         <div className="relative w-full px-4 md:px-6">
-            <div className="flex justify-center gap-6">
-                <aside className="hidden w-64 flex-shrink-0 xl:block">
+            <div className="post-detail-layout">
+                <aside className="post-detail-sidebar">
                     <div className="sticky top-28 space-y-4">
                         {renderSidebarSlot('left')}
                     </div>
                 </aside>
 
-                <div className="max-w-4xl w-full">
+                <div className="post-detail-main">
                     <div className="mt-6" role="main">
                         <article lang="ko">
                             <div className={cx('mb-12 transition-opacity sm:mb-16', mutedPostClass)}>
@@ -153,7 +153,7 @@ const BannerPreviewFrame = ({
                     </div>
                 </div>
 
-                <aside className="hidden w-64 flex-shrink-0 xl:block">
+                <aside className="post-detail-sidebar">
                     <div className="sticky top-28 space-y-4">
                         <div className="text-xs text-content-hint">
                             TOC / 우측 사이드바

--- a/backend/islands/apps/remotes/styles/tailwind.css
+++ b/backend/islands/apps/remotes/styles/tailwind.css
@@ -45,6 +45,39 @@
     --ease-apple: var(--ease-apple);
 }
 
+@layer components {
+    /* Shared by post detail, post editor, and banner preview. Keep post layout widths here. */
+    .post-detail-layout {
+        display: grid;
+        width: 100%;
+        max-width: 91rem;
+        margin-inline: auto;
+        gap: 1.5rem;
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .post-detail-main {
+        width: 100%;
+        min-width: 0;
+    }
+
+    .post-detail-sidebar {
+        display: none;
+        width: 16rem;
+        flex-shrink: 0;
+    }
+
+    @media (min-width: 80rem) {
+        .post-detail-layout {
+            grid-template-columns: 16rem minmax(0, 56rem) 16rem;
+        }
+
+        .post-detail-sidebar {
+            display: block;
+        }
+    }
+}
+
 @utility dim-overlay-soft {
     background-color: var(--color-dim-soft);
 }

--- a/backend/src/board/templates/board/posts/post_detail.html
+++ b/backend/src/board/templates/board/posts/post_detail.html
@@ -52,9 +52,9 @@
 
 {% block content %}
 <div class="relative w-full px-4 md:px-6">
-    <div class="flex justify-center gap-6">
+    <div class="post-detail-layout">
         <!-- Left Sidebar Space (Always present on desktop) -->
-        <aside class="hidden xl:block w-64 flex-shrink-0">
+        <aside class="post-detail-sidebar">
             <div class="sticky top-28 space-y-4">
                 {% if banners.left %}
                     {% for banner in banners.left %}
@@ -65,7 +65,7 @@
         </aside>
 
         <!-- Main Content Area (Original Width) -->
-        <div class="max-w-4xl w-full">
+        <div class="post-detail-main">
             <div class="mt-6" role="main">
                 <article itemscope itemtype="https://schema.org/BlogPosting" lang="{{ LANGUAGE_CODE|default:'ko' }}">
                     <meta itemprop="headline" content="{{ post.title }}">
@@ -462,7 +462,7 @@
         </div>
 
         <!-- Right Sidebar Space (Always present on desktop) -->
-        <aside class="hidden xl:block w-64 flex-shrink-0">
+        <aside class="post-detail-sidebar">
             <div class="sticky top-28 space-y-4">
                 <!-- Table of Contents -->
                 {% if table_of_contents %}


### PR DESCRIPTION
## 🎯 Goal
- Fix the post detail body snapping horizontally during initial load on long posts.
- Keep the post detail, post editor, and banner preview layouts aligned so future width changes do not drift across surfaces.

## 🔧 Core Changes
- Replaced the post detail flex wrapper with a shared grid-based post layout that reserves both sidebar columns from the start.
- Reused the same shared layout classes in the post editor wrapper and banner preview frame.
- Ignored the root Turbo cache directory.

## 🤔 Key Decisions
- Centralized post layout dimensions in Tailwind component classes instead of repeating arbitrary width classes in templates and React components.
- Kept the main content width capped at the existing 56rem value while reserving 16rem sidebar columns on desktop.

## 🧪 Verification Guide
### How to verify
1. Open a long post detail page and confirm the body column does not snap left after the right sidebar appears.
2. Open the post editor and confirm its editable width matches the post detail content column.
3. Open banner settings preview and confirm sidebar and inline banner slots align with the post detail layout.

### Expected result
- Post detail content, editor content, and banner preview content share the same responsive layout widths without initial horizontal jumping.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)

Verification run:
- npm run islands:lint (passes with existing warnings)
- npm run islands:type-check
- npm run islands:build