### PR TITLE
✨ Add post trust info and sharing options

### DIFF
--- a/backend/src/board/templates/board/posts/post_detail.html
+++ b/backend/src/board/templates/board/posts/post_detail.html
@@ -200,8 +200,8 @@
 
                     <section class="mb-16 pt-8" aria-labelledby="post-info-heading">
                         <h2 id="post-info-heading" class="text-base font-semibold text-content">글 정보</h2>
-                        <dl class="mt-4 space-y-4 text-sm">
-                            <div class="sm:flex sm:items-start sm:gap-6">
+                        <dl class="mt-4 divide-y divide-line-light text-sm">
+                            <div class="py-3 first:pt-0 sm:flex sm:items-start sm:gap-6">
                                 <dt class="text-xs font-medium text-content-hint sm:w-24 sm:flex-shrink-0">작성자</dt>
                                 <dd class="mt-1 min-w-0 sm:mt-0">
                                     <a href="/@{{ post.author_username }}" class="font-semibold text-content hover:text-content-secondary transition-colors">{{ post.author_username }}</a>
@@ -210,14 +210,14 @@
                                     {% endif %}
                                 </dd>
                             </div>
-                            <div class="sm:flex sm:items-start sm:gap-6">
+                            <div class="py-3 sm:flex sm:items-start sm:gap-6">
                                 <dt class="text-xs font-medium text-content-hint sm:w-24 sm:flex-shrink-0">최초 발행</dt>
                                 <dd class="mt-1 text-content-secondary sm:mt-0">
                                     <time datetime="{{ post.published_date|date:'c' }}">{{ post.created_date_display }}</time>
                                 </dd>
                             </div>
                             {% if show_post_updated_date %}
-                            <div class="sm:flex sm:items-start sm:gap-6">
+                            <div class="py-3 sm:flex sm:items-start sm:gap-6">
                                 <dt class="text-xs font-medium text-content-hint sm:w-24 sm:flex-shrink-0">수정일</dt>
                                 <dd class="mt-1 text-content-secondary sm:mt-0">
                                     <time datetime="{{ post.updated_date|date:'c' }}">{{ post.updated_date_display }}</time>
@@ -225,7 +225,7 @@
                             </div>
                             {% endif %}
                             {% if author_homepage %}
-                            <div class="sm:flex sm:items-start sm:gap-6">
+                            <div class="py-3 sm:flex sm:items-start sm:gap-6">
                                 <dt class="text-xs font-medium text-content-hint sm:w-24 sm:flex-shrink-0">저자 홈페이지</dt>
                                 <dd class="mt-1 min-w-0 sm:mt-0">
                                     <a href="{{ author_homepage }}" target="_blank" rel="noopener noreferrer" class="break-words text-content-secondary hover:text-content transition-colors">{{ author_homepage }}</a>

--- a/backend/src/board/templates/board/posts/post_detail.html
+++ b/backend/src/board/templates/board/posts/post_detail.html
@@ -199,7 +199,7 @@
                     {% endif %}
 
                     <section class="mb-16 pt-8" aria-labelledby="post-info-heading">
-                        <h2 id="post-info-heading" class="text-base font-semibold text-content">글 정보</h2>
+                        <h2 id="post-info-heading" class="text-sm font-semibold text-content-secondary">글 정보</h2>
                         <dl class="mt-4 divide-y divide-line-light text-sm">
                             <div class="py-3 first:pt-0 sm:flex sm:items-start sm:gap-6">
                                 <dt class="text-xs font-medium text-content-hint sm:w-24 sm:flex-shrink-0">작성자</dt>

--- a/backend/src/board/templates/board/posts/post_detail.html
+++ b/backend/src/board/templates/board/posts/post_detail.html
@@ -200,35 +200,35 @@
 
                     <section class="border-t border-line-light pt-6" aria-labelledby="post-info-heading">
                         <h2 id="post-info-heading" class="text-base font-semibold text-content">글 정보</h2>
