### PR TITLE
♻️ Improve comment service contract

### DIFF
--- a/backend/islands/apps/remotes/src/lib/api/comments.ts
+++ b/backend/islands/apps/remotes/src/lib/api/comments.ts
@@ -10,14 +10,23 @@ export interface Comment {
     countLikes: number;
     isLiked: boolean;
     isEdited: boolean;
+    isDeleted?: boolean;
     isMine?: boolean;
     parentId?: number;
+    permissions?: CommentPermissions;
     replies?: Comment[];
+}
+
+export interface CommentPermissions {
+    canEdit: boolean;
+    canDelete: boolean;
+    canLike: boolean;
+    canReply: boolean;
 }
 
 export type CommentsResponse = Response<{ comments: Comment[] }>;
 export type CommentResponse = Response<{ textMd: string }>;
-export type CommentActionResponse = Response<{ success: boolean }>;
+export type CommentActionResponse = Response<Partial<Comment> & { success?: boolean }>;
 
 export const getComments = async (postUrl: string) => {
     return http.get<CommentsResponse>(`v1/posts/${postUrl}/comments`);

--- a/backend/src/board/services/comment_list_service.py
+++ b/backend/src/board/services/comment_list_service.py
@@ -63,15 +63,11 @@ class CommentListService:
     @staticmethod
     def serialize_comment(comment, user_id: int, is_authenticated: bool) -> dict:
         return {
-            'id': comment.id,
-            'author': comment.author_username(),
-            'author_image': None if not comment.author else comment.author.profile.get_thumbnail(),
-            'is_mine': is_authenticated and comment.author_id == user_id,
-            'is_edited': comment.edited,
-            'rendered_content': comment.get_text_html(),
-            'created_date': comment.time_since(),
-            'count_likes': comment.count_likes,
-            'is_liked': comment.has_liked,
+            **CommentListService.serialize_comment_base(
+                comment,
+                user_id=user_id,
+                is_authenticated=is_authenticated,
+            ),
             'replies': [
                 CommentListService.serialize_reply(
                     reply,
@@ -84,16 +80,78 @@ class CommentListService:
         }
 
     @staticmethod
-    def serialize_reply(reply, parent_id: int, user_id: int, is_authenticated: bool) -> dict:
-        return {
-            'id': reply.id,
-            'author': reply.author_username(),
-            'author_image': None if not reply.author else reply.author.profile.get_thumbnail(),
-            'is_mine': is_authenticated and reply.author_id == user_id,
-            'is_edited': reply.edited,
-            'rendered_content': reply.get_text_html(),
-            'created_date': reply.time_since(),
-            'count_likes': reply.count_likes,
-            'is_liked': reply.has_liked,
-            'parent_id': parent_id,
+    def serialize_created_comment(comment, user) -> dict:
+        user_id = user.id if user.id else -1
+        is_authenticated = user.is_authenticated
+
+        return CommentListService.serialize_comment_base(
+            comment,
+            parent_id=comment.parent_id,
+            user_id=user_id,
+            is_authenticated=is_authenticated,
+        )
+
+    @staticmethod
+    def serialize_comment_base(
+        comment,
+        user_id: int,
+        is_authenticated: bool,
+        parent_id: int | None = None,
+    ) -> dict:
+        payload = {
+            'id': comment.id,
+            'author': comment.author_username(),
+            'author_image': None if not comment.author else comment.author.profile.get_thumbnail(),
+            'is_mine': is_authenticated and comment.author_id == user_id,
+            'is_edited': comment.edited,
+            'is_deleted': comment.is_deleted(),
+            'rendered_content': comment.get_text_html(),
+            'created_date': comment.time_since(),
+            'count_likes': CommentListService.get_count_likes(comment),
+            'is_liked': CommentListService.get_has_liked(comment, user_id),
+            'permissions': CommentListService.serialize_permissions(
+                comment,
+                user_id=user_id,
+                is_authenticated=is_authenticated,
+            ),
         }
+
+        if parent_id:
+            payload['parent_id'] = parent_id
+
+        return payload
+
+    @staticmethod
+    def serialize_reply(reply, parent_id: int, user_id: int, is_authenticated: bool) -> dict:
+        return CommentListService.serialize_comment_base(
+            reply,
+            parent_id=parent_id,
+            user_id=user_id,
+            is_authenticated=is_authenticated,
+        )
+
+    @staticmethod
+    def serialize_permissions(comment, user_id: int, is_authenticated: bool) -> dict:
+        is_mine = is_authenticated and comment.author_id == user_id
+        is_deleted = comment.is_deleted()
+
+        return {
+            'can_edit': is_mine and not is_deleted,
+            'can_delete': is_mine and not is_deleted,
+            'can_like': is_authenticated and not is_mine and not is_deleted,
+            'can_reply': is_authenticated and not is_deleted,
+        }
+
+    @staticmethod
+    def get_count_likes(comment) -> int:
+        if hasattr(comment, 'count_likes'):
+            return comment.count_likes
+        return comment.likes.count()
+
+    @staticmethod
+    def get_has_liked(comment, user_id: int) -> bool:
+        if hasattr(comment, 'has_liked'):
+            return comment.has_liked
+        if user_id < 1:
+            return False
+        return comment.likes.filter(id=user_id).exists()

--- a/backend/src/board/services/comment_service.py
+++ b/backend/src/board/services/comment_service.py
@@ -10,11 +10,14 @@ from typing import Optional, Set, Tuple
 
 from django.contrib.auth.models import User
 from django.db import transaction
+from django.db.models import Case, Count, Exists, OuterRef, Value, When
+from django.http import Http404
 
 from board.constants.config_meta import CONFIG_TYPE
 from board.models import Comment, Post
 from board.modules.notify import create_notify
 from board.modules.response import ErrorCode
+from board.services.public_post_service import PublicPostService
 from modules import markdown
 
 
@@ -29,6 +32,37 @@ class CommentValidationError(Exception):
 class CommentService:
     """Service class for handling comment-related business logic"""
     MENTION_PATTERN = re.compile(r'`@([a-zA-Z0-9\.\_\-\+]*)`\s?')
+
+    @staticmethod
+    def get_comment_queryset(user: User):
+        user_id = user.id if user.id else -1
+
+        return Comment.objects.select_related(
+            'author',
+            'author__config',
+            'author__profile',
+            'post',
+            'post__config',
+        ).annotate(
+            count_likes=Count('likes', distinct=True),
+            has_liked=Case(
+                When(
+                    Exists(
+                        Comment.objects.filter(
+                            id=OuterRef('id'),
+                            likes__id=user_id,
+                        )
+                    ),
+                    then=Value(True),
+                ),
+                default=Value(False),
+            ),
+        )
+
+    @staticmethod
+    def validate_comment_belongs_to_public_post(comment: Comment) -> None:
+        if not PublicPostService.is_public(comment.post):
+            raise Http404
 
     @staticmethod
     def validate_user_can_comment(user: User) -> None:
@@ -94,7 +128,7 @@ class CommentService:
         Raises:
             CommentValidationError: If user cannot edit
         """
-        if user != comment.author:
+        if not CommentService.can_user_edit_comment(user, comment):
             raise CommentValidationError(
                 ErrorCode.AUTHENTICATION,
                 '댓글 수정 권한이 없습니다.'
@@ -112,7 +146,7 @@ class CommentService:
         Raises:
             CommentValidationError: If user cannot delete
         """
-        if user != comment.author:
+        if not CommentService.can_user_delete_comment(user, comment):
             raise CommentValidationError(
                 ErrorCode.AUTHENTICATION,
                 '댓글 삭제 권한이 없습니다.'
@@ -147,6 +181,16 @@ class CommentService:
                 ErrorCode.REJECT,
                 '삭제된 댓글입니다.'
             )
+
+    @staticmethod
+    def get_edit_markdown(user: User, comment: Comment) -> str:
+        CommentService.validate_comment_belongs_to_public_post(comment)
+
+        if comment.is_deleted():
+            raise Http404
+
+        CommentService.validate_user_can_edit(user, comment)
+        return comment.text_md
 
     @staticmethod
     def extract_mentioned_users(text_md: str) -> Set[str]:
@@ -385,6 +429,13 @@ class CommentService:
 
     @staticmethod
     @transaction.atomic
+    def update_public_comment(user: User, comment: Comment, text_md: str) -> Comment:
+        CommentService.validate_comment_belongs_to_public_post(comment)
+        CommentService.validate_user_can_edit(user, comment)
+        return CommentService.update_comment(comment, text_md)
+
+    @staticmethod
+    @transaction.atomic
     def delete_comment(comment: Comment) -> Comment:
         """
         Soft delete comment by removing author.
@@ -398,6 +449,13 @@ class CommentService:
         comment.author = None
         comment.save()
         return comment
+
+    @staticmethod
+    @transaction.atomic
+    def delete_public_comment(user: User, comment: Comment) -> Comment:
+        CommentService.validate_comment_belongs_to_public_post(comment)
+        CommentService.validate_user_can_delete(user, comment)
+        return CommentService.delete_comment(comment)
 
     @staticmethod
     @transaction.atomic
@@ -430,6 +488,12 @@ class CommentService:
             return True, comment.likes.count()
 
     @staticmethod
+    @transaction.atomic
+    def toggle_public_comment_like(user: User, comment: Comment) -> Tuple[bool, int]:
+        CommentService.validate_comment_belongs_to_public_post(comment)
+        return CommentService.toggle_like(user, comment)
+
+    @staticmethod
     def can_user_edit_comment(user: User, comment: Comment) -> bool:
         """
         Check if user can edit comment.
@@ -455,6 +519,4 @@ class CommentService:
         Returns:
             True if user can delete, False otherwise
         """
-        return user.is_authenticated and (
-            user == comment.author or user.is_staff
-        )
+        return user.is_authenticated and user == comment.author

--- a/backend/src/board/tests/api/test_comment.py
+++ b/backend/src/board/tests/api/test_comment.py
@@ -68,7 +68,34 @@ class CommentTestCase(TestCase):
     def test_get_post_comment_list(self):
         """포스트 댓글 목록 조회 테스트"""
         response = self.client.get('/v1/posts/test-post/comments')
+        content = json.loads(response.content)
+
         self.assertEqual(response.status_code, 200)
+        comment = content['body']['comments'][0]
+        self.assertFalse(comment['isDeleted'])
+        self.assertEqual(comment['permissions'], {
+            'canEdit': False,
+            'canDelete': False,
+            'canLike': False,
+            'canReply': False,
+        })
+
+    def test_get_post_comment_list_includes_viewer_permissions(self):
+        """로그인 사용자의 댓글 권한 정보를 목록 응답에 포함한다."""
+        self.client.login(username='viewer', password='test')
+
+        response = self.client.get('/v1/posts/test-post/comments')
+        content = json.loads(response.content)
+
+        self.assertEqual(response.status_code, 200)
+        comment = content['body']['comments'][0]
+        self.assertTrue(comment['isMine'])
+        self.assertEqual(comment['permissions'], {
+            'canEdit': True,
+            'canDelete': True,
+            'canLike': False,
+            'canReply': True,
+        })
 
     def test_post_comment_list_hides_comments_when_post_hidden(self):
         """숨김 글의 댓글은 공개 댓글 목록에 노출되지 않는다."""
@@ -113,8 +140,17 @@ class CommentTestCase(TestCase):
             'comment_md': '# New Comment',
         }
         response = self.client.post('/v1/comments?url=test-post', data)
+        content = json.loads(response.content)
+
         self.assertEqual(response.status_code, 200)
         self.assertEqual(Comment.objects.last().text_md, '# New Comment')
+        self.assertFalse(content['body']['isDeleted'])
+        self.assertEqual(content['body']['permissions'], {
+            'canEdit': True,
+            'canDelete': True,
+            'canLike': False,
+            'canReply': True,
+        })
 
     def test_create_comment_requires_csrf_token_when_enforced(self):
         """세션 기반 댓글 생성 API는 CSRF 토큰을 요구한다."""
@@ -431,8 +467,12 @@ class CommentTestCase(TestCase):
         self.client.login(username='author', password='test')
         response = self.client.put(
             f'/v1/comments/{last_comment.id}', "like=like")
+        content = json.loads(response.content)
+
         self.assertEqual(response.status_code, 200)
         self.assertEqual(Comment.objects.last().likes.count(), 1)
+        self.assertTrue(content['body']['isLiked'])
+        self.assertEqual(content['body']['countLikes'], 1)
 
     def test_notify_user_comment_like_when_user_agree_notify(self):
         """댓글 좋아요 시 알림 발송 테스트"""
@@ -476,8 +516,12 @@ class CommentTestCase(TestCase):
 
         response = self.client.put(
             f'/v1/comments/{last_comment.id}', "like=like")
+        content = json.loads(response.content)
+
         self.assertEqual(response.status_code, 200)
         self.assertEqual(Comment.objects.last().likes.count(), 0)
+        self.assertFalse(content['body']['isLiked'])
+        self.assertEqual(content['body']['countLikes'], 0)
 
     def test_user_comment_self_like(self):
         """자신의 댓글에 좋아요 시도 시 실패 테스트"""
@@ -514,6 +558,23 @@ class CommentTestCase(TestCase):
         self.assertEqual(comment.text_md, 'Edited comment')
         self.assertTrue(comment.edited)
 
+    def test_edit_comment_on_hidden_post_returns_404(self):
+        """비공개 글의 댓글은 공개 댓글 수정 API에서 수정할 수 없다."""
+        post = Post.objects.get(url='test-post')
+        post.config.hide = True
+        post.config.save()
+        comment = Comment.objects.last()
+        self.client.login(username='viewer', password='test')
+
+        response = self.client.put(
+            f'/v1/comments/{comment.id}',
+            'comment=comment&comment_md=Edited comment'
+        )
+
+        self.assertEqual(response.status_code, 404)
+        comment.refresh_from_db()
+        self.assertEqual(comment.text_md, 'Comment')
+
     def test_edit_comment_not_author(self):
         """본인이 아닌 댓글 수정 시도 시 실패"""
         comment = Comment.objects.last()
@@ -548,10 +609,33 @@ class CommentTestCase(TestCase):
         self.client.login(username='viewer', password='test')
 
         response = self.client.delete(f'/v1/comments/{comment_id}')
+        content = json.loads(response.content)
+
         self.assertEqual(response.status_code, 200)
 
         comment.refresh_from_db()
         self.assertIsNone(comment.author)  # Soft delete removes author
+        self.assertTrue(content['body']['isDeleted'])
+        self.assertEqual(content['body']['permissions'], {
+            'canEdit': False,
+            'canDelete': False,
+            'canLike': False,
+            'canReply': False,
+        })
+
+    def test_delete_comment_on_hidden_post_returns_404(self):
+        """비공개 글의 댓글은 공개 댓글 삭제 API에서 삭제할 수 없다."""
+        post = Post.objects.get(url='test-post')
+        post.config.hide = True
+        post.config.save()
+        comment = Comment.objects.last()
+        self.client.login(username='viewer', password='test')
+
+        response = self.client.delete(f'/v1/comments/{comment.id}')
+
+        self.assertEqual(response.status_code, 404)
+        comment.refresh_from_db()
+        self.assertIsNotNone(comment.author)
 
     def test_delete_comment_not_author(self):
         """본인이 아닌 댓글 삭제 시도 시 실패"""

--- a/backend/src/board/tests/services/test_comment_list_service.py
+++ b/backend/src/board/tests/services/test_comment_list_service.py
@@ -47,6 +47,39 @@ class CommentListServiceTestCase(TestCase):
         self.assertTrue(comment['is_mine'])
         self.assertEqual(comment['count_likes'], 0)
         self.assertFalse(comment['is_liked'])
+        self.assertFalse(comment['is_deleted'])
+        self.assertEqual(comment['permissions'], {
+            'can_edit': True,
+            'can_delete': True,
+            'can_like': False,
+            'can_reply': True,
+        })
         self.assertEqual(len(comment['replies']), 1)
         self.assertEqual(comment['replies'][0]['parent_id'], self.parent.id)
         self.assertFalse(comment['replies'][0]['is_mine'])
+        self.assertEqual(comment['replies'][0]['permissions'], {
+            'can_edit': False,
+            'can_delete': False,
+            'can_like': True,
+            'can_reply': True,
+        })
+
+    def test_serialize_deleted_comment_marks_deleted_permissions(self):
+        self.parent.author = None
+        self.parent.save(update_fields=['author'])
+
+        payload = CommentListService.serialize_post_comments(
+            self.post.url,
+            self.viewer,
+        )
+
+        comment = payload['comments'][0]
+        self.assertEqual(comment['author'], 'Ghost')
+        self.assertTrue(comment['is_deleted'])
+        self.assertEqual(comment['rendered_content'], '<p>삭제된 댓글입니다.</p>')
+        self.assertEqual(comment['permissions'], {
+            'can_edit': False,
+            'can_delete': False,
+            'can_like': False,
+            'can_reply': False,
+        })

--- a/backend/src/board/views/api/v1/comment.py
+++ b/backend/src/board/views/api/v1/comment.py
@@ -1,23 +1,16 @@
-import re
-
-from django.conf import settings
-from django.contrib.auth.models import User
-from django.db.models import F, Count, Case, When, Exists, OuterRef, Value
+from django.db.models import F
 from django.http import Http404, QueryDict
 from django.shortcuts import get_object_or_404
 
-from board.constants.config_meta import CONFIG_TYPE
 from board.models import Comment, Post
-from board.modules.notify import create_notify
-from board.modules.response import StatusDone, StatusError, ErrorCode
+from board.modules.response import StatusDone, StatusError
 from board.modules.paginator import Paginator
+from board.services.comment_list_service import CommentListService
 from board.services.comment_service import CommentService, CommentValidationError
 from board.services.public_post_service import PublicPostService
-from modules import markdown
 
 
 def comment_list(request):
-    """Create a new comment using CommentService"""
     if request.method == 'POST':
         try:
             post = get_object_or_404(
@@ -29,12 +22,10 @@ def comment_list(request):
             text_md = request.POST.get('comment_md', '')
             parent_id = request.POST.get('parent_id')
 
-            # Get parent comment if parent_id is provided
             parent = None
             if parent_id:
                 parent = get_object_or_404(Comment, id=parent_id)
 
-            # Create comment using service
             comment = CommentService.create_comment(
                 user=request.user,
                 post=post,
@@ -42,17 +33,10 @@ def comment_list(request):
                 parent=parent
             )
 
-            return StatusDone({
-                'id': comment.id,
-                'author': comment.author.username,
-                'author_image': comment.author.profile.get_thumbnail(),
-                'is_edited': comment.edited,
-                'rendered_content': comment.text_html,
-                'created_date': comment.time_since(),
-                'count_likes': 0,
-                'is_liked': False,
-                'parent_id': parent.id if parent else None,
-            })
+            return StatusDone(CommentListService.serialize_created_comment(
+                comment,
+                request.user,
+            ))
 
         except CommentValidationError as e:
             return StatusError(e.code, e.message)
@@ -61,97 +45,55 @@ def comment_list(request):
 
 
 def comment_detail(request, id):
-    comment = get_object_or_404(Comment.objects.select_related(
-        'author',
-        'author__config',
-        'post',
-        'post__config',
-    ).annotate(
-        count_likes=Count('likes', distinct=True),
-        has_liked=Case(
-            When(
-                Exists(
-                    Comment.objects.filter(
-                        id=OuterRef('id'),
-                        likes__id=request.user.id if request.user.id else -1
-                    )
-                ),
-                then=Value(True)
-            ),
-            default=Value(False),
-        )
-    ), id=id)
+    comment = get_object_or_404(
+        CommentService.get_comment_queryset(request.user),
+        id=id,
+    )
 
     if request.method == 'GET':
-        if comment.is_deleted() or not PublicPostService.is_public(comment.post):
-            raise Http404
-        if not request.user.is_authenticated or request.user != comment.author:
-            return StatusError(ErrorCode.AUTHENTICATION)
-
-        return StatusDone({
-            'text_md': comment.text_md,
-        })
+        try:
+            return StatusDone({
+                'text_md': CommentService.get_edit_markdown(request.user, comment),
+            })
+        except CommentValidationError as e:
+            return StatusError(e.code, e.message)
 
     if request.method == 'PUT':
         body = QueryDict(request.body)
 
         if body.get('like'):
-            if not request.user.is_active:
-                return StatusError(ErrorCode.NEED_LOGIN)
-
-            if not PublicPostService.is_public(comment.post):
-                raise Http404
-
-            if request.user == comment.author:
-                return StatusError(ErrorCode.AUTHENTICATION)
-
-            if comment.is_deleted():
-                return StatusError(ErrorCode.REJECT)
-
-            if comment.has_liked:
-                comment.likes.remove(request.user)
+            try:
+                is_liked, count_likes = CommentService.toggle_public_comment_like(
+                    request.user,
+                    comment,
+                )
                 return StatusDone({
-                    'count_likes': comment.count_likes - 1,
+                    'is_liked': is_liked,
+                    'count_likes': count_likes,
                 })
-            else:
-                comment.likes.add(request.user)
-                if comment.author.config.get_meta(CONFIG_TYPE.NOTIFY_COMMENT_LIKE):
-                    send_notify_content = (
-                        f"'{comment.post.title}'글에 작성한 "
-                        f"회원님의 #{comment.pk} 댓글을 "
-                        f"@{request.user.username}님께서 추천했습니다.")
-                    create_notify(
-                        user=comment.author,
-                        url=comment.post.get_absolute_url(),
-                        content=send_notify_content)
-                return StatusDone({
-                    'count_likes': comment.count_likes + 1,
-                })
+            except CommentValidationError as e:
+                return StatusError(e.code, e.message)
 
         if body.get('comment'):
-            if not request.user == comment.author:
-                return StatusError(ErrorCode.AUTHENTICATION)
-
-            text_md = body.get('comment_md')
-            text_html = markdown.parse_comment_to_html(text_md)
-
-            comment.text_md = text_md
-            comment.text_html = text_html
-            comment.edited = True
-            comment.save()
-            return StatusDone()
+            try:
+                CommentService.update_public_comment(
+                    request.user,
+                    comment,
+                    body.get('comment_md', ''),
+                )
+                return StatusDone()
+            except CommentValidationError as e:
+                return StatusError(e.code, e.message)
 
     if request.method == 'DELETE':
-        if not request.user == comment.author:
-            return StatusError(ErrorCode.AUTHENTICATION)
-
-        comment.author = None
-        comment.save()
-        return StatusDone({
-            'author': comment.author_username(),
-            'author_image': None if not comment.author else comment.author.profile.get_thumbnail(),
-            'rendered_content': comment.get_text_html(),
-        })
+        try:
+            CommentService.delete_public_comment(request.user, comment)
+            return StatusDone(CommentListService.serialize_created_comment(
+                comment,
+                request.user,
+            ))
+        except CommentValidationError as e:
+            return StatusError(e.code, e.message)
 
     raise Http404
 


### PR DESCRIPTION
## 🎯 Goal
- Prepare the comment API contract for the upcoming comment UI refactor.
- Move public comment edit/delete/like rules out of the view so the behavior has one service-level owner.

## 🔧 Core Changes
- Added shared comment serialization for list/create/delete responses, including deleted state and viewer permissions.
- Moved public post checks and edit/delete/like permission checks into `CommentService`.
- Tightened API tests around comment permissions, deleted comments, like responses, and hidden-post edit/delete protection.
- Updated the remotes comment API type to accept the richer action response shape.

## 🤔 Key Decisions
- Split this as PR 1 because it changes backend response shape and service ownership without touching the visible comment UI.
- Kept the frontend behavior unchanged for now; the next PR can consume `permissions` and simplify component state separately.

## 🧪 Verification Guide
### How to verify
1. Run `npm run server:test -- board.tests.api.test_comment board.tests.services.test_comment_list_service`.
2. Run `npm run islands:type-check`.
3. Run `npm run islands:lint`.

### Expected result
- Comment API tests pass.
- Island type-check passes.
- Island lint finishes with existing warnings only.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)