### PR TITLE
✨ Add full-width media size option

### DIFF
--- a/backend/islands/packages/editor/src/TiptapEditor/components/menus/MediaFloatingMenu.tsx
+++ b/backend/islands/packages/editor/src/TiptapEditor/components/menus/MediaFloatingMenu.tsx
@@ -219,6 +219,7 @@ const MediaFloatingMenu = ({ editor }: MediaFloatingMenuProps) => {
                                         }}
                                         className={fieldClassName}>
                                         <option value="">원본</option>
+                                        <option value="full">본문 폭</option>
                                         <option value="large">크게</option>
                                         <option value="medium">보통</option>
                                         <option value="small">작게</option>

--- a/backend/islands/packages/editor/src/TiptapEditor/components/nodeviews/ImageNodeView.tsx
+++ b/backend/islands/packages/editor/src/TiptapEditor/components/nodeviews/ImageNodeView.tsx
@@ -43,7 +43,11 @@ export const ImageNodeView = ({ node, selected, editor, getPos }: NodeViewProps)
                 data-shadow={shadow ? 'true' : undefined}
                 data-border-radius={borderRadius || undefined}
                 data-size={sizePreset || undefined}>
-                <div style={{ position: 'relative' }}>
+                <div
+                    style={{
+                        position: 'relative',
+                        width: sizePreset === 'full' ? '100%' : undefined
+                    }}>
                     <img
                         src={src}
                         alt={alt || ''}
@@ -53,7 +57,8 @@ export const ImageNodeView = ({ node, selected, editor, getPos }: NodeViewProps)
                             objectFit,
                             aspectRatio,
                             width,
-                            height
+                            height,
+                            sizePreset
                         })}
                         width={width || undefined}
                         height={height || undefined}

--- a/backend/islands/packages/editor/src/TiptapEditor/components/nodeviews/VideoNodeView.tsx
+++ b/backend/islands/packages/editor/src/TiptapEditor/components/nodeviews/VideoNodeView.tsx
@@ -80,7 +80,11 @@ export const VideoNodeView = ({ node, selected, editor, getPos }: NodeViewProps)
                 data-shadow={shadow ? 'true' : undefined}
                 data-border-radius={borderRadius || undefined}
                 data-size={sizePreset || undefined}>
-                <div style={{ position: 'relative' }}>
+                <div
+                    style={{
+                        position: 'relative',
+                        width: sizePreset === 'full' ? '100%' : undefined
+                    }}>
                     <video
                         ref={videoRef}
                         draggable={false}
@@ -88,7 +92,8 @@ export const VideoNodeView = ({ node, selected, editor, getPos }: NodeViewProps)
                             objectFit,
                             aspectRatio,
                             width,
-                            height
+                            height,
+                            sizePreset
                         })}
                         poster={poster || undefined}
                         width={width || undefined}

--- a/backend/islands/packages/editor/src/TiptapEditor/extensions/CustomImage.ts
+++ b/backend/islands/packages/editor/src/TiptapEditor/extensions/CustomImage.ts
@@ -30,7 +30,7 @@ export const CustomImage = Node.create({
             shadow: { default: false },
             aspectRatio: { default: null },
             borderRadius: { default: null },
-            sizePreset: { default: null } // 'small', 'medium', 'large', null(=full)
+            sizePreset: { default: null } // 'small', 'medium', 'large', 'full', null(=natural)
         };
     },
 
