### PR TITLE
🐛 Fix comment reply permission handling

### DIFF
--- a/backend/islands/apps/remotes/src/components/remotes/Comments/components/CommentActions.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/Comments/components/CommentActions.tsx
@@ -22,16 +22,17 @@ export const CommentActions = ({
     onLike,
     onReply
 }: CommentActionsProps) => {
-    const showLike = !isDeleted && (permissions.canLike || !isLoggedIn);
+    const showLikeAction = !isDeleted && (permissions.canLike || !isLoggedIn);
+    const showLikeCount = !isDeleted && !showLikeAction && countLikes > 0;
     const showReply = !isDeleted && !!onReply && (permissions.canReply || !isLoggedIn);
 
-    if (!showLike && !showReply) {
+    if (!showLikeAction && !showLikeCount && !showReply) {
         return null;
     }
 
     return (
         <div className="flex items-center gap-1 mt-4 flex-wrap">
-            {showLike && (
+            {showLikeAction && (
                 <button
                     className={`
                         inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-md
@@ -50,6 +51,15 @@ export const CommentActions = ({
                     />
                     {countLikes > 0 && <span>{countLikes}</span>}
                 </button>
+            )}
+
+            {showLikeCount && (
+                <span
+                    className="inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs font-semibold text-content-secondary"
+                    aria-label={`좋아요 ${countLikes}개`}>
+                    <ThumbsUp className="w-4 h-4" aria-hidden="true" />
+                    <span>{countLikes}</span>
+                </span>
             )}
 
             {showReply && (

--- a/backend/src/board/services/comment_list_service.py
+++ b/backend/src/board/services/comment_list_service.py
@@ -10,12 +10,22 @@ class CommentListService:
     @staticmethod
     def get_post_parent_comments(post_url: str, user_id: int):
         replies_queryset = CommentListService.annotate_comment_queryset(
-            Comment.objects.select_related('author', 'author__profile'),
+            Comment.objects.select_related(
+                'author',
+                'author__profile',
+                'post',
+                'post__config',
+            ),
             user_id,
         ).order_by('created_date')
 
         return CommentListService.annotate_comment_queryset(
-            Comment.objects.select_related('author', 'author__profile'),
+            Comment.objects.select_related(
+                'author',
+                'author__profile',
+                'post',
+                'post__config',
+            ),
             user_id,
         ).prefetch_related(
             Prefetch('replies', queryset=replies_queryset)
@@ -134,12 +144,13 @@ class CommentListService:
     def serialize_permissions(comment, user_id: int, is_authenticated: bool) -> dict:
         is_mine = is_authenticated and comment.author_id == user_id
         is_deleted = comment.is_deleted()
+        can_post_accept_replies = not comment.post.config.block_comment
 
         return {
             'can_edit': is_mine and not is_deleted,
             'can_delete': is_mine and not is_deleted,
             'can_like': is_authenticated and not is_mine and not is_deleted,
-            'can_reply': is_authenticated and not is_deleted,
+            'can_reply': is_authenticated and not is_deleted and can_post_accept_replies,
         }
 
     @staticmethod

--- a/backend/src/board/services/comment_service.py
+++ b/backend/src/board/services/comment_service.py
@@ -117,6 +117,14 @@ class CommentService:
             )
 
     @staticmethod
+    def validate_parent_allows_reply(parent: Optional[Comment]) -> None:
+        if parent and parent.is_deleted():
+            raise CommentValidationError(
+                ErrorCode.REJECT,
+                '삭제된 댓글에는 답글을 달 수 없습니다.'
+            )
+
+    @staticmethod
     def validate_user_can_edit(user: User, comment: Comment) -> None:
         """
         Validate if user can edit the comment.
@@ -375,6 +383,7 @@ class CommentService:
         CommentService.validate_user_can_comment(user)
         CommentService.validate_post_allows_public_comment(post)
         CommentService.validate_parent_belongs_to_post(parent, post)
+        CommentService.validate_parent_allows_reply(parent)
 
         # 1레벨 제한: 대댓글의 대댓글 방지
         if parent and parent.parent:

--- a/backend/src/board/tests/api/test_comment.py
+++ b/backend/src/board/tests/api/test_comment.py
@@ -280,6 +280,24 @@ class CommentTestCase(TestCase):
         self.assertEqual(reply.parent_id, parent_comment.id)
         self.assertEqual(reply.text_md, 'Reply to comment')
 
+    def test_create_reply_to_deleted_comment_returns_error(self):
+        """삭제된 댓글에는 대댓글을 생성할 수 없다."""
+        parent_comment = Comment.objects.last()
+        parent_comment.author = None
+        parent_comment.save(update_fields=['author'])
+        initial_count = Comment.objects.count()
+
+        self.client.login(username='author', password='test')
+        response = self.client.post('/v1/comments?url=test-post', {
+            'comment_md': 'Reply to deleted comment',
+            'parent_id': parent_comment.id,
+        })
+
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'ERROR')
+        self.assertIn('삭제된 댓글에는 답글을 달 수 없습니다', content['errorMessage'])
+        self.assertEqual(Comment.objects.count(), initial_count)
+
     def test_prevent_deeply_nested_comments(self):
         """대댓글의 대댓글 방지 테스트"""
         parent_comment = Comment.objects.last()

--- a/backend/src/board/tests/services/test_comment_list_service.py
+++ b/backend/src/board/tests/services/test_comment_list_service.py
@@ -83,3 +83,20 @@ class CommentListServiceTestCase(TestCase):
             'can_like': False,
             'can_reply': False,
         })
+
+    def test_serialize_blocked_post_comment_marks_reply_permission_false(self):
+        self.post.config.block_comment = True
+        self.post.config.save(update_fields=['block_comment'])
+
+        payload = CommentListService.serialize_post_comments(
+            self.post.url,
+            self.viewer,
+        )
+
+        comment = payload['comments'][0]
+        self.assertEqual(comment['permissions'], {
+            'can_edit': True,
+            'can_delete': True,
+            'can_like': False,
+            'can_reply': False,
+        })


### PR DESCRIPTION
## 🎯 Goal
- Fix regressions found by team-agent review after the comment service/UI refactor.
- Keep comment action visibility aligned with the server-side comment creation rules.

## 🔧 Core Changes
- Prevent replies to soft-deleted comments in `CommentService`.
- Mark `permissions.canReply` as false when the post has comments blocked.
- Keep rendering like counts for users who cannot press the like action, such as the comment author.
- Added backend tests for deleted-parent replies and blocked-post reply permissions.

## 🤔 Key Decisions
- Kept the fix scoped to permission consistency rather than changing the broader comment UI shape again.
- Left anonymous users seeing action buttons so existing login-prompt behavior stays intact.

## 🧪 Verification Guide
### How to verify
1. Run `npm run server:test -- board.tests.api.test_comment board.tests.services.test_comment_list_service`.
2. Run `npm run islands:type-check`.
3. Run `npm run islands:lint`.

### Expected result
- Comment tests pass with the added deleted-parent and blocked-post permission cases.
- Island type-check passes.
- Island lint finishes with existing warnings only.
- A comment author can still see the like count on their own comment.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)
