### PR TITLE
🐛 Align post cover layout spacing

### DIFF
--- a/backend/islands/apps/remotes/styles/tailwind.css
+++ b/backend/islands/apps/remotes/styles/tailwind.css
@@ -47,13 +47,21 @@
 
 @layer components {
     /* Shared by post detail, post editor, and banner preview. Keep post layout widths here. */
+    .post-detail-frame,
     .post-detail-layout {
-        display: grid;
         width: 100%;
         max-width: 91rem;
         margin-inline: auto;
+    }
+
+    .post-detail-layout {
+        display: grid;
         gap: 1.5rem;
         grid-template-columns: minmax(0, 1fr);
+    }
+
+    .post-detail-body--after-cover {
+        padding-top: 2rem;
     }
 
     .post-detail-main {
@@ -74,6 +82,12 @@
 
         .post-detail-sidebar {
             display: block;
+        }
+    }
+
+    @media (min-width: 40rem) {
+        .post-detail-body--after-cover {
+            padding-top: 2.5rem;
         }
     }
 }

--- a/backend/src/board/templates/board/posts/covers/overlay.html
+++ b/backend/src/board/templates/board/posts/covers/overlay.html
@@ -1,7 +1,7 @@
 <section class="post-cover-overlay relative isolate flex min-h-[52vh] items-end overflow-hidden">
     <img class="absolute inset-0 -z-10 h-full w-full object-cover" src="{{ post.image.url }}" alt="{{ post.title }}">
     <div class="post-cover-overlay-shade absolute inset-0 -z-10"></div>
-    <div class="mx-auto w-full max-w-7xl px-4 pb-10 pt-28 md:px-6 sm:pb-14">
+    <div class="post-detail-frame px-4 pb-10 pt-28 md:px-6 sm:pb-14">
         {% include 'board/posts/covers/_series_badge.html' with cover_inverted=True %}
 
         <h1 class="max-w-4xl text-3xl sm:text-4xl lg:text-4xl font-bold text-white {% if not post.subtitle %}mb-6{% else %}mb-4{% endif %} leading-tight break-words">

--- a/backend/src/board/templates/board/posts/covers/split.html
+++ b/backend/src/board/templates/board/posts/covers/split.html
@@ -1,5 +1,5 @@
 <section class="post-cover-split px-4 md:px-6">
-    <div class="mx-auto grid max-w-7xl gap-8 py-10 sm:py-14 lg:grid-cols-2 lg:items-center">
+    <div class="post-detail-frame grid gap-8 py-10 sm:py-14 lg:grid-cols-2 lg:items-center">
         <div class="{% if post.config.cover_image_position == 'left' %}lg:order-2{% endif %}">
             {% include 'board/posts/covers/_series_badge.html' with cover_inverted=False %}
 

--- a/backend/src/board/templates/board/posts/post_detail.html
+++ b/backend/src/board/templates/board/posts/post_detail.html
@@ -56,7 +56,7 @@
         {% include post_cover_template %}
     {% endif %}
 
-    <div class="px-4 md:px-6">
+    <div class="post-detail-body px-4 md:px-6{% if post_cover_is_full_bleed %} post-detail-body--after-cover{% endif %}">
         <div class="post-detail-layout">
         <!-- Left Sidebar Space (Always present on desktop) -->
         <aside class="post-detail-sidebar">

--- a/backend/src/board/tests/templates/test_post_detail.py
+++ b/backend/src/board/tests/templates/test_post_detail.py
@@ -291,7 +291,7 @@ class PostDetailViewTestCase(TestCase):
         self.assertContains(response, '/@testauthor')
 
     def test_post_detail_uses_split_cover_outside_content_grid(self):
-        """분할 커버는 본문 그리드 바깥 커버 템플릿으로 렌더링한다."""
+        """분할 커버는 본문 그리드 바깥에서 상세 공통 프레임으로 렌더링한다."""
         self.set_post_image_path()
         self.post.config.cover_layout = 'split'
         self.post.config.cover_image_position = 'left'
@@ -308,6 +308,14 @@ class PostDetailViewTestCase(TestCase):
         self.assertTrue(response.context['post_cover_is_full_bleed'])
         self.assertContains(response, 'post-cover-split')
         self.assertNotContains(response, 'post-cover-default')
+
+        content = response.content.decode()
+        split_start = content.index('post-cover-split')
+        split_end = content.index('</section>', split_start)
+        split_markup = content[split_start:split_end]
+
+        self.assertIn('post-detail-frame', split_markup)
+        self.assertIn('post-detail-body--after-cover', content)
 
     def test_post_detail_overlay_cover_uses_theme_independent_light_text(self):
         """이미지 배경 커버 텍스트는 테마 토큰 반전 없이 흰색 계열로 렌더링한다."""
@@ -336,6 +344,7 @@ class PostDetailViewTestCase(TestCase):
         overlay_end = content.index('</section>', overlay_start)
         overlay_markup = content[overlay_start:overlay_end]
 
+        self.assertIn('post-detail-frame', overlay_markup)
         self.assertIn('text-white ', overlay_markup)
         self.assertIn('text-white/85', overlay_markup)
         self.assertIn('text-white/80', overlay_markup)
@@ -359,6 +368,7 @@ class PostDetailViewTestCase(TestCase):
         self.assertFalse(response.context['post_cover_is_full_bleed'])
         self.assertContains(response, 'post-cover-default')
         self.assertNotContains(response, 'post-cover-overlay')
+        self.assertNotContains(response, 'post-detail-body--after-cover')
 
     def test_post_detail_cover_hidden_keeps_share_image_metadata(self):
         """커버 숨김은 상세 상단 이미지만 숨기고 공유용 대표 이미지는 유지한다."""


### PR DESCRIPTION
## 🎯 Goal
- Fix post cover layouts where full-bleed cover styles made the following detail layout feel too tight.
- Align split and overlay cover content width with the canonical post detail frame.

## 🔧 Core Changes
- Added a shared `post-detail-frame` width utility next to `post-detail-layout`.
- Updated split and overlay cover templates to use the shared post detail frame width.
- Added top spacing before the detail grid only when the selected cover is full-bleed.
- Extended post detail template tests for split/overlay layout classes.

## 🤔 Key Decisions
- Reused the existing 91rem post detail width instead of keeping cover-specific `max-w-7xl` values.
- Kept spacing conditional to full-bleed covers so the default/basic detail layout does not change.

## 🧪 Verification Guide
### How to verify
1. Open a post using the image background cover style.
2. Confirm the ToC/right sidebar starts with comfortable spacing below the cover.
3. Open a post using the split cover style.
4. Confirm the split cover aligns with the left-banner/content/right-banner frame width.

### Expected result
- Full-bleed covers no longer make the following detail grid feel attached to the cover.
- Split/overlay cover content uses the same outer frame as the post detail layout.

## ✅ Checklist
- [x] Lint completed (`npm run islands:lint`, warnings only)
- [x] Type-check completed (`npm run islands:type-check`)
- [x] Tests completed (`npm run server:test -- board.tests.templates.test_post_detail`)
- [x] Documentation updated (if needed)