-                        <dl class="mt-4 grid gap-5 text-sm sm:grid-cols-2">
-                            <div>
-                                <dt class="text-xs font-medium text-content-hint">작성자</dt>
-                                <dd class="mt-1">
+                        <dl class="mt-4 divide-y divide-line-light text-sm">
+                            <div class="py-3 first:pt-0 sm:flex sm:items-start sm:gap-6">
+                                <dt class="text-xs font-medium text-content-hint sm:w-24 sm:flex-shrink-0">작성자</dt>
+                                <dd class="mt-1 min-w-0 sm:mt-0">
                                     <a href="/@{{ post.author_username }}" class="font-semibold text-content hover:text-content-secondary transition-colors">{{ post.author_username }}</a>
                                     {% if author_bio %}
                                     <p class="mt-1 leading-relaxed text-content-secondary">{{ author_bio }}</p>
                                     {% endif %}
                                 </dd>
                             </div>
-                            <div>
-                                <dt class="text-xs font-medium text-content-hint">최초 발행</dt>
-                                <dd class="mt-1 text-content-secondary">
+                            <div class="py-3 sm:flex sm:items-start sm:gap-6">
+                                <dt class="text-xs font-medium text-content-hint sm:w-24 sm:flex-shrink-0">최초 발행</dt>
+                                <dd class="mt-1 text-content-secondary sm:mt-0">
                                     <time datetime="{{ post.published_date|date:'c' }}">{{ post.created_date_display }}</time>
                                 </dd>
                             </div>
                             {% if show_post_updated_date %}
-                            <div>
-                                <dt class="text-xs font-medium text-content-hint">수정일</dt>
-                                <dd class="mt-1 text-content-secondary">
+                            <div class="py-3 sm:flex sm:items-start sm:gap-6">
+                                <dt class="text-xs font-medium text-content-hint sm:w-24 sm:flex-shrink-0">수정일</dt>
+                                <dd class="mt-1 text-content-secondary sm:mt-0">
                                     <time datetime="{{ post.updated_date|date:'c' }}">{{ post.updated_date_display }}</time>
                                 </dd>
                             </div>
                             {% endif %}
                             {% if author_homepage %}
-                            <div>
-                                <dt class="text-xs font-medium text-content-hint">저자 홈페이지</dt>
-                                <dd class="mt-1">
-                                    <a href="{{ author_homepage }}" target="_blank" rel="noopener noreferrer" class="text-content-secondary hover:text-content transition-colors">{{ author_homepage }}</a>
+                            <div class="py-3 sm:flex sm:items-start sm:gap-6">
+                                <dt class="text-xs font-medium text-content-hint sm:w-24 sm:flex-shrink-0">저자 홈페이지</dt>
+                                <dd class="mt-1 min-w-0 sm:mt-0">
+                                    <a href="{{ author_homepage }}" target="_blank" rel="noopener noreferrer" class="break-words text-content-secondary hover:text-content transition-colors">{{ author_homepage }}</a>
                                 </dd>
                             </div>
                             {% endif %}

--- a/backend/src/board/templates/board/posts/post_detail.html
+++ b/backend/src/board/templates/board/posts/post_detail.html
@@ -144,7 +144,11 @@
                                     {{ post.author_username }}
                                 </a>
                                 <span class="text-line-strong">·</span>
-                                <span class="text-content-secondary" itemprop="datePublished" content="{{ post.published_date|date:'c' }}">{{ post.created_date_display }}</span>
+                                <span class="text-content-secondary" itemprop="datePublished" content="{{ post.published_date|date:'c' }}">{{ post.created_date_display }} 발행</span>
+                                {% if show_post_updated_date %}
+                                <span class="text-line-strong">·</span>
+                                <span class="text-content-secondary" itemprop="dateModified" content="{{ post.updated_date|date:'c' }}">{{ post.updated_date_display }} 수정</span>
+                                {% endif %}
                                 <span class="text-line-strong">·</span>
                                 <span class="text-content-secondary" aria-label="읽는 시간">{{ post.read_time }}분 소요</span>
                             </div>
@@ -193,6 +197,43 @@
                         {% endfor %}
                     </div>
                     {% endif %}
