### PR TITLE
🐛 Preserve post images during publish

### DIFF
--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/EditPostEditor.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/EditPostEditor.tsx
@@ -55,6 +55,7 @@ const EditPostEditor = ({ username, postUrl }: EditPostEditorProps) => {
         url: ''
     });
     const [isSubmitting, setIsSubmitting] = useState(false);
+    const [isEditorMediaUploading, setIsEditorMediaUploading] = useState(false);
 
     const formRef = useRef<HTMLFormElement>(null);
     const initialDataRef = useRef<DirtySnapshot | null>(null);
@@ -210,6 +211,11 @@ const EditPostEditor = ({ username, postUrl }: EditPostEditorProps) => {
     const submitCurrentPost = async (isDraft = false) => {
         if (!validateForm()) return;
 
+        if (isEditorMediaUploading) {
+            toast.warning('파일 업로드가 끝난 뒤 수정해주세요.');
+            return;
+        }
+
         setIsSubmitting(true);
         try {
             const form = formRef.current;
@@ -312,6 +318,7 @@ const EditPostEditor = ({ username, postUrl }: EditPostEditorProps) => {
                 onTagsChange={setTags}
                 onImageUpload={handleImageUpload}
                 onEditorImageUpload={handleEditorImageUpload}
+                onEditorUploadStateChange={setIsEditorMediaUploading}
                 onRemoveImage={handleRemoveImage}
             />
 
@@ -320,6 +327,7 @@ const EditPostEditor = ({ username, postUrl }: EditPostEditorProps) => {
                 mode="edit"
                 isSaving={false}
                 isSubmitting={isSubmitting}
+                isMediaUploading={isEditorMediaUploading}
                 lastSaved={null}
                 onManualSave={() => { }}
                 onSubmit={() => handleSubmit()}

--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/NewPostEditor.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/NewPostEditor.tsx
@@ -59,6 +59,7 @@ const NewPostEditor = ({
     const [isUrlAutoSync, setIsUrlAutoSync] = useState(true);
     const [currentDraftUrl, setCurrentDraftUrl] = useState(draftUrl);
     const [showPublishChecklist, setShowPublishChecklist] = useState(false);
+    const [isEditorMediaUploading, setIsEditorMediaUploading] = useState(false);
 
     const [formData, setFormData] = useState({
         title: '',
@@ -173,7 +174,7 @@ const NewPostEditor = ({
     };
 
     const autoSaveOptions = {
-        enabled: !isLoading,
+        enabled: !isLoading && !isEditorMediaUploading,
         draftUrl: currentDraftUrl,
         onSuccess: handleAutoSaveSuccess,
         onError: handleAutoSaveError
@@ -338,6 +339,11 @@ const NewPostEditor = ({
     };
 
     const handleManualSave = async () => {
+        if (isEditorMediaUploading) {
+            toast.warning('파일 업로드가 끝난 뒤 저장해주세요.');
+            return;
+        }
+
         const success = await manualSave();
         if (success) {
             toast.success('임시저장되었습니다.');
@@ -396,6 +402,11 @@ const NewPostEditor = ({
     };
 
     const handleSubmit = async (isDraft = false) => {
+        if (isEditorMediaUploading) {
+            toast.warning('파일 업로드가 끝난 뒤 발행해주세요.');
+            return;
+        }
+
         if (isDraft) {
             await submitCurrentPost(true);
             return;
@@ -409,6 +420,11 @@ const NewPostEditor = ({
     };
 
     const handleConfirmPublish = async () => {
+        if (isEditorMediaUploading) {
+            toast.warning('파일 업로드가 끝난 뒤 발행해주세요.');
+            return;
+        }
+
         if (publishChecklist.missingRecommended.length > 0) {
             const labels = publishChecklist.missingRecommended.map(item => item.label).join(', ');
             toast.warning(`권장 항목이 비어 있습니다: ${labels}`);
@@ -451,6 +467,7 @@ const NewPostEditor = ({
                 onTagsChange={setTags}
                 onImageUpload={handleImageUpload}
                 onEditorImageUpload={handleEditorImageUpload}
+                onEditorUploadStateChange={setIsEditorMediaUploading}
                 onRemoveImage={handleRemoveImage}
             />
 
@@ -459,6 +476,7 @@ const NewPostEditor = ({
                 mode={draftUrl ? 'draft' : 'new'}
                 isSaving={isSaving}
                 isSubmitting={isSubmitting}
+                isMediaUploading={isEditorMediaUploading}
                 lastSaved={lastSaved}
                 hasSaveError={hasSaveError}
                 hasPendingChanges={hasPendingChanges}

--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/components/PostActions.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/components/PostActions.tsx
@@ -8,6 +8,7 @@ interface PostActionsProps {
     mode: 'new' | 'edit' | 'draft';
     isSaving: boolean;
     isSubmitting: boolean;
+    isMediaUploading?: boolean;
     lastSaved: Date | null;
     hasSaveError?: boolean;
     hasPendingChanges?: boolean;
@@ -31,6 +32,7 @@ const PostActions = ({
     mode,
     isSaving,
     isSubmitting,
+    isMediaUploading = false,
     lastSaved,
     hasSaveError = false,
     hasPendingChanges = false,
@@ -42,6 +44,7 @@ const PostActions = ({
 }: PostActionsProps) => {
     const isEdit = mode === 'edit';
     const submitLabel = isEdit ? '수정' : '발행';
+    const isBusy = isSubmitting || isSaving || isMediaUploading;
     const [, setTick] = useState(0);
 
     // Update time display every 30 seconds
@@ -123,7 +126,7 @@ const PostActions = ({
                     <button
                         type="button"
                         onClick={onManualSave}
-                        disabled={isSubmitting || isSaving}
+                        disabled={isBusy}
                         className="flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium text-content-secondary hover:text-content hover:bg-surface-subtle active:scale-95 rounded-full transition-all motion-interaction disabled:opacity-50"
                         title="임시 저장">
                         <span>임시 저장</span>
@@ -134,7 +137,7 @@ const PostActions = ({
             {/* Publish/Update Button */}
             <Button
                 onClick={onSubmit}
-                disabled={isSubmitting || isSaving}
+                disabled={isBusy}
                 variant="primary"
                 className="!rounded-full"
                 leftIcon={<Send className="w-4 h-4" />}

--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/components/PostForm.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/components/PostForm.tsx
@@ -29,6 +29,7 @@ interface PostFormProps {
     onTagsChange: (tags: string[]) => void;
     onImageUpload: (event: React.ChangeEvent<HTMLInputElement>) => void;
     onEditorImageUpload?: (file: File) => Promise<string | undefined>;
+    onEditorUploadStateChange?: (isUploading: boolean) => void;
     onRemoveImage: () => void;
 }
 
@@ -45,6 +46,7 @@ const PostForm = ({
     onTagsChange,
     onImageUpload,
     onEditorImageUpload,
+    onEditorUploadStateChange,
     onRemoveImage
 }: PostFormProps) => {
     const internalFormRef = useRef<HTMLFormElement>(null);
@@ -98,6 +100,7 @@ const PostForm = ({
                             onChange={onContentChange}
                             placeholder="내용을 입력하세요"
                             onImageUpload={onEditorImageUpload}
+                            onUploadStateChange={onEditorUploadStateChange}
                         />
                     )}
                 </div>

--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/hooks/useFormSubmit.ts
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/hooks/useFormSubmit.ts
@@ -82,6 +82,7 @@ export const useFormSubmit = (options: UseFormSubmitOptions) => {
             addHiddenField(form, 'url', normalizeUrlForSubmit(data.url));
             addHiddenField(form, 'tag', data.tags.join(','));
             addHiddenField(form, 'series', data.seriesId);
+            addHiddenField(form, 'content_html', data.content);
 
             if (isDraft) {
                 addHiddenField(form, 'is_draft', 'true');

--- a/backend/islands/packages/editor/src/TiptapEditor/TiptapEditor.tsx
+++ b/backend/islands/packages/editor/src/TiptapEditor/TiptapEditor.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useEditor, EditorContent } from '@tiptap/react';
 import MenuBar from './components/menus/MenuBar';
 import { getEditorExtensions } from './config/editorConfig';
@@ -13,6 +13,7 @@ interface TiptapEditorProps {
     placeholder?: string;
     onImageUpload?: (file: File) => Promise<string | undefined>;
     onImageUploadError?: (errorMessage: string) => void;
+    onUploadStateChange?: (isUploading: boolean) => void;
 }
 
 interface HandlersRef {
@@ -27,7 +28,8 @@ const TiptapEditor = ({
     height = 'auto',
     placeholder = '내용을 입력하세요…',
     onImageUpload,
-    onImageUploadError
+    onImageUploadError,
+    onUploadStateChange
 }: TiptapEditorProps) => {
     const handleChange = (html: string) => {
         if (onChange) {
@@ -36,6 +38,7 @@ const TiptapEditor = ({
     };
 
     const handlersRef = useRef<HandlersRef>({ handleImagePaste: () => {} });
+    const [isMenuUploading, setIsMenuUploading] = useState(false);
 
     const editor = useEditor({
         extensions: getEditorExtensions(placeholder),
@@ -88,11 +91,21 @@ const TiptapEditor = ({
         }
     });
 
-    const { handleDrop, handlePaste: handleImagePaste, isUploading } = useImageUpload({
+    const {
+        handleDrop,
+        handlePaste: handleImagePaste,
+        isUploading: isDropPasteUploading
+    } = useImageUpload({
         editor,
         onImageUpload,
         onImageUploadError
     });
+    const isUploading = isDropPasteUploading || isMenuUploading;
+
+    useEffect(() => {
+        onUploadStateChange?.(isUploading);
+        return () => onUploadStateChange?.(false);
+    }, [isUploading, onUploadStateChange]);
 
     useEffect(() => {
         handlersRef.current = { handleImagePaste };
@@ -125,6 +138,7 @@ const TiptapEditor = ({
                     editor={editor}
                     onImageUpload={onImageUpload}
                     onImageUploadError={onImageUploadError}
+                    onUploadStateChange={setIsMenuUploading}
                 />
             )}
 

--- a/backend/islands/packages/editor/src/TiptapEditor/components/menus/MenuBar.tsx
+++ b/backend/islands/packages/editor/src/TiptapEditor/components/menus/MenuBar.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { Editor } from '@tiptap/react';
 import YoutubeModal from '../modals/YoutubeModal';
 import FloatingMenuBar from './FloatingMenuBar';
@@ -13,22 +13,29 @@ interface MenuBarProps {
     editor: Editor | null;
     onImageUpload?: (file: File) => Promise<string | undefined>;
     onImageUploadError?: (errorMessage: string) => void;
+    onUploadStateChange?: (isUploading: boolean) => void;
 }
 
 const MenuBar = ({
     editor,
     onImageUpload,
-    onImageUploadError
+    onImageUploadError,
+    onUploadStateChange
 }: MenuBarProps) => {
     const [isYoutubeModalOpen, setIsYoutubeModalOpen] = useState(false);
     const imageInput = useRef<HTMLInputElement>(null);
     const videoInput = useRef<HTMLInputElement>(null);
-    const { handleImageUpload, handleVideoUpload } = useImageUpload({
+    const { handleImageUpload, handleVideoUpload, isUploading } = useImageUpload({
         editor,
         onImageUpload,
         onImageUploadError
     });
     const { isVisible: isSlashMenuVisible, slashPos, closeMenu } = useSlashCommand(editor);
+
+    useEffect(() => {
+        onUploadStateChange?.(isUploading);
+        return () => onUploadStateChange?.(false);
+    }, [isUploading, onUploadStateChange]);
 
     if (!editor) return null;
 

--- a/backend/src/board/services/post_service.py
+++ b/backend/src/board/services/post_service.py
@@ -207,9 +207,21 @@ class PostService:
         if image is not None:
             new_hash = PostService._compute_image_hash(image)
 
-            existing = Post.objects.filter(
+            if (
+                post.pk
+                and post.image
+                and post.image_hash == new_hash
+                and post.image.storage.exists(post.image.name)
+            ):
+                return
+
+            existing_images = Post.objects.filter(
                 image_hash=new_hash,
-            ).exclude(image='').first()
+            ).exclude(image='')
+            if post.pk:
+                existing_images = existing_images.exclude(pk=post.pk)
+
+            existing = existing_images.first()
 
             if existing and existing.image and existing.image.storage.exists(existing.image.name):
                 if post.image:

--- a/backend/src/board/tests/services/test_image_dedup.py
+++ b/backend/src/board/tests/services/test_image_dedup.py
@@ -199,3 +199,32 @@ class ImageDedupTestCase(TestCase):
 
         self.assertEqual(post.image.name, 'images/title/thumb-test.jpg')
         self.assertTrue(getattr(post, '_skip_thumbnail', False))
+
+    @patch('board.services.post_service.PostService._compute_image_hash')
+    def test_set_image_with_dedup_does_not_reuse_self(self, mock_hash):
+        """같은 포스트의 기존 이미지는 중복 이미지 후보에서 제외"""
+        mock_hash.return_value = 'e' * 64
+
+        post = Post.objects.create(
+            url='self-dedup-current',
+            title='Self Dedup Current',
+            author=self.user,
+            published_date=timezone.now(),
+        )
+        Post.objects.filter(pk=post.pk).update(
+            image='images/title/current.jpg',
+            image_hash='e' * 64,
+        )
+        post.refresh_from_db()
+        PostContent.objects.create(post=post, content_html='')
+        PostConfig.objects.create(post=post)
+
+        new_image = self._create_test_image('same-content.jpg')
+
+        with patch.object(default_storage, 'exists', return_value=True):
+            with patch.object(post.image, 'delete') as mock_delete:
+                PostService._set_image_with_dedup(post, image=new_image)
+
+        self.assertEqual(post.image.name, 'images/title/current.jpg')
+        self.assertFalse(mock_delete.called)
+        self.assertFalse(getattr(post, '_skip_thumbnail', False))


### PR DESCRIPTION
## 🎯 Goal
- Fix title image loss when publishing a post that re-submits the same already-saved image.
- Prevent post saves and publishes from racing ahead of in-progress editor media uploads.

## 🔧 Core Changes
- Preserve the current post image when the same image hash already belongs to that post, and exclude the current post from cross-post image deduplication.
- Surface editor media upload state through the post editor form and disable save, publish, and autosave while uploads are pending.
- Submit the current editor content as content_html for the native form submit path.
- Add a regression test for the self-deduplication case.

## 🤔 Key Decisions
- Treat the current post's own image hash as a no-op instead of a reusable duplicate, because deduplication should only reuse files from other posts.
- Block save/publish/autosave while editor media is uploading to avoid persisting content before image uploads finish.

## 🧪 Verification Guide
### How to verify
1. Create or edit a draft with a title image, let it save, then publish without replacing the image.
2. Insert an editor image and try to save or publish while the upload is still in progress.
3. Run the focused backend image dedup test and islands lint/type checks.

### Expected result
- The title image remains attached after publishing.
- Save, publish, and autosave wait until editor media uploads complete.
- Focused backend tests, islands lint, and islands type checks pass.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (not needed)