### PR TITLE
✨ Add profile image cropping and cover layout polish

### DIFF
--- a/backend/islands/apps/remotes/package.json
+++ b/backend/islands/apps/remotes/package.json
@@ -32,6 +32,7 @@
         "driver.js": "^1.4.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-easy-crop": "^5.5.7",
         "react-hook-form": "^7.71.2",
         "styled-jsx": "^5.1.7",
         "zod": "^4.3.6"

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/ProfileSetting/ProfileSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/ProfileSetting/ProfileSetting.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import type { ChangeEvent } from 'react';
 import { toast } from '~/utils/toast';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
@@ -6,7 +7,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useConfirm } from '~/hooks/useConfirm';
 import { SettingsHeader } from '../../components';
-import { Button, Input, Card } from '~/components/shared';
+import { Button, Input, Card, ImageCropDialog } from '~/components/shared';
 import {
     deleteCover,
     getProfileSettings,
@@ -22,11 +23,33 @@ const profileSchema = z.object({
 });
 
 type ProfileFormInputs = z.infer<typeof profileSchema>;
+type ImageCropTarget = 'avatar' | 'cover';
+
+interface ImageCropState {
+    target: ImageCropTarget;
+    file: File;
+}
+
+const IMAGE_CROP_CONFIG = {
+    avatar: {
+        title: '프로필 이미지 자르기',
+        aspectRatio: 1,
+        outputWidth: 400,
+        outputHeight: 400
+    },
+    cover: {
+        title: '커버 이미지 자르기',
+        aspectRatio: 3,
+        outputWidth: 1500,
+        outputHeight: 500
+    }
+} as const;
 
 const ProfileSetting = () => {
     const [avatar, setAvatar] = useState('/resources/staticfiles/images/default-avatar.jpg');
     const [cover, setCover] = useState<string | null>(null);
     const [isLoading, setIsLoading] = useState(false);
+    const [imageCropState, setImageCropState] = useState<ImageCropState | null>(null);
     const { confirm } = useConfirm();
 
     const { register, handleSubmit, reset, formState: { errors } } = useForm<ProfileFormInputs>({ resolver: zodResolver(profileSchema) });
@@ -75,67 +98,68 @@ const ProfileSetting = () => {
         }
     };
 
-    const handleAvatarChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
-        const file = e.target.files?.[0];
+    const handleAvatarChange = (event: ChangeEvent<HTMLInputElement>) => {
+        const file = event.target.files?.[0];
         if (!file) return;
 
-        const confirmed = await confirm({
-            title: '프로필 이미지 변경',
-            message: '프로필 이미지를 변경하시겠습니까?',
-            confirmText: '변경'
+        setImageCropState({
+            target: 'avatar',
+            file
         });
-
-        if (!confirmed) {
-            e.target.value = '';
-            return;
-        }
-
-        try {
-            const { data } = await uploadAvatar(file);
-
-            if (data.status === 'DONE') {
-                setAvatar(data.body.url);
-                toast.success('프로필 이미지가 업데이트 되었습니다.');
-                refetch();
-            } else {
-                toast.error('프로필 이미지 업데이트에 실패했습니다.');
-            }
-        } catch {
-            toast.error('프로필 이미지 업데이트에 실패했습니다.');
-        } finally {
-            e.target.value = '';
-        }
+        event.target.value = '';
     };
 
-    const handleCoverChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
-        const file = e.target.files?.[0];
+    const handleCoverChange = (event: ChangeEvent<HTMLInputElement>) => {
+        const file = event.target.files?.[0];
         if (!file) return;
 
-        const confirmed = await confirm({
-            title: '커버 이미지 변경',
-            message: '커버 이미지를 변경하시겠습니까?',
-            confirmText: '변경'
+        setImageCropState({
+            target: 'cover',
+            file
         });
+        event.target.value = '';
+    };
 
-        if (!confirmed) {
-            e.target.value = '';
-            return;
+    const handleImageCropComplete = async (croppedFile: File) => {
+        const target = imageCropState?.target;
+        if (!target) {
+            throw new Error('Image crop target is not set.');
         }
 
-        try {
-            const { data } = await uploadCover(file);
+        const isAvatarTarget = target === 'avatar';
+        const successMessage = isAvatarTarget
+            ? '프로필 이미지가 업데이트 되었습니다.'
+            : '커버 이미지가 업데이트 되었습니다.';
+        const errorMessage = isAvatarTarget
+            ? '프로필 이미지 업데이트에 실패했습니다.'
+            : '커버 이미지 업데이트에 실패했습니다.';
 
-            if (data.status === 'DONE') {
-                setCover(data.body.url);
-                toast.success('커버 이미지가 업데이트 되었습니다.');
-                refetch();
+        try {
+            if (isAvatarTarget) {
+                const { data } = await uploadAvatar(croppedFile);
+                if (data.status === 'DONE') {
+                    setAvatar(data.body.url);
+                    toast.success(successMessage);
+                    refetch();
+                    return;
+                }
             } else {
-                toast.error('커버 이미지 업데이트에 실패했습니다.');
+                const { data } = await uploadCover(croppedFile);
+                if (data.status === 'DONE') {
+                    setCover(data.body.url);
+                    toast.success(successMessage);
+                    refetch();
+                    return;
+                }
             }
-        } catch {
-            toast.error('커버 이미지 업데이트에 실패했습니다.');
-        } finally {
-            e.target.value = '';
+
+            toast.error(errorMessage);
+            throw new Error(errorMessage);
+        } catch (error) {
+            if (!(error instanceof Error && error.message === errorMessage)) {
+                toast.error(errorMessage);
+            }
+            throw error;
         }
     };
 
@@ -165,6 +189,10 @@ const ProfileSetting = () => {
             toast.error('커버 이미지 삭제에 실패했습니다.');
         }
     };
+
+    const imageCropConfig = imageCropState
+        ? IMAGE_CROP_CONFIG[imageCropState.target]
+        : null;
 
     return (
         <div>
@@ -211,7 +239,7 @@ const ProfileSetting = () => {
                     <div className="space-y-4">
                         {cover ? (
                             <div className="relative group">
-                                <div className="aspect-[21/9] w-full rounded-2xl overflow-hidden ring-1 ring-line/5">
+                                <div className="aspect-[3/1] w-full rounded-2xl overflow-hidden ring-1 ring-line/5">
                                     <img
                                         src={cover}
                                         alt="커버 이미지"
@@ -235,7 +263,7 @@ const ProfileSetting = () => {
                             </div>
                         ) : (
                             <label htmlFor="cover-input-empty" className="block">
-                                <div className="aspect-[21/9] w-full rounded-2xl border-2 border-dashed border-line hover:border-line hover:bg-surface-subtle transition-all duration-200 cursor-pointer flex flex-col items-center justify-center gap-3 group">
+                                <div className="aspect-[3/1] w-full rounded-2xl border-2 border-dashed border-line hover:border-line hover:bg-surface-subtle transition-all duration-200 cursor-pointer flex flex-col items-center justify-center gap-3 group">
                                     <svg className="w-12 h-12 text-content-hint group-hover:text-content-hint transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
                                     </svg>
@@ -268,7 +296,7 @@ const ProfileSetting = () => {
                         )}
                         <div>
                             <p className="text-sm text-content-secondary mb-1">프로필 페이지 상단에 표시되는 배너 이미지입니다.</p>
-                            <p className="text-xs text-content-hint">권장 크기: 1200x514px (21:9 비율), 최대 5MB</p>
+                            <p className="text-xs text-content-hint">권장 크기: 1500x500px (3:1 비율), 최대 5MB</p>
                         </div>
                     </div>
                 </Card>
@@ -321,6 +349,19 @@ const ProfileSetting = () => {
                     {isLoading ? '저장 중...' : '프로필 저장'}
                 </Button>
             </form>
+
+            {imageCropConfig && (
+                <ImageCropDialog
+                    isOpen={Boolean(imageCropState)}
+                    file={imageCropState?.file ?? null}
+                    title={imageCropConfig.title}
+                    aspectRatio={imageCropConfig.aspectRatio}
+                    outputWidth={imageCropConfig.outputWidth}
+                    outputHeight={imageCropConfig.outputHeight}
+                    onClose={() => setImageCropState(null)}
+                    onComplete={handleImageCropComplete}
+                />
+            )}
         </div>
     );
 };

--- a/backend/islands/apps/remotes/src/components/shared/ImageCropDialog.tsx
+++ b/backend/islands/apps/remotes/src/components/shared/ImageCropDialog.tsx
@@ -1,0 +1,243 @@
+import { useEffect, useState } from 'react';
+import type { ChangeEvent } from 'react';
+import Cropper from 'react-easy-crop';
+import type { Area, Point } from 'react-easy-crop';
+import { Modal } from '@blex/ui/modal';
+import { cx } from '~/lib/classnames';
+
+interface ImageCropDialogProps {
+    isOpen: boolean;
+    file: File | null;
+    title: string;
+    aspectRatio: number;
+    outputWidth: number;
+    outputHeight: number;
+    onClose: () => void;
+    onComplete: (file: File) => void | Promise<void>;
+}
+
+const MAX_ZOOM = 3;
+const MIN_ZOOM = 1;
+const JPEG_QUALITY = 0.92;
+
+const extensionByType: Record<string, string> = {
+    'image/jpeg': 'jpg',
+    'image/png': 'png',
+    'image/webp': 'webp'
+};
+
+const getOutputType = (fileType: string) => {
+    if (['image/jpeg', 'image/png', 'image/webp'].includes(fileType)) {
+        return fileType;
+    }
+    return 'image/jpeg';
+};
+
+const getCroppedFileName = (name: string, outputType: string) => {
+    const baseName = name.replace(/\.[^.]+$/, '') || 'image';
+    const extension = extensionByType[outputType] ?? 'jpg';
+    return `${baseName}-cropped.${extension}`;
+};
+
+const createImage = async (sourceUrl: string) => new Promise<HTMLImageElement>((resolve, reject) => {
+    const image = new Image();
+    image.onload = () => resolve(image);
+    image.onerror = () => reject(new Error('Failed to load image.'));
+    image.src = sourceUrl;
+});
+
+const createCroppedFile = async ({
+    sourceUrl,
+    cropArea,
+    file,
+    outputWidth,
+    outputHeight
+}: {
+    sourceUrl: string;
+    cropArea: Area;
+    file: File;
+    outputWidth: number;
+    outputHeight: number;
+}) => {
+    const image = await createImage(sourceUrl);
+    const canvas = document.createElement('canvas');
+    const context = canvas.getContext('2d');
+
+    if (!context) {
+        throw new Error('Canvas context is not available.');
+    }
+
+    canvas.width = outputWidth;
+    canvas.height = outputHeight;
+    context.drawImage(
+        image,
+        cropArea.x,
+        cropArea.y,
+        cropArea.width,
+        cropArea.height,
+        0,
+        0,
+        outputWidth,
+        outputHeight
+    );
+
+    const outputType = getOutputType(file.type);
+    const blob = await new Promise<Blob>((resolve, reject) => {
+        canvas.toBlob((nextBlob) => {
+            if (nextBlob) {
+                resolve(nextBlob);
+                return;
+            }
+            reject(new Error('Failed to create cropped image.'));
+        }, outputType, JPEG_QUALITY);
+    });
+
+    return new File([blob], getCroppedFileName(file.name, outputType), {
+        type: outputType,
+        lastModified: Date.now()
+    });
+};
+
+export const ImageCropDialog = ({
+    isOpen,
+    file,
+    title,
+    aspectRatio,
+    outputWidth,
+    outputHeight,
+    onClose,
+    onComplete
+}: ImageCropDialogProps) => {
+    const [sourceUrl, setSourceUrl] = useState<string | null>(null);
+    const [crop, setCrop] = useState<Point>({
+        x: 0,
+        y: 0
+    });
+    const [zoom, setZoom] = useState(MIN_ZOOM);
+    const [cropArea, setCropArea] = useState<Area | null>(null);
+    const [isProcessing, setIsProcessing] = useState(false);
+    const [errorMessage, setErrorMessage] = useState('');
+
+    useEffect(() => {
+        if (!isOpen || !file) {
+            setSourceUrl(null);
+            return undefined;
+        }
+
+        const nextSourceUrl = URL.createObjectURL(file);
+        setSourceUrl(nextSourceUrl);
+        setCrop({
+            x: 0,
+            y: 0
+        });
+        setZoom(MIN_ZOOM);
+        setCropArea(null);
+        setErrorMessage('');
+
+        return () => URL.revokeObjectURL(nextSourceUrl);
+    }, [file, isOpen]);
+
+    const handleZoomChange = (event: ChangeEvent<HTMLInputElement>) => {
+        setZoom(Number(event.target.value));
+    };
+
+    const handleApply = async () => {
+        if (!file || !sourceUrl || !cropArea) return;
+
+        setIsProcessing(true);
+        setErrorMessage('');
+
+        try {
+            const croppedFile = await createCroppedFile({
+                sourceUrl,
+                cropArea,
+                file,
+                outputWidth,
+                outputHeight
+            });
+            await onComplete(croppedFile);
+            onClose();
+        } catch {
+            setErrorMessage('이미지를 적용하지 못했습니다.');
+        } finally {
+            setIsProcessing(false);
+        }
+    };
+
+    const handleClose = () => {
+        if (!isProcessing) {
+            onClose();
+        }
+    };
+
+    return (
+        <Modal
+            isOpen={isOpen}
+            onClose={handleClose}
+            title={title}
+            maxWidth="3xl">
+            <Modal.Body className="space-y-5">
+                <div
+                    className={cx(
+                        'relative mx-auto w-full overflow-hidden bg-line-light ring-1 ring-line',
+                        'max-w-2xl rounded-2xl'
+                    )}
+                    style={{ aspectRatio }}>
+                    {sourceUrl && (
+                        <Cropper
+                            image={sourceUrl}
+                            crop={crop}
+                            zoom={zoom}
+                            minZoom={MIN_ZOOM}
+                            maxZoom={MAX_ZOOM}
+                            aspect={aspectRatio}
+                            cropShape="rect"
+                            showGrid
+                            onCropChange={setCrop}
+                            onCropComplete={(_, croppedAreaPixels) => setCropArea(croppedAreaPixels)}
+                            onZoomChange={setZoom}
+                            classes={{ cropAreaClassName: 'ring-content-inverted/80' }}
+                        />
+                    )}
+                </div>
+
+                <div className="space-y-2">
+                    <div className="flex items-center justify-between gap-3 text-sm font-semibold text-content-secondary">
+                        <label htmlFor="image-crop-zoom">확대</label>
+                        <span>{Math.round(zoom * 100)}%</span>
+                    </div>
+                    <input
+                        id="image-crop-zoom"
+                        type="range"
+                        min={MIN_ZOOM}
+                        max={MAX_ZOOM}
+                        step={0.01}
+                        value={zoom}
+                        onChange={handleZoomChange}
+                        disabled={isProcessing}
+                        className="w-full accent-action"
+                    />
+                </div>
+
+                {errorMessage && (
+                    <p className="text-sm font-medium text-danger">{errorMessage}</p>
+                )}
+            </Modal.Body>
+
+            <Modal.Footer>
+                <Modal.FooterAction
+                    variant="secondary"
+                    onClick={handleClose}
+                    disabled={isProcessing}>
+                    취소
+                </Modal.FooterAction>
+                <Modal.FooterAction
+                    onClick={handleApply}
+                    isLoading={isProcessing}
+                    disabled={!sourceUrl || !cropArea}>
+                    적용
+                </Modal.FooterAction>
+            </Modal.Footer>
+        </Modal>
+    );
+};

--- a/backend/islands/apps/remotes/src/components/shared/index.ts
+++ b/backend/islands/apps/remotes/src/components/shared/index.ts
@@ -7,6 +7,7 @@ export { Input } from '@blex/ui/input';
 export { LoadingState } from '@blex/ui/loading-state';
 export { Modal } from '@blex/ui/modal';
 export { Select } from '@blex/ui/select';
+export { ImageCropDialog } from './ImageCropDialog';
 
 export {
     DIM_OVERLAY_DEFAULT,

--- a/backend/islands/apps/remotes/styles/tailwind.css
+++ b/backend/islands/apps/remotes/styles/tailwind.css
@@ -69,6 +69,11 @@
         min-width: 0;
     }
 
+    .post-cover-overlay-copy {
+        width: 100%;
+        min-width: 0;
+    }
+
     .post-detail-sidebar {
         display: none;
         width: 16rem;
@@ -82,6 +87,10 @@
 
         .post-detail-sidebar {
             display: block;
+        }
+
+        .post-cover-overlay-copy {
+            grid-column: 2;
         }
     }
 

--- a/backend/islands/pnpm-lock.yaml
+++ b/backend/islands/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       react-dom:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
+      react-easy-crop:
+        specifier: ^5.5.7
+        version: 5.5.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react-hook-form:
         specifier: ^7.71.2
         version: 7.71.2(react@19.2.4)
@@ -2936,6 +2939,9 @@ packages:
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
+  normalize-wheel@1.0.1:
+    resolution: {integrity: sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -3158,6 +3164,12 @@ packages:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
       react: ^19.2.4
+
+  react-easy-crop@5.5.7:
+    resolution: {integrity: sha512-kYo4NtMeXFQB7h1U+h5yhUkE46WQbQdq7if54uDlbMdZHdRgNehfvaFrXnFw5NR1PNoUOJIfTwLnWmEx/MaZnA==}
+    peerDependencies:
+      react: '>=16.4.0'
+      react-dom: '>=16.4.0'
 
   react-grab@0.1.34:
     resolution: {integrity: sha512-jtdOdv0kb90oqL+pMszSh9DOLgVRaX4ZE6XN4GkDEpNNUqveQfZT014+EeJraljpqQfuWKW+96NrrRqUD93D2g==}
@@ -6286,6 +6298,8 @@ snapshots:
 
   node-releases@2.0.27: {}
 
+  normalize-wheel@1.0.1: {}
+
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
@@ -6551,6 +6565,13 @@ snapshots:
     dependencies:
       react: 19.2.4
       scheduler: 0.27.0
+
+  react-easy-crop@5.5.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      normalize-wheel: 1.0.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      tslib: 2.8.1
 
   react-grab@0.1.34(react@19.2.4):
     dependencies:

--- a/backend/src/board/templates/board/author/components/author_header.html
+++ b/backend/src/board/templates/board/author/components/author_header.html
@@ -4,21 +4,23 @@
 
 <div class="relative overflow-hidden pb-12 sm:pb-16">
     {% if author.profile.cover %}
-    <div class="relative h-44 w-full overflow-hidden sm:h-56 md:h-64">
-        <img
-            src="{{ author.profile.cover.url }}"
-            alt="{{ author.username }} cover"
-            class="h-full w-full object-cover object-center"
-        />
-        <div class="absolute inset-0 bg-surface-page/5"></div>
-        <div class="absolute inset-x-0 bottom-0 h-14 bg-gradient-to-b from-transparent to-surface-page/35 sm:h-16 md:h-20"></div>
-        {% if request.user == author %}
-        <a href="/settings/profile"
-           class="absolute right-4 top-4 inline-flex items-center gap-2 rounded-full border border-white/30 bg-black/25 px-3 py-1.5 text-xs font-semibold text-white/90 backdrop-blur-sm transition-colors duration-150 hover:border-white/50 hover:bg-black/35 hover:text-white">
-            <i class="fas fa-camera text-[11px]"></i>
-            <span>커버 변경</span>
-        </a>
-        {% endif %}
+    <div class="mx-auto max-w-4xl px-4 pt-6 sm:px-6 sm:pt-8">
+        <div class="relative aspect-[3/1] w-full overflow-hidden rounded-2xl ring-1 ring-line/60">
+            <img
+                src="{{ author.profile.cover.url }}"
+                alt="{{ author.username }} cover"
+                class="h-full w-full object-cover object-center"
+            />
+            <div class="absolute inset-0 bg-surface-page/5"></div>
+            <div class="absolute inset-x-0 bottom-0 h-14 bg-gradient-to-b from-transparent to-surface-page/35 sm:h-16 md:h-20"></div>
+            {% if request.user == author %}
+            <a href="/settings/profile"
+               class="absolute right-4 top-4 inline-flex items-center gap-2 rounded-full border border-white/30 bg-black/25 px-3 py-1.5 text-xs font-semibold text-white/90 backdrop-blur-sm transition-colors duration-150 hover:border-white/50 hover:bg-black/35 hover:text-white">
+                <i class="fas fa-camera text-[11px]"></i>
+                <span>커버 변경</span>
+            </a>
+            {% endif %}
+        </div>
     </div>
     {% endif %}
 

--- a/backend/src/board/templates/board/posts/covers/overlay.html
+++ b/backend/src/board/templates/board/posts/covers/overlay.html
@@ -1,18 +1,22 @@
-<section class="post-cover-overlay relative isolate flex min-h-[52vh] items-end overflow-hidden">
+<section class="post-cover-overlay relative isolate flex min-h-[clamp(20rem,44vh,32rem)] items-end overflow-hidden">
     <img class="absolute inset-0 -z-10 h-full w-full object-cover" src="{{ post.image.url }}" alt="{{ post.title }}">
     <div class="post-cover-overlay-shade absolute inset-0 -z-10"></div>
-    <div class="post-detail-frame px-4 pb-10 pt-28 md:px-6 sm:pb-14">
-        {% include 'board/posts/covers/_series_badge.html' with cover_inverted=True %}
+    <div class="w-full px-4 pb-10 pt-28 md:px-6 sm:pb-14">
+        <div class="post-detail-layout">
+            <div class="post-cover-overlay-copy">
+                {% include 'board/posts/covers/_series_badge.html' with cover_inverted=True %}
 
-        <h1 class="max-w-4xl text-3xl sm:text-4xl lg:text-4xl font-bold text-white {% if not post.subtitle %}mb-6{% else %}mb-4{% endif %} leading-tight break-words">
-            {{ post.title }}
-        </h1>
-        {% if post.subtitle %}
-        <p class="max-w-3xl text-lg sm:text-xl text-white/85 mb-6 leading-relaxed font-medium">
-            {{ post.subtitle }}
-        </p>
-        {% endif %}
+                <h1 class="text-3xl sm:text-4xl lg:text-4xl font-bold text-white {% if not post.subtitle %}mb-6{% else %}mb-4{% endif %} leading-tight break-words">
+                    {{ post.title }}
+                </h1>
+                {% if post.subtitle %}
+                <p class="text-lg sm:text-xl text-white/85 mb-6 leading-relaxed font-medium">
+                    {{ post.subtitle }}
+                </p>
+                {% endif %}
 
-        {% include 'board/posts/covers/_post_meta.html' with cover_inverted=True cover_meta_border=False %}
+                {% include 'board/posts/covers/_post_meta.html' with cover_inverted=True cover_meta_border=False %}
+            </div>
+        </div>
     </div>
 </section>

--- a/backend/src/board/tests/templates/test_author.py
+++ b/backend/src/board/tests/templates/test_author.py
@@ -270,6 +270,22 @@ class AuthorPostsPageTestCase(TestCase):
         self.assertEqual(owner_response.status_code, 200)
         self.assertContains(owner_response, '/settings/profile')
 
+    def test_author_overview_cover_uses_cropped_card_ratio(self):
+        """프로필 커버는 크롭 결과와 같은 3:1 카드 비율로 노출한다."""
+        profile = Profile.objects.get(user=self.user)
+        profile.cover = 'images/avatar/test/cover.png'
+        profile.save(update_fields=['cover'])
+
+        response = self.client.get(
+            reverse('user_profile', kwargs={'username': self.user.username})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'mx-auto max-w-4xl px-4 pt-6 sm:px-6 sm:pt-8')
+        self.assertContains(response, 'relative aspect-[3/1] w-full overflow-hidden rounded-2xl ring-1 ring-line/60')
+        self.assertContains(response, f'alt="{self.user.username} cover"')
+        self.assertNotContains(response, 'h-44 w-full overflow-hidden sm:h-56 md:h-64')
+
     def test_author_overview_pinned_posts_setting_entrypoint_is_owner_only(self):
         """고정 포스트 설정 진입점은 작성자 본인에게만 노출한다."""
         visitor_response = self.client.get(

--- a/backend/src/board/tests/templates/test_post_detail.py
+++ b/backend/src/board/tests/templates/test_post_detail.py
@@ -344,7 +344,9 @@ class PostDetailViewTestCase(TestCase):
         overlay_end = content.index('</section>', overlay_start)
         overlay_markup = content[overlay_start:overlay_end]
 
-        self.assertIn('post-detail-frame', overlay_markup)
+        self.assertIn('min-h-[clamp(20rem,44vh,32rem)]', overlay_markup)
+        self.assertIn('post-detail-layout', overlay_markup)
+        self.assertIn('post-cover-overlay-copy', overlay_markup)
         self.assertIn('text-white ', overlay_markup)
         self.assertIn('text-white/85', overlay_markup)
         self.assertIn('text-white/80', overlay_markup)


### PR DESCRIPTION
## 🎯 Goal
- Make image-based profile and post cover surfaces feel predictable and visually aligned.
- Let users crop profile avatars and profile covers before upload so the saved image matches the visible profile result.
- Keep the post overlay cover title aligned with the post body width while preserving the intended cover treatment.

## 🔧 Core Changes
- Added a reusable `ImageCropDialog` powered by `react-easy-crop`.
- Applied cropping only to profile avatar and profile cover uploads.
- Changed profile covers to render as a contained 3:1 image card, matching the crop output ratio.
- Polished overlay post cover title layout so the title content aligns with the post detail body grid.
- Added template coverage for the 3:1 profile cover contract and updated overlay cover expectations.

## 🤔 Key Decisions
- Kept profile cover crop and post overlay cover layout polish in one PR because both changes improve image presentation predictability across public reading/profile surfaces.
- Kept post cover upload/cropping untouched; this PR only changes existing post overlay display layout.
- Rendered profile cover as a contained 3:1 card instead of a full-bleed background so users can trust the crop result.
- Removed the extra crop preview/minimap because the main crop frame is already the saved output contract.

## 🧪 Verification Guide
### How to verify
1. Open profile settings and upload a profile image; confirm the crop dialog uses a square frame and the saved avatar appears round in the profile UI.
2. Upload a profile cover; confirm the crop dialog, settings preview, and public profile cover all use a 3:1 frame.
3. Open a post using the overlay cover style; confirm the title block aligns with the post body width.

### Expected result
- Profile avatar and cover uploads are cropped before upload.
- Profile cover display matches the user-selected 3:1 crop.
- Overlay post title layout is visually aligned with the post detail body.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)

Verification run:
- `npm run server:test -- board.tests.templates.test_author board.tests.templates.test_post_detail`
- `npm run islands:type-check`
- `npm run islands:lint` (passes with existing warnings)
- `npm run islands:build` (passes with existing large chunk warning)
- `git diff --check`