+
+                    <section class="border-t border-line-light pt-6" aria-labelledby="post-info-heading">
+                        <h2 id="post-info-heading" class="text-base font-semibold text-content">글 정보</h2>
+                        <dl class="mt-4 grid gap-5 text-sm sm:grid-cols-2">
+                            <div>
+                                <dt class="text-xs font-medium text-content-hint">작성자</dt>
+                                <dd class="mt-1">
+                                    <a href="/@{{ post.author_username }}" class="font-semibold text-content hover:text-content-secondary transition-colors">{{ post.author_username }}</a>
+                                    {% if author_bio %}
+                                    <p class="mt-1 leading-relaxed text-content-secondary">{{ author_bio }}</p>
+                                    {% endif %}
+                                </dd>
+                            </div>
+                            <div>
+                                <dt class="text-xs font-medium text-content-hint">최초 발행</dt>
+                                <dd class="mt-1 text-content-secondary">
+                                    <time datetime="{{ post.published_date|date:'c' }}">{{ post.created_date_display }}</time>
+                                </dd>
+                            </div>
+                            {% if show_post_updated_date %}
+                            <div>
+                                <dt class="text-xs font-medium text-content-hint">수정일</dt>
+                                <dd class="mt-1 text-content-secondary">
+                                    <time datetime="{{ post.updated_date|date:'c' }}">{{ post.updated_date_display }}</time>
+                                </dd>
+                            </div>
+                            {% endif %}
+                            {% if author_homepage %}
+                            <div>
+                                <dt class="text-xs font-medium text-content-hint">저자 홈페이지</dt>
+                                <dd class="mt-1">
+                                    <a href="{{ author_homepage }}" target="_blank" rel="noopener noreferrer" class="text-content-secondary hover:text-content transition-colors">{{ author_homepage }}</a>
+                                </dd>
+                            </div>
+                            {% endif %}
+                        </dl>
+                    </section>
                 </article>
 
                 <!-- Floating Action Bar -->
@@ -215,7 +256,7 @@
                         }
                     },
                     openLinkCopyMenu() {
-                        if (this.isCoarsePointer() || !this.getAgentUrl()) {
+                        if (this.isCoarsePointer()) {
                             return;
                         }
 
@@ -252,6 +293,25 @@
 
                         await this.copyToClipboard(agentUrl, '에이전트용 링크가 복사되었습니다');
                     },
+                    openSharePopup(url) {
+                        const popup = window.open(url, '_blank', 'noopener,noreferrer,width=720,height=640');
+                        if (popup) {
+                            popup.opener = null;
+                        }
+                    },
+                    shareToX() {
+                        const url = encodeURIComponent(this.getPageUrl());
+                        const text = encodeURIComponent('{{ post.title|escapejs }}');
+                        this.openSharePopup(`https://twitter.com/intent/tweet?text=${text}&url=${url}`);
+                    },
+                    shareToLinkedIn() {
+                        const url = encodeURIComponent(this.getPageUrl());
+                        this.openSharePopup(`https://www.linkedin.com/sharing/share-offsite/?url=${url}`);
+                    },
+                    shareToFacebook() {
+                        const url = encodeURIComponent(this.getPageUrl());
+                        this.openSharePopup(`https://www.facebook.com/sharer/sharer.php?u=${url}`);
+                    },
                     async handleShareClick() {
                         const decodedUrl = this.getPageUrl();
                         if (this.isCoarsePointer()) {
@@ -273,13 +333,8 @@
                             return;
                         }
 
-                        if (this.getAgentUrl()) {
-                            this.cancelLinkCopyHide();
-                            this.linkCopyMenuOpen = true;
-                            return;
-                        }
-
-                        await this.copyToClipboard(decodedUrl);
+                        this.cancelLinkCopyHide();
+                        this.linkCopyMenuOpen = true;
                     }
                 }"
                 {% if show_agent_post_markdown %}data-agent-copy-url="{{ post_markdown_url }}"{% endif %}
@@ -315,7 +370,6 @@
                                 <i class="fas fa-share-alt"></i>
                             </button>
 
-                            {% if aeo_enabled %}
                             <div x-show="linkCopyMenuOpen"
                                 x-transition:enter="transition ease-out duration-150"
                                 x-transition:enter-start="opacity-0 translate-y-1 scale-95"
@@ -325,10 +379,10 @@
                                 x-transition:leave-end="opacity-0 translate-y-1 scale-95"
                                 @mouseenter="cancelLinkCopyHide()"
                                 @mouseleave="scheduleCloseLinkCopyMenu()"
