### PR TITLE
🐛 Store editor media URLs as relative paths

### DIFF
--- a/backend/islands/packages/editor/src/TiptapEditor/TiptapEditor.tsx
+++ b/backend/islands/packages/editor/src/TiptapEditor/TiptapEditor.tsx
@@ -3,6 +3,7 @@ import { useEditor, EditorContent } from '@tiptap/react';
 import MenuBar from './components/menus/MenuBar';
 import { getEditorExtensions } from './config/editorConfig';
 import { useImageUpload } from './hooks/useImageUpload';
+import { normalizeMediaUrlsInHtml } from './utils/mediaUrls';
 
 interface TiptapEditorProps {
     name: string;
@@ -31,7 +32,7 @@ const TiptapEditor = ({
 }: TiptapEditorProps) => {
     const handleChange = (html: string) => {
         if (onChange) {
-            onChange(html);
+            onChange(normalizeMediaUrlsInHtml(html));
         }
     };
 
@@ -102,7 +103,7 @@ const TiptapEditor = ({
         if (editor && content !== undefined) {
             const currentContent = editor.getHTML();
             if (content !== currentContent && !editor.isFocused) {
-                const cleanedContent = content
+                const cleanedContent = normalizeMediaUrlsInHtml(content)
                     .replace(/\.preview\.jpg/g, '')
                     .replace(/data-src="([^"]+)"/g, 'src="$1"')
                     .replace(/class="[^"]*lazy[^"]*"/g, '')
@@ -118,7 +119,7 @@ const TiptapEditor = ({
             onDragOver={(e) => e.preventDefault()}
             onDrop={handleDrop}
             style={{ minHeight: height }}>
-            <input type="hidden" name={name} value={editor?.getHTML() || content} />
+            <input type="hidden" name={name} value={normalizeMediaUrlsInHtml(editor?.getHTML() || content)} />
 
             {editable && (
                 <MenuBar

--- a/backend/islands/packages/editor/src/TiptapEditor/extensions/CustomImage.ts
+++ b/backend/islands/packages/editor/src/TiptapEditor/extensions/CustomImage.ts
@@ -1,6 +1,7 @@
 import { Node, ReactNodeViewRenderer } from '@tiptap/react';
 import { ImageNodeView } from '../components/nodeviews/ImageNodeView';
 import { buildFigureAttrsForHTML } from '../utils/mediaStyles';
+import { normalizeMediaUrlForStorage } from '../utils/mediaUrls';
 
 export const CustomImage = Node.create({
     name: 'image',
@@ -45,7 +46,7 @@ export const CustomImage = Node.create({
 
                     if (!img) return false;
 
-                    let src = img.src || img.getAttribute('src') || '';
+                    let src = img.getAttribute('src') || img.src || '';
 
                     if (img.dataset.src) {
                         src = img.dataset.src;
@@ -55,7 +56,7 @@ export const CustomImage = Node.create({
                     }
 
                     return {
-                        src,
+                        src: normalizeMediaUrlForStorage(src),
                         alt: img.alt || null,
                         title: img.title || null,
                         width: img.width || null,
@@ -76,7 +77,7 @@ export const CustomImage = Node.create({
                 tag: 'img',
                 getAttrs: (element) => {
                     const img = element as HTMLImageElement;
-                    let src = img.src || img.getAttribute('src') || '';
+                    let src = img.getAttribute('src') || img.src || '';
 
                     if (img.dataset.src) {
                         src = img.dataset.src;
@@ -86,7 +87,7 @@ export const CustomImage = Node.create({
                     }
 
                     return {
-                        src,
+                        src: normalizeMediaUrlForStorage(src),
                         alt: img.alt || null,
                         title: img.title || null,
                         width: img.width || null,
@@ -112,7 +113,7 @@ export const CustomImage = Node.create({
         } = HTMLAttributes;
 
         const imgAttrs: Record<string, string> = {
-            src: src || '',
+            src: normalizeMediaUrlForStorage(src) || '',
             alt: alt || ''
         };
 

--- a/backend/islands/packages/editor/src/TiptapEditor/extensions/VideoNode.ts
+++ b/backend/islands/packages/editor/src/TiptapEditor/extensions/VideoNode.ts
@@ -1,6 +1,7 @@
 import { Node, ReactNodeViewRenderer } from '@tiptap/react';
 import { VideoNodeView } from '../components/nodeviews/VideoNodeView';
 import { buildFigureAttrsForHTML } from '../utils/mediaStyles';
+import { normalizeMediaUrlForStorage } from '../utils/mediaUrls';
 
 export const VideoNode = Node.create({
     name: 'video',
@@ -78,7 +79,7 @@ export const VideoNode = Node.create({
                     const source = video.querySelector('source');
 
                     // data-src가 있으면 즉시 src로 사용 (lazy 로딩 제거)
-                    let finalSrc = video.src || source?.src || null;
+                    let finalSrc = video.getAttribute('src') || source?.getAttribute('src') || video.src || source?.src || null;
                     const dataSrc = source?.getAttribute('data-src') || video.getAttribute('data-src') || null;
                     if (dataSrc) {
                         finalSrc = dataSrc;
@@ -89,8 +90,8 @@ export const VideoNode = Node.create({
                     const playMode = hasControls ? 'video' : 'gif';
 
                     return {
-                        src: finalSrc,
-                        poster: video.poster || null,
+                        src: normalizeMediaUrlForStorage(finalSrc),
+                        poster: normalizeMediaUrlForStorage(video.getAttribute('poster') || video.poster || null),
                         width: video.width || null,
                         height: video.height || null,
                         align: figure.style.textAlign || figure.getAttribute('data-align') || 'center',
@@ -117,7 +118,7 @@ export const VideoNode = Node.create({
                     const source = video.querySelector('source');
 
                     // data-src가 있으면 즉시 src로 사용 (lazy 로딩 제거)
-                    let finalSrc = video.src || source?.src || null;
+                    let finalSrc = video.getAttribute('src') || source?.getAttribute('src') || video.src || source?.src || null;
                     const dataSrc = source?.getAttribute('data-src') || video.getAttribute('data-src') || null;
                     if (dataSrc) {
                         finalSrc = dataSrc;
@@ -128,8 +129,8 @@ export const VideoNode = Node.create({
                     const playMode = hasControls ? 'video' : 'gif';
 
                     return {
-                        src: finalSrc,
-                        poster: video.poster || null,
+                        src: normalizeMediaUrlForStorage(finalSrc),
+                        poster: normalizeMediaUrlForStorage(video.getAttribute('poster') || video.poster || null),
                         width: video.width || null,
                         height: video.height || null,
                         align: 'center',
@@ -182,7 +183,7 @@ export const VideoNode = Node.create({
             videoAttrs.controls = '';
         }
 
-        if (poster) videoAttrs.poster = poster;
+        if (poster) videoAttrs.poster = normalizeMediaUrlForStorage(poster);
         if (width) videoAttrs.width = width;
         if (height) videoAttrs.height = height;
 
@@ -203,7 +204,7 @@ export const VideoNode = Node.create({
         }
 
         const sourceAttrs: Record<string, string> = { type: 'video/mp4' };
-        if (src) sourceAttrs.src = src;
+        if (src) sourceAttrs.src = normalizeMediaUrlForStorage(src);
 
         // figure 스타일 (공유 유틸 사용)
         const { attrs: figureAttrs } = buildFigureAttrsForHTML({

--- a/backend/islands/packages/editor/src/TiptapEditor/hooks/useImageUpload.tsx
+++ b/backend/islands/packages/editor/src/TiptapEditor/hooks/useImageUpload.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import type { Editor } from '@tiptap/react';
+import { normalizeMediaUrlForStorage } from '../utils/mediaUrls';
 
 interface UseImageUploadProps {
     editor: Editor | null;
@@ -30,7 +31,8 @@ export const useImageUpload = ({ editor, onImageUpload, onImageUploadError }: Us
 
         setUploadingCount(prev => prev + 1);
         try {
-            const url = await onImageUpload(file);
+            const uploadedUrl = await onImageUpload(file);
+            const url = normalizeMediaUrlForStorage(uploadedUrl);
 
             if (url) {
                 // position이 지정되지 않았으면 현재 selection 사용

--- a/backend/islands/packages/editor/src/TiptapEditor/utils/mediaUrls.ts
+++ b/backend/islands/packages/editor/src/TiptapEditor/utils/mediaUrls.ts
@@ -1,0 +1,129 @@
+const MEDIA_PATH_PREFIXES = ['/resources/media/'];
+
+const getCurrentOrigin = () => {
+    if (typeof window === 'undefined') return null;
+    return window.location.origin;
+};
+
+const getMediaPathPrefixes = () => {
+    if (typeof window === 'undefined') return MEDIA_PATH_PREFIXES;
+
+    const configuration = (window as Window & {
+        configuration?: { media?: string };
+    }).configuration;
+    const configuredMedia = configuration?.media;
+
+    if (!configuredMedia) return MEDIA_PATH_PREFIXES;
+
+    try {
+        const mediaUrl = new URL(configuredMedia, window.location.href);
+        return Array.from(new Set([...MEDIA_PATH_PREFIXES, mediaUrl.pathname]));
+    } catch {
+        return MEDIA_PATH_PREFIXES;
+    }
+};
+
+const hasMediaPath = (pathname: string) => {
+    return getMediaPathPrefixes().some(prefix => pathname.startsWith(prefix));
+};
+
+export const normalizeMediaUrlForStorage = (url: string | null | undefined) => {
+    if (!url) return url || '';
+
+    const currentOrigin = getCurrentOrigin();
+    if (!currentOrigin) return url;
+
+    try {
+        const parsedUrl = new URL(url, window.location.href);
+
+        if (!['http:', 'https:'].includes(parsedUrl.protocol)) return url;
+        if (parsedUrl.origin !== currentOrigin) return url;
+        if (!hasMediaPath(parsedUrl.pathname)) return url;
+
+        return `${parsedUrl.pathname}${parsedUrl.search}${parsedUrl.hash}`;
+    } catch {
+        return url;
+    }
+};
+
+const normalizeMediaSrcsetForStorage = (srcset: string | null | undefined) => {
+    if (!srcset) return srcset || '';
+
+    let changed = false;
+    const candidates = splitSrcsetCandidates(srcset).map(candidate => {
+        const trimmedCandidate = candidate.trim();
+        if (!trimmedCandidate || trimmedCandidate.startsWith('data:')) return candidate;
+
+        const [url, ...descriptors] = trimmedCandidate.split(/\s+/);
+        const normalizedUrl = normalizeMediaUrlForStorage(url);
+        if (normalizedUrl === url) return candidate;
+
+        changed = true;
+        return [normalizedUrl, ...descriptors].join(' ');
+    });
+
+    return changed ? candidates.join(', ') : srcset;
+};
+
+function splitSrcsetCandidates(srcset: string) {
+    const candidates: string[] = [];
+    let start = 0;
+    let inDataUrl = false;
+    let sawNonWhitespace = false;
+    let sawWhitespaceAfterUrl = false;
+
+    const resetCandidateState = () => {
+        inDataUrl = false;
+        sawNonWhitespace = false;
+        sawWhitespaceAfterUrl = false;
+    };
+
+    for (let index = 0; index < srcset.length; index += 1) {
+        const char = srcset[index];
+
+        if (!sawNonWhitespace && !/\s/.test(char)) {
+            sawNonWhitespace = true;
+            inDataUrl = srcset.slice(index).toLowerCase().startsWith('data:');
+        } else if (inDataUrl && sawNonWhitespace && /\s/.test(char)) {
+            sawWhitespaceAfterUrl = true;
+        }
+
+        if (char !== ',') continue;
+        if (inDataUrl && !sawWhitespaceAfterUrl) continue;
+
+        candidates.push(srcset.slice(start, index));
+        start = index + 1;
+        resetCandidateState();
+    }
+
+    candidates.push(srcset.slice(start));
+    return candidates;
+}
+
+export const normalizeMediaUrlsInHtml = (html: string) => {
+    if (!html || typeof document === 'undefined') return html || '';
+
+    const currentOrigin = getCurrentOrigin();
+    if (!currentOrigin || !html.includes(currentOrigin)) return html;
+
+    const template = document.createElement('template');
+    template.innerHTML = html;
+
+    let changed = false;
+
+    template.content.querySelectorAll('img, video, source').forEach(element => {
+        ['src', 'poster', 'data-src', 'srcset'].forEach(attribute => {
+            const value = element.getAttribute(attribute);
+            const normalized = attribute === 'srcset'
+                ? normalizeMediaSrcsetForStorage(value)
+                : normalizeMediaUrlForStorage(value);
+
+            if (value && normalized !== value) {
+                element.setAttribute(attribute, normalized);
+                changed = true;
+            }
+        });
+    });
+
+    return changed ? template.innerHTML : html;
+};

--- a/backend/src/board/services/post_content_service.py
+++ b/backend/src/board/services/post_content_service.py
@@ -1,12 +1,224 @@
+import re
+from html.parser import HTMLParser
+from urllib.parse import urlsplit, urlunsplit
+
+from django.conf import settings
+
 from modules.markdown import parse_post_to_html
 
 from board.modules.read_time import calc_read_time
 
 
 class PostContentService:
+    MEDIA_PATH_PREFIXES = ('/resources/media/',)
+    MEDIA_URL_ATTRIBUTES = {
+        'img': ('src', 'data-src', 'srcset'),
+        'video': ('src', 'poster', 'data-src'),
+        'source': ('src', 'data-src', 'srcset'),
+    }
+    ATTRIBUTE_PATTERN = re.compile(
+        r'(?P<prefix>\s(?P<name>[a-zA-Z:-]+)\s*=\s*)'
+        r'(?:(?P<quote>["\'])(?P<quoted_value>.*?)(?P=quote)|(?P<unquoted_value>[^\s"\'=<>`]+))',
+        re.DOTALL,
+    )
+
+    @staticmethod
+    def _configured_site_origin() -> str:
+        parsed = urlsplit((settings.SITE_URL or '').strip())
+        if parsed.scheme not in {'http', 'https'} or not parsed.netloc:
+            return ''
+        return f'{parsed.scheme}://{parsed.netloc}'.lower()
+
+    @staticmethod
+    def _media_path_prefixes() -> tuple[str, ...]:
+        prefixes = set(PostContentService.MEDIA_PATH_PREFIXES)
+        media_url_path = urlsplit(settings.MEDIA_URL or '').path
+
+        if media_url_path:
+            prefixes.add(media_url_path)
+
+        return tuple(
+            prefix if prefix.endswith('/') else f'{prefix}/'
+            for prefix in prefixes
+        )
+
+    @staticmethod
+    def _is_media_path(path: str) -> bool:
+        return any(
+            path.startswith(prefix)
+            for prefix in PostContentService._media_path_prefixes()
+        )
+
+    @staticmethod
+    def _normalize_media_url(url: str) -> str:
+        if not url:
+            return url
+
+        parsed = urlsplit(url)
+        if parsed.scheme not in {'http', 'https'} or not parsed.netloc:
+            return url
+
+        site_origin = PostContentService._configured_site_origin()
+        url_origin = f'{parsed.scheme}://{parsed.netloc}'.lower()
+
+        if not site_origin or url_origin != site_origin:
+            return url
+
+        if not PostContentService._is_media_path(parsed.path):
+            return url
+
+        return urlunsplit(('', '', parsed.path, parsed.query, parsed.fragment))
+
+    @staticmethod
+    def _normalize_srcset(value: str) -> str:
+        candidates = []
+        changed = False
+
+        for candidate in PostContentService._split_srcset_candidates(value):
+            stripped = candidate.strip()
+            if not stripped or stripped.startswith('data:'):
+                candidates.append(candidate)
+                continue
+
+            parts = stripped.split()
+            normalized_url = PostContentService._normalize_media_url(parts[0])
+            if normalized_url == parts[0]:
+                candidates.append(candidate)
+                continue
+
+            changed = True
+            candidates.append(' '.join([normalized_url, *parts[1:]]))
+
+        return ', '.join(candidates) if changed else value
+
+    @staticmethod
+    def _split_srcset_candidates(value: str) -> list[str]:
+        candidates = []
+        start = 0
+        in_data_url = False
+        saw_non_whitespace = False
+        saw_whitespace_after_url = False
+
+        def reset_candidate_state() -> None:
+            nonlocal in_data_url, saw_non_whitespace, saw_whitespace_after_url
+            in_data_url = False
+            saw_non_whitespace = False
+            saw_whitespace_after_url = False
+
+        for index, char in enumerate(value):
+            if not saw_non_whitespace and not char.isspace():
+                saw_non_whitespace = True
+                in_data_url = value[index:].lower().startswith('data:')
+            elif in_data_url and saw_non_whitespace and char.isspace():
+                saw_whitespace_after_url = True
+
+            if char != ',':
+                continue
+            if in_data_url and not saw_whitespace_after_url:
+                continue
+
+            candidates.append(value[start:index])
+            start = index + 1
+            reset_candidate_state()
+
+        candidates.append(value[start:])
+        return candidates
+
+    @staticmethod
+    def _normalize_media_start_tag(tag_name: str, raw_tag: str) -> str:
+        allowed_attributes = PostContentService.MEDIA_URL_ATTRIBUTES[tag_name]
+
+        def normalize_attribute(attribute_match: re.Match) -> str:
+            attribute_name = attribute_match.group('name').lower()
+            if attribute_name not in allowed_attributes:
+                return attribute_match.group(0)
+
+            quote = attribute_match.group('quote')
+            value = (
+                attribute_match.group('quoted_value')
+                if quote
+                else attribute_match.group('unquoted_value')
+            )
+            normalized = (
+                PostContentService._normalize_srcset(value)
+                if attribute_name == 'srcset'
+                else PostContentService._normalize_media_url(value)
+            )
+
+            if normalized == value:
+                return attribute_match.group(0)
+
+            if quote:
+                return f"{attribute_match.group('prefix')}{quote}{normalized}{quote}"
+            return f"{attribute_match.group('prefix')}{normalized}"
+
+        return PostContentService.ATTRIBUTE_PATTERN.sub(
+            normalize_attribute,
+            raw_tag,
+        )
+
     @staticmethod
     def normalize_content_html(html: str) -> str:
-        return html or ''
+        if not html:
+            return ''
+
+        site_origin = PostContentService._configured_site_origin()
+        if not site_origin or site_origin not in html.lower():
+            return html
+
+        class MediaUrlParser(HTMLParser):
+            def __init__(self, source: str):
+                super().__init__(convert_charrefs=False)
+                self.source = source
+                self.line_offsets = [0]
+                for newline in re.finditer('\n', source):
+                    self.line_offsets.append(newline.end())
+                self.cursor = 0
+                self.parts: list[str] = []
+                self.failed = False
+
+            def replace_start_tag(self, tag: str) -> None:
+                raw_tag = self.get_starttag_text()
+                if raw_tag is None:
+                    self.failed = True
+                    return
+
+                line_number, offset = self.getpos()
+                line_index = line_number - 1
+                if line_index < 0 or line_index >= len(self.line_offsets):
+                    self.failed = True
+                    return
+
+                tag_index = self.line_offsets[line_index] + offset
+                if self.source[tag_index:tag_index + len(raw_tag)] != raw_tag:
+                    self.failed = True
+                    return
+
+                self.parts.append(self.source[self.cursor:tag_index])
+                tag_name = tag.lower()
+                if tag_name in PostContentService.MEDIA_URL_ATTRIBUTES:
+                    self.parts.append(
+                        PostContentService._normalize_media_start_tag(tag_name, raw_tag)
+                    )
+                else:
+                    self.parts.append(raw_tag)
+                self.cursor = tag_index + len(raw_tag)
+
+            def handle_starttag(self, tag: str, attrs) -> None:
+                self.replace_start_tag(tag)
+
+            def handle_startendtag(self, tag: str, attrs) -> None:
+                self.replace_start_tag(tag)
+
+        parser = MediaUrlParser(html)
+        parser.feed(html)
+        parser.close()
+
+        if parser.failed:
+            return html
+
+        parser.parts.append(html[parser.cursor:])
+        return ''.join(parser.parts)
 
     @staticmethod
     def html_input_to_content_html(html: str) -> str:

--- a/backend/src/board/tests/services/test_post_content_service.py
+++ b/backend/src/board/tests/services/test_post_content_service.py
@@ -1,0 +1,163 @@
+from django.test import SimpleTestCase, override_settings
+
+from board.services.post_content_service import PostContentService
+
+
+class PostContentServiceTest(SimpleTestCase):
+    @override_settings(
+        SITE_URL='https://blex.example',
+        MEDIA_URL='/resources/media/',
+    )
+    def test_normalize_content_html_strips_same_origin_media_urls(self):
+        html = (
+            '<figure>'
+            '<img src="https://blex.example/resources/media/images/content/a.png" '
+            'data-src="https://blex.example/resources/media/images/content/a.preview.jpg" '
+            'srcset="https://blex.example/resources/media/images/content/a.png 1x, '
+            'https://blex.example/resources/media/images/content/a@2x.png 2x" />'
+            '<video poster="https://blex.example/resources/media/images/content/poster.jpg">'
+            '<source src="https://blex.example/resources/media/images/content/a.mp4?token=1#t=0" '
+            'srcset="https://blex.example/resources/media/images/content/a.webm 1x" />'
+            '</video>'
+            '</figure>'
+        )
+
+        normalized = PostContentService.normalize_content_html(html)
+
+        self.assertNotIn('https://blex.example', normalized)
+        self.assertIn('src="/resources/media/images/content/a.png"', normalized)
+        self.assertIn('data-src="/resources/media/images/content/a.preview.jpg"', normalized)
+        self.assertIn('/resources/media/images/content/a@2x.png 2x', normalized)
+        self.assertIn('poster="/resources/media/images/content/poster.jpg"', normalized)
+        self.assertIn('src="/resources/media/images/content/a.mp4?token=1#t=0"', normalized)
+        self.assertIn('srcset="/resources/media/images/content/a.webm 1x"', normalized)
+
+    @override_settings(
+        SITE_URL='https://blex.example',
+        MEDIA_URL='/resources/media/',
+    )
+    def test_normalize_content_html_keeps_external_media_urls(self):
+        html = (
+            '<p><img src="https://cdn.example/resources/media/images/content/a.png"></p>'
+            '<video poster="https://video.example/resources/media/poster.jpg">'
+            '<source src="https://video.example/resources/media/a.mp4">'
+            '</video>'
+        )
+
+        self.assertEqual(PostContentService.normalize_content_html(html), html)
+
+    @override_settings(
+        SITE_URL='https://blex.example',
+        MEDIA_URL='/resources/media/',
+    )
+    def test_normalize_content_html_ignores_non_media_same_origin_urls(self):
+        html = '<p><img src="https://blex.example/assets/images/logo.png"></p>'
+
+        self.assertEqual(PostContentService.normalize_content_html(html), html)
+
+    @override_settings(
+        SITE_URL='https://blex.example',
+        MEDIA_URL='/resources/media/',
+    )
+    def test_normalize_content_html_preserves_unrelated_markup(self):
+        html = (
+            '<p data-note="keep & raw">Hello<br></p>'
+            '<img class="hero" src="https://blex.example/resources/media/images/content/a.png" />'
+        )
+
+        normalized = PostContentService.normalize_content_html(html)
+
+        self.assertEqual(
+            normalized,
+            '<p data-note="keep & raw">Hello<br></p>'
+            '<img class="hero" src="/resources/media/images/content/a.png" />',
+        )
+
+    @override_settings(
+        SITE_URL='https://blex.example',
+        MEDIA_URL='/resources/media/',
+    )
+    def test_normalize_content_html_ignores_comments_and_script_text(self):
+        html = (
+            '<!-- <img src="https://blex.example/resources/media/images/content/comment.png"> -->'
+            '<script>const html = \'<img src="https://blex.example/resources/media/images/content/script.png">\';</script>'
+            '<img src="https://blex.example/resources/media/images/content/real.png">'
+        )
+
+        normalized = PostContentService.normalize_content_html(html)
+
+        self.assertIn('https://blex.example/resources/media/images/content/comment.png', normalized)
+        self.assertIn('https://blex.example/resources/media/images/content/script.png', normalized)
+        self.assertIn('src="/resources/media/images/content/real.png"', normalized)
+
+    @override_settings(
+        SITE_URL='https://blex.example',
+        MEDIA_URL='/resources/media/',
+    )
+    def test_normalize_content_html_uses_parser_position_not_matching_comment_text(self):
+        raw_tag = '<img src="https://blex.example/resources/media/images/content/a.png">'
+        html = f'<!-- {raw_tag} -->{raw_tag}'
+
+        normalized = PostContentService.normalize_content_html(html)
+
+        self.assertEqual(
+            normalized,
+            f'<!-- {raw_tag} --><img src="/resources/media/images/content/a.png">',
+        )
+
+    @override_settings(
+        SITE_URL='https://blex.example',
+        MEDIA_URL='/resources/media/',
+    )
+    def test_normalize_content_html_handles_angle_brackets_in_attributes(self):
+        html = '<img alt="1 > 0" src="https://blex.example/resources/media/images/content/a.png">'
+
+        self.assertEqual(
+            PostContentService.normalize_content_html(html),
+            '<img alt="1 > 0" src="/resources/media/images/content/a.png">',
+        )
+
+    @override_settings(
+        SITE_URL='https://blex.example',
+        MEDIA_URL='/resources/media/',
+    )
+    def test_normalize_content_html_preserves_external_srcset_formatting(self):
+        html = (
+            '<img src="https://blex.example/resources/media/images/content/a.png">'
+            '<img srcset="https://cdn.example/a.png 1x,https://cdn.example/b.png 2x">'
+        )
+
+        normalized = PostContentService.normalize_content_html(html)
+
+        self.assertIn(
+            '<img srcset="https://cdn.example/a.png 1x,https://cdn.example/b.png 2x">',
+            normalized,
+        )
+
+    @override_settings(
+        SITE_URL='https://blex.example',
+        MEDIA_URL='/resources/media/',
+    )
+    def test_normalize_content_html_preserves_data_url_commas_in_srcset(self):
+        html = (
+            '<img srcset="data:image/png;base64,AAAA 1x, '
+            'https://blex.example/resources/media/images/content/a.png 2x">'
+        )
+
+        self.assertEqual(
+            PostContentService.normalize_content_html(html),
+            '<img srcset="data:image/png;base64,AAAA 1x, '
+            '/resources/media/images/content/a.png 2x">',
+        )
+
+    @override_settings(
+        SITE_URL='https://blex.example',
+        MEDIA_URL='/resources/media/',
+    )
+    def test_normalize_content_html_handles_unquoted_media_attributes(self):
+        html = '<img src=https://blex.example/resources/media/images/content/a.png>'
+
+        self.assertEqual(
+            PostContentService.normalize_content_html(html),
+            '<img src=/resources/media/images/content/a.png>',
+        )


### PR DESCRIPTION
## 🎯 Goal
- Prevent pasted or uploaded post body media from being stored with the current site domain baked into the saved HTML.
- Keep post content portable across domain changes, reverse proxies, and self-hosted deployments.

## 🔧 Core Changes
- Normalize same-origin editor media URLs under `/resources/media/` to root-relative paths before insertion, rendering, and form submission.
- Add backend content normalization for post create, update, draft, and publish save paths.
- Preserve external media URLs, non-media same-origin URLs, comments, script text, data URL `srcset` candidates, and unrelated HTML formatting.
- Add regression coverage for quoted, unquoted, `srcset`, data URL, comment/script, and parser-position edge cases.

## 🤔 Key Decisions
- Normalize only same-origin media paths so external CDN or third-party media remains untouched.
- Keep backend normalization as a defensive save-layer guard even though the editor also normalizes before submit.
- Use parser positions on the backend to rewrite only actual media start tags while preserving original HTML slices.

## 🧪 Verification Guide
### How to verify
1. Paste or upload an image/video into a post body and save or publish it.
2. Inspect the saved `content_html` for the post.
3. Repeat with an external image URL or CDN URL.

### Expected result
- Same-origin body media is stored as `/resources/media/...` without the domain.
- External media URLs remain absolute and unchanged.
- Saved posts still render their images and videos normally.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (not needed)