### PR TITLE
♻️ Improve editor media drag and drop UX

### DIFF
--- a/backend/islands/apps/remotes/e2e/editor-media-upload.spec.ts
+++ b/backend/islands/apps/remotes/e2e/editor-media-upload.spec.ts
@@ -227,4 +227,59 @@ test.describe('PostEditor media drag and drop', () => {
         expect(html).not.toContain('remote-image.png');
         expectNoRuntimeErrors(errors);
     });
+
+    test('does not treat ProseMirror media node moves as external media drops', async ({ page }) => {
+        const errors = collectRuntimeSignals(page);
+        await mountPostEditor(page);
+
+        const editor = page.locator('.ProseMirror');
+        const dropPoint = await getVisibleDropPoint(editor);
+
+        await dispatchHtmlDrop(
+            page,
+            dropPoint,
+            '<div data-pm-slice="0 0 []"><figure><img src="https://example.com/internal-image.png" alt="Internal"></figure></div>'
+        );
+
+        await expect(page.locator('text=이미지나 비디오는 파일로 내려놓아 주세요.')).toHaveCount(0);
+        expectNoRuntimeErrors(errors);
+    });
+
+    test('drags an inserted image node without showing the external media warning', async ({ page }) => {
+        const errors = collectRuntimeSignals(page);
+        await page.route('**/v1/image', async (route) => {
+            await route.fulfill({
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    status: 'DONE',
+                    body: { url: uploadedImageUrl }
+                })
+            });
+        });
+
+        await mountPostEditor(page);
+
+        const editor = page.locator('.ProseMirror');
+        await editor.click();
+        await page.keyboard.type('Alpha');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('Beta');
+        await page.keyboard.press('Enter');
+
+        await dispatchFileDrop(page, await getVisibleDropPoint(editor.locator('p').last()), {
+            name: 'move.png',
+            type: 'image/png'
+        });
+
+        await expect(editor.locator('figure img[src^="data:image/png"]')).toBeVisible();
+
+        const warning = page.locator('text=이미지나 비디오는 파일로 내려놓아 주세요.');
+        const dragHandle = editor.locator('figure [data-drag-handle]');
+        await expect(dragHandle).toBeVisible();
+
+        await dragHandle.dragTo(editor.locator('p').first(), { force: true });
+
+        await expect(warning).toHaveCount(0);
+        expectNoRuntimeErrors(errors);
+    });
 });

--- a/backend/islands/apps/remotes/e2e/editor-media-upload.spec.ts
+++ b/backend/islands/apps/remotes/e2e/editor-media-upload.spec.ts
@@ -1,0 +1,230 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+
+const uploadedImageUrl = 'data:image/png;base64,R0lGODlhAQABAAAAACw=';
+const uploadedVideoUrl = 'data:video/mp4;base64,AAAA';
+
+const collectRuntimeSignals = (page: Page) => {
+    const errors: string[] = [];
+
+    page.on('pageerror', (error) => {
+        errors.push(`pageerror: ${error.message}`);
+    });
+
+    page.on('console', (message) => {
+        if (message.type() === 'error') {
+            errors.push(`console.error: ${message.text()}`);
+        }
+    });
+
+    return errors;
+};
+
+const expectNoRuntimeErrors = (errors: string[]) => {
+    expect(errors, errors.join('\n')).toEqual([]);
+};
+
+const mountPostEditor = async (page: Page) => {
+    await page.route('**/v1/setting/series', async (route) => {
+        await route.fulfill({
+            contentType: 'application/json',
+            body: JSON.stringify({
+                status: 'DONE',
+                body: { series: [] }
+            })
+        });
+    });
+
+    await page.goto('/');
+    await page.waitForFunction(() => Boolean(customElements.get('island-component')));
+    await page.evaluate(() => {
+        const island = document.createElement('island-component');
+        island.setAttribute('name', 'PostEditor');
+        island.setAttribute('props', encodeURIComponent(JSON.stringify({
+            mode: 'new',
+            username: 'smoke-admin'
+        })));
+        document.body.appendChild(island);
+    });
+
+    await expect(page.locator('island-component[name="PostEditor"]')).toHaveAttribute('data-island-status', 'mounted');
+    await expect(page.locator('.ProseMirror')).toBeVisible();
+};
+
+const getVisibleDropPoint = async (locator: Locator) => {
+    await locator.scrollIntoViewIfNeeded();
+
+    const box = await locator.boundingBox();
+    if (!box) {
+        throw new Error('Could not find a visible element for drop point');
+    }
+
+    return {
+        x: box.x + box.width / 2,
+        y: box.y + Math.min(box.height / 2, 24)
+    };
+};
+
+const dispatchFileDrop = async (
+    page: Page,
+    point: { x: number; y: number },
+    file: { name: string; type: string; body?: string }
+) => {
+    await page.evaluate(({ point, file }) => {
+        const target = document.elementFromPoint(point.x, point.y);
+        if (!target) {
+            throw new Error('No element at drop point');
+        }
+
+        const dataTransfer = new DataTransfer();
+        dataTransfer.items.add(new File(
+            [file.body ?? 'blex media upload e2e'],
+            file.name,
+            { type: file.type }
+        ));
+
+        for (const eventName of ['dragenter', 'dragover', 'drop']) {
+            target.dispatchEvent(new DragEvent(eventName, {
+                bubbles: true,
+                cancelable: true,
+                clientX: point.x,
+                clientY: point.y,
+                dataTransfer
+            }));
+        }
+    }, { point, file });
+};
+
+const dispatchHtmlDrop = async (
+    page: Page,
+    point: { x: number; y: number },
+    html: string
+) => {
+    await page.evaluate(({ point, html }) => {
+        const target = document.elementFromPoint(point.x, point.y);
+        if (!target) {
+            throw new Error('No element at drop point');
+        }
+
+        const dataTransfer = new DataTransfer();
+        dataTransfer.setData('text/html', html);
+
+        for (const eventName of ['dragenter', 'dragover', 'drop']) {
+            target.dispatchEvent(new DragEvent(eventName, {
+                bubbles: true,
+                cancelable: true,
+                clientX: point.x,
+                clientY: point.y,
+                dataTransfer
+            }));
+        }
+    }, { point, html });
+};
+
+test.describe('PostEditor media drag and drop', () => {
+    test('drops an image at the visual drop position instead of the stale cursor', async ({ page }) => {
+        const errors = collectRuntimeSignals(page);
+        let finishUpload: (() => void) | null = null;
+        const uploadCanFinish = new Promise<void>((resolve) => {
+            finishUpload = resolve;
+        });
+
+        await page.route('**/v1/image', async (route) => {
+            await uploadCanFinish;
+            await route.fulfill({
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    status: 'DONE',
+                    body: { url: uploadedImageUrl }
+                })
+            });
+        });
+
+        await mountPostEditor(page);
+
+        const editor = page.locator('.ProseMirror');
+        await editor.click();
+        await page.keyboard.type('Alpha');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('Beta');
+        await page.keyboard.press('Enter');
+
+        const paragraphs = editor.locator('p');
+        await expect(paragraphs.nth(0)).toHaveText('Alpha');
+        await expect(paragraphs.nth(1)).toHaveText('Beta');
+
+        await paragraphs.nth(0).click();
+        const dropPoint = await getVisibleDropPoint(paragraphs.nth(2));
+
+        await dispatchFileDrop(page, dropPoint, {
+            name: 'drop.png',
+            type: 'image/png'
+        });
+
+        await expect(editor.locator('.media-upload-placeholder')).toContainText('이미지 업로드 중');
+        await expect(page.locator('[role="status"]')).toContainText('파일 업로드 중');
+
+        finishUpload?.();
+
+        await expect(editor.locator('figure img[src^="data:image/png"]')).toBeVisible();
+        await expect(editor.locator('.media-upload-placeholder')).toHaveCount(0);
+
+        const html = await page.locator('input[name="content_html"]').inputValue();
+        expect(html).toContain(uploadedImageUrl);
+        expect(html).not.toContain('media-upload-placeholder');
+        expect(html.indexOf('Alpha')).toBeLessThan(html.indexOf('Beta'));
+        expect(html.indexOf('Beta')).toBeLessThan(html.indexOf(uploadedImageUrl));
+        expectNoRuntimeErrors(errors);
+    });
+
+    test('accepts dropped video files and inserts a video node', async ({ page }) => {
+        const errors = collectRuntimeSignals(page);
+
+        await page.route('**/v1/image', async (route) => {
+            await route.fulfill({
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    status: 'DONE',
+                    body: { url: uploadedVideoUrl }
+                })
+            });
+        });
+
+        await mountPostEditor(page);
+
+        const editor = page.locator('.ProseMirror');
+        const dropPoint = await getVisibleDropPoint(editor);
+
+        await dispatchFileDrop(page, dropPoint, {
+            name: 'clip.mp4',
+            type: 'video/mp4'
+        });
+
+        await expect(editor.locator('figure video source[src^="data:video/mp4"]')).toHaveCount(1);
+
+        const html = await page.locator('input[name="content_html"]').inputValue();
+        expect(html).toContain(uploadedVideoUrl);
+        expect(html).not.toContain('media-upload-placeholder');
+        expectNoRuntimeErrors(errors);
+    });
+
+    test('blocks dragged remote media html instead of silently copying it into the document', async ({ page }) => {
+        const errors = collectRuntimeSignals(page);
+        await mountPostEditor(page);
+
+        const editor = page.locator('.ProseMirror');
+        const dropPoint = await getVisibleDropPoint(editor);
+
+        await dispatchHtmlDrop(
+            page,
+            dropPoint,
+            '<img src="https://example.com/remote-image.png" alt="Remote">'
+        );
+
+        await expect(page.locator('text=이미지나 비디오는 파일로 내려놓아 주세요.')).toBeVisible();
+        await expect(editor.locator('figure')).toHaveCount(0);
+
+        const html = await page.locator('input[name="content_html"]').inputValue();
+        expect(html).not.toContain('remote-image.png');
+        expectNoRuntimeErrors(errors);
+    });
+});