-                                class="absolute bottom-full left-1/2 mb-3 w-64 -translate-x-1/2 rounded-xl border border-line bg-surface-elevated p-2 text-left shadow-floating z-40"
+                                class="absolute bottom-full left-1/2 mb-3 w-72 -translate-x-1/2 rounded-xl border border-line bg-surface-elevated p-2 text-left shadow-floating z-40"
                                 style="display: none;">
                                 <div class="px-2 pb-1 text-[11px] font-bold uppercase tracking-wider text-content-hint">
-                                    링크 복사
+                                    공유
                                 </div>
                                 <button @click="copyToClipboard(); closeLinkCopyMenu()"
                                     class="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-sm text-content-secondary transition-colors duration-150 hover:bg-surface-subtle hover:text-content active:scale-[0.98]">
@@ -340,6 +394,38 @@
                                         <span class="text-xs text-content-hint">브라우저에서 여는 주소</span>
                                     </span>
                                 </button>
+                                <button @click="shareToX(); closeLinkCopyMenu()"
+                                    class="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-sm text-content-secondary transition-colors duration-150 hover:bg-surface-subtle hover:text-content active:scale-[0.98]">
+                                    <span class="flex h-8 w-8 items-center justify-center rounded-lg bg-surface-subtle text-xs">
+                                        <i class="fab fa-twitter"></i>
+                                    </span>
+                                    <span class="flex flex-col">
+                                        <span class="font-semibold">X에 공유</span>
+                                        <span class="text-xs text-content-hint">새 창에서 공유 글 작성</span>
+                                    </span>
+                                </button>
+                                <button @click="shareToLinkedIn(); closeLinkCopyMenu()"
+                                    class="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-sm text-content-secondary transition-colors duration-150 hover:bg-surface-subtle hover:text-content active:scale-[0.98]">
+                                    <span class="flex h-8 w-8 items-center justify-center rounded-lg bg-surface-subtle text-xs">
+                                        <i class="fab fa-linkedin-in"></i>
+                                    </span>
+                                    <span class="flex flex-col">
+                                        <span class="font-semibold">LinkedIn에 공유</span>
+                                        <span class="text-xs text-content-hint">전문 네트워크에 공유</span>
+                                    </span>
+                                </button>
+                                <button @click="shareToFacebook(); closeLinkCopyMenu()"
+                                    class="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-sm text-content-secondary transition-colors duration-150 hover:bg-surface-subtle hover:text-content active:scale-[0.98]">
+                                    <span class="flex h-8 w-8 items-center justify-center rounded-lg bg-surface-subtle text-xs">
+                                        <i class="fab fa-facebook-f"></i>
+                                    </span>
+                                    <span class="flex flex-col">
+                                        <span class="font-semibold">Facebook에 공유</span>
+                                        <span class="text-xs text-content-hint">피드 또는 메시지로 공유</span>
+                                    </span>
+                                </button>
+                                {% if show_agent_post_markdown %}
+                                <div class="my-1 h-px bg-line-light"></div>
                                 <button @click="copyAgentLink(); closeLinkCopyMenu()"
                                     class="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-sm text-content-secondary transition-colors duration-150 hover:bg-surface-subtle hover:text-content active:scale-[0.98]">
                                     <span class="flex h-8 w-8 items-center justify-center rounded-lg bg-surface-subtle text-xs">
@@ -350,8 +436,8 @@
                                         <span class="text-xs text-content-hint">*.md 참조 주소</span>
                                     </span>
                                 </button>
+                                {% endif %}
                             </div>
-                            {% endif %}
                         </div>
 
                         <!-- Edit Button -->

--- a/backend/src/board/templates/board/posts/post_detail.html
+++ b/backend/src/board/templates/board/posts/post_detail.html
@@ -397,7 +397,7 @@
                                 <button @click="shareToX(); closeLinkCopyMenu()"
                                     class="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-sm text-content-secondary transition-colors duration-150 hover:bg-surface-subtle hover:text-content active:scale-[0.98]">
                                     <span class="flex h-8 w-8 items-center justify-center rounded-lg bg-surface-subtle text-xs">
-                                        <i class="fab fa-twitter"></i>
+                                        <i class="fab fa-x-twitter"></i>
                                     </span>
                                     <span class="flex flex-col">
                                         <span class="font-semibold">X에 공유</span>