@@ -118,7 +118,7 @@ export const CustomImage = Node.create({
         };
 
         if (title) imgAttrs.title = title;
-        if (width) imgAttrs.width = width;
+        if (width && sizePreset !== 'full') imgAttrs.width = width;
         if (height) imgAttrs.height = height;
 
         const imgStyles: string[] = [];
@@ -131,6 +131,12 @@ export const CustomImage = Node.create({
         }
         if (objectFit) {
             imgStyles.push(`object-fit: ${objectFit}`);
+        }
+        if (sizePreset === 'full') {
+            imgStyles.push('width: 100%');
+            if (!height) {
+                imgStyles.push('height: auto');
+            }
         }
         if (imgStyles.length > 0) {
             imgAttrs.style = imgStyles.join('; ');

--- a/backend/islands/packages/editor/src/TiptapEditor/extensions/VideoNode.ts
+++ b/backend/islands/packages/editor/src/TiptapEditor/extensions/VideoNode.ts
@@ -30,7 +30,7 @@ export const VideoNode = Node.create({
             border: { default: false },
             shadow: { default: false },
             borderRadius: { default: null }, // 0, 4, 8, 16, 9999 (px)
-            sizePreset: { default: null }, // 'small', 'medium', 'large', null(=full)
+            sizePreset: { default: null }, // 'small', 'medium', 'large', 'full', null(=natural)
             // 재생 모드: 'gif'(움짤) 또는 'video'(일반 영상)
             playMode: { default: 'gif' },
             autoplay: {
@@ -184,7 +184,7 @@ export const VideoNode = Node.create({
         }
 
         if (poster) videoAttrs.poster = normalizeMediaUrlForStorage(poster);
-        if (width) videoAttrs.width = width;
+        if (width && sizePreset !== 'full') videoAttrs.width = width;
         if (height) videoAttrs.height = height;
 
         // 비디오 스타일
@@ -198,6 +198,12 @@ export const VideoNode = Node.create({
         }
         if (objectFit) {
             videoStyles.push(`object-fit: ${objectFit}`);
+        }
+        if (sizePreset === 'full') {
+            videoStyles.push('width: 100%');
+            if (!height) {
+                videoStyles.push('height: auto');
+            }
         }
         if (videoStyles.length > 0) {
             videoAttrs.style = videoStyles.join('; ');

--- a/backend/islands/packages/editor/src/TiptapEditor/utils/mediaStyles.ts
+++ b/backend/islands/packages/editor/src/TiptapEditor/utils/mediaStyles.ts
@@ -1,8 +1,10 @@
 import type { CSSProperties } from 'react';
 
+export const FULL_WIDTH_SIZE_PRESET = 'full';
+
 /**
  * 사이즈 프리셋 → px 매핑
- * px 기반이라 모바일에서는 컨테이너 폭을 초과하지 않아 자연스럽게 꽉 참
+ * px 기반이라 모바일에서는 컨테이너 폭을 초과하지 않음
  */
 export const SIZE_PRESETS: Record<string, number> = {
     small: 320,
@@ -56,6 +58,11 @@ export function getFigureStyle(attrs: {
         }
     }
 
+    if (attrs.sizePreset === FULL_WIDTH_SIZE_PRESET) {
+        style.width = '100%';
+        style.maxWidth = '100%';
+    }
+
     // 장식 속성 (기존 콘텐츠 호환용)
     if (attrs.border) {
         style.border = MEDIA_BORDER_STYLE;
@@ -80,6 +87,7 @@ export function getMediaStyle(attrs: {
     aspectRatio?: string | null;
     width?: number | null;
     height?: number | null;
+    sizePreset?: string | null;
 }): CSSProperties {
     const style: CSSProperties = {
         display: 'block',
@@ -97,6 +105,12 @@ export function getMediaStyle(attrs: {
     }
     if (attrs.width) style.width = `${attrs.width}px`;
     if (attrs.height) style.height = `${attrs.height}px`;
+    if (attrs.sizePreset === FULL_WIDTH_SIZE_PRESET) {
+        style.width = '100%';
+        if (!attrs.height) {
+            style.height = 'auto';
+        }
+    }
 
     return style;
 }
@@ -134,6 +148,11 @@ export function buildFigureAttrsForHTML(attrs: {
         } else if (attrs.align === 'right') {
             styles.push('margin-left: auto', 'margin-right: 0');
         }
+    }
+
+    if (attrs.sizePreset === FULL_WIDTH_SIZE_PRESET) {
+        styles.push('width: 100%', 'max-width: 100%');
+        result['data-size'] = FULL_WIDTH_SIZE_PRESET;
     }
 
     if (attrs.border) {


### PR DESCRIPTION
## 🎯 Goal
- Let authors force images and videos to fill the post content width when the original media is narrower than the body.
- Close the gap between existing natural/preset sizes and a true body-width media option.

## 🔧 Core Changes
- Added a `본문 폭` media size option in the editor floating media menu.
- Persisted the option as `data-size=\"full\"` in generated post HTML.
- Applied full-width rendering to both image and video node views and saved HTML output.

## 🤔 Key Decisions
- Kept the existing preset model and added one explicit `full` preset instead of changing the behavior of `원본` or `크게`.
- Applied width at both the figure and media element level so editor preview and published content match.

## 🧪 Verification Guide
### How to verify
1. Open the post editor and insert an image or video.
2. Select the media and choose `본문 폭` from the size dropdown.
3. Save or publish and inspect the rendered post body.

### Expected result
- The selected image or video fills the available post content width without changing unrelated size presets.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)