### PR TITLE
🐛 Show author about save feedback

### DIFF
--- a/backend/src/board/services/user_service.py
+++ b/backend/src/board/services/user_service.py
@@ -277,13 +277,16 @@ class UserService:
 
     @staticmethod
     @transaction.atomic
-    def update_user_about(user: User, about_md: str) -> None:
+    def update_user_about(user: User, about_md: str) -> Dict[str, str]:
         """
         Update user's about page.
 
         Args:
             user: User instance
             about_md: About page content in markdown
+
+        Returns:
+            Dictionary with about_md and about_html
         """
         about_html = parse_post_to_html(about_md)
 
@@ -296,6 +299,11 @@ class UserService:
             profile.about_md = about_md
             profile.about_html = about_html
             profile.save()
+
+        return {
+            'about_md': about_md,
+            'about_html': about_html,
+        }
 
     @staticmethod
     def check_username_redirect(old_username: str) -> Optional[Dict[str, str]]:

--- a/backend/src/board/templates/board/author/author_about_edit.html
+++ b/backend/src/board/templates/board/author/author_about_edit.html
@@ -22,7 +22,7 @@
              x-data="{
                 content: '{{ about_md|escapejs }}',
                 username: '{{ author.username }}',
-                redirectPath: '/@{{ author.username }}/about',
+                redirectPath: '/@{{ author.username }}',
                 placeholder: '마크다운으로 작성해 보세요.',
                 isSaving: false,
                 message: '',
@@ -41,20 +41,23 @@
                     try {
                         const formData = new FormData();
                         formData.append('about_md', this.content);
-                        formData.append('csrfmiddlewaretoken', document.querySelector('[name=csrfmiddlewaretoken]').value);
+                        formData.append('csrfmiddlewaretoken', '{{ csrf_token|escapejs }}');
 
                         const response = await fetch(`/@${this.username}/about/edit`, {
                             method: 'POST',
-                            body: formData
+                            body: formData,
+                            headers: {
+                                'X-CSRFToken': '{{ csrf_token|escapejs }}'
+                            }
                         });
+                        const data = await response.json().catch(() => ({}));
         
-                        if (response.ok) {
-                            this.message = '소개가 업데이트되었습니다.';
+                        if (response.ok && data.status === 'success') {
+                            this.message = data.message || '소개글을 저장했습니다.';
                             this.isSuccess = true;
                             window.location.replace(this.redirectPath);
                         } else {
-                            const errorData = await response.json();
-                            this.message = errorData.detail || '저장 실패: 알 수 없는 오류가 발생했습니다.';
+                            this.message = data.message || '저장 실패: 알 수 없는 오류가 발생했습니다.';
                             this.isSuccess = false;
                         }
                     } catch (error) {
@@ -65,6 +68,7 @@
                     }
                 }
             }">
+            <script type="application/json" x-ref="formData">{"initialValue":"{{ about_md|escapejs }}","username":"{{ author.username|escapejs }}","redirectPath":"/@{{ author.username|escapejs }}"}</script>
             <textarea
                 x-model="content"
                 :placeholder="placeholder"

--- a/backend/src/board/templates/board/author/components/readme_section.html
+++ b/backend/src/board/templates/board/author/components/readme_section.html
@@ -6,8 +6,11 @@
         editing: false,
         saving: false,
         message: '',
+        messageType: 'success',
         initialContent: '{{ about_md|default:''|escapejs }}',
         content: '{{ about_md|default:''|escapejs }}',
+        renderedContent: '{{ about_html|default:''|escapejs }}',
+        hasRenderedContent: {% if about_html %}true{% else %}false{% endif %},
         startEditing() {
             this.content = this.initialContent;
             this.message = '';
@@ -41,12 +44,20 @@
 
                 if (!response.ok || data.status !== 'success') {
                     this.message = data.message || '소개글을 저장하지 못했습니다.';
+                    this.messageType = 'error';
                     return;
                 }
 
-                window.location.reload();
+                this.initialContent = data.about_md || '';
+                this.content = data.about_md || '';
+                this.renderedContent = data.about_html || '';
+                this.hasRenderedContent = Boolean(this.renderedContent);
+                this.message = data.message || '소개글을 저장했습니다.';
+                this.messageType = 'success';
+                this.editing = false;
             } catch (error) {
                 this.message = '네트워크 오류로 저장하지 못했습니다.';
+                this.messageType = 'error';
             } finally {
                 this.saving = false;
             }