--- a/backend/src/board/templates/board/posts/post_detail.html
+++ b/backend/src/board/templates/board/posts/post_detail.html
@@ -198,10 +198,10 @@
                     </div>
                     {% endif %}
 
-                    <section class="border-t border-line-light pt-6" aria-labelledby="post-info-heading">
+                    <section class="mb-16 pt-8" aria-labelledby="post-info-heading">
                         <h2 id="post-info-heading" class="text-base font-semibold text-content">글 정보</h2>
-                        <dl class="mt-4 divide-y divide-line-light text-sm">
-                            <div class="py-3 first:pt-0 sm:flex sm:items-start sm:gap-6">
+                        <dl class="mt-4 space-y-4 text-sm">
+                            <div class="sm:flex sm:items-start sm:gap-6">
                                 <dt class="text-xs font-medium text-content-hint sm:w-24 sm:flex-shrink-0">작성자</dt>
                                 <dd class="mt-1 min-w-0 sm:mt-0">
                                     <a href="/@{{ post.author_username }}" class="font-semibold text-content hover:text-content-secondary transition-colors">{{ post.author_username }}</a>
@@ -210,14 +210,14 @@
                                     {% endif %}
                                 </dd>
                             </div>
-                            <div class="py-3 sm:flex sm:items-start sm:gap-6">
+                            <div class="sm:flex sm:items-start sm:gap-6">
                                 <dt class="text-xs font-medium text-content-hint sm:w-24 sm:flex-shrink-0">최초 발행</dt>
                                 <dd class="mt-1 text-content-secondary sm:mt-0">
                                     <time datetime="{{ post.published_date|date:'c' }}">{{ post.created_date_display }}</time>
                                 </dd>
                             </div>
                             {% if show_post_updated_date %}
-                            <div class="py-3 sm:flex sm:items-start sm:gap-6">
+                            <div class="sm:flex sm:items-start sm:gap-6">
                                 <dt class="text-xs font-medium text-content-hint sm:w-24 sm:flex-shrink-0">수정일</dt>
                                 <dd class="mt-1 text-content-secondary sm:mt-0">
                                     <time datetime="{{ post.updated_date|date:'c' }}">{{ post.updated_date_display }}</time>
@@ -225,7 +225,7 @@
                             </div>
                             {% endif %}
                             {% if author_homepage %}
-                            <div class="py-3 sm:flex sm:items-start sm:gap-6">
+                            <div class="sm:flex sm:items-start sm:gap-6">
                                 <dt class="text-xs font-medium text-content-hint sm:w-24 sm:flex-shrink-0">저자 홈페이지</dt>
                                 <dd class="mt-1 min-w-0 sm:mt-0">
                                     <a href="{{ author_homepage }}" target="_blank" rel="noopener noreferrer" class="break-words text-content-secondary hover:text-content transition-colors">{{ author_homepage }}</a>

--- a/backend/src/board/tests/templates/test_post_detail.py
+++ b/backend/src/board/tests/templates/test_post_detail.py
@@ -46,6 +46,11 @@ class PostDetailViewTestCase(TestCase):
         setting.aeo_enabled = True
         setting.save(update_fields=['aeo_enabled'])
 