--- a/backend/islands/apps/remotes/scripts/run-smoke-server.sh
+++ b/backend/islands/apps/remotes/scripts/run-smoke-server.sh
@@ -40,7 +40,9 @@ fi
 if [ -n "${BLEX_E2E_DB_PATH:-}" ]; then
     export BLEX_SQLITE_DB_PATH="$BLEX_E2E_DB_PATH"
 else
-    TEMP_DB_FILE="$(mktemp "${TMPDIR:-/tmp}/blex-smoke-db.XXXXXX.sqlite3")"
+    TEMP_DB_BASE="$(mktemp "${TMPDIR:-/tmp}/blex-smoke-db.XXXXXX")"
+    TEMP_DB_FILE="$TEMP_DB_BASE.sqlite3"
+    rm -f "$TEMP_DB_BASE"
     export BLEX_SQLITE_DB_PATH="$TEMP_DB_FILE"
 fi
 

--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/EditPostEditor.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/EditPostEditor.tsx
@@ -186,16 +186,16 @@ const EditPostEditor = ({ username, postUrl }: EditPostEditorProps) => {
     };
 
     const handleEditorImageUpload = async (file: File) => {
-        try {
-            const { data } = await api.uploadImage(file);
-            if (data.status === 'DONE') {
-                return data.body.url;
-            }
-        } catch (error) {
+        const { data } = await api.uploadImage(file).catch((error) => {
             logger.error('Image upload failed', error);
-            toast.error('이미지 업로드에 실패했습니다.');
+            throw new Error('파일 업로드에 실패했습니다.');
+        });
+
+        if (data.status === 'DONE') {
+            return data.body.url;
         }
-        return undefined;
+
+        throw new Error(data.errorMessage || '파일 업로드에 실패했습니다.');
     };
 
     const validateForm = () => {
@@ -312,6 +312,7 @@ const EditPostEditor = ({ username, postUrl }: EditPostEditorProps) => {
                 onTagsChange={setTags}
                 onImageUpload={handleImageUpload}
                 onEditorImageUpload={handleEditorImageUpload}
+                onEditorImageUploadError={(errorMessage) => toast.error(errorMessage)}
                 onRemoveImage={handleRemoveImage}
             />
 

--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/NewPostEditor.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/NewPostEditor.tsx
@@ -124,15 +124,15 @@ const NewPostEditor = ({
     }), [formData, tags, selectedSeries.url, imagePreview, imageFile, imageDeleted]);
 
     const handleEditorImageUpload = async (file: File) => {
-        try {
-            const { data } = await api.uploadImage(file);
-            if (data.status === 'DONE') {
-                return data.body.url;
-            }
-        } catch {
-            toast.error('이미지 업로드에 실패했습니다.');
+        const { data } = await api.uploadImage(file).catch(() => {
+            throw new Error('파일 업로드에 실패했습니다.');
+        });
+
+        if (data.status === 'DONE') {
+            return data.body.url;
         }
-        return undefined;
+
+        throw new Error(data.errorMessage || '파일 업로드에 실패했습니다.');
     };
 
     const handleAutoSaveSuccess = (url?: string) => {
@@ -451,6 +451,7 @@ const NewPostEditor = ({
                 onTagsChange={setTags}
                 onImageUpload={handleImageUpload}
                 onEditorImageUpload={handleEditorImageUpload}
+                onEditorImageUploadError={(errorMessage) => toast.error(errorMessage)}
                 onRemoveImage={handleRemoveImage}
             />
 

--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/components/PostForm.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/components/PostForm.tsx
@@ -29,6 +29,7 @@ interface PostFormProps {
     onTagsChange: (tags: string[]) => void;
     onImageUpload: (event: React.ChangeEvent<HTMLInputElement>) => void;
     onEditorImageUpload?: (file: File) => Promise<string | undefined>;
+    onEditorImageUploadError?: (errorMessage: string) => void;
     onRemoveImage: () => void;
 }
 
@@ -45,6 +46,7 @@ const PostForm = ({
     onTagsChange,
     onImageUpload,
     onEditorImageUpload,
+    onEditorImageUploadError,
     onRemoveImage
 }: PostFormProps) => {
     const internalFormRef = useRef<HTMLFormElement>(null);
@@ -98,6 +100,7 @@ const PostForm = ({
                             onChange={onContentChange}
                             placeholder="내용을 입력하세요"
                             onImageUpload={onEditorImageUpload}
+                            onImageUploadError={onEditorImageUploadError}
                         />
                     )}
                 </div>

--- a/backend/islands/apps/remotes/src/utils/toast.ts
+++ b/backend/islands/apps/remotes/src/utils/toast.ts
@@ -18,8 +18,13 @@ type ToastOptions = {
 };
 
 const ensureToaster = () => {
-    if (typeof document === 'undefined' || document.getElementById(TOASTER_ROOT_ID)) {
-        return;
+    if (typeof document === 'undefined') {
+        return null;
+    }
+
+    const existingToaster = document.getElementById(TOASTER_ROOT_ID);
+    if (existingToaster) {
+        return existingToaster;
     }
 
     const toaster = document.createElement('island-component');
@@ -28,54 +33,84 @@ const ensureToaster = () => {
     toaster.dataset.islandName = 'Toaster';
     toaster.dataset.islandStatus = 'pending';
     document.body.appendChild(toaster);
+
+    return toaster;
+};
+
+const runWhenToasterReady = <T>(callback: () => T) => {
+    const toaster = ensureToaster();
+    if (!toaster || toaster.dataset.islandStatus === 'mounted') {
+        return callback();
+    }
+
+    let isResolved = false;
+    let observer: MutationObserver | undefined;
+    const timeoutRef: { id?: number } = {};
+
+    const run = () => {
+        if (isResolved) return;
+
+        isResolved = true;
+        if (timeoutRef.id !== undefined) {
+            window.clearTimeout(timeoutRef.id);
+        }
+        observer?.disconnect();
+        callback();
+    };
+
+    if (typeof MutationObserver !== 'undefined') {
+        observer = new MutationObserver(() => {
+            if (toaster.dataset.islandStatus === 'mounted') {
+                run();
+            }
+        });
+        observer.observe(toaster, {
+            attributes: true,
+            attributeFilter: ['data-island-status']
+        });
+    }
+
+    timeoutRef.id = window.setTimeout(run, 1000);
 };
 
 export const toast = Object.assign(
     (message: ToastMessage, options?: ToastOptions) => {
-        ensureToaster();
-        return sonnerToast(message, options);
+        return runWhenToasterReady(() => sonnerToast(message, options));
     },
     {
         success: (message: ToastMessage, options?: ToastOptions) => {
-            ensureToaster();
-            return sonnerToast.success(message, {
+            return runWhenToasterReady(() => sonnerToast.success(message, {
                 duration: DURATION.success,
                 ...options
-            });
+            }));
         },
         error: (message: ToastMessage, options?: ToastOptions) => {
-            ensureToaster();
-            return sonnerToast.error(message, {
+            return runWhenToasterReady(() => sonnerToast.error(message, {
                 duration: DURATION.error,
                 ...options
-            });
+            }));
         },
         info: (message: ToastMessage, options?: ToastOptions) => {
-            ensureToaster();
-            return sonnerToast.info(message, {
+            return runWhenToasterReady(() => sonnerToast.info(message, {
                 duration: DURATION.info,
                 ...options
-            });
+            }));
         },
         warning: (message: ToastMessage, options?: ToastOptions) => {
-            ensureToaster();
-            return sonnerToast.warning(message, {
+            return runWhenToasterReady(() => sonnerToast.warning(message, {
                 duration: DURATION.warning,
                 ...options
-            });
+            }));
         },
         loading: (...args: Parameters<typeof sonnerToast.loading>) => {
-            ensureToaster();
-            return sonnerToast.loading(...args);
+            return runWhenToasterReady(() => sonnerToast.loading(...args));
         },
         promise: (...args: Parameters<typeof sonnerToast.promise>) => {
-            ensureToaster();
-            return sonnerToast.promise(...args);
+            return runWhenToasterReady(() => sonnerToast.promise(...args));
         },
         dismiss: sonnerToast.dismiss,
         message: (...args: Parameters<typeof sonnerToast.message>) => {
-            ensureToaster();
-            return sonnerToast.message(...args);
+            return runWhenToasterReady(() => sonnerToast.message(...args));
         }
     }
 );

--- a/backend/islands/packages/editor/src/TiptapEditor/TiptapEditor.tsx
+++ b/backend/islands/packages/editor/src/TiptapEditor/TiptapEditor.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react';
 import { useEditor, EditorContent } from '@tiptap/react';
 import MenuBar from './components/menus/MenuBar';
 import { getEditorExtensions } from './config/editorConfig';
+import { hasProseMirrorSliceData } from './config/mediaUpload';
 import { useImageUpload } from './hooks/useImageUpload';
 
 interface TiptapEditorProps {
@@ -69,6 +70,7 @@ const TiptapEditor = ({
                         !dataTransfer
                         || dataTransfer.files.length > 0
                         || view.dragging
+                        || hasProseMirrorSliceData(dataTransfer)
                         || !mayContainExternalMediaReference(dataTransfer)
                     ) {
                         return false;
@@ -179,6 +181,7 @@ const TiptapEditor = ({
                 !dataTransfer
                 || dataTransfer.files.length > 0
                 || editor.view.dragging
+                || hasProseMirrorSliceData(dataTransfer)
                 || !mayContainExternalMediaReference(dataTransfer)
             ) {
                 return;

--- a/backend/islands/packages/editor/src/TiptapEditor/TiptapEditor.tsx
+++ b/backend/islands/packages/editor/src/TiptapEditor/TiptapEditor.tsx
@@ -17,7 +17,23 @@ interface TiptapEditorProps {
 
 interface HandlersRef {
     handleImagePaste: (event: ClipboardEvent) => void;
+    handleMediaDrop: (
+        event: DragEvent,
+        position?: number,
+        options?: { invalidPositionMessage?: string }
+    ) => boolean;
 }
+
+const removeUploadPlaceholders = (html: string) => {
+    return html.replace(/<div[^>]*data-upload-placeholder="true"[^>]*>[\s\S]*?<\/div>/g, '');
+};
+
+const mayContainExternalMediaReference = (dataTransfer: DataTransfer) => {
+    const types = Array.from(dataTransfer.types ?? []);
+    return types.includes('text/html')
+        || types.includes('text/uri-list')
+        || types.includes('text/plain');
+};
 
 const TiptapEditor = ({
     name,
@@ -35,7 +51,10 @@ const TiptapEditor = ({
         }
     };
 
-    const handlersRef = useRef<HandlersRef>({ handleImagePaste: () => {} });
+    const handlersRef = useRef<HandlersRef>({
+        handleImagePaste: () => {},
+        handleMediaDrop: () => false
+    });
 
     const editor = useEditor({
         extensions: getEditorExtensions(placeholder),
@@ -43,25 +62,70 @@ const TiptapEditor = ({
         editable,
         editorProps: {
             attributes: { class: 'prose prose-lg max-w-none blog-post-content' },
-            handleDrop: (view, event, _slice, moved) => {
-                // 외부 파일 드롭은 React onDrop(useImageUpload)에서 처리
-                if (!moved) return false;
+            handleDOMEvents: {
+                drop: (view, event) => {
+                    const dataTransfer = event.dataTransfer;
+                    if (
+                        !dataTransfer
+                        || dataTransfer.files.length > 0
+                        || view.dragging
+                        || !mayContainExternalMediaReference(dataTransfer)
+                    ) {
+                        return false;
+                    }
 
+                    const posInfo = view.posAtCoords({
+                        left: event.clientX,
+                        top: event.clientY
+                    });
+
+                    return handlersRef.current.handleMediaDrop(event, posInfo?.pos);
+                }
+            },
+            handleDrop: (view, event, _slice, moved) => {
                 const coords = {
                     left: event.clientX,
                     top: event.clientY
                 };
                 const posInfo = view.posAtCoords(coords);
-                if (!posInfo) return false;
+                const isInternalDrag = Boolean(view.dragging);
+                let isColumnsContainerDrop = false;
 
-                const $pos = view.state.doc.resolve(posInfo.pos);
+                if (posInfo) {
+                    const $pos = view.state.doc.resolve(posInfo.pos);
+                    let isInsideColumn = false;
+                    let isInsideColumns = false;
 
-                // columns 구조 내에서 드롭 위치 확인
-                for (let d = $pos.depth; d >= 0; d--) {
-                    // column 안이면 ProseMirror가 정상 처리
-                    if ($pos.node(d).type.name === 'column') return false;
-                    // columns 컨테이너 레벨이면 차단 (새 column 생성 방지)
-                    if ($pos.node(d).type.name === 'columns') return true;
+                    // columns 구조 내에서 드롭 위치 확인
+                    for (let d = $pos.depth; d >= 0; d--) {
+                        // column 안이면 ProseMirror가 정상 처리
+                        if ($pos.node(d).type.name === 'column') {
+                            isInsideColumn = true;
+                            break;
+                        }
+                        // columns 컨테이너 레벨이면 차단 (새 column 생성 방지)
+                        if ($pos.node(d).type.name === 'columns') {
+                            isInsideColumns = true;
+                            break;
+                        }
+                    }
+
+                    isColumnsContainerDrop = isInsideColumns && !isInsideColumn;
+                }
+
+                if (isColumnsContainerDrop) {
+                    if (isInternalDrag || moved) return true;
+                    return handlersRef.current.handleMediaDrop(
+                        event,
+                        posInfo?.pos,
+                        { invalidPositionMessage: '컬럼 안쪽에 파일을 내려놓아 주세요.' }
+                    );
+                }
+
+                if (isInternalDrag || moved) return false;
+
+                if (handlersRef.current.handleMediaDrop(event, posInfo?.pos)) {
+                    return true;
                 }
 
                 return false;
@@ -73,7 +137,7 @@ const TiptapEditor = ({
 
                 if (items) {
                     for (let i = 0; i < items.length; i++) {
-                        if (items[i].type.startsWith('image/')) {
+                        if (items[i].type.startsWith('image/') || items[i].type.startsWith('video/')) {
                             handlersRef.current.handleImagePaste(event);
                             return true;
                         }
@@ -84,23 +148,60 @@ const TiptapEditor = ({
             }
         },
         onUpdate: ({ editor }) => {
-            handleChange(editor.getHTML());
+            handleChange(removeUploadPlaceholders(editor.getHTML()));
         }
     });
 
-    const { handleDrop, handlePaste: handleImagePaste, isUploading } = useImageUpload({
+    const {
+        handleDrop: handleMediaDrop,
+        handlePaste: handleImagePaste,
+        isUploading,
+        uploadingCount
+    } = useImageUpload({
         editor,
         onImageUpload,
         onImageUploadError
     });
 
     useEffect(() => {
-        handlersRef.current = { handleImagePaste };
-    }, [handleImagePaste]);
+        handlersRef.current = {
+            handleImagePaste,
+            handleMediaDrop
+        };
+    }, [handleImagePaste, handleMediaDrop]);
+
+    useEffect(() => {
+        if (!editor) return;
+
+        const handleExternalMediaDrop = (event: DragEvent) => {
+            const dataTransfer = event.dataTransfer;
+            if (
+                !dataTransfer
+                || dataTransfer.files.length > 0
+                || editor.view.dragging
+                || !mayContainExternalMediaReference(dataTransfer)
+            ) {
+                return;
+            }
+
+            const posInfo = editor.view.posAtCoords({
+                left: event.clientX,
+                top: event.clientY
+            });
+
+            handlersRef.current.handleMediaDrop(event, posInfo?.pos);
+        };
+
+        editor.view.dom.addEventListener('drop', handleExternalMediaDrop, { capture: true });
+
+        return () => {
+            editor.view.dom.removeEventListener('drop', handleExternalMediaDrop, { capture: true });
+        };
+    }, [editor]);
 
     useEffect(() => {
         if (editor && content !== undefined) {
-            const currentContent = editor.getHTML();
+            const currentContent = removeUploadPlaceholders(editor.getHTML());
             if (content !== currentContent && !editor.isFocused) {
                 const cleanedContent = content
                     .replace(/\.preview\.jpg/g, '')
@@ -114,11 +215,8 @@ const TiptapEditor = ({
     }, [editor, content]);
 
     return (
-        <div
-            onDragOver={(e) => e.preventDefault()}
-            onDrop={handleDrop}
-            style={{ minHeight: height }}>
-            <input type="hidden" name={name} value={editor?.getHTML() || content} />
+        <div style={{ minHeight: height }}>
+            <input type="hidden" name={name} value={editor ? removeUploadPlaceholders(editor.getHTML()) : content} />
 
             {editable && (
                 <MenuBar
@@ -131,9 +229,12 @@ const TiptapEditor = ({
             <EditorContent editor={editor} />
 
             {isUploading && (
-                <div className="flex items-center gap-2 px-3 py-2 text-sm text-content-secondary bg-surface-subtle rounded-lg mt-2 animate-pulse border border-line-light">
+                <div
+                    role="status"
+                    aria-live="polite"
+                    className="flex items-center gap-2 px-3 py-2 text-sm text-content-secondary bg-surface-subtle rounded-lg mt-2 animate-pulse border border-line-light">
                     <div className="w-4 h-4 border-2 border-line border-t-content-secondary rounded-full animate-spin" />
-                    <span>파일 업로드 중...</span>
+                    <span>{uploadingCount > 1 ? `파일 ${uploadingCount}개 업로드 중...` : '파일 업로드 중...'}</span>
                 </div>
             )}
 
@@ -155,6 +256,36 @@ const TiptapEditor = ({
                     transition: opacity 0.2s;
                     &:hover { opacity: 0.9; }
                     &:active { cursor: grabbing; }
+                }
+                .ProseMirror .media-upload-placeholder {
+                    display: flex;
+                    align-items: center;
+                    gap: 8px;
+                    margin: 16px 0;
+                    padding: 14px 16px;
+                    border: 1px dashed var(--color-line);
+                    border-radius: 8px;
+                    color: var(--color-content-secondary);
+                    background: var(--color-surface-subtle);
+                    font-size: 14px;
+                    line-height: 1.4;
+                }
+                .ProseMirror .media-upload-placeholder__spinner {
+                    width: 16px;
+                    height: 16px;
+                    flex: 0 0 auto;
+                    border: 2px solid var(--color-line);
+                    border-top-color: var(--color-content-secondary);
+                    border-radius: 9999px;
+                    animation: media-upload-spin 0.8s linear infinite;
+                }
+                .ProseMirror .media-upload-placeholder__text {
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                }
+                @keyframes media-upload-spin {
+                    to { transform: rotate(360deg); }
                 }
                 .code-block-wrapper .code-block-header {
                     display: flex;

--- a/backend/islands/packages/editor/src/TiptapEditor/components/menus/MediaFloatingMenu.tsx
+++ b/backend/islands/packages/editor/src/TiptapEditor/components/menus/MediaFloatingMenu.tsx
@@ -7,6 +7,9 @@ interface MediaFloatingMenuProps {
 }
 
 const MEDIA_TYPES = ['image', 'video', 'iframe'];
+const fieldClassName = 'px-2 py-1 text-xs bg-surface-elevated text-content border border-line rounded-md hover:bg-surface-subtle focus:outline-none focus:ring-2 focus:ring-action/20 focus:border-action placeholder:text-content-hint';
+const dividerClassName = 'w-px h-5 bg-line';
+const mediaTypesWithStyle = ['image', 'video'];
 
 const MediaFloatingMenu = ({ editor }: MediaFloatingMenuProps) => {
     const [selectedNode, setSelectedNode] = useState<{ type: string; attrs: Record<string, unknown>; pos: number } | null>(null);
@@ -18,7 +21,7 @@ const MediaFloatingMenu = ({ editor }: MediaFloatingMenuProps) => {
     useEffect(() => {
         if (!editor) return;
 
-        const handleSelectionUpdate = () => {
+        const syncSelectedNode = () => {
             const { selection, doc } = editor.state;
             const { from } = selection;
             const node = doc.nodeAt(from);
@@ -45,26 +48,12 @@ const MediaFloatingMenu = ({ editor }: MediaFloatingMenuProps) => {
             }
         };
 
-        const handleTransaction = () => {
-            const { selection, doc } = editor.state;
-            const { from } = selection;
-            const node = doc.nodeAt(from);
-
-            if (node && MEDIA_TYPES.includes(node.type.name) && selectedPosRef.current === from) {
-                setSelectedNode({
-                    type: node.type.name,
-                    attrs: node.attrs,
-                    pos: from
-                });
-            }
-        };
-
-        editor.on('selectionUpdate', handleSelectionUpdate);
-        editor.on('transaction', handleTransaction);
+        editor.on('selectionUpdate', syncSelectedNode);
+        editor.on('transaction', syncSelectedNode);
 
         return () => {
-            editor.off('selectionUpdate', handleSelectionUpdate);
-            editor.off('transaction', handleTransaction);
+            editor.off('selectionUpdate', syncSelectedNode);
+            editor.off('transaction', syncSelectedNode);
         };
     }, [editor]);
 
@@ -86,11 +75,30 @@ const MediaFloatingMenu = ({ editor }: MediaFloatingMenuProps) => {
         updateAttribute('caption', caption.trim() === '' ? null : caption);
     };
 
+    const handleToggle = (e: React.MouseEvent, attr: string) => {
+        e.preventDefault();
+        e.stopPropagation();
+        updateAttribute(attr, !selectedNode.attrs[attr]);
+    };
+
+    const handleObjectFitChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+        e.preventDefault();
+        e.stopPropagation();
+        updateAttribute('objectFit', e.target.value);
+    };
+
     const handleAspectRatioChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
         e.preventDefault();
         e.stopPropagation();
         const value = e.target.value;
         updateAttribute('aspectRatio', value === '' ? null : value);
+    };
+
+    const handleBorderRadiusChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+        e.preventDefault();
+        e.stopPropagation();
+        const value = e.target.value;
+        updateAttribute('borderRadius', value === '' ? null : value);
     };
 
     const handlePlayModeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -134,8 +142,8 @@ const MediaFloatingMenu = ({ editor }: MediaFloatingMenuProps) => {
             className={`
                 w-7 h-7 rounded-md flex items-center justify-center transition-all
                 ${active
-                    ? 'bg-blue-500 text-white'
-                    : 'text-gray-600 hover:bg-gray-100'
+                    ? 'bg-action text-content-inverted'
+                    : 'text-content-secondary hover:text-content hover:bg-surface-subtle active:scale-95'
                 }
             `}
             title={title}>
@@ -161,7 +169,7 @@ const MediaFloatingMenu = ({ editor }: MediaFloatingMenuProps) => {
                                 type="button"
                                 onClick={() => setIsOpen(true)}
                                 onMouseDown={(e) => e.preventDefault()}
-                                className="w-7 h-7 rounded-full floating-glass-surface flex items-center justify-center text-gray-500 hover:text-gray-800 transition-all"
+                                className="w-7 h-7 rounded-full floating-glass-surface flex items-center justify-center text-content-secondary hover:text-content transition-all"
                                 title="설정">
                                 <i className="fas fa-cog text-xs" />
                             </button>
@@ -175,7 +183,7 @@ const MediaFloatingMenu = ({ editor }: MediaFloatingMenuProps) => {
                 <Popover.Anchor virtualRef={{ current: anchorElement }} />
                 <Popover.Portal>
                     <Popover.Content
-                        className="z-[1100] floating-glass-surface rounded-xl p-2 flex items-center gap-2 outline-none"
+                        className="z-[1100] floating-glass-surface rounded-xl p-2 flex flex-col gap-2 outline-none"
                         side="top"
                         sideOffset={10}
                         onOpenAutoFocus={(e) => e.preventDefault()}
@@ -188,94 +196,127 @@ const MediaFloatingMenu = ({ editor }: MediaFloatingMenuProps) => {
                             e.stopPropagation();
                         }}
                         onClick={(e) => e.stopPropagation()}>
-                        {/* 정렬 (image, video) */}
-                        {(selectedNode.type === 'image' || selectedNode.type === 'video') && (
-                            <div className="flex gap-0.5 bg-gray-100 rounded-lg p-0.5">
-                                <IconButton icon="fas fa-align-left" active={selectedNode.attrs.align === 'left'} onClick={(e) => handleAlignChange(e, 'left')} title="왼쪽 정렬" />
-                                <IconButton icon="fas fa-align-center" active={selectedNode.attrs.align === 'center'} onClick={(e) => handleAlignChange(e, 'center')} title="가운데 정렬" />
-                                <IconButton icon="fas fa-align-right" active={selectedNode.attrs.align === 'right'} onClick={(e) => handleAlignChange(e, 'right')} title="오른쪽 정렬" />
-                            </div>
-                        )}
+                        <div className="flex items-center gap-2">
+                            {/* 정렬 (image, video) */}
+                            {(selectedNode.type === 'image' || selectedNode.type === 'video') && (
+                                <div className="flex gap-0.5 bg-surface-subtle rounded-lg p-0.5">
+                                    <IconButton icon="fas fa-align-left" active={selectedNode.attrs.align === 'left'} onClick={(e) => handleAlignChange(e, 'left')} title="왼쪽 정렬" />
+                                    <IconButton icon="fas fa-align-center" active={selectedNode.attrs.align === 'center'} onClick={(e) => handleAlignChange(e, 'center')} title="가운데 정렬" />
+                                    <IconButton icon="fas fa-align-right" active={selectedNode.attrs.align === 'right'} onClick={(e) => handleAlignChange(e, 'right')} title="오른쪽 정렬" />
+                                </div>
+                            )}
 
-                        {/* 크기 (image, video) */}
-                        {(selectedNode.type === 'image' || selectedNode.type === 'video') && (
-                            <>
-                                <div className="w-px h-5 bg-gray-300" />
-                                <select
-                                    value={selectedNode.attrs.sizePreset as string || ''}
-                                    onChange={(e) => {
-                                        e.preventDefault();
-                                        e.stopPropagation();
-                                        updateAttribute('sizePreset', e.target.value || null);
-                                    }}
-                                    className="px-2 py-1 text-xs bg-gray-50 border border-gray-200 rounded-md hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500">
-                                    <option value="">원본</option>
-                                    <option value="large">크게</option>
-                                    <option value="medium">보통</option>
-                                    <option value="small">작게</option>
-                                </select>
-                            </>
-                        )}
+                            {/* 크기 (image, video) */}
+                            {(selectedNode.type === 'image' || selectedNode.type === 'video') && (
+                                <>
+                                    <div className={dividerClassName} />
+                                    <select
+                                        value={selectedNode.attrs.sizePreset as string || ''}
+                                        onChange={(e) => {
+                                            e.preventDefault();
+                                            e.stopPropagation();
+                                            updateAttribute('sizePreset', e.target.value || null);
+                                        }}
+                                        className={fieldClassName}>
+                                        <option value="">원본</option>
+                                        <option value="large">크게</option>
+                                        <option value="medium">보통</option>
+                                        <option value="small">작게</option>
+                                    </select>
+                                </>
+                            )}
 
-                        {/* 비율 (image, video) */}
-                        {(selectedNode.type === 'image' || selectedNode.type === 'video') && (
-                            <>
-                                <div className="w-px h-5 bg-gray-300" />
-                                <select
-                                    value={selectedNode.attrs.aspectRatio as string || ''}
-                                    onChange={handleAspectRatioChange}
-                                    className="px-2 py-1 text-xs bg-gray-50 border border-gray-200 rounded-md hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500">
-                                    <option value="">비율</option>
-                                    <option value="16:9">16:9</option>
-                                    <option value="4:3">4:3</option>
-                                    <option value="2:1">2:1</option>
-                                    <option value="1:1">1:1</option>
-                                    <option value="9:16">9:16</option>
-                                </select>
-                            </>
-                        )}
-
-                        {/* 재생 모드 (video) */}
-                        {selectedNode.type === 'video' && (
-                            <>
-                                <div className="w-px h-5 bg-gray-300" />
-                                <select
-                                    value={selectedNode.attrs.playMode as string || 'gif'}
-                                    onChange={handlePlayModeChange}
-                                    className="px-2 py-1 text-xs bg-gray-50 border border-gray-200 rounded-md hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500">
-                                    <option value="gif">움짤</option>
-                                    <option value="video">영상</option>
-                                </select>
-                            </>
-                        )}
-
-                        {/* 비율 (iframe) */}
-                        {selectedNode.type === 'iframe' && (
+                            {/* 비율 */}
+                            <div className={dividerClassName} />
                             <select
-                                value={selectedNode.attrs.aspectRatio as string || '16:9'}
+                                value={selectedNode.attrs.aspectRatio as string || (selectedNode.type === 'iframe' ? '16:9' : '')}
                                 onChange={handleAspectRatioChange}
-                                className="px-2 py-1 text-xs bg-gray-50 border border-gray-200 rounded-md hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500">
-                                <option value="16:9">16:9 (와이드)</option>
-                                <option value="4:3">4:3 (표준)</option>
-                                <option value="21:9">21:9 (시네마)</option>
-                                <option value="1:1">1:1 (정사각)</option>
+                                className={fieldClassName}>
+                                {selectedNode.type === 'iframe' ? (
+                                    <>
+                                        <option value="16:9">16:9 (와이드)</option>
+                                        <option value="4:3">4:3 (표준)</option>
+                                        <option value="21:9">21:9 (시네마)</option>
+                                        <option value="1:1">1:1 (정사각)</option>
+                                    </>
+                                ) : (
+                                    <>
+                                        <option value="">비율</option>
+                                        <option value="16:9">16:9</option>
+                                        <option value="4:3">4:3</option>
+                                        <option value="2:1">2:1</option>
+                                        <option value="1:1">1:1</option>
+                                        <option value="9:16">9:16</option>
+                                    </>
+                                )}
                             </select>
-                        )}
 
-                        {/* 캡션 */}
-                        <div className="w-px h-5 bg-gray-300" />
-                        <input
-                            type="text"
-                            placeholder="캡션..."
-                            value={selectedNode.attrs.caption as string || ''}
-                            onChange={(e) => handleCaptionChange(e.target.value)}
-                            onKeyDown={(e) => {
-                                if (e.key === 'Enter') {
-                                    e.currentTarget.blur();
-                                }
-                            }}
-                            className="w-36 px-2 py-1 text-xs bg-gray-50 border border-gray-200 rounded-md hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500"
-                        />
+                            {/* 재생 모드 (video) */}
+                            {selectedNode.type === 'video' && (
+                                <>
+                                    <div className={dividerClassName} />
+                                    <select
+                                        value={selectedNode.attrs.playMode as string || 'gif'}
+                                        onChange={handlePlayModeChange}
+                                        className={fieldClassName}>
+                                        <option value="gif">움짤</option>
+                                        <option value="video">영상</option>
+                                    </select>
+                                </>
+                            )}
+                        </div>
+
+                        <div className="flex items-center gap-2">
+                            {/* 스타일 (image, video) */}
+                            {mediaTypesWithStyle.includes(selectedNode.type) && (
+                                <>
+                                    <select
+                                        value={selectedNode.attrs.objectFit as string || 'cover'}
+                                        onChange={handleObjectFitChange}
+                                        className={fieldClassName}>
+                                        <option value="cover">맞춤</option>
+                                        <option value="contain">포함</option>
+                                        <option value="fill">채움</option>
+                                        <option value="none">원본</option>
+                                    </select>
+
+                                    <div className={dividerClassName} />
+                                    <div className="flex gap-0.5 bg-surface-subtle rounded-lg p-0.5">
+                                        <IconButton icon="fas fa-border-all" active={!!selectedNode.attrs.border} onClick={(e) => handleToggle(e, 'border')} title="테두리" />
+                                        <IconButton icon="fas fa-clone" active={!!selectedNode.attrs.shadow} onClick={(e) => handleToggle(e, 'shadow')} title="그림자" />
+                                    </div>
+
+                                    <div className={dividerClassName} />
+                                    <select
+                                        value={selectedNode.attrs.borderRadius as string || ''}
+                                        onChange={handleBorderRadiusChange}
+                                        className={fieldClassName}>
+                                        <option value="">둥글기</option>
+                                        <option value="0">각짐</option>
+                                        <option value="4">약간</option>
+                                        <option value="8">보통</option>
+                                        <option value="16">많이</option>
+                                        <option value="9999">원형</option>
+                                    </select>
+
+                                    <div className={dividerClassName} />
+                                </>
+                            )}
+
+                            {/* 캡션 */}
+                            <input
+                                type="text"
+                                placeholder="캡션..."
+                                value={selectedNode.attrs.caption as string || ''}
+                                onChange={(e) => handleCaptionChange(e.target.value)}
+                                onKeyDown={(e) => {
+                                    if (e.key === 'Enter') {
+                                        e.currentTarget.blur();
+                                    }
+                                }}
+                                className={`w-36 ${fieldClassName}`}
+                            />
+                        </div>
                     </Popover.Content>
                 </Popover.Portal>
             </Popover.Root>

--- a/backend/islands/packages/editor/src/TiptapEditor/components/menus/MenuBar.tsx
+++ b/backend/islands/packages/editor/src/TiptapEditor/components/menus/MenuBar.tsx
@@ -8,6 +8,10 @@ import SlashCommandMenu from './SlashCommandMenu';
 import EditorHelpText from '../ui/EditorHelpText';
 import { useImageUpload } from '../../hooks/useImageUpload';
 import { useSlashCommand } from '../../hooks/useSlashCommand';
+import {
+    ACCEPTED_IMAGE_INPUT_TYPES,
+    ACCEPTED_VIDEO_INPUT_TYPES
+} from '../../config/mediaUpload';
 
 interface MenuBarProps {
     editor: Editor | null;
@@ -57,7 +61,7 @@ const MenuBar = ({
             <input
                 ref={imageInput}
                 type="file"
-                accept="image/*"
+                accept={ACCEPTED_IMAGE_INPUT_TYPES}
                 multiple
                 className="hidden"
                 onChange={handleImageUpload}
@@ -65,7 +69,7 @@ const MenuBar = ({
             <input
                 ref={videoInput}
                 type="file"
-                accept="video/mp4,video/webm"
+                accept={ACCEPTED_VIDEO_INPUT_TYPES}
                 multiple
                 className="hidden"
                 onChange={handleVideoUpload}

--- a/backend/islands/packages/editor/src/TiptapEditor/components/nodeviews/ImageNodeView.tsx
+++ b/backend/islands/packages/editor/src/TiptapEditor/components/nodeviews/ImageNodeView.tsx
@@ -1,8 +1,9 @@
 import { NodeViewWrapper } from '@tiptap/react';
 import type { NodeViewProps } from '@tiptap/react';
+import { NodeSelection } from '@tiptap/pm/state';
 import { getFigureStyle, getMediaStyle } from '../../utils/mediaStyles';
 
-export const ImageNodeView = ({ node, selected }: NodeViewProps) => {
+export const ImageNodeView = ({ node, selected, editor, getPos }: NodeViewProps) => {
     const {
         src,
         alt,
@@ -18,6 +19,15 @@ export const ImageNodeView = ({ node, selected }: NodeViewProps) => {
         borderRadius,
         sizePreset
     } = node.attrs;
+
+    const selectNode = () => {
+        const pos = typeof getPos === 'function' ? getPos() : null;
+        if (typeof pos !== 'number') return;
+
+        const { view } = editor;
+        view.dispatch(view.state.tr.setSelection(NodeSelection.create(view.state.doc, pos)));
+        view.focus();
+    };
 
     return (
         <NodeViewWrapper>
@@ -50,6 +60,17 @@ export const ImageNodeView = ({ node, selected }: NodeViewProps) => {
                     />
                     {/* 투명 오버레이: 클릭 시 노드 선택 */}
                     <div
+                        data-drag-handle=""
+                        onMouseDown={(event) => {
+                            if (event.button === 0) {
+                                selectNode();
+                            }
+                        }}
+                        onClick={(event) => {
+                            event.preventDefault();
+                            event.stopPropagation();
+                            selectNode();
+                        }}
                         style={{
                             position: 'absolute',
                             top: 0,

--- a/backend/islands/packages/editor/src/TiptapEditor/components/nodeviews/VideoNodeView.tsx
+++ b/backend/islands/packages/editor/src/TiptapEditor/components/nodeviews/VideoNodeView.tsx
@@ -1,9 +1,10 @@
 import { useRef, useEffect } from 'react';
 import { NodeViewWrapper } from '@tiptap/react';
 import type { NodeViewProps } from '@tiptap/react';
+import { NodeSelection } from '@tiptap/pm/state';
 import { getFigureStyle, getMediaStyle } from '../../utils/mediaStyles';
 
-export const VideoNodeView = ({ node, selected }: NodeViewProps) => {
+export const VideoNodeView = ({ node, selected, editor, getPos }: NodeViewProps) => {
     const videoRef = useRef<HTMLVideoElement>(null);
     const {
         src,
@@ -23,6 +24,15 @@ export const VideoNodeView = ({ node, selected }: NodeViewProps) => {
         muted,
         loop
     } = node.attrs;
+
+    const selectNode = () => {
+        const pos = typeof getPos === 'function' ? getPos() : null;
+        if (typeof pos !== 'number') return;
+
+        const { view } = editor;
+        view.dispatch(view.state.tr.setSelection(NodeSelection.create(view.state.doc, pos)));
+        view.focus();
+    };
 
     // 프로그래밍적으로 video 속성 제어 (HTML 어트리뷰트만으로는 muted가 안 먹힘)
     useEffect(() => {
@@ -88,6 +98,17 @@ export const VideoNodeView = ({ node, selected }: NodeViewProps) => {
                     </video>
                     {/* 투명 오버레이: 클릭 시 노드 선택 (네이티브 재생 차단) */}
                     <div
+                        data-drag-handle=""
+                        onMouseDown={(event) => {
+                            if (event.button === 0) {
+                                selectNode();
+                            }
+                        }}
+                        onClick={(event) => {
+                            event.preventDefault();
+                            event.stopPropagation();
+                            selectNode();
+                        }}
                         style={{
                             position: 'absolute',
                             top: 0,

--- a/backend/islands/packages/editor/src/TiptapEditor/config/editorConfig.ts
+++ b/backend/islands/packages/editor/src/TiptapEditor/config/editorConfig.ts
@@ -34,6 +34,7 @@ import { VideoNode } from '../extensions/VideoNode';
 import { CustomImage } from '../extensions/CustomImage';
 import { CodeBlockWithLanguageSelector } from '../extensions/CodeBlockWithLanguageSelector';
 import { ColumnsNode, ColumnNode } from '../extensions/ColumnsNode';
+import { UploadPlaceholderNode } from '../extensions/UploadPlaceholderNode';
 import { editorLowlight } from './lowlightConfig';
 
 export const getEditorExtensions = (placeholder: string) => [
@@ -54,6 +55,7 @@ export const getEditorExtensions = (placeholder: string) => [
     History,
     Dropcursor,
     Gapcursor,
+    UploadPlaceholderNode,
     CustomImage,
     Link.configure({ openOnClick: false }),
     Placeholder.configure({ placeholder }),

--- a/backend/islands/packages/editor/src/TiptapEditor/config/mediaUpload.ts
+++ b/backend/islands/packages/editor/src/TiptapEditor/config/mediaUpload.ts
@@ -12,3 +12,8 @@ export const ACCEPTED_VIDEO_INPUT_TYPES = [
     ...ACCEPTED_VIDEO_TYPES,
     ...ACCEPTED_VIDEO_EXTENSIONS.map(extension => `.${extension}`)
 ].join(',');
+
+export const hasProseMirrorSliceData = (dataTransfer: DataTransfer) => {
+    return Array.from(dataTransfer.types).includes('application/x-prosemirror-slice')
+        || dataTransfer.getData('text/html').includes('data-pm-slice');
+};

--- a/backend/islands/packages/editor/src/TiptapEditor/config/mediaUpload.ts
+++ b/backend/islands/packages/editor/src/TiptapEditor/config/mediaUpload.ts
@@ -1,0 +1,14 @@
+export const ACCEPTED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/gif'] as const;
+export const ACCEPTED_VIDEO_TYPES = ['video/mp4', 'video/webm'] as const;
+export const ACCEPTED_IMAGE_EXTENSIONS = ['jpg', 'jpeg', 'png', 'gif'] as const;
+export const ACCEPTED_VIDEO_EXTENSIONS = ['mp4', 'webm'] as const;
+
+export const ACCEPTED_IMAGE_INPUT_TYPES = [
+    ...ACCEPTED_IMAGE_TYPES,
+    ...ACCEPTED_IMAGE_EXTENSIONS.map(extension => `.${extension}`)
+].join(',');
+
+export const ACCEPTED_VIDEO_INPUT_TYPES = [
+    ...ACCEPTED_VIDEO_TYPES,
+    ...ACCEPTED_VIDEO_EXTENSIONS.map(extension => `.${extension}`)
+].join(',');

--- a/backend/islands/packages/editor/src/TiptapEditor/extensions/UploadPlaceholderNode.ts
+++ b/backend/islands/packages/editor/src/TiptapEditor/extensions/UploadPlaceholderNode.ts
@@ -1,0 +1,43 @@
+import { Node } from '@tiptap/react';
+
+export const UploadPlaceholderNode = Node.create({
+    name: 'uploadPlaceholder',
+
+    group: 'block',
+
+    atom: true,
+
+    selectable: false,
+
+    draggable: false,
+
+    addAttributes() {
+        return {
+            id: { default: null },
+            fileName: { default: null },
+            mediaType: { default: 'file' }
+        };
+    },
+
+    parseHTML() {
+        return [
+            { tag: 'div[data-upload-placeholder]' }
+        ];
+    },
+
+    renderHTML({ HTMLAttributes }) {
+        const mediaType = HTMLAttributes.mediaType === 'video' ? '비디오' : '이미지';
+        const fileName = HTMLAttributes.fileName ? ` · ${HTMLAttributes.fileName}` : '';
+
+        return [
+            'div',
+            {
+                'data-upload-placeholder': 'true',
+                'data-upload-id': HTMLAttributes.id || '',
+                class: 'media-upload-placeholder'
+            },
+            ['span', { class: 'media-upload-placeholder__spinner' }],
+            ['span', { class: 'media-upload-placeholder__text' }, `${mediaType} 업로드 중...${fileName}`]
+        ];
+    }
+});

--- a/backend/islands/packages/editor/src/TiptapEditor/hooks/useImageUpload.tsx
+++ b/backend/islands/packages/editor/src/TiptapEditor/hooks/useImageUpload.tsx
@@ -8,7 +8,8 @@ import {
     ACCEPTED_IMAGE_EXTENSIONS,
     ACCEPTED_IMAGE_TYPES,
     ACCEPTED_VIDEO_EXTENSIONS,
-    ACCEPTED_VIDEO_TYPES
+    ACCEPTED_VIDEO_TYPES,
+    hasProseMirrorSliceData
 } from '../config/mediaUpload';
 
 interface UseImageUploadProps {
@@ -190,7 +191,7 @@ export const useImageUpload = ({ editor, onImageUpload, onImageUploadError }: Us
                 src: url,
                 align: 'center',
                 playMode: 'gif',
-                aspectRatio: null,
+                aspectRatio: '16:9',
                 objectFit: 'cover'
             };
 
@@ -433,6 +434,7 @@ export const useImageUpload = ({ editor, onImageUpload, onImageUploadError }: Us
 
         const dataTransfer = event.dataTransfer;
         if (!dataTransfer) return false;
+        if (hasProseMirrorSliceData(dataTransfer)) return false;
 
         const { mediaFiles, rejectedFiles } = getMediaFiles(dataTransfer.files);
         const hasExternalMedia = hasExternalMediaContent(dataTransfer);

--- a/backend/islands/packages/editor/src/TiptapEditor/hooks/useImageUpload.tsx
+++ b/backend/islands/packages/editor/src/TiptapEditor/hooks/useImageUpload.tsx
@@ -1,5 +1,15 @@
 import { useState } from 'react';
 import type { Editor } from '@tiptap/react';
+import { Fragment, Slice } from '@tiptap/pm/model';
+import type { Node as ProseMirrorNode } from '@tiptap/pm/model';
+import type { Transaction } from '@tiptap/pm/state';
+import { dropPoint } from '@tiptap/pm/transform';
+import {
+    ACCEPTED_IMAGE_EXTENSIONS,
+    ACCEPTED_IMAGE_TYPES,
+    ACCEPTED_VIDEO_EXTENSIONS,
+    ACCEPTED_VIDEO_TYPES
+} from '../config/mediaUpload';
 
 interface UseImageUploadProps {
     editor: Editor | null;
@@ -7,82 +17,366 @@ interface UseImageUploadProps {
     onImageUploadError?: (errorMessage: string) => void;
 }
 
+interface TransactionEvent {
+    transaction: Transaction;
+}
+
+interface DropOptions {
+    invalidPositionMessage?: string;
+}
+
+interface UploadSlot {
+    file: File;
+    placeholderId: string;
+    positionTracker: ReturnType<typeof createPositionTracker>;
+    placeholderTracker: ReturnType<typeof createPositionTracker>;
+}
+
+interface ActivePlaceholder {
+    position: number;
+    node: ProseMirrorNode;
+}
+
+const createPositionTracker = (
+    editor: Editor,
+    position: number,
+    clampPosition: (position: number) => number,
+    assoc = 1
+) => {
+    let currentPosition = clampPosition(position);
+    const handleTransaction = ({ transaction }: TransactionEvent) => {
+        currentPosition = clampPosition(transaction.mapping.map(currentPosition, assoc));
+    };
+
+    editor.on('transaction', handleTransaction);
+
+    return {
+        getPosition: () => clampPosition(currentPosition),
+        stop: () => {
+            editor.off('transaction', handleTransaction);
+        }
+    };
+};
+
 export const useImageUpload = ({ editor, onImageUpload, onImageUploadError }: UseImageUploadProps) => {
     const [uploadingCount, setUploadingCount] = useState(0);
+
+    const getFileExtension = (file: File) => {
+        return file.name.split('.').pop()?.toLowerCase() ?? '';
+    };
+
     const isMediaFile = (file: File) => {
-        const validImageTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif'];
-        const validVideoTypes = ['video/mp4', 'video/webm'];
-        return validImageTypes.includes(file.type) || validVideoTypes.includes(file.type);
+        const extension = getFileExtension(file);
+        return ACCEPTED_IMAGE_TYPES.includes(file.type as typeof ACCEPTED_IMAGE_TYPES[number])
+            || ACCEPTED_VIDEO_TYPES.includes(file.type as typeof ACCEPTED_VIDEO_TYPES[number])
+            || ACCEPTED_IMAGE_EXTENSIONS.includes(extension as typeof ACCEPTED_IMAGE_EXTENSIONS[number])
+            || ACCEPTED_VIDEO_EXTENSIONS.includes(extension as typeof ACCEPTED_VIDEO_EXTENSIONS[number]);
     };
 
     const isVideoFile = (file: File) => {
-        const validVideoTypes = ['video/mp4', 'video/webm'];
-        return validVideoTypes.includes(file.type);
+        return ACCEPTED_VIDEO_TYPES.includes(file.type as typeof ACCEPTED_VIDEO_TYPES[number])
+            || ACCEPTED_VIDEO_EXTENSIONS.includes(getFileExtension(file) as typeof ACCEPTED_VIDEO_EXTENSIONS[number]);
     };
 
-    const uploadMedia = async (file: File, position?: number) => {
+    const getSupportedFileMessage = () => '지원하는 파일은 JPG, PNG, GIF, MP4, WebM입니다.';
+
+    const clampPosition = (position: number) => {
+        if (!editor) return position;
+        return Math.max(0, Math.min(position, editor.state.doc.content.size));
+    };
+
+    const trackPosition = (position: number, assoc = 1) => {
+        if (!editor) {
+            return {
+                getPosition: () => position,
+                stop: () => {}
+            };
+        }
+
+        return createPositionTracker(editor, position, clampPosition, assoc);
+    };
+
+    const getMediaType = (file: File) => {
+        return isVideoFile(file) ? 'video' : 'image';
+    };
+
+    const makeUploadId = () => {
+        return `upload-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    };
+
+    const createUploadPlaceholder = (file: File) => {
+        if (!editor?.schema.nodes.uploadPlaceholder) return null;
+
+        return editor.schema.nodes.uploadPlaceholder.create({
+            id: makeUploadId(),
+            fileName: file.name,
+            mediaType: getMediaType(file)
+        });
+    };
+
+    const getDropPositionForNode = (node: NonNullable<ReturnType<typeof createUploadPlaceholder>>, position: number) => {
+        if (!editor) return null;
+
+        const insertPosition = dropPoint(
+            editor.state.doc,
+            clampPosition(position),
+            new Slice(Fragment.from(node), 0, 0)
+        );
+
+        return insertPosition ?? null;
+    };
+
+    const insertUploadPlaceholder = (
+        node: NonNullable<ReturnType<typeof createUploadPlaceholder>>,
+        position: number
+    ) => {
+        if (!editor) return false;
+
+        const insertPosition = clampPosition(position);
+        const transaction = editor.state.tr.insert(insertPosition, node).setMeta('addToHistory', false);
+
+        try {
+            editor.view.dispatch(transaction);
+            return true;
+        } catch {
+            return false;
+        }
+    };
+
+    const deleteUploadPlaceholder = (position: number) => {
+        if (!editor) return false;
+
+        const deletePosition = clampPosition(position);
+        const node = editor.state.doc.nodeAt(deletePosition);
+
+        if (node?.type.name !== 'uploadPlaceholder') {
+            return false;
+        }
+
+        editor.view.dispatch(
+            editor.state.tr
+                .delete(deletePosition, deletePosition + node.nodeSize)
+                .setMeta('addToHistory', false)
+        );
+        return true;
+    };
+
+    const getNextPosition = (insertPosition: number, type: 'image' | 'video', attrs: Record<string, unknown>) => {
+        if (!editor) return insertPosition;
+
+        const mediaNode = editor.schema.nodes[type]?.create(attrs);
+        const paragraphNode = editor.schema.nodes.paragraph?.create();
+
+        if (!mediaNode || !paragraphNode) {
+            return insertPosition;
+        }
+
+        return clampPosition(insertPosition + mediaNode.nodeSize + paragraphNode.nodeSize);
+    };
+
+    const insertUploadedMedia = (file: File, url: string, position: number, replaceTo?: number) => {
+        if (!editor) return position;
+
+        const insertPosition = clampPosition(position);
+        const target = typeof replaceTo === 'number'
+            ? {
+                from: insertPosition,
+                to: clampPosition(replaceTo)
+            }
+            : insertPosition;
+
+        if (isVideoFile(file) || url.includes('.mp4') || url.includes('.webm')) {
+            const attrs = {
+                src: url,
+                align: 'center',
+                playMode: 'gif',
+                aspectRatio: null,
+                objectFit: 'cover'
+            };
+
+            editor.chain()
+                .focus()
+                .insertContentAt(target, [
+                    {
+                        type: 'video',
+                        attrs
+                    },
+                    { type: 'paragraph' }
+                ])
+                .run();
+
+            return getNextPosition(insertPosition, 'video', attrs);
+        }
+
+        const attrs = {
+            src: url,
+            alt: file.name || '',
+            align: 'center',
+            objectFit: 'cover'
+        };
+
+        editor.chain()
+            .focus()
+            .insertContentAt(target, [
+                {
+                    type: 'image',
+                    attrs
+                },
+                { type: 'paragraph' }
+            ])
+            .run();
+
+        return getNextPosition(insertPosition, 'image', attrs);
+    };
+
+    const prepareUploadSlot = (file: File, position: number): UploadSlot | null => {
+        if (!editor) return null;
+        if (!isMediaFile(file)) {
+            onImageUploadError?.(getSupportedFileMessage());
+            return null;
+        }
+
+        const placeholderNode = createUploadPlaceholder(file);
+        if (!placeholderNode) {
+            onImageUploadError?.('파일 업로드 위치를 만들 수 없습니다.');
+            return null;
+        }
+
+        const insertPosition = getDropPositionForNode(placeholderNode, position);
+        if (insertPosition === null) {
+            onImageUploadError?.('이 위치에는 파일을 넣을 수 없습니다.');
+            return null;
+        }
+
+        const positionTracker = trackPosition(insertPosition);
+        const placeholderTracker = trackPosition(insertPosition, -1);
+        const isPlaceholderInserted = insertUploadPlaceholder(placeholderNode, insertPosition);
+
+        if (!isPlaceholderInserted) {
+            positionTracker.stop();
+            placeholderTracker.stop();
+            onImageUploadError?.('파일 업로드 위치를 만들 수 없습니다.');
+            return null;
+        }
+
+        return {
+            file,
+            placeholderId: String(placeholderNode.attrs.id ?? ''),
+            positionTracker,
+            placeholderTracker
+        };
+    };
+
+    const getActivePlaceholder = (slot: UploadSlot): ActivePlaceholder | null => {
+        if (!editor) return null;
+
+        const position = slot.placeholderTracker.getPosition();
+        const node = editor.state.doc.nodeAt(position);
+        if (
+            node?.type.name === 'uploadPlaceholder'
+            && node.attrs.id === slot.placeholderId
+        ) {
+            return {
+                position,
+                node
+            };
+        }
+
+        let foundPlaceholder: ActivePlaceholder | null = null;
+        editor.state.doc.descendants((descendant, descendantPosition) => {
+            if (foundPlaceholder) return false;
+            if (
+                descendant.type.name === 'uploadPlaceholder'
+                && descendant.attrs.id === slot.placeholderId
+            ) {
+                foundPlaceholder = {
+                    position: descendantPosition,
+                    node: descendant
+                };
+                return false;
+            }
+            return true;
+        });
+
+        return foundPlaceholder;
+    };
+
+    const deleteActivePlaceholder = (slot: UploadSlot) => {
+        const activePlaceholder = getActivePlaceholder(slot);
+        if (!activePlaceholder) return false;
+        return deleteUploadPlaceholder(activePlaceholder.position);
+    };
+
+    const uploadPreparedMedia = async (slot: UploadSlot) => {
         if (!editor || !onImageUpload) return;
 
-        if (!isMediaFile(file)) {
-            onImageUploadError?.('지원하지 않는 파일 형식입니다.');
-            return;
-        }
-
-        setUploadingCount(prev => prev + 1);
         try {
-            const url = await onImageUpload(file);
+            if (!getActivePlaceholder(slot)) {
+                return slot.positionTracker.getPosition();
+            }
+
+            const url = await onImageUpload(slot.file);
 
             if (url) {
-                // position이 지정되지 않았으면 현재 selection 사용
-                const insertPos = position ?? editor.state.selection.to;
-
-                if (isVideoFile(file) || url.includes('.mp4') || url.includes('.webm')) {
-                    // 비디오는 video 노드로 삽입
-                    editor.chain()
-                        .insertContentAt(insertPos, [
-                            {
-                                type: 'video',
-                                attrs: {
-                                    src: url,
-                                    align: 'center',
-                                    playMode: 'gif', // 기본값: 움짤 모드
-                                    aspectRatio: null,
-                                    objectFit: 'cover'
-                                }
-                            },
-                            { type: 'paragraph' }
-                        ])
-                        .focus()
-                        .run();
-                } else {
-                    // 일반 이미지는 실제 URL로 삽입
-                    editor.chain()
-                        .insertContentAt(insertPos, [
-                            {
-                                type: 'image',
-                                attrs: {
-                                    src: url,
-                                    alt: file.name || '',
-                                    align: 'center',
-                                    objectFit: 'cover'
-                                }
-                            },
-                            { type: 'paragraph' }
-                        ])
-                        .focus()
-                        .run();
+                const activePlaceholder = getActivePlaceholder(slot);
+                if (!activePlaceholder) {
+                    return slot.positionTracker.getPosition();
                 }
 
-                // 삽입 후 새로운 위치 반환 (다음 파일을 위해)
-                return editor.state.doc.content.size;
+                const replaceTo = activePlaceholder.position + activePlaceholder.node.nodeSize;
+                const nextPosition = insertUploadedMedia(slot.file, url, activePlaceholder.position, replaceTo);
+                return nextPosition;
             } else {
+                deleteActivePlaceholder(slot);
                 onImageUploadError?.('파일 업로드에 실패했습니다.');
             }
-        } catch {
-            onImageUploadError?.('파일 업로드에 실패했습니다.');
+        } catch (error) {
+            deleteActivePlaceholder(slot);
+            onImageUploadError?.(error instanceof Error ? error.message : '파일 업로드에 실패했습니다.');
         } finally {
+            slot.positionTracker.stop();
+            slot.placeholderTracker.stop();
             setUploadingCount(prev => Math.max(0, prev - 1));
         }
+    };
+
+    const uploadMediaFiles = async (files: File[], position: number) => {
+        if (!editor || !onImageUpload) return;
+
+        let nextPosition = position;
+        const uploadSlots: UploadSlot[] = [];
+
+        for (const file of files) {
+            const slot = prepareUploadSlot(file, nextPosition);
+            if (!slot) continue;
+
+            uploadSlots.push(slot);
+            nextPosition = slot.positionTracker.getPosition();
+        }
+
+        if (uploadSlots.length === 0) return;
+
+        setUploadingCount(prev => prev + uploadSlots.length);
+
+        for (const slot of uploadSlots) {
+            await uploadPreparedMedia(slot);
+        }
+    };
+
+    const getMediaFiles = (fileList: FileList | File[]) => {
+        const files = Array.from(fileList);
+        return {
+            mediaFiles: files.filter(isMediaFile),
+            rejectedFiles: files.filter(file => !isMediaFile(file))
+        };
+    };
+
+    const hasExternalMediaContent = (dataTransfer: DataTransfer) => {
+        const html = dataTransfer.getData('text/html');
+        if (/<(?:img|video|source)\b/i.test(html)) return true;
+
+        const uri = dataTransfer.getData('text/uri-list') || dataTransfer.getData('text/plain');
+        return /\.(?:jpe?g|png|gif|webp|avif|mp4|webm)(?:[?#].*)?$/i.test(uri.trim());
     };
 
     const handlePaste = async (event: ClipboardEvent) => {
@@ -104,9 +398,7 @@ export const useImageUpload = ({ editor, onImageUpload, onImageUploadError }: Us
 
         if (mediaFiles.length > 0) {
             event.preventDefault();
-            for (const file of mediaFiles) {
-                await uploadMedia(file);
-            }
+            await uploadMediaFiles(mediaFiles, editor.state.selection.to);
         }
     };
 
@@ -114,38 +406,72 @@ export const useImageUpload = ({ editor, onImageUpload, onImageUploadError }: Us
         const files = event.target.files;
         if (!files || files.length === 0) return;
 
-        for (let i = 0; i < files.length; i++) {
-            await uploadMedia(files[i]);
+        const { mediaFiles, rejectedFiles } = getMediaFiles(files);
+        if (rejectedFiles.length > 0) {
+            onImageUploadError?.(getSupportedFileMessage());
         }
+
+        await uploadMediaFiles(mediaFiles, editor?.state.selection.to ?? 0);
+        event.target.value = '';
     };
 
     const handleVideoUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
         const files = event.target.files;
         if (!files || files.length === 0) return;
 
-        for (let i = 0; i < files.length; i++) {
-            await uploadMedia(files[i]);
+        const { mediaFiles, rejectedFiles } = getMediaFiles(files);
+        if (rejectedFiles.length > 0) {
+            onImageUploadError?.(getSupportedFileMessage());
         }
+
+        await uploadMediaFiles(mediaFiles, editor?.state.selection.to ?? 0);
+        event.target.value = '';
     };
 
-    const handleDrop = async (e: React.DragEvent<HTMLDivElement>) => {
-        const { files } = e.dataTransfer;
+    const handleDrop = (event: DragEvent, position?: number, options?: DropOptions) => {
+        if (!editor) return false;
 
-        // 외부 파일 드롭이 아니면 ProseMirror가 내부 노드 이동을 처리하도록 그대로 둠
-        if (files.length === 0) return;
+        const dataTransfer = event.dataTransfer;
+        if (!dataTransfer) return false;
 
-        const mediaFiles = Array.from(files).filter(
-            file => file.type.startsWith('image/') || file.type.startsWith('video/')
-        );
+        const { mediaFiles, rejectedFiles } = getMediaFiles(dataTransfer.files);
+        const hasExternalMedia = hasExternalMediaContent(dataTransfer);
+        const hasHandledMediaPayload = mediaFiles.length > 0 || rejectedFiles.length > 0 || hasExternalMedia;
 
-        if (mediaFiles.length === 0) return;
-
-        e.preventDefault();
-        e.stopPropagation();
-
-        for (const file of mediaFiles) {
-            await uploadMedia(file);
+        if (options?.invalidPositionMessage && hasHandledMediaPayload) {
+            event.preventDefault();
+            event.stopPropagation();
+            onImageUploadError?.(options.invalidPositionMessage);
+            return true;
         }
+
+        if (mediaFiles.length === 0) {
+            if (rejectedFiles.length > 0) {
+                event.preventDefault();
+                event.stopPropagation();
+                onImageUploadError?.(getSupportedFileMessage());
+                return true;
+            }
+
+            if (hasExternalMedia) {
+                event.preventDefault();
+                event.stopPropagation();
+                onImageUploadError?.('이미지나 비디오는 파일로 내려놓아 주세요.');
+                return true;
+            }
+
+            return false;
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+
+        if (rejectedFiles.length > 0) {
+            onImageUploadError?.(getSupportedFileMessage());
+        }
+
+        void uploadMediaFiles(mediaFiles, position ?? editor.state.selection.to);
+        return true;
     };
 
     return {

--- a/backend/islands/packages/editor/src/TiptapEditor/utils/mediaStyles.ts
+++ b/backend/islands/packages/editor/src/TiptapEditor/utils/mediaStyles.ts
@@ -10,6 +10,9 @@ export const SIZE_PRESETS: Record<string, number> = {
     large: 640
 };
 
+const MEDIA_BORDER_STYLE = '1px solid var(--color-line-strong, #d2d2d7)';
+const MEDIA_SHADOW_STYLE = '8px 8px 40px 2px var(--color-shadow-lg, rgba(0, 0, 0, 0.15))';
+
 /**
  * figure 컨테이너 스타일 (이미지/비디오 공용)
  */
@@ -55,11 +58,11 @@ export function getFigureStyle(attrs: {
 
     // 장식 속성 (기존 콘텐츠 호환용)
     if (attrs.border) {
-        style.border = '1px solid #e5e7eb';
+        style.border = MEDIA_BORDER_STYLE;
         style.overflow = 'hidden';
     }
     if (attrs.shadow) {
-        style.boxShadow = '8px 8px 40px 2px rgba(0, 0, 0, 0.15)';
+        style.boxShadow = MEDIA_SHADOW_STYLE;
     }
     if (attrs.borderRadius) {
         style.borderRadius = `${attrs.borderRadius}px`;
@@ -134,11 +137,11 @@ export function buildFigureAttrsForHTML(attrs: {
     }
 
     if (attrs.border) {
-        styles.push('border: 1px solid #e5e7eb', 'overflow: hidden');
+        styles.push(`border: ${MEDIA_BORDER_STYLE}`, 'overflow: hidden');
         result['data-border'] = 'true';
     }
     if (attrs.shadow) {
-        styles.push('box-shadow: 8px 8px 40px 2px rgba(0, 0, 0, 0.15)');
+        styles.push(`box-shadow: ${MEDIA_SHADOW_STYLE}`);
         result['data-shadow'] = 'true';
     }
     if (attrs.borderRadius) {


### PR DESCRIPTION
## 🎯 Goal
- Make editor image/video drag repositioning behave like an internal ProseMirror move instead of showing the external media drop warning.
- Restore and dark-mode-proof the media settings popover controls for image and video nodes.

## 🔧 Core Changes
- Detect ProseMirror slice payloads during drops and let internal media moves pass through the editor flow.
- Add explicit media node selection and drag handles for image/video node views.
- Apply semantic surface/content/line tokens to the media settings popover.
- Restore image/video object-fit, border, shadow, and radius controls.
- Use theme CSS variables for media border and shadow styles.
- Add focused editor media smoke coverage for internal media move warnings.

## 🤔 Key Decisions
- Kept E2E coverage narrow and user-flow focused instead of adding a broad style-control matrix.
- Used existing editor node attributes and media style helpers instead of introducing a new styling path.

## 🧪 Verification Guide
### How to verify
1. Open the post editor and insert an image or video.
2. Click the inserted media node and open its settings popover in light and dark mode.
3. Drag the inserted media node to another paragraph.

### Expected result
- The popover controls remain readable in dark mode, style controls are available, border/shadow render correctly, and internal media drags do not show the external-file warning.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)

Verification run:
- `npm run islands:type-check`
- `npm run islands:lint`
- `npm run islands:build`
- `PORT=8017 pnpm --dir backend/islands/apps/remotes exec playwright test e2e/editor-media-upload.spec.ts`