@@ -58,12 +69,14 @@
             <p class="mb-2 text-xs font-bold uppercase tracking-[0.18em] text-content-hint">About</p>
             <h2 class="text-2xl font-bold text-content">소개</h2>
         </div>
-        {% if about_html %}
-            <div class="prose blog-post-content" x-show="!editing">
-                {{ about_html|safe }}
+        {% if user == author %}
+        <p x-show="message" x-cloak x-text="message" :class="messageType === 'error' ? 'text-danger' : 'text-success'" class="mb-4 text-sm"></p>
+        {% endif %}
+        {% if user == author %}
+            <div class="prose blog-post-content" x-show="!editing && hasRenderedContent" x-html="renderedContent">
+                {% if about_html %}{{ about_html|safe }}{% endif %}
             </div>
-        {% else %}
-            <div class="rounded-2xl border border-dashed border-line bg-surface px-5 py-4" x-show="!editing">
+            <div class="rounded-2xl border border-dashed border-line bg-surface px-5 py-4" x-show="!editing && !hasRenderedContent" x-cloak>
                 <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                     <p class="text-sm text-content-secondary">소개글을 작성하면 프로필에 표시됩니다.</p>
                     <button type="button" @click="startEditing()" class="inline-flex items-center justify-center rounded-lg bg-surface-subtle px-4 py-2 text-sm font-semibold text-content-secondary transition-colors hover:bg-surface-subtle/80 hover:text-content">
@@ -72,11 +85,15 @@
                     </button>
                 </div>
             </div>
+        {% elif about_html %}
+            <div class="prose blog-post-content">
+                {{ about_html|safe }}
+            </div>
         {% endif %}
 
-        {% if user == author and about_html %}
+        {% if user == author %}
         <div class="mt-6" x-show="!editing">
-            <button type="button" @click="startEditing()" class="inline-flex items-center justify-center rounded-lg bg-surface-subtle px-4 py-2 text-sm font-semibold text-content-secondary transition-colors hover:bg-surface-subtle/80 hover:text-content">
+            <button type="button" x-show="hasRenderedContent" @click="startEditing()" class="inline-flex items-center justify-center rounded-lg bg-surface-subtle px-4 py-2 text-sm font-semibold text-content-secondary transition-colors hover:bg-surface-subtle/80 hover:text-content">
                 <i class="fas fa-edit mr-2"></i>
                 소개글 수정
             </button>
@@ -91,7 +108,6 @@
                 class="min-h-64 w-full resize-y rounded-xl border border-line bg-surface-subtle p-4 text-sm leading-relaxed text-content placeholder-content-hint focus:border-line-strong focus:outline-none focus:ring-2 focus:ring-line/10"
                 placeholder="소개글을 작성하세요"></textarea>
             <div class="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                <p x-show="message" x-text="message" class="text-sm text-danger"></p>
                 <div class="flex justify-end gap-2 sm:ml-auto">
                     <button type="button" @click="cancelEditing()" :disabled="saving" class="inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-semibold text-content-secondary transition-colors hover:bg-surface-subtle hover:text-content disabled:opacity-50">
                         취소

--- a/backend/src/board/tests/templates/test_author.py
+++ b/backend/src/board/tests/templates/test_author.py
@@ -230,7 +230,20 @@ class AuthorPostsPageTestCase(TestCase):
         self.assertContains(owner_response, 'Visible author intro')
         self.assertContains(owner_response, '소개글 수정')
         self.assertNotContains(owner_response, f'href="{edit_path}"')
