### PR TITLE
♻️ Refactor comment UI state handling

### DIFF
--- a/backend/islands/apps/remotes/src/components/remotes/Comments/Comments.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/Comments/Comments.tsx
@@ -1,24 +1,8 @@
-import { useState, useRef, useCallback } from 'react';
-import { useQuery } from '@tanstack/react-query';
-import { AxiosError } from 'axios';
 import { AlertTriangle, MessageCircle, RotateCw } from '@blex/ui/icons';
-import { useConfirm } from '~/hooks/useConfirm';
 import { isLoggedIn as checkIsLoggedIn, showLoginPrompt } from '~/utils/loginPrompt';
-import { toast } from '~/utils/toast';
-import { logger } from '~/utils/logger';
-import {
-    getComments,
-    createComment,
-    getComment,
-    updateComment,
-    deleteComment as deleteCommentAPI,
-    toggleCommentLike,
-    getCommentAuthors
-} from '~/lib/api';
-
 import { CommentList } from './components/CommentList';
 import { CommentForm } from './components/CommentForm';
-import type { Comment } from '~/lib/api/comments';
+import { useCommentsController } from './hooks/useCommentsController';
 
 interface CommentsProps {
     postUrl: string;
@@ -26,244 +10,37 @@ interface CommentsProps {
 
 const Comments = (props: CommentsProps) => {
     const { postUrl } = props;
-    const { confirm } = useConfirm();
-
-    const [commentText, setCommentText] = useState('');
-    const [isSubmitting, setIsSubmitting] = useState(false);
-    const [editingCommentId, setEditingCommentId] = useState<number | null>(null);
-    const [editText, setEditText] = useState('');
-    const [replyingToCommentId, setReplyingToCommentId] = useState<number | null>(null);
-    const [replyText, setReplyText] = useState('');
-    const [replyParentId, setReplyParentId] = useState<number | null>(null);
-
     const isLoggedIn = checkIsLoggedIn();
-    const commentListRef = useRef<HTMLDivElement>(null);
-
-    const scrollToLatestComment = useCallback(() => {
-        setTimeout(() => {
-            if (commentListRef.current) {
-                const comments = commentListRef.current.querySelectorAll('[data-comment-id]');
-                const lastComment = comments[comments.length - 1];
-                lastComment?.scrollIntoView({
-                    behavior: 'smooth',
-                    block: 'center'
-                });
-            }
-        }, 300);
-    }, []);
-
-    const { data, isError, isLoading, refetch } = useQuery({
-        queryKey: [postUrl, 'comments'],
-        queryFn: async () => {
-            const response = await getComments(postUrl);
-            if (response.data.status === 'ERROR') {
-                throw new Error(response.data.errorMessage);
-            }
-            return response.data.body;
-        },
-        enabled: !!postUrl
+    const {
+        comments,
+        mentionableUsers,
+        commentListRef,
+        isError,
+        isLoading,
+        refetch,
+        commentText,
+        setCommentText,
+        isSubmitting,
+        editingCommentId,
+        editText,
+        setEditText,
+        replyingToCommentId,
+        replyText,
+        setReplyText,
+        handleLike,
+        handleWrite,
+        startEditing,
+        cancelEditing,
+        saveEdit,
+        deleteComment,
+        startReplying,
+        cancelReplying,
+        handleReply
+    } = useCommentsController({
+        postUrl,
+        isLoggedIn,
+        onRequireLogin: showLoginPrompt
     });
-
-    const mentionableUsers = data?.comments ? getCommentAuthors(data.comments) : [];
-
-    const getErrorMessage = (error: unknown, fallback: string): string => {
-        if (error instanceof AxiosError && error.response?.data?.errorMessage) {
-            return error.response.data.errorMessage;
-        }
-        return fallback;
-    };
-
-    const findRootParentId = (commentId: number, comments: Comment[]): number => {
-        for (const comment of comments) {
-            if (comment.id === commentId) {
-                return comment.id;
-            }
-            if (comment.replies) {
-                for (const reply of comment.replies) {
-                    if (reply.id === commentId) {
-                        return comment.id;
-                    }
-                }
-            }
-        }
-        return commentId;
-    };
-
-    const handleLike = async (commentId: number) => {
-        if (!isLoggedIn) {
-            showLoginPrompt('좋아요');
-            return;
-        }
-
-        try {
-            const response = await toggleCommentLike(commentId);
-
-            if (response.data.status === 'DONE') {
-                refetch();
-            } else {
-                toast.error(response.data.errorMessage || '좋아요 처리에 실패했습니다.');
-            }
-        } catch (error) {
-            toast.error(getErrorMessage(error, '좋아요 처리 중 오류가 발생했습니다.'));
-        }
-    };
-
-    const handleWrite = async () => {
-        if (!isLoggedIn) {
-            showLoginPrompt('댓글 작성');
-            return;
-        }
-
-        if (!commentText.trim()) {
-            toast.error('댓글 내용을 입력해주세요.');
-            return;
-        }
-
-        setIsSubmitting(true);
-
-        try {
-            const response = await createComment(postUrl, commentText);
-
-            if (response.data.status === 'DONE') {
-                setCommentText('');
-                await refetch();
-                scrollToLatestComment();
-                toast.success('댓글이 작성되었습니다.');
-            } else {
-                toast.error(response.data.errorMessage || '댓글 작성에 실패했습니다.');
-            }
-        } catch (error) {
-            toast.error(getErrorMessage(error, '댓글 작성 중 오류가 발생했습니다.'));
-        } finally {
-            setIsSubmitting(false);
-        }
-    };
-
-    const startEditing = async (commentId: number) => {
-        try {
-            const { data } = await getComment(commentId);
-
-            if (data.status === 'DONE') {
-                setEditingCommentId(commentId);
-                setEditText(data.body.textMd || '');
-            } else {
-                toast.error('댓글 정보를 불러오는데 실패했습니다.');
-            }
-        } catch (err) {
-            logger.error('댓글 수정 오류:', err);
-            toast.error('댓글 정보를 불러오는 중 오류가 발생했습니다.');
-        }
-    };
-
-    const cancelEditing = () => {
-        setEditingCommentId(null);
-        setEditText('');
-    };
-
-    const saveEdit = async (commentId: number) => {
-        if (!editText.trim()) {
-            toast.error('댓글 내용을 입력해주세요.');
-            return;
-        }
-
-        setIsSubmitting(true);
-
-        try {
-            const response = await updateComment(commentId, editText);
-
-            if (response.data.status === 'DONE') {
-                setEditingCommentId(null);
-                setEditText('');
-                refetch();
-                toast.success('댓글이 수정되었습니다.');
-            } else {
-                toast.error(response.data.errorMessage || '댓글 수정에 실패했습니다.');
-            }
-        } catch (error) {
-            toast.error(getErrorMessage(error, '댓글 수정 중 오류가 발생했습니다.'));
-        } finally {
-            setIsSubmitting(false);
-        }
-    };
-
-    const deleteComment = async (commentId: number) => {
-        const confirmed = await confirm({
-            title: '댓글 삭제',
-            message: '이 댓글을 삭제하시겠습니까?',
-            confirmText: '삭제',
-            variant: 'danger'
-        });
-
-        if (!confirmed) return;
-
-        try {
-            const response = await deleteCommentAPI(commentId);
-
-            if (response.data.status === 'DONE') {
-                refetch();
-                toast.success('댓글이 삭제되었습니다.');
-            } else {
-                toast.error(response.data.errorMessage || '댓글 삭제에 실패했습니다.');
-            }
-        } catch (error) {
-            toast.error(getErrorMessage(error, '댓글 삭제 중 오류가 발생했습니다.'));
-        }
-    };
-
-    const startReplying = (commentId: number, authorUsername: string) => {
-        if (!isLoggedIn) {
-            showLoginPrompt('답글 작성');
-            return;
-        }
-        setReplyingToCommentId(commentId);
-        const rootParentId = findRootParentId(commentId, data?.comments ?? []);
-        setReplyParentId(rootParentId);
-        setReplyText(`\`@${authorUsername}\` `);
-    };
-
-    const cancelReplying = () => {
-        setReplyingToCommentId(null);
-        setReplyText('');
-        setReplyParentId(null);
-    };
-
-    const handleReply = async () => {
-        if (!isLoggedIn) {
-            showLoginPrompt('답글 작성');
-            return;
-        }
-
-        if (!replyText.trim()) {
-            toast.error('답글 내용을 입력해주세요.');
-            return;
-        }
-
-        if (!replyParentId) {
-            toast.error('답글을 작성할 댓글을 찾을 수 없습니다.');
-            return;
-        }
-
-        setIsSubmitting(true);
-
-        try {
-            const response = await createComment(postUrl, replyText, replyParentId);
-
-            if (response.data.status === 'DONE') {
-                setReplyText('');
-                setReplyingToCommentId(null);
-                setReplyParentId(null);
-                await refetch();
-                scrollToLatestComment();
-                toast.success('답글이 작성되었습니다.');
-            } else {
-                toast.error(response.data.errorMessage || '답글 작성에 실패했습니다.');
-            }
-        } catch (error) {
-            toast.error(getErrorMessage(error, '답글 작성 중 오류가 발생했습니다.'));
-        } finally {
-            setIsSubmitting(false);
-        }
-    };
 
     if (isError) {
         return (
@@ -302,8 +79,8 @@ const Comments = (props: CommentsProps) => {
         <div className="space-y-8">
             <div ref={commentListRef}>
                 <CommentList
-                    comments={data?.comments ?? []}
-                    currentUser={window.configuration.user?.username}
+                    comments={comments}
+                    isLoggedIn={isLoggedIn}
                     editingCommentId={editingCommentId}
                     editText={editText}
                     isSubmitting={isSubmitting}

--- a/backend/islands/apps/remotes/src/components/remotes/Comments/components/CommentActions.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/Comments/components/CommentActions.tsx
@@ -1,10 +1,13 @@
 import { Reply, ThumbsUp } from '@blex/ui/icons';
+import type { CommentPermissions } from '~/lib/api/comments';
 
 interface CommentActionsProps {
     commentId: number;
     isLiked: boolean;
     countLikes: number;
     isDeleted: boolean;
+    isLoggedIn: boolean;
+    permissions: CommentPermissions;
     onLike: (commentId: number) => void;
     onReply?: () => void;
 }
@@ -14,12 +17,21 @@ export const CommentActions = ({
     isLiked,
     countLikes,
     isDeleted,
+    isLoggedIn,
+    permissions,
     onLike,
     onReply
 }: CommentActionsProps) => {
+    const showLike = !isDeleted && (permissions.canLike || !isLoggedIn);
+    const showReply = !isDeleted && !!onReply && (permissions.canReply || !isLoggedIn);
+
+    if (!showLike && !showReply) {
+        return null;
+    }
+
     return (
         <div className="flex items-center gap-1 mt-4 flex-wrap">
-            {!isDeleted && (
+            {showLike && (
                 <button
                     className={`
                         inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-md
@@ -40,7 +52,7 @@ export const CommentActions = ({
                 </button>
             )}
 
-            {!isDeleted && onReply && (
+            {showReply && (
                 <button
                     className="inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs font-semibold text-content-secondary hover:text-content hover:bg-surface-subtle transition-colors duration-150"
                     onClick={onReply}

--- a/backend/islands/apps/remotes/src/components/remotes/Comments/components/CommentHeader.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/Comments/components/CommentHeader.tsx
@@ -3,42 +3,58 @@ import { Pencil } from '@blex/ui/icons';
 
 interface CommentHeaderProps {
     author: string;
-    authorImage: string;
+    authorImage: string | null;
     createdDate: string;
     isEdited: boolean;
+    isDeleted: boolean;
 }
 
 export const CommentHeader = ({
     author,
     authorImage,
     createdDate,
-    isEdited
+    isEdited,
+    isDeleted
 }: CommentHeaderProps) => {
+    const avatar = authorImage ? (
+        <img
+            src={getStaticPath(authorImage)}
+            alt={`${author}의 프로필 이미지`}
+            className="w-11 h-11 rounded-full object-cover ring-2 ring-line-light group-hover/avatar:ring-line transition-all duration-200"
+        />
+    ) : (
+        <div className="w-11 h-11 rounded-full bg-action flex items-center justify-center text-content-inverted font-semibold text-sm ring-2 ring-line-light group-hover/avatar:ring-line transition-all duration-200">
+            {author.charAt(0).toUpperCase()}
+        </div>
+    );
+
     return (
         <div className="flex items-start gap-4">
-            <a
-                href={`/@${author}`}
-                className="flex-shrink-0 group/avatar transition-transform hover:scale-105 duration-200"
-                aria-label={`${author}의 프로필 보기`}>
-                {authorImage ? (
-                    <img
-                        src={getStaticPath(authorImage)}
-                        alt={`${author}의 프로필 이미지`}
-                        className="w-11 h-11 rounded-full object-cover ring-2 ring-line-light group-hover/avatar:ring-line transition-all duration-200"
-                    />
-                ) : (
-                    <div className="w-11 h-11 rounded-full bg-action flex items-center justify-center text-content-inverted font-semibold text-sm ring-2 ring-line-light group-hover/avatar:ring-line transition-all duration-200">
-                        {author.charAt(0).toUpperCase()}
-                    </div>
-                )}
-            </a>
+            {isDeleted ? (
+                <div className="flex-shrink-0 group/avatar">
+                    {avatar}
+                </div>
+            ) : (
+                <a
+                    href={`/@${author}`}
+                    className="flex-shrink-0 group/avatar transition-transform hover:scale-105 duration-200"
+                    aria-label={`${author}의 프로필 보기`}>
+                    {avatar}
+                </a>
+            )}
             <div className="flex-1 min-w-0 pt-1">
                 <div className="flex items-baseline gap-2 flex-wrap">
-                    <a
-                        href={`/@${author}`}
-                        className="font-semibold text-content hover:text-content text-sm transition-colors duration-150">
-                        {author}
-                    </a>
+                    {isDeleted ? (
+                        <span className="font-semibold text-content text-sm">
+                            {author}
+                        </span>
+                    ) : (
+                        <a
+                            href={`/@${author}`}
+                            className="font-semibold text-content hover:text-content text-sm transition-colors duration-150">
+                            {author}
+                        </a>
+                    )}
                     <time className="text-content-secondary text-xs font-medium" dateTime={createdDate}>
                         {createdDate}
                     </time>

--- a/backend/islands/apps/remotes/src/components/remotes/Comments/components/CommentItem.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/Comments/components/CommentItem.tsx
@@ -5,11 +5,15 @@ import { CommentContent } from './CommentContent';
 import { CommentActions } from './CommentActions';
 import { CommentEditForm } from './CommentEditForm';
 import { CommentForm } from './CommentForm';
-import type { Comment } from '~/lib/api/comments';
+import {
+    isCommentDeleted,
+    resolveCommentPermissions,
+    type Comment
+} from '~/lib/api/comments';
 
 interface CommentItemProps {
     comment: Comment;
-    currentUser: string | undefined;
+    isLoggedIn: boolean;
     editingCommentId: number | null;
     editText: string;
     isSubmitting: boolean;
@@ -30,7 +34,7 @@ interface CommentItemProps {
 
 export const CommentItem = ({
     comment,
-    currentUser,
+    isLoggedIn,
     editingCommentId,
     editText,
     isSubmitting,
@@ -51,13 +55,24 @@ export const CommentItem = ({
     const isEditing = editingCommentId === comment.id;
     const isReplying = replyingToCommentId === comment.id;
     const isReply = !!comment.parentId;
-    const canManage = comment.author !== 'Ghost' && (
-        comment.isMine === true ||
-        (typeof comment.isMine !== 'boolean' && !!currentUser && comment.author === currentUser)
-    );
+    const isDeleted = isCommentDeleted(comment);
+    const permissions = resolveCommentPermissions(comment);
+    const menuItems = [
+        ...(permissions.canEdit ? [{
+            label: '수정',
+            icon: 'fas fa-pen',
+            onClick: () => onEdit(comment.id)
+        }] : []),
+        ...(permissions.canDelete ? [{
+            label: '삭제',
+            icon: 'fas fa-trash',
+            onClick: () => onDelete(comment.id),
+            variant: 'danger' as const
+        }] : [])
+    ];
 
     return (
-        <div className="group" data-comment-id={comment.id}>
+        <div className="group" data-comment-id={comment.id} role={isReply ? undefined : 'listitem'}>
             <article
                 className={`
                     relative
@@ -70,7 +85,7 @@ export const CommentItem = ({
                     }
                 `}
                 aria-label={`${comment.author}의 ${isReply ? '답글' : '댓글'}`}>
-                {canManage && !isEditing && (
+                {menuItems.length > 0 && !isEditing && (
                     <div className="absolute top-4 right-4 z-10" onClick={(e) => e.stopPropagation()}>
                         <Dropdown
                             trigger={(
@@ -81,19 +96,7 @@ export const CommentItem = ({
                                     <i className="fas fa-ellipsis-v text-sm" />
                                 </button>
                             )}
-                            items={[
-                                {
-                                    label: '수정',
-                                    icon: 'fas fa-pen',
-                                    onClick: () => onEdit(comment.id)
-                                },
-                                {
-                                    label: '삭제',
-                                    icon: 'fas fa-trash',
-                                    onClick: () => onDelete(comment.id),
-                                    variant: 'danger'
-                                }
-                            ]}
+                            items={menuItems}
                         />
                     </div>
                 )}
@@ -102,6 +105,7 @@ export const CommentItem = ({
                     authorImage={comment.authorImage}
                     createdDate={comment.createdDate}
                     isEdited={comment.isEdited}
+                    isDeleted={isDeleted}
                 />
 
                 <div className="mt-4 ml-0 sm:ml-14">
@@ -120,7 +124,9 @@ export const CommentItem = ({
                                 commentId={comment.id}
                                 isLiked={comment.isLiked}
                                 countLikes={comment.countLikes}
-                                isDeleted={comment.author === 'Ghost'}
+                                isDeleted={isDeleted}
+                                isLoggedIn={isLoggedIn}
+                                permissions={permissions}
                                 onLike={onLike}
                                 onReply={() => onReply(comment.id, comment.author)}
                             />
@@ -160,7 +166,7 @@ export const CommentItem = ({
                         <CommentItem
                             key={reply.id}
                             comment={reply}
-                            currentUser={currentUser}
+                            isLoggedIn={isLoggedIn}
                             editingCommentId={editingCommentId}
                             editText={editText}
                             isSubmitting={isSubmitting}

--- a/backend/islands/apps/remotes/src/components/remotes/Comments/components/CommentList.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/Comments/components/CommentList.tsx
@@ -4,7 +4,7 @@ import type { Comment } from '~/lib/api/comments';
 
 interface CommentListProps {
     comments: Comment[];
-    currentUser: string | undefined;
+    isLoggedIn: boolean;
     editingCommentId: number | null;
     editText: string;
     isSubmitting: boolean;
@@ -25,7 +25,7 @@ interface CommentListProps {
 
 export const CommentList = ({
     comments,
-    currentUser,
+    isLoggedIn,
     editingCommentId,
     editText,
     isSubmitting,
@@ -53,7 +53,7 @@ export const CommentList = ({
                 <CommentItem
                     key={comment.id}
                     comment={comment}
-                    currentUser={currentUser}
+                    isLoggedIn={isLoggedIn}
                     editingCommentId={editingCommentId}
                     editText={editText}
                     isSubmitting={isSubmitting}

--- a/backend/islands/apps/remotes/src/components/remotes/Comments/hooks/useCommentsController.ts
+++ b/backend/islands/apps/remotes/src/components/remotes/Comments/hooks/useCommentsController.ts
@@ -1,0 +1,332 @@
+import { useRef, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+import { useConfirm } from '~/hooks/useConfirm';
+import {
+    createComment,
+    deleteComment as deleteCommentAPI,
+    getComment,
+    getCommentAuthors,
+    getComments,
+    toggleCommentLike,
+    updateComment,
+    type Comment
+} from '~/lib/api';
+import { toast } from '~/utils/toast';
+import { logger } from '~/utils/logger';
+import {
+    appendCommentToTree,
+    findRootParentId,
+    mergeCommentInTree,
+    updateCommentInTree
+} from '../utils/commentTree';
+
+interface CommentsData {
+    comments: Comment[];
+}
+
+interface UseCommentsControllerOptions {
+    postUrl: string;
+    isLoggedIn: boolean;
+    onRequireLogin: (action: string) => void;
+}
+
+const getCommentsQueryKey = (postUrl: string) => [postUrl, 'comments'] as const;
+
+const getErrorMessage = (error: unknown, fallback: string): string => {
+    if (error instanceof AxiosError && error.response?.data?.errorMessage) {
+        return error.response.data.errorMessage;
+    }
+    return fallback;
+};
+
+export const useCommentsController = ({
+    postUrl,
+    isLoggedIn,
+    onRequireLogin
+}: UseCommentsControllerOptions) => {
+    const { confirm } = useConfirm();
+    const queryClient = useQueryClient();
+    const commentListRef = useRef<HTMLDivElement>(null);
+
+    const [commentText, setCommentText] = useState('');
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [editingCommentId, setEditingCommentId] = useState<number | null>(null);
+    const [editText, setEditText] = useState('');
+    const [replyingToCommentId, setReplyingToCommentId] = useState<number | null>(null);
+    const [replyText, setReplyText] = useState('');
+    const [replyParentId, setReplyParentId] = useState<number | null>(null);
+
+    const queryKey = getCommentsQueryKey(postUrl);
+    const commentsQuery = useQuery({
+        queryKey,
+        queryFn: async () => {
+            const response = await getComments(postUrl);
+            if (response.data.status === 'ERROR') {
+                throw new Error(response.data.errorMessage);
+            }
+            return response.data.body;
+        },
+        enabled: !!postUrl
+    });
+
+    const comments = commentsQuery.data?.comments ?? [];
+    const mentionableUsers = getCommentAuthors(comments);
+
+    const updateComments = (updater: (comments: Comment[]) => Comment[]) => {
+        queryClient.setQueryData<CommentsData>(queryKey, (currentData) => {
+            if (!currentData) {
+                return currentData;
+            }
+
+            return {
+                ...currentData,
+                comments: updater(currentData.comments)
+            };
+        });
+    };
+
+    const scrollToLatestComment = () => {
+        setTimeout(() => {
+            const commentList = commentListRef.current;
+            if (!commentList) return;
+
+            const renderedComments = commentList.querySelectorAll('[data-comment-id]');
+            const lastComment = renderedComments[renderedComments.length - 1];
+            lastComment?.scrollIntoView({
+                behavior: 'smooth',
+                block: 'center'
+            });
+        }, 300);
+    };
+
+    const handleLike = async (commentId: number) => {
+        if (!isLoggedIn) {
+            onRequireLogin('좋아요');
+            return;
+        }
+
+        try {
+            const response = await toggleCommentLike(commentId);
+
+            if (response.data.status === 'DONE') {
+                const likeState = response.data.body;
+                updateComments((currentComments) => updateCommentInTree(
+                    currentComments,
+                    commentId,
+                    (comment) => ({
+                        ...comment,
+                        isLiked: likeState.isLiked,
+                        countLikes: likeState.countLikes
+                    })
+                ));
+                return;
+            }
+
+            toast.error(response.data.errorMessage || '좋아요 처리에 실패했습니다.');
+        } catch (error) {
+            toast.error(getErrorMessage(error, '좋아요 처리 중 오류가 발생했습니다.'));
+        }
+    };
+
+    const handleWrite = async () => {
+        if (!isLoggedIn) {
+            onRequireLogin('댓글 작성');
+            return;
+        }
+
+        if (!commentText.trim()) {
+            toast.error('댓글 내용을 입력해주세요.');
+            return;
+        }
+
+        setIsSubmitting(true);
+
+        try {
+            const response = await createComment(postUrl, commentText);
+
+            if (response.data.status === 'DONE') {
+                const createdComment = response.data.body;
+                setCommentText('');
+                updateComments((currentComments) => appendCommentToTree(
+                    currentComments,
+                    createdComment
+                ));
+                scrollToLatestComment();
+                toast.success('댓글이 작성되었습니다.');
+                return;
+            }
+
+            toast.error(response.data.errorMessage || '댓글 작성에 실패했습니다.');
+        } catch (error) {
+            toast.error(getErrorMessage(error, '댓글 작성 중 오류가 발생했습니다.'));
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    const startEditing = async (commentId: number) => {
+        try {
+            const { data } = await getComment(commentId);
+
+            if (data.status === 'DONE') {
+                setEditingCommentId(commentId);
+                setEditText(data.body.textMd || '');
+                return;
+            }
+
+            toast.error(data.errorMessage || '댓글 정보를 불러오는데 실패했습니다.');
+        } catch (error) {
+            logger.error('댓글 수정 오류:', error);
+            toast.error('댓글 정보를 불러오는 중 오류가 발생했습니다.');
+        }
+    };
+
+    const cancelEditing = () => {
+        setEditingCommentId(null);
+        setEditText('');
+    };
+
+    const saveEdit = async (commentId: number) => {
+        if (!editText.trim()) {
+            toast.error('댓글 내용을 입력해주세요.');
+            return;
+        }
+
+        setIsSubmitting(true);
+
+        try {
+            const response = await updateComment(commentId, editText);
+
+            if (response.data.status === 'DONE') {
+                setEditingCommentId(null);
+                setEditText('');
+                await commentsQuery.refetch();
+                toast.success('댓글이 수정되었습니다.');
+                return;
+            }
+
+            toast.error(response.data.errorMessage || '댓글 수정에 실패했습니다.');
+        } catch (error) {
+            toast.error(getErrorMessage(error, '댓글 수정 중 오류가 발생했습니다.'));
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    const deleteComment = async (commentId: number) => {
+        const confirmed = await confirm({
+            title: '댓글 삭제',
+            message: '이 댓글을 삭제하시겠습니까?',
+            confirmText: '삭제',
+            variant: 'danger'
+        });
+
+        if (!confirmed) return;
+
+        try {
+            const response = await deleteCommentAPI(commentId);
+
+            if (response.data.status === 'DONE') {
+                const deletedComment = response.data.body;
+                updateComments((currentComments) => mergeCommentInTree(
+                    currentComments,
+                    deletedComment
+                ));
+                toast.success('댓글이 삭제되었습니다.');
+                return;
+            }
+
+            toast.error(response.data.errorMessage || '댓글 삭제에 실패했습니다.');
+        } catch (error) {
+            toast.error(getErrorMessage(error, '댓글 삭제 중 오류가 발생했습니다.'));
+        }
+    };
+
+    const startReplying = (commentId: number, authorUsername: string) => {
+        if (!isLoggedIn) {
+            onRequireLogin('답글 작성');
+            return;
+        }
+
+        setReplyingToCommentId(commentId);
+        setReplyParentId(findRootParentId(commentId, comments));
+        setReplyText(`\`@${authorUsername}\` `);
+    };
+
+    const cancelReplying = () => {
+        setReplyingToCommentId(null);
+        setReplyText('');
+        setReplyParentId(null);
+    };
+
+    const handleReply = async () => {
+        if (!isLoggedIn) {
+            onRequireLogin('답글 작성');
+            return;
+        }
+
+        if (!replyText.trim()) {
+            toast.error('답글 내용을 입력해주세요.');
+            return;
+        }
+
+        if (!replyParentId) {
+            toast.error('답글을 작성할 댓글을 찾을 수 없습니다.');
+            return;
+        }
+
+        setIsSubmitting(true);
+
+        try {
+            const response = await createComment(postUrl, replyText, replyParentId);
+
+            if (response.data.status === 'DONE') {
+                const createdReply = response.data.body;
+                setReplyText('');
+                setReplyingToCommentId(null);
+                setReplyParentId(null);
+                updateComments((currentComments) => appendCommentToTree(
+                    currentComments,
+                    createdReply
+                ));
+                scrollToLatestComment();
+                toast.success('답글이 작성되었습니다.');
+                return;
+            }
+
+            toast.error(response.data.errorMessage || '답글 작성에 실패했습니다.');
+        } catch (error) {
+            toast.error(getErrorMessage(error, '답글 작성 중 오류가 발생했습니다.'));
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    return {
+        comments,
+        mentionableUsers,
+        commentListRef,
+        isError: commentsQuery.isError,
+        isLoading: commentsQuery.isLoading,
+        refetch: commentsQuery.refetch,
+        commentText,
+        setCommentText,
+        isSubmitting,
+        editingCommentId,
+        editText,
+        setEditText,
+        replyingToCommentId,
+        replyText,
+        setReplyText,
+        handleLike,
+        handleWrite,
+        startEditing,
+        cancelEditing,
+        saveEdit,
+        deleteComment,
+        startReplying,
+        cancelReplying,
+        handleReply
+    };
+};

--- a/backend/islands/apps/remotes/src/components/remotes/Comments/utils/commentTree.ts
+++ b/backend/islands/apps/remotes/src/components/remotes/Comments/utils/commentTree.ts
@@ -1,0 +1,82 @@
+import type { Comment } from '~/lib/api/comments';
+
+type CommentUpdater = (comment: Comment) => Comment;
+
+export const updateCommentInTree = (
+    comments: Comment[],
+    commentId: number,
+    updater: CommentUpdater
+): Comment[] => {
+    return comments.map((comment) => {
+        if (comment.id === commentId) {
+            return updater(comment);
+        }
+
+        if (!comment.replies?.length) {
+            return comment;
+        }
+
+        return {
+            ...comment,
+            replies: updateCommentInTree(comment.replies, commentId, updater)
+        };
+    });
+};
+
+export const mergeCommentInTree = (
+    comments: Comment[],
+    updatedComment: Comment
+): Comment[] => {
+    return updateCommentInTree(comments, updatedComment.id, (comment) => ({
+        ...comment,
+        ...updatedComment,
+        replies: updatedComment.replies ?? comment.replies
+    }));
+};
+
+export const appendCommentToTree = (
+    comments: Comment[],
+    createdComment: Comment
+): Comment[] => {
+    if (!createdComment.parentId) {
+        return [
+            ...comments,
+            {
+                ...createdComment,
+                replies: createdComment.replies ?? []
+            }
+        ];
+    }
+
+    return updateCommentInTree(comments, createdComment.parentId, (comment) => ({
+        ...comment,
+        replies: [
+            ...(comment.replies ?? []),
+            {
+                ...createdComment,
+                replies: createdComment.replies ?? []
+            }
+        ]
+    }));
+};
+
+export const findRootParentId = (
+    commentId: number,
+    comments: Comment[]
+): number => {
+    for (const comment of comments) {
+        if (comment.id === commentId) {
+            return comment.id;
+        }
+
+        if (!comment.replies?.length) {
+            continue;
+        }
+
+        if (comment.replies.some((reply) => reply.id === commentId)) {
+            return comment.id;
+        }
+    }
+
+    return commentId;
+};

--- a/backend/islands/apps/remotes/src/lib/api/comments.ts
+++ b/backend/islands/apps/remotes/src/lib/api/comments.ts
@@ -3,10 +3,10 @@ import { http, type Response } from '../http.module';
 export interface Comment {
     id: number;
     author: string;
-    authorImage: string;
+    authorImage: string | null;
     createdDate: string;
     renderedContent: string;
-    contentMarkdown: string;
+    contentMarkdown?: string;
     countLikes: number;
     isLiked: boolean;
     isEdited: boolean;
@@ -24,9 +24,32 @@ export interface CommentPermissions {
     canReply: boolean;
 }
 
+export const isCommentDeleted = (comment: Comment) => {
+    return comment.isDeleted ?? comment.author === 'Ghost';
+};
+
+export const resolveCommentPermissions = (comment: Comment): CommentPermissions => {
+    if (comment.permissions) {
+        return comment.permissions;
+    }
+
+    const isDeleted = isCommentDeleted(comment);
+    const canManage = comment.isMine === true && !isDeleted;
+
+    return {
+        canEdit: canManage,
+        canDelete: canManage,
+        canLike: false,
+        canReply: false
+    };
+};
+
 export type CommentsResponse = Response<{ comments: Comment[] }>;
 export type CommentResponse = Response<{ textMd: string }>;
-export type CommentActionResponse = Response<Partial<Comment> & { success?: boolean }>;
+export type CreateCommentResponse = Response<Comment>;
+export type UpdateCommentResponse = Response<Record<string, never>>;
+export type DeleteCommentResponse = Response<Comment>;
+export type ToggleCommentLikeResponse = Response<Pick<Comment, 'isLiked' | 'countLikes'>>;
 
 export const getComments = async (postUrl: string) => {
     return http.get<CommentsResponse>(`v1/posts/${postUrl}/comments`);
@@ -39,7 +62,7 @@ export const createComment = async (postUrl: string, commentMarkdown: string, pa
         formData.append('parent_id', parentId.toString());
     }
 
-    return http.post<CommentActionResponse>(`v1/comments?url=${postUrl}`, formData, { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } });
+    return http.post<CreateCommentResponse>(`v1/comments?url=${postUrl}`, formData, { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } });
 };
 
 export const getComment = async (commentId: number) => {
@@ -51,18 +74,18 @@ export const updateComment = async (commentId: number, commentMarkdown: string) 
     formData.append('comment', 'true');
     formData.append('comment_md', commentMarkdown);
 
-    return http.put<CommentActionResponse>(`v1/comments/${commentId}`, formData, { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } });
+    return http.put<UpdateCommentResponse>(`v1/comments/${commentId}`, formData, { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } });
 };
 
 export const deleteComment = async (commentId: number) => {
-    return http.delete<CommentActionResponse>(`v1/comments/${commentId}`);
+    return http.delete<DeleteCommentResponse>(`v1/comments/${commentId}`);
 };
 
 export const toggleCommentLike = async (commentId: number) => {
     const formData = new URLSearchParams();
     formData.append('like', 'like');
 
-    return http.put<CommentActionResponse>(`v1/comments/${commentId}`, formData, { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } });
+    return http.put<ToggleCommentLikeResponse>(`v1/comments/${commentId}`, formData, { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } });
 };
 
 export const getCommentAuthors = (comments: Comment[]): string[] => {
@@ -70,7 +93,7 @@ export const getCommentAuthors = (comments: Comment[]): string[] => {
 
     const collectAuthors = (commentList: Comment[]) => {
         commentList.forEach(comment => {
-            if (comment.author && comment.author !== 'Ghost') {
+            if (comment.author && !isCommentDeleted(comment)) {
                 authors.add(comment.author);
             }
             if (comment.replies && comment.replies.length > 0) {


### PR DESCRIPTION
## 🎯 Goal
- Continue the comment refactor after the backend contract cleanup.
- Make the comment UI rely on the API-provided deleted state and permissions instead of guessing from usernames or global user state.

## 🔧 Core Changes
- Extracted comment fetching and mutation handling from `Comments.tsx` into `useCommentsController`.
- Added comment tree helpers for updating likes, appending comments/replies, and applying soft-delete responses in React Query cache.
- Updated comment action rendering to use `permissions` and `isDeleted`, while still showing login-prompt actions to anonymous users.
- Tightened comment API response types for create, update, delete, and like responses.
- Stopped linking deleted comment authors to a fake `@Ghost` profile.

## 🤔 Key Decisions
- Kept edit saves as a refetch because the current edit API returns no rendered HTML.
- Used cache updates for create, reply, like, and delete where the API already returns enough data.
- Kept this PR frontend-only so it stays separate from the service-contract PR.

## 🧪 Verification Guide
### How to verify
1. Run `npm run islands:type-check`.
2. Run `npm run islands:lint`.
3. On a post detail page, verify comment create/reply/like/delete still updates the list without a full comment reload.

### Expected result
- Island type-check passes.
- Island lint finishes with existing warnings only.
- Comment actions match the current viewer: owners see edit/delete, non-owners can like/reply, anonymous users get the login prompt.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)