+    def set_post_dates(self, published_date, updated_date):
+        self.post.published_date = published_date
+        self.post.updated_date = updated_date
+        self.post.save(update_fields=['published_date', 'updated_date'])
+
     def test_post_detail_context_has_toc(self):
         url = reverse('post_detail', kwargs={
             'username': 'testauthor',
@@ -207,6 +212,10 @@ class PostDetailViewTestCase(TestCase):
         self.assertNotContains(response, 'aria-label="AI용 Markdown 복사"')
         self.assertNotContains(response, 'data-ai-markdown-url=')
         self.assertNotContains(response, 'data-agent-copy-url=')
+        self.assertContains(response, '일반 링크')
+        self.assertContains(response, 'X에 공유')
+        self.assertContains(response, 'LinkedIn에 공유')
+        self.assertContains(response, 'Facebook에 공유')
         self.assertNotContains(response, '*.md 참조 주소')
 
     def test_post_detail_uses_noindex_only_when_seo_disabled(self):
@@ -226,6 +235,55 @@ class PostDetailViewTestCase(TestCase):
         self.assertNotContains(response, 'max-snippet:-1')
         self.assertEqual(response['X-Robots-Tag'], 'noindex, nofollow')
 
+    def test_post_detail_hides_updated_date_when_display_date_matches(self):
+        """표시 날짜가 같으면 초 단위 updated_date 차이를 수정 표시로 보여주지 않는다."""
+        self.set_post_dates(
+            timezone.make_aware(datetime.datetime(2026, 5, 30, 10, 0, 0)),
+            timezone.make_aware(datetime.datetime(2026, 5, 30, 18, 0, 0)),
+        )
+
+        response = self.client.get(reverse('post_detail', kwargs={
+            'username': 'testauthor',
+            'post_url': 'test-post'
+        }))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.context['show_post_updated_date'])
+        self.assertContains(response, '2026-05-30 발행')
+        self.assertNotContains(response, '2026-05-30 수정')
+        self.assertNotContains(response, '수정일')
+
+    def test_post_detail_shows_updated_date_when_display_date_differs(self):
+        """표시 날짜가 다르면 상단 메타와 글 정보에 수정일을 보여준다."""
+        self.set_post_dates(
+            timezone.make_aware(datetime.datetime(2026, 5, 30, 10, 0, 0)),
+            timezone.make_aware(datetime.datetime(2026, 5, 31, 10, 0, 0)),
+        )
+
+        response = self.client.get(reverse('post_detail', kwargs={
+            'username': 'testauthor',
+            'post_url': 'test-post'
+        }))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.context['show_post_updated_date'])
+        self.assertContains(response, '2026-05-30 발행')
+        self.assertContains(response, '2026-05-31 수정')
+        self.assertContains(response, '수정일')
+
+    def test_post_detail_shows_post_info_section(self):
+        """포스트 상세 하단에 사람이 확인할 수 있는 글 정보를 보여준다."""
+        response = self.client.get(reverse('post_detail', kwargs={
+            'username': 'testauthor',
+            'post_url': 'test-post'
+        }))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '글 정보')
+        self.assertContains(response, '작성자')
+        self.assertContains(response, '최초 발행')
+        self.assertContains(response, '/@testauthor')
+
     def test_post_detail_shows_agent_link_copy_option_when_aeo_enabled(self):
         """AEO가 켜져 있으면 링크 복사 드롭다운에 .md 참조 링크 옵션을 표시한다."""
         self.enable_aeo()
@@ -238,6 +296,8 @@ class PostDetailViewTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, 'aria-label="AI용 Markdown 복사"')
         self.assertNotContains(response, 'data-ai-markdown-url=')
+        self.assertContains(response, 'X에 공유')
+        self.assertContains(response, 'LinkedIn에 공유')
         self.assertContains(response, '에이전트용 링크')
         self.assertContains(response, '*.md 참조 주소')
 
@@ -288,6 +348,25 @@ class PostDetailViewTestCase(TestCase):
             response['Link']
         )
         self.assertEqual(response['X-Llms-Txt'], llms_txt_url)
+
+    def test_post_detail_hides_markdown_source_for_hidden_post_when_aeo_enabled(self):
+        """AEO가 켜져 있어도 공개 글이 아니면 Markdown 원문을 노출하지 않는다."""
+        self.enable_aeo()
+        self.post.config.hide = True
+        self.post.config.save(update_fields=['hide'])
+        self.client.login(username='testauthor', password='password123')
+
+        response = self.client.get(reverse('post_detail', kwargs={
+            'username': 'testauthor',
+            'post_url': 'test-post'
+        }))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.context['show_agent_post_markdown'])
+        self.assertNotContains(response, 'data-agent-copy-url=')
+        self.assertNotContains(response, '*.md 참조 주소')
+        self.assertNotIn('Link', response)
+        self.assertNotIn('X-Llms-Txt', response)
 
     def test_post_detail_shows_hidden_status_notice_for_author(self):
         """비공개 글은 작성자에게 항상 상단 상태 안내를 보여준다."""

--- a/backend/src/board/tests/templates/test_post_detail.py
+++ b/backend/src/board/tests/templates/test_post_detail.py
@@ -214,6 +214,7 @@ class PostDetailViewTestCase(TestCase):
         self.assertNotContains(response, 'data-agent-copy-url=')
         self.assertContains(response, '일반 링크')
         self.assertContains(response, 'X에 공유')