-        self.assertNotContains(owner_response, '소개글 작성')
+        self.assertContains(owner_response, 'x-show=hasRenderedContent')
+
+    def test_author_overview_inline_intro_editor_updates_without_reload(self):
+        """소개글 인라인 편집은 저장 후 페이지 새로고침 없이 렌더 HTML을 갱신한다."""
+        self.client.login(username='testauthor', password='testpass123')
+
+        response = self.client.get(
+            reverse('user_profile', kwargs={'username': self.user.username})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'x-html=renderedContent')
+        self.assertContains(response, 'data.about_html')
+        self.assertNotContains(response, 'window.location.reload()')
 
     def test_author_overview_omits_sidebar_stats_and_quick_links(self):
         """작성자 개요에서는 중복되는 통계와 바로가기 사이드바를 노출하지 않는다."""
@@ -951,3 +964,25 @@ class AuthorAboutPageTestCase(TestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'board/author/author_about_edit.html')
+        self.assertContains(response, 'x-ref=formData')
+
+    def test_author_about_edit_post_returns_rendered_content(self):
+        """소개글 저장 응답은 새로고침 없이 반영할 수 있는 렌더 HTML을 반환한다."""
+        self.client.login(username='testauthor', password='testpass123')
+        about_md = '# Updated Intro\n\nThis is **bold**.'
+
+        response = self.client.post(
+            reverse('user_about_edit', kwargs={'username': self.user.username}),
+            {'about_md': about_md},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data['status'], 'success')
+        self.assertEqual(data['about_md'], about_md)
+        self.assertIn('Updated Intro', data['about_html'])
+        self.assertIn('<strong>bold</strong>', data['about_html'])
+
+        self.profile.refresh_from_db()
+        self.assertEqual(self.profile.about_md, about_md)
+        self.assertEqual(self.profile.about_html, data['about_html'])

--- a/backend/src/board/views/author.py
+++ b/backend/src/board/views/author.py
@@ -15,7 +15,6 @@ from board.services.discovery_metadata_service import DiscoveryMetadataService
 from board.services.public_post_service import PublicPostService
 from board.services.public_series_service import PublicSeriesService
 from board.models import Comment, Post, Series, PostLikes, Tag, Profile, SiteNotice, SiteContentScope
-from modules import markdown
 
 
 def author_overview(request, username):
@@ -337,11 +336,14 @@ def author_about_edit(request, username):
 
     if request.method == 'POST':
         new_about_md = request.POST.get('about_md', '')
-        profile.about_md = new_about_md
-        profile.about_html = markdown.parse_post_to_html(new_about_md)
         try:
-            profile.save()
-            return JsonResponse({'status': 'success', 'message': '소개가 성공적으로 업데이트되었습니다.'})
+            about = UserService.update_user_about(author, new_about_md)
+            return JsonResponse({
+                'status': 'success',
+                'message': '소개글을 저장했습니다.',
+                'about_md': about['about_md'],
+                'about_html': about['about_html'],
+            })
         except Exception as e:
             return JsonResponse({'status': 'error', 'message': str(e)}, status=500)
 


### PR DESCRIPTION
## 🎯 Goal
- Fix the author introduction editor feeling like it only blinks after saving.
- Make successful saves visible immediately instead of relying on a full page reload.

## 🔧 Core Changes
- Return saved Markdown and rendered HTML from the author about save endpoint.
- Update the inline author introduction editor in place after a successful save and show a success message.
- Fix the standalone about edit page Alpine initialization so it no longer references a missing form data node.
- Keep the existing visitor behavior for empty introductions.

## 🤔 Key Decisions
- Reused `UserService.update_user_about` for the author about view so Markdown rendering and persistence stay in one path.
- Kept the inline editor as an Alpine template component because this is server-rendered profile UI, not an Islands form.

## 🧪 Verification Guide
### How to verify
1. Open your profile overview while logged in.
2. Click `소개글 수정`, change the textarea content, and save.
3. Confirm the rendered introduction updates without a full page reload and a success message appears.
4. Open `/@{username}/about/edit`, edit the textarea, and save.

### Expected result
- Inline author introduction saves show visible feedback and immediately update the displayed content.
- The standalone edit page saves without JavaScript initialization errors.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)