+        self.assertContains(response, 'fa-x-twitter')
         self.assertContains(response, 'LinkedIn에 공유')
         self.assertContains(response, 'Facebook에 공유')
         self.assertNotContains(response, '*.md 참조 주소')

--- a/backend/src/board/views/post.py
+++ b/backend/src/board/views/post.py
@@ -44,7 +44,13 @@ def post_detail(request, username, post_url):
     ):
         raise Http404("Post does not exist")
 
-    post.created_date_display = post.published_date.strftime('%Y-%m-%d')
+    post.created_date_display = timezone.localtime(post.published_date).strftime('%Y-%m-%d')
+    post.updated_date_display = timezone.localtime(post.updated_date).strftime('%Y-%m-%d')
+    show_post_updated_date = post.created_date_display != post.updated_date_display
+
+    author_profile = getattr(author, 'profile', None)
+    author_bio = author_profile.bio.strip() if author_profile and author_profile.bio else ''
+    author_homepage = author_profile.homepage.strip() if author_profile and author_profile.homepage else ''
 
     # Initialize series attributes to avoid AttributeError
     post.series_total = 0
@@ -95,6 +101,9 @@ def post_detail(request, username, post_url):
         'can_edit_post': can_edit_post,
         'post_visibility_status': post_visibility_status,
         'show_agent_post_markdown': show_agent_post_markdown,
+        'show_post_updated_date': show_post_updated_date,
+        'author_bio': author_bio,
+        'author_homepage': author_homepage,
         **DiscoveryMetadataService.build_user_rss_feed_metadata(author, request),
     }
     if show_agent_post_markdown:


### PR DESCRIPTION
## 🎯 Goal
- Show lightweight trust information on public post detail pages so readers can see who wrote the post and when it was published or materially updated.
- Keep agent-facing Markdown discovery available without adding confusing visible source links for normal readers.
- Improve desktop sharing so readers can share posts through common channels without depending on AEO settings.

## 🔧 Core Changes
- Adds conditional updated-date display to the post header, hidden when the displayed publish/update dates are the same.
- Adds a quiet bottom `글 정보` row-list with author, first published date, optional updated date, and optional author homepage.
- Changes the floating share menu to always expose human sharing options: link copy, X, LinkedIn, and Facebook.
- Keeps the agent Markdown share option behind `AEO enabled + public post`, while preserving existing alternate/link-header discovery.

## 🤔 Key Decisions
- Did not expose a visible `Markdown 원문` link in the bottom trust section because the agent URL already belongs in machine discovery and the share menu, not in the primary reader-facing trust info.
- Kept `글 정보` as a quiet row-list instead of a card so it reads as supporting metadata, not another content block.
- Compared publish/update visibility by displayed local date, not raw datetime, so same-day save timestamp changes do not create noisy `수정` labels.
- Kept mobile sharing on `navigator.share` first; desktop gets explicit social share targets.
- Left Instagram/Pinterest out of this pass: Instagram is better handled by native mobile share, and Pinterest is image/use-case dependent.

## 🧪 Verification Guide
### How to verify
1. Open a public post whose publish and update dates are the same displayed date.
2. Open a public post whose update date is later than its publish date.
3. Toggle AEO off and on, then inspect the share menu on a public post.
4. View a hidden post as the author while AEO is enabled.

### Expected result
- Same-day updates do not show a visible updated-date label.
- Later updates show `YYYY-MM-DD 수정` in the header and `수정일` in `글 정보`.
- Desktop share menu always includes link copy, X, LinkedIn, and Facebook.
- Agent Markdown share and response headers appear only for public posts when AEO is enabled.

## ✅ Checklist
- [x] Lint not required (Django template/view only)
- [x] Type-check not required (Django template/view only)
- [x] Tests completed
- [x] Documentation updated (Ocean Brain ticket and scope memo)

Tested with:
- `npm run server:test -- board.tests.templates.test_post_detail`

Documentation updated:
- `BLEX 티켓 - 글 신뢰 정보 표시`
- `BLEX 메모 - 글 신뢰 정보 1차 구현 범위`