### PR TITLE
♻️ Refactor site content APIs and settings counts

### DIFF
--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/FormsSetting/FormsSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/FormsSetting/FormsSetting.tsx
@@ -151,7 +151,7 @@ const FormsManagement = () => {
     return (
         <div>
             <SettingsHeader
-                title="서식"
+                title={`서식 (${forms.length})`}
                 description="자주 사용하는 서식을 미리 만들어두면, 글을 더 빠르게 작성할 수 있어요."
                 actionPosition="right"
                 action={

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/PostsSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/PostsSetting.tsx
@@ -57,6 +57,7 @@ const syncTabToURL = (tab: PostStatusTab) => {
 
 const PostsSetting = () => {
     const [activeTab, setActiveTab] = useState<PostStatusTab>(getInitialTab);
+    const [postCounts, setPostCounts] = useState<Partial<Record<PostStatusTab, number>>>({});
     const {
         filters,
         tags,
@@ -74,10 +75,23 @@ const PostsSetting = () => {
         syncTabToURL(tab);
     };
 
+    const handleCountChange = (tab: PostStatusTab, count: number) => {
+        setPostCounts(prev => {
+            if (prev[tab] === count) return prev;
+            return {
+                ...prev,
+                [tab]: count
+            };
+        });
+    };
+
+    const activeCount = postCounts[activeTab];
+    const title = activeCount === undefined ? '포스트' : `포스트 (${activeCount})`;
+
     return (
         <div>
             <SettingsHeader
-                title="포스트"
+                title={title}
                 description="발행, 예약, 임시 포스트를 관리하세요."
                 actionPosition="right"
                 action={
@@ -144,6 +158,7 @@ const PostsSetting = () => {
                             filters={filters}
                             series={series}
                             onPageChange={(page) => handleFilterChange('page', page)}
+                            onCountChange={(count) => handleCountChange('published', count)}
                             emptyMessage="발행 포스트가 없습니다."
                         />
                     )}
@@ -152,12 +167,15 @@ const PostsSetting = () => {
                             filters={filters}
                             series={series}
                             onPageChange={(page) => handleFilterChange('page', page)}
+                            onCountChange={(count) => handleCountChange('scheduled', count)}
                             source="scheduled"
                             emptyMessage="예약 포스트가 없습니다."
                         />
                     )}
                     {activeTab === 'drafts' && (
-                        <DraftPostListContent />
+                        <DraftPostListContent
+                            onCountChange={(count) => handleCountChange('drafts', count)}
+                        />
                     )}
                 </div>
             </Suspense>

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/DraftPostListContent.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/DraftPostListContent.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { SettingsEmptyState, SettingsListItem } from '../../../components';
 import { Dropdown, getIconClass, SUBTITLE, TITLE } from '~/components/shared';
@@ -7,7 +8,11 @@ import { deleteDraft } from '~/lib/api/posts';
 import { getMediaPath } from '~/modules/static.module';
 import { toast } from '~/utils/toast';
 
-export const DraftPostListContent = () => {
+interface DraftPostListContentProps {
+    onCountChange?: (count: number) => void;
+}
+
+export const DraftPostListContent = ({ onCountChange }: DraftPostListContentProps) => {
     const { confirm } = useConfirm();
     const { data: draftPosts, refetch } = useSuspenseQuery({
         queryKey: ['draft-posts'],
@@ -19,6 +24,10 @@ export const DraftPostListContent = () => {
             throw new Error('임시 포스트 목록을 불러오는데 실패했습니다.');
         }
     });
+
+    useEffect(() => {
+        onCountChange?.(draftPosts?.length ?? 0);
+    }, [draftPosts?.length, onCountChange]);
 
     const handleDraftDelete = async (url: string) => {
         const confirmed = await confirm({

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/PostListContent.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/PostListContent.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { usePostsQuery, type FilterOptions, type PostsSource } from '../hooks/usePostsData';
 import { usePostsActions } from '../hooks';
 import PostCard from './PostCard';
@@ -8,6 +9,7 @@ interface PostListContentProps {
     filters: FilterOptions;
     series: Series[] | undefined;
     onPageChange: (page: string) => void;
+    onCountChange?: (count: number) => void;
     source?: PostsSource;
     emptyMessage?: string;
 }
@@ -16,6 +18,7 @@ export const PostListContent = ({
     filters,
     series,
     onPageChange,
+    onCountChange,
     source = 'published',
     emptyMessage = '포스트가 없습니다.'
 }: PostListContentProps) => {
@@ -39,6 +42,12 @@ export const PostListContent = ({
         setPosts,
         refetch
     });
+
+    const totalCount = postsData?.totalCount ?? posts.length;
+
+    useEffect(() => {
+        onCountChange?.(totalCount);
+    }, [onCountChange, totalCount]);
 
     if (!postsData) return null;
 

--- a/backend/islands/apps/remotes/src/lib/api/posts.ts
+++ b/backend/islands/apps/remotes/src/lib/api/posts.ts
@@ -23,6 +23,7 @@ interface PostsResponseBody {
     posts: Post[];
     username: string;
     lastPage: number;
+    totalCount: number;
 }
 
 export type PostsResponse = Response<PostsResponseBody>;
@@ -32,8 +33,10 @@ export interface PostsFilters {
     tag?: string;
     series?: string;
     hide?: string;
+    visibility?: string;
     sort?: string;
-    page?: number;
+    order?: string;
+    page?: string | number;
 }
 
 export const getPosts = async (filters: PostsFilters = {}) => {

--- a/backend/islands/apps/remotes/src/lib/api/settings.ts
+++ b/backend/islands/apps/remotes/src/lib/api/settings.ts
@@ -680,7 +680,9 @@ export const deleteBrandAsset = async (assetType: BrandAssetType, theme: BrandAs
 // Utility API
 export interface UtilityStats {
     totalPosts: number;
+    publicPosts: number;
     publishedPosts: number;
+    scheduledPosts: number;
     hiddenPosts: number;
     draftPosts: number;
     totalComments: number;

--- a/backend/src/board/admin/series.py
+++ b/backend/src/board/admin/series.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 from django.utils.html import format_html
 
 from board.models import Series, Post
+from board.services.public_post_service import PublicPostService
 
 from .service import AdminDisplayService, AdminLinkService
 from .constants import (
@@ -144,19 +145,20 @@ class SeriesAdmin(admin.ModelAdmin):
         if not posts:
             return format_html('<p style="color: {};">포스트 없음</p>', COLOR_MUTED)
 
-        visible_posts = obj.posts.filter(config__hide=False).count()
-        hidden_posts = obj.posts.filter(config__hide=True).count()
+        total_posts = posts.count()
+        public_posts = PublicPostService.filter_public_posts(posts).count()
+        non_public_posts = total_posts - public_posts
 
         return format_html(
             '<div style="background: {}; padding: 12px; border-radius: 6px; border: 1px solid {};">'
             '<p style="margin: 4px 0; color: {};"><strong>총 포스트:</strong> {}</p>'
-            '<p style="margin: 4px 0; color: {};"><strong>공개:</strong> <span style="color: {};">{}</span></p>'
-            '<p style="margin: 4px 0; color: {};"><strong>숨김:</strong> <span style="color: {};">{}</span></p>'
+            '<p style="margin: 4px 0; color: {};"><strong>공개 노출:</strong> <span style="color: {};">{}</span></p>'
+            '<p style="margin: 4px 0; color: {};"><strong>비공개 상태:</strong> <span style="color: {};">{}</span></p>'
             '</div>',
             COLOR_DARKENED_BG, COLOR_BORDER,
-            COLOR_TEXT, posts.count(),
-            COLOR_TEXT, COLOR_SUCCESS, visible_posts,
-            COLOR_TEXT, COLOR_DANGER, hidden_posts
+            COLOR_TEXT, total_posts,
+            COLOR_TEXT, COLOR_SUCCESS, public_posts,
+            COLOR_TEXT, COLOR_DANGER, non_public_posts
         )
     posts_summary.short_description = '포스트 요약'
 

--- a/backend/src/board/admin/utilities/database.py
+++ b/backend/src/board/admin/utilities/database.py
@@ -7,6 +7,8 @@ from django.contrib.sessions.models import Session
 from django.utils import timezone
 
 from board.models import Post, Comment, Profile, Series, ImageCache
+from board.services.post_status_service import PostStatusService
+from board.services.public_post_service import PublicPostService
 
 
 class DatabaseStatsService:
@@ -19,9 +21,11 @@ class DatabaseStatsService:
 
         # 포스트 통계
         stats['total_posts'] = Post.objects.count()
-        stats['published_posts'] = Post.objects.filter(config__hide=False).count()
+        stats['public_posts'] = PublicPostService.filter_public_posts(Post.objects).count()
+        stats['published_posts'] = PostStatusService.filter_published(Post.objects).count()
+        stats['scheduled_posts'] = PostStatusService.filter_scheduled(Post.objects).count()
         stats['hidden_posts'] = Post.objects.filter(config__hide=True).count()
-        stats['draft_posts'] = Post.objects.filter(published_date__isnull=True).count()
+        stats['draft_posts'] = PostStatusService.filter_drafts(Post.objects).count()
 
         # 댓글 통계
         stats['total_comments'] = Comment.objects.count()

--- a/backend/src/board/services/api_request_body_service.py
+++ b/backend/src/board/services/api_request_body_service.py
@@ -38,7 +38,13 @@ class ApiRequestBodyService:
             )
 
         try:
-            return ApiRequestBodyService.parse_json(request, default=default), None
+            data = ApiRequestBodyService.parse_json(request, default=default)
+            if not isinstance(data, dict):
+                return None, StatusError(
+                    error_code,
+                    message or ApiRequestBodyService.DEFAULT_INVALID_JSON_MESSAGE,
+                )
+            return data, None
         except (json.JSONDecodeError, UnicodeDecodeError):
             return None, StatusError(
                 error_code,
@@ -54,7 +60,8 @@ class ApiRequestBodyService:
         treated as an empty payload and existing fields remain unchanged.
         """
         try:
-            return ApiRequestBodyService.parse_json(request)
+            data = ApiRequestBodyService.parse_json(request)
+            return data if isinstance(data, dict) else {}
         except (json.JSONDecodeError, UnicodeDecodeError):
             return {}
 
@@ -62,6 +69,16 @@ class ApiRequestBodyService:
     def parse_json_or_querydict(request):
         """Parse JSON, falling back to QueryDict for form-encoded bodies."""
         try:
-            return ApiRequestBodyService.parse_json(request)
+            data = ApiRequestBodyService.parse_json(request)
+            return data if isinstance(data, dict) else QueryDict(request.body)
         except (json.JSONDecodeError, UnicodeDecodeError):
             return QueryDict(request.body)
+
+    @staticmethod
+    def parse_json_or_post(request):
+        """Parse JSON, falling back to request.POST for legacy form endpoints."""
+        try:
+            data = ApiRequestBodyService.parse_json(request)
+            return data if isinstance(data, dict) else request.POST
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return request.POST

--- a/backend/src/board/services/auth_request_parser.py
+++ b/backend/src/board/services/auth_request_parser.py
@@ -1,4 +1,4 @@
-import json
+from board.services.api_request_body_service import ApiRequestBodyService
 
 
 class AuthRequestParser:
@@ -6,7 +6,4 @@ class AuthRequestParser:
 
     @staticmethod
     def parse_login_request(request) -> dict:
-        try:
-            return json.loads(request.body.decode('utf-8')) if request.body else {}
-        except (json.JSONDecodeError, UnicodeDecodeError):
-            return {}
+        return ApiRequestBodyService.parse_json_or_empty_for_legacy_only(request)

--- a/backend/src/board/services/site_content_api_service.py
+++ b/backend/src/board/services/site_content_api_service.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+from django.contrib.auth.models import User
+from django.db.models import QuerySet
+
+from board.html_utils import sanitize_html
+from board.models import (
+    BannerPosition,
+    BannerType,
+    SiteBanner,
+    SiteContentScope,
+    SiteNotice,
+    StaticPage,
+)
+from board.modules.response import ErrorCode
+
+
+class SiteContentApiError(Exception):
+    def __init__(self, code: ErrorCode, message: str):
+        self.code = code
+        self.message = message
+        super().__init__(message)
+
+
+class SiteContentApiService:
+    @staticmethod
+    def scoped_notice_queryset(scope: str, user: User | None = None) -> QuerySet[SiteNotice]:
+        queryset = SiteNotice.objects.filter(scope=scope)
+        if scope == SiteContentScope.USER:
+            queryset = queryset.filter(user=user)
+        return queryset
+
+    @staticmethod
+    def scoped_banner_queryset(scope: str, user: User | None = None) -> QuerySet[SiteBanner]:
+        queryset = SiteBanner.objects.filter(scope=scope)
+        if scope == SiteContentScope.USER:
+            queryset = queryset.filter(user=user)
+        return queryset
+
+    @staticmethod
+    def serialize_notice(notice: SiteNotice) -> dict:
+        return {
+            'id': notice.id,
+            'title': notice.title,
+            'url': notice.url,
+            'is_active': notice.is_active,
+            'created_date': notice.created_date.isoformat(),
+            'updated_date': notice.updated_date.isoformat(),
+        }
+
+    @staticmethod
+    def serialize_banner(banner: SiteBanner, *, include_created_by: bool = False) -> dict:
+        data = {
+            'id': banner.id,
+            'title': banner.title,
+            'content_html': banner.content_html,
+            'banner_type': banner.banner_type,
+            'position': banner.position,
+            'is_active': banner.is_active,
+            'order': banner.order,
+            'created_date': banner.created_date.isoformat(),
+            'updated_date': banner.updated_date.isoformat(),
+        }
+        if include_created_by:
+            data['created_by'] = banner.user.username if banner.user else None
+        return data
+
+    @staticmethod
+    def serialize_static_page(page: StaticPage) -> dict:
+        return {
+            'id': page.id,
+            'title': page.title,
+            'slug': page.slug,
+            'content': page.content,
+            'meta_description': page.meta_description,
+            'is_published': page.is_published,
+            'show_in_footer': page.show_in_footer,
+            'order': page.order,
+            'created_date': page.created_date.isoformat(),
+            'updated_date': page.updated_date.isoformat(),
+        }
+
+    @staticmethod
+    def validate_notice_payload(data: dict) -> None:
+        if not data.get('title', ''):
+            raise SiteContentApiError(ErrorCode.VALIDATE, '공지 제목을 입력해주세요.')
+        if not data.get('url', ''):
+            raise SiteContentApiError(ErrorCode.VALIDATE, 'URL을 입력해주세요.')
+
+    @staticmethod
+    def validate_banner_payload(data: dict) -> None:
+        if not data.get('title', ''):
+            raise SiteContentApiError(ErrorCode.VALIDATE, '배너 이름을 입력해주세요.')
+        if not data.get('content_html', ''):
+            raise SiteContentApiError(ErrorCode.VALIDATE, '배너 내용을 입력해주세요.')
+        SiteContentApiService.validate_banner_position(
+            data.get('banner_type', BannerType.HORIZONTAL),
+            data.get('position', BannerPosition.TOP),
+        )
+
+    @staticmethod
+    def validate_banner_position(banner_type: str, position: str) -> None:
+        if banner_type == BannerType.HORIZONTAL and position not in {
+            BannerPosition.TOP,
+            BannerPosition.BOTTOM,
+        }:
+            raise SiteContentApiError(ErrorCode.VALIDATE, '줄배너는 상단 또는 하단에만 배치할 수 있습니다.')
+
+        if banner_type == BannerType.SIDEBAR and position not in {
+            BannerPosition.LEFT,
+            BannerPosition.RIGHT,
+        }:
+            raise SiteContentApiError(ErrorCode.VALIDATE, '사이드배너는 좌측 또는 우측에만 배치할 수 있습니다.')
+
+    @staticmethod
+    def create_notice(scope: str, user: User | None, data: dict) -> SiteNotice:
+        SiteContentApiService.validate_notice_payload(data)
+        return SiteNotice.objects.create(
+            scope=scope,
+            user=user if scope == SiteContentScope.USER else None,
+            title=data.get('title', ''),
+            url=data.get('url', ''),
+            is_active=data.get('is_active', True),
+        )
+
+    @staticmethod
+    def update_notice(notice: SiteNotice, data: dict) -> SiteNotice:
+        for field in ('title', 'url', 'is_active'):
+            if field in data:
+                setattr(notice, field, data[field])
+        notice.save()
+        return notice
+
+    @staticmethod
+    def create_banner(
+        scope: str,
+        user: User | None,
+        data: dict,
+        *,
+        sanitize_content: bool,
+    ) -> SiteBanner:
+        SiteContentApiService.validate_banner_payload(data)
+        content_html = data.get('content_html', '')
+        if sanitize_content:
+            content_html = sanitize_html(content_html)
+
+        return SiteBanner.objects.create(
+            scope=scope,
+            user=user,
+            title=data.get('title', ''),
+            content_html=content_html,
+            banner_type=data.get('banner_type', BannerType.HORIZONTAL),
+            position=data.get('position', BannerPosition.TOP),
+            is_active=data.get('is_active', True),
+            order=data.get('order', 0),
+        )
+
+    @staticmethod
+    def update_banner(
+        banner: SiteBanner,
+        data: dict,
+        *,
+        sanitize_content: bool,
+    ) -> SiteBanner:
+        if 'title' in data:
+            banner.title = data['title']
+        if 'content_html' in data:
+            content_html = data['content_html']
+            banner.content_html = sanitize_html(content_html) if sanitize_content else content_html
+        if 'banner_type' in data:
+            banner.banner_type = data['banner_type']
+        if 'position' in data:
+            banner.position = data['position']
+        if 'is_active' in data:
+            banner.is_active = data['is_active']
+        if 'order' in data:
+            banner.order = data['order']
+
+        SiteContentApiService.validate_banner_position(banner.banner_type, banner.position)
+        banner.save()
+        return banner
+
+    @staticmethod
+    def update_banner_order(scope: str, user: User | None, order_list: list) -> None:
+        queryset = SiteContentApiService.scoped_banner_queryset(scope, user)
+        for item in order_list:
+            if len(item) != 2:
+                continue
+
+            banner_id, order = item
+            try:
+                banner = queryset.get(id=banner_id)
+            except SiteBanner.DoesNotExist:
+                continue
+
+            banner.order = order
+            banner.save()
+
+    @staticmethod
+    def validate_static_page_payload(data: dict) -> None:
+        if not data.get('title', ''):
+            raise SiteContentApiError(ErrorCode.VALIDATE, '제목을 입력해주세요.')
+        if not data.get('slug', ''):
+            raise SiteContentApiError(ErrorCode.VALIDATE, 'URL 슬러그를 입력해주세요.')
+
+    @staticmethod
+    def create_static_page(user: User, data: dict) -> StaticPage:
+        SiteContentApiService.validate_static_page_payload(data)
+        slug = data.get('slug', '')
+        if StaticPage.objects.filter(slug=slug).exists():
+            raise SiteContentApiError(ErrorCode.ALREADY_EXISTS, '이미 사용 중인 슬러그입니다.')
+
+        return StaticPage.objects.create(
+            title=data.get('title', ''),
+            slug=slug,
+            content=data.get('content', ''),
+            meta_description=data.get('meta_description', ''),
+            is_published=data.get('is_published', True),
+            show_in_footer=data.get('show_in_footer', False),
+            order=data.get('order', 0),
+            author=user,
+        )
+
+    @staticmethod
+    def update_static_page(page: StaticPage, data: dict) -> StaticPage:
+        if 'title' in data:
+            page.title = data['title']
+
+        if 'slug' in data:
+            new_slug = data['slug']
+            if new_slug != page.slug and StaticPage.objects.filter(slug=new_slug).exists():
+                raise SiteContentApiError(ErrorCode.ALREADY_EXISTS, '이미 사용 중인 슬러그입니다.')
+            page.slug = new_slug
+
+        for field in (
+            'content',
+            'meta_description',
+            'is_published',
+            'show_in_footer',
+            'order',
+        ):
+            if field in data:
+                setattr(page, field, data[field])
+
+        page.save()
+        return page

--- a/backend/src/board/tests/api/test_comment.py
+++ b/backend/src/board/tests/api/test_comment.py
@@ -576,6 +576,19 @@ class CommentTestCase(TestCase):
         self.assertEqual(comment.text_md, 'Edited comment')
         self.assertTrue(comment.edited)
 
+    def test_edit_comment_non_object_json_returns_not_found_instead_of_server_error(self):
+        """댓글 수정 API는 JSON 객체가 아닌 body에서도 500을 내지 않는다."""
+        comment = Comment.objects.last()
+        self.client.login(username='viewer', password='test')
+
+        response = self.client.put(
+            f'/v1/comments/{comment.id}',
+            data='[]',
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 404)
+
     def test_edit_comment_on_hidden_post_returns_404(self):
         """비공개 글의 댓글은 공개 댓글 수정 API에서 수정할 수 없다."""
         post = Post.objects.get(url='test-post')

--- a/backend/src/board/tests/api/test_setting.py
+++ b/backend/src/board/tests/api/test_setting.py
@@ -232,6 +232,7 @@ class SettingTestCase(TestCase):
         self.assertEqual(content['status'], 'DONE')
         post_urls = [item['url'] for item in content['body']['posts']]
         self.assertEqual(post_urls, ['scheduled-post'])
+        self.assertEqual(content['body']['totalCount'], 1)
         scheduled_data = content['body']['posts'][0]
         self.assertEqual(scheduled_data['image'], 'images/title/test/scheduled-post.png')
         self.assertEqual(scheduled_data['isHide'], False)
@@ -253,6 +254,39 @@ class SettingTestCase(TestCase):
         self.assertEqual(content['status'], 'DONE')
         self.assertEqual(content['body']['posts'], [])
         self.assertEqual(content['body']['lastPage'], 1)
+        self.assertEqual(content['body']['totalCount'], 0)
+
+    def test_get_setting_posts_returns_filtered_total_count(self):
+        """포스트 설정 목록은 현재 필터 결과의 전체 개수를 내려준다."""
+        user = User.objects.get(username='test')
+        public_post = Post.objects.create(
+            url='public-post',
+            title='Public Post',
+            author=user,
+            published_date=timezone.now(),
+        )
+        PostContent.objects.create(post=public_post, content_html='<p>Public</p>')
+        PostConfig.objects.create(post=public_post, hide=False)
+
+        hidden_post = Post.objects.create(
+            url='hidden-post',
+            title='Hidden Post',
+            author=user,
+            published_date=timezone.now(),
+        )
+        PostContent.objects.create(post=hidden_post, content_html='<p>Hidden</p>')
+        PostConfig.objects.create(post=hidden_post, hide=True)
+        self.client.login(username='test', password='test')
+
+        response = self.client.get('/v1/setting/posts', {
+            'visibility': 'public',
+        })
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'DONE')
+        self.assertEqual(content['body']['totalCount'], 1)
+        self.assertEqual(content['body']['posts'][0]['url'], 'public-post')
 
     def test_get_setting_reserved_posts_orders_by_count_fields(self):
         """예약 포스트 설정 목록은 좋아요/댓글 수 정렬을 지원한다."""

--- a/backend/src/board/tests/api/test_two_factor_auth.py
+++ b/backend/src/board/tests/api/test_two_factor_auth.py
@@ -97,6 +97,38 @@ class TwoFactorAuthTestCase(TestCase):
         user = User.objects.get(username='test2fa')
         self.assertFalse(hasattr(user, 'twofactorauth'))
 
+    def test_enable_2fa_empty_verification_body_returns_invalid_parameter(self):
+        """2FA 설정 완료 요청에서 인증 코드가 없으면 500 대신 API 에러를 반환"""
+        self.client.login(username='test2fa', password='test2fa')
+        self.client.post('/v1/auth/security')
+
+        response = self.client.post(
+            '/v1/auth/security/verify',
+            data='',
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'ERROR')
+        self.assertEqual(content['errorCode'], 'error:IP')
+
+    def test_enable_2fa_non_object_json_body_returns_invalid_parameter(self):
+        """2FA 설정 완료 요청에서 JSON 객체가 아니어도 500이 나지 않는다."""
+        self.client.login(username='test2fa', password='test2fa')
+        self.client.post('/v1/auth/security')
+
+        response = self.client.post(
+            '/v1/auth/security/verify',
+            data='[]',
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'ERROR')
+        self.assertEqual(content['errorCode'], 'error:IP')
+
     def test_enable_2fa_already_enabled(self):
         """이미 2FA가 활성화된 상태에서 재활성화 시도 테스트"""
         user = User.objects.get(username='test2fa')

--- a/backend/src/board/tests/services/test_api_request_body_service.py
+++ b/backend/src/board/tests/services/test_api_request_body_service.py
@@ -30,8 +30,6 @@ class ApiRequestBodyServiceTestCase(TestCase):
         self.assertIsNotNone(error)
         self.assertEqual(error.status_code, 200)
 
-
-
     def test_parse_json_or_error_can_require_body(self):
         from board.modules.response import ErrorCode
 
@@ -63,6 +61,15 @@ class ApiRequestBodyServiceTestCase(TestCase):
         self.assertIsNotNone(error)
         self.assertContains(error, 'error:IP')
 
+    def test_parse_json_or_error_rejects_non_object_json(self):
+        request = self.factory.post('/v1/example', data=b'[]', content_type='application/json')
+
+        data, error = ApiRequestBodyService.parse_json_or_error(request)
+
+        self.assertIsNone(data)
+        self.assertIsNotNone(error)
+        self.assertContains(error, 'error:VA')
+
     def test_parse_json_or_querydict_falls_back_to_form_body(self):
         request = self.factory.post(
             '/v1/example',
@@ -75,7 +82,29 @@ class ApiRequestBodyServiceTestCase(TestCase):
         self.assertEqual(data.get('title'), 'Form Title')
         self.assertEqual(data.get('post_ids'), '1,2')
 
+    def test_parse_json_or_querydict_falls_back_for_non_object_json(self):
+        request = self.factory.put('/v1/example/1', data=b'[]', content_type='application/json')
+
+        data = ApiRequestBodyService.parse_json_or_querydict(request)
+
+        self.assertIsNone(data.get('like'))
+
+    def test_parse_json_or_post_falls_back_to_request_post(self):
+        request = self.factory.post(
+            '/v1/example',
+            data={'title': 'Form Title'},
+        )
+
+        data = ApiRequestBodyService.parse_json_or_post(request)
+
+        self.assertEqual(data.get('title'), 'Form Title')
+
     def test_parse_json_or_empty_for_legacy_only_returns_default_for_invalid_json(self):
         request = self.factory.put('/v1/example/1', data=b'{invalid', content_type='application/json')
+
+        self.assertEqual(ApiRequestBodyService.parse_json_or_empty_for_legacy_only(request), {})
+
+    def test_parse_json_or_empty_for_legacy_only_returns_default_for_non_object_json(self):
+        request = self.factory.put('/v1/example/1', data=b'[]', content_type='application/json')
 
         self.assertEqual(ApiRequestBodyService.parse_json_or_empty_for_legacy_only(request), {})

--- a/backend/src/board/views/api/v1/auth.py
+++ b/backend/src/board/views/api/v1/auth.py
@@ -1,6 +1,5 @@
 import datetime
 import traceback
-import json
 import io
 import pyotp
 import qrcode
@@ -10,7 +9,7 @@ from django.conf import settings
 from django.contrib import auth
 from django.contrib.auth.models import User
 from django.db import transaction
-from django.http import Http404, QueryDict
+from django.http import Http404
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 
@@ -24,6 +23,7 @@ from board.services.auth_request_parser import AuthRequestParser
 from board.services.author_invite_service import AuthorInviteError, AuthorInviteService
 from board.services.auth_service import AuthService, OAuthService, AuthValidationError
 from board.services.initial_setup_service import InitialSetupService
+from board.services.api_request_body_service import ApiRequestBodyService
 from modules import oauth
 from modules.challenge import auth_hcaptcha
 from modules.sub_task import SubTaskProcessor
@@ -123,7 +123,7 @@ def sign(request):
 
     if request.method == 'PATCH':
         user = request.user
-        body = QueryDict(request.body)
+        body = ApiRequestBodyService.parse_json_or_querydict(request)
 
         if body.get('username', ''):
             six_months_ago = timezone.now() - datetime.timedelta(days=180)
@@ -280,7 +280,7 @@ def security(request):
             })
         except Exception as e:
             traceback.print_exc()
-            return StatusError(ErrorCode.ERROR, f'2FA 설정 초기화에 실패했습니다: {str(e)}')
+            return StatusError(ErrorCode.REJECT, f'2FA 설정 초기화에 실패했습니다: {str(e)}')
 
     if request.method == 'DELETE':
         if not hasattr(request.user, 'twofactorauth'):
@@ -304,20 +304,20 @@ def security_verify(request):
         try:
             setup_data = request.session.get('totp_setup')
             if not setup_data:
-                return StatusError(ErrorCode.ERROR, '2FA 설정 세션이 만료되었습니다. 다시 시도해주세요.')
+                return StatusError(ErrorCode.EXPIRED, '2FA 설정 세션이 만료되었습니다. 다시 시도해주세요.')
 
             if setup_data['user_id'] != request.user.id:
-                return StatusError(ErrorCode.ERROR, '잘못된 세션입니다.')
+                return StatusError(ErrorCode.AUTHENTICATION, '잘못된 세션입니다.')
 
             if hasattr(request.user, 'twofactorauth'):
                 del request.session['totp_setup']
                 return StatusError(ErrorCode.ALREADY_CONNECTED)
 
-            data = json.loads(request.body.decode('utf-8')) if request.body else {}
+            data = ApiRequestBodyService.parse_json_or_empty_for_legacy_only(request)
             code = data.get('code', '').strip()
 
             if not code:
-                return StatusError(ErrorCode.ERROR, '인증 코드를 입력해주세요.')
+                return StatusError(ErrorCode.INVALID_PARAMETER, '인증 코드를 입력해주세요.')
 
             totp = pyotp.TOTP(setup_data['secret'])
             if not totp.verify(code, valid_window=1):
@@ -334,7 +334,7 @@ def security_verify(request):
 
         except Exception as e:
             traceback.print_exc()
-            return StatusError(ErrorCode.ERROR, f'2FA 활성화에 실패했습니다: {str(e)}')
+            return StatusError(ErrorCode.REJECT, f'2FA 활성화에 실패했습니다: {str(e)}')
 
     raise Http404
 

--- a/backend/src/board/views/api/v1/banner.py
+++ b/backend/src/board/views/api/v1/banner.py
@@ -1,192 +1,86 @@
 from django.http import Http404
 from django.shortcuts import get_object_or_404
-from board.models import SiteBanner, SiteContentScope
-from board.modules.response import StatusDone, StatusError, ErrorCode
-from board.services.api_request_body_service import ApiRequestBodyService
+
+from board.models import SiteContentScope
+from board.modules.response import StatusDone, StatusError
 from board.services.api_permission_service import ApiPermissionService
-from board.html_utils import sanitize_html
+from board.services.api_request_body_service import ApiRequestBodyService
+from board.services.site_content_api_service import (
+    SiteContentApiError,
+    SiteContentApiService,
+)
+
+
+def _user_banner_queryset(user):
+    return SiteContentApiService.scoped_banner_queryset(SiteContentScope.USER, user)
+
+
+def _banner_error(error: SiteContentApiError):
+    return StatusError(error.code, error.message)
 
 
 def banner(request, banner_id=None):
-    """
-    Banner CRUD API endpoint
-
-    GET /v1/banners - List all banners for current user
-    POST /v1/banners - Create new banner
-    GET /v1/banners/:id - Get banner details
-    PUT /v1/banners/:id - Update banner
-    DELETE /v1/banners/:id - Delete banner
-    """
     permission_error = ApiPermissionService.require_editor(request.user)
     if permission_error:
         return permission_error
 
     user = request.user
+    queryset = _user_banner_queryset(user)
 
-    # List all banners
     if request.method == 'GET' and banner_id is None:
-        banners = SiteBanner.objects.filter(
-            scope=SiteContentScope.USER,
-            user=user,
-        ).order_by('order', '-created_date')
-
+        banners = queryset.order_by('order', '-created_date')
         return StatusDone({
-            'banners': list(map(lambda banner: {
-                'id': banner.id,
-                'title': banner.title,
-                'content_html': banner.content_html,
-                'banner_type': banner.banner_type,
-                'position': banner.position,
-                'is_active': banner.is_active,
-                'order': banner.order,
-                'created_date': banner.created_date.isoformat(),
-                'updated_date': banner.updated_date.isoformat(),
-            }, banners))
+            'banners': [
+                SiteContentApiService.serialize_banner(item)
+                for item in banners
+            ]
         })
 
-    # Get single banner
     if request.method == 'GET' and banner_id:
-        banner = get_object_or_404(
-            SiteBanner,
-            id=banner_id,
-            scope=SiteContentScope.USER,
-            user=user,
-        )
+        banner_item = get_object_or_404(queryset, id=banner_id)
+        return StatusDone(SiteContentApiService.serialize_banner(banner_item))
 
-        return StatusDone({
-            'id': banner.id,
-            'title': banner.title,
-            'content_html': banner.content_html,
-            'banner_type': banner.banner_type,
-            'position': banner.position,
-            'is_active': banner.is_active,
-            'order': banner.order,
-        })
-
-    # Create new banner
     if request.method == 'POST':
         post_data, body_error = ApiRequestBodyService.parse_json_or_error(request)
         if body_error:
             return body_error
 
-        title = post_data.get('title', '')
-        content_html = post_data.get('content_html', '')
-        banner_type = post_data.get('banner_type', 'horizontal')
-        position = post_data.get('position', 'top')
-        is_active = post_data.get('is_active', True)
-        order = post_data.get('order', 0)
+        try:
+            banner_item = SiteContentApiService.create_banner(
+                SiteContentScope.USER,
+                user,
+                post_data,
+                sanitize_content=True,
+            )
+        except SiteContentApiError as error:
+            return _banner_error(error)
 
-        # Validation
-        if not title:
-            return StatusError(ErrorCode.VALIDATE, '배너 이름을 입력해주세요.')
+        return StatusDone(SiteContentApiService.serialize_banner(banner_item))
 
-        if not content_html:
-            return StatusError(ErrorCode.VALIDATE, '배너 내용을 입력해주세요.')
-
-        # Validate banner type and position compatibility
-        if banner_type == 'horizontal' and position not in ['top', 'bottom']:
-            return StatusError(ErrorCode.VALIDATE, '줄배너는 상단 또는 하단에만 배치할 수 있습니다.')
-
-        if banner_type == 'sidebar' and position not in ['left', 'right']:
-            return StatusError(ErrorCode.VALIDATE, '사이드배너는 좌측 또는 우측에만 배치할 수 있습니다.')
-
-        # Sanitize HTML content to prevent XSS
-        sanitized_content = sanitize_html(content_html)
-
-        # Create banner
-        banner = SiteBanner.objects.create(
-            scope=SiteContentScope.USER,
-            user=user,
-            title=title,
-            content_html=sanitized_content,
-            banner_type=banner_type,
-            position=position,
-            is_active=is_active,
-            order=order
-        )
-
-        return StatusDone({
-            'id': banner.id,
-            'title': banner.title,
-            'content_html': banner.content_html,
-            'banner_type': banner.banner_type,
-            'position': banner.position,
-            'is_active': banner.is_active,
-            'order': banner.order,
-        })
-
-    # Update banner
     if request.method == 'PUT' and banner_id:
-        banner = get_object_or_404(
-            SiteBanner,
-            id=banner_id,
-            scope=SiteContentScope.USER,
-            user=user,
-        )
-
+        banner_item = get_object_or_404(queryset, id=banner_id)
         put_data = ApiRequestBodyService.parse_json_or_empty_for_legacy_only(request)
 
-        # Update fields if provided
-        if 'title' in put_data:
-            banner.title = put_data['title']
+        try:
+            SiteContentApiService.update_banner(
+                banner_item,
+                put_data,
+                sanitize_content=True,
+            )
+        except SiteContentApiError as error:
+            return _banner_error(error)
 
-        if 'content_html' in put_data:
-            # Sanitize HTML content to prevent XSS
-            banner.content_html = sanitize_html(put_data['content_html'])
+        return StatusDone(SiteContentApiService.serialize_banner(banner_item))
 
-        if 'banner_type' in put_data:
-            banner.banner_type = put_data['banner_type']
-
-        if 'position' in put_data:
-            banner.position = put_data['position']
-
-        if 'is_active' in put_data:
-            banner.is_active = put_data['is_active']
-
-        if 'order' in put_data:
-            banner.order = put_data['order']
-
-        # Validate
-        if banner.banner_type == 'horizontal' and banner.position not in ['top', 'bottom']:
-            return StatusError(ErrorCode.VALIDATE, '줄배너는 상단 또는 하단에만 배치할 수 있습니다.')
-
-        if banner.banner_type == 'sidebar' and banner.position not in ['left', 'right']:
-            return StatusError(ErrorCode.VALIDATE, '사이드배너는 좌측 또는 우측에만 배치할 수 있습니다.')
-
-        banner.save()
-
-        return StatusDone({
-            'id': banner.id,
-            'title': banner.title,
-            'content_html': banner.content_html,
-            'banner_type': banner.banner_type,
-            'position': banner.position,
-            'is_active': banner.is_active,
-            'order': banner.order,
-        })
-
-    # Delete banner
     if request.method == 'DELETE' and banner_id:
-        banner = get_object_or_404(
-            SiteBanner,
-            id=banner_id,
-            scope=SiteContentScope.USER,
-            user=user,
-        )
-        banner.delete()
-
+        banner_item = get_object_or_404(queryset, id=banner_id)
+        banner_item.delete()
         return StatusDone({'message': '배너가 삭제되었습니다.'})
 
     raise Http404
 
 
 def banner_order(request):
-    """
-    Update banner order
-
-    PUT /v1/banners/order
-    Body: { order: [[id1, order1], [id2, order2], ...] }
-    """
     permission_error = ApiPermissionService.require_editor(request.user)
     if permission_error:
         return permission_error
@@ -198,22 +92,9 @@ def banner_order(request):
     if body_error:
         return body_error
 
-    order_list = put_data.get('order', [])
-
-    for item in order_list:
-        if len(item) != 2:
-            continue
-
-        banner_id, order = item
-        try:
-            banner = SiteBanner.objects.get(
-                id=banner_id,
-                scope=SiteContentScope.USER,
-                user=request.user,
-            )
-            banner.order = order
-            banner.save()
-        except SiteBanner.DoesNotExist:
-            continue
-
+    SiteContentApiService.update_banner_order(
+        SiteContentScope.USER,
+        request.user,
+        put_data.get('order', []),
+    )
     return StatusDone({'message': '배너 순서가 업데이트되었습니다.'})

--- a/backend/src/board/views/api/v1/comment.py
+++ b/backend/src/board/views/api/v1/comment.py
@@ -1,10 +1,11 @@
 from django.db.models import F
-from django.http import Http404, QueryDict
+from django.http import Http404
 from django.shortcuts import get_object_or_404
 
 from board.models import Comment, Post
 from board.modules.response import StatusDone, StatusError
 from board.modules.paginator import Paginator
+from board.services.api_request_body_service import ApiRequestBodyService
 from board.services.comment_list_service import CommentListService
 from board.services.comment_service import CommentService, CommentValidationError
 from board.services.public_post_service import PublicPostService
@@ -59,7 +60,7 @@ def comment_detail(request, id):
             return StatusError(e.code, e.message)
 
     if request.method == 'PUT':
-        body = QueryDict(request.body)
+        body = ApiRequestBodyService.parse_json_or_querydict(request)
 
         if body.get('like'):
             try:

--- a/backend/src/board/views/api/v1/developer_token.py
+++ b/backend/src/board/views/api/v1/developer_token.py
@@ -1,5 +1,3 @@
-import json
-
 from django.http import Http404
 from django.shortcuts import get_object_or_404
 
@@ -11,15 +9,13 @@ from board.services.developer_token_service import (
     DeveloperAuthError,
     DeveloperTokenService,
 )
+from board.services.api_request_body_service import ApiRequestBodyService
 
 
 class DeveloperTokenAPI:
     @staticmethod
     def json_body(request):
-        try:
-            return json.loads(request.body.decode('utf-8')) if request.body else {}
-        except (json.JSONDecodeError, UnicodeDecodeError):
-            return {}
+        return ApiRequestBodyService.parse_json_or_empty_for_legacy_only(request)
 
     @staticmethod
     def auth_error(error):

--- a/backend/src/board/views/api/v1/draft.py
+++ b/backend/src/board/views/api/v1/draft.py
@@ -1,20 +1,16 @@
-import json
-
 from django.http import Http404
 from django.http.multipartparser import MultiPartParser
 from django.shortcuts import get_object_or_404
 
 from board.models import Post
 from board.decorators import api_editor_required
+from board.services.api_request_body_service import ApiRequestBodyService
 from board.services.post_service import PostService, PostValidationError
-from board.modules.response import StatusDone, StatusError, ErrorCode
+from board.modules.response import StatusDone, StatusError
 
 
 @api_editor_required
 def drafts_list(request):
-    if not request.user.is_active:
-        return StatusError(ErrorCode.NEED_LOGIN)
-
     if request.method == 'GET':
         drafts = PostService.get_user_drafts(request.user)
         return StatusDone({
@@ -32,10 +28,7 @@ def drafts_list(request):
             data = request.POST
             files = request.FILES
         else:
-            try:
-                data = json.loads(request.body)
-            except (ValueError, json.JSONDecodeError):
-                data = request.POST
+            data = ApiRequestBodyService.parse_json_or_post(request)
             files = {}
 
         title = data.get('title', '')
@@ -81,9 +74,6 @@ def drafts_list(request):
 
 @api_editor_required
 def drafts_detail(request, url):
-    if not request.user.is_active:
-        return StatusError(ErrorCode.NEED_LOGIN)
-
     draft = get_object_or_404(
         Post.objects.select_related('content', 'config', 'series').prefetch_related('tags'),
         url=url,
@@ -123,11 +113,7 @@ def drafts_detail(request, url):
             parser = MultiPartParser(request.META, request, request.upload_handlers)
             data, files = parser.parse()
         else:
-            try:
-                data = json.loads(request.body)
-            except (ValueError, json.JSONDecodeError):
-                from django.http import QueryDict
-                data = QueryDict(request.body)
+            data = ApiRequestBodyService.parse_json_or_querydict(request)
             files = {}
 
         image = files.get('image') if files else None

--- a/backend/src/board/views/api/v1/form.py
+++ b/backend/src/board/views/api/v1/form.py
@@ -1,18 +1,15 @@
-import json
 from django.shortcuts import get_object_or_404
-from django.http import Http404, QueryDict
+from django.http import Http404
 
 from board.models import Form
 from board.decorators import api_editor_required
 from board.modules.time import convert_to_localtime
 from board.modules.response import StatusDone, StatusError, ErrorCode
+from board.services.api_request_body_service import ApiRequestBodyService
 
 
 @api_editor_required
 def forms_list(request):
-    if not request.user.is_active:
-        return StatusError(ErrorCode.NEED_LOGIN)
-
     if request.method == 'GET':
         forms = Form.objects.filter(user=request.user)
         return StatusDone({
@@ -24,33 +21,29 @@ def forms_list(request):
         })
 
     if request.method == 'POST':
-        try:
-            if request.content_type == 'application/json':
-                data = json.loads(request.body)
-                title = data.get('title', '')
-                content = data.get('content', '')
-            else:
-                title = request.POST.get('title', '')
-                content = request.POST.get('content', '')
-            
-            form = Form(
-                user=request.user,
-                title=title,
-                content=content
+        if request.content_type == 'application/json':
+            data, body_error = ApiRequestBodyService.parse_json_or_error(
+                request,
+                error_code=ErrorCode.INVALID_PARAMETER,
             )
-            form.save()
-            return StatusDone({
-                'id': form.id
-            })
-        except json.JSONDecodeError:
-            return StatusError(ErrorCode.INVALID_PARAMETER)
+            if body_error:
+                return body_error
+        else:
+            data = request.POST
+
+        form = Form(
+            user=request.user,
+            title=data.get('title', ''),
+            content=data.get('content', ''),
+        )
+        form.save()
+        return StatusDone({
+            'id': form.id
+        })
 
 
 @api_editor_required
 def forms_detail(request, id):
-    if not request.user.is_active:
-        return StatusError(ErrorCode.NEED_LOGIN)
-
     if request.method == 'GET':
         form = get_object_or_404(Form, id=id, user=request.user)
         return StatusDone({
@@ -60,23 +53,21 @@ def forms_detail(request, id):
         })
 
     if request.method == 'PUT':
-        try:
-            if request.content_type == 'application/json':
-                data = json.loads(request.body)
-                title = data.get('title', '')
-                content = data.get('content', '')
-            else:
-                body = QueryDict(request.body)
-                title = body.get('title', '')
-                content = body.get('content', '')
-            
-            form = get_object_or_404(Form, id=id, user=request.user)
-            form.title = title
-            form.content = content
-            form.save()
-            return StatusDone()
-        except json.JSONDecodeError:
-            return StatusError(ErrorCode.INVALID_PARAMETER)
+        if request.content_type == 'application/json':
+            data, body_error = ApiRequestBodyService.parse_json_or_error(
+                request,
+                error_code=ErrorCode.INVALID_PARAMETER,
+            )
+            if body_error:
+                return body_error
+        else:
+            data = ApiRequestBodyService.parse_json_or_querydict(request)
+
+        form = get_object_or_404(Form, id=id, user=request.user)
+        form.title = data.get('title', '')
+        form.content = data.get('content', '')
+        form.save()
+        return StatusDone()
 
     if request.method == 'DELETE':
         form = get_object_or_404(Form, id=id, user=request.user)

--- a/backend/src/board/views/api/v1/global_banner.py
+++ b/backend/src/board/views/api/v1/global_banner.py
@@ -1,149 +1,77 @@
 from django.http import Http404
 from django.shortcuts import get_object_or_404
-from board.models import SiteBanner, SiteContentScope
-from board.modules.response import StatusDone, StatusError, ErrorCode
-from board.services.api_request_body_service import ApiRequestBodyService
+
+from board.models import SiteContentScope
+from board.modules.response import StatusDone, StatusError
 from board.services.api_permission_service import ApiPermissionService
-
-
-def _serialize_global_banner(banner):
-    return {
-        'id': banner.id,
-        'title': banner.title,
-        'content_html': banner.content_html,
-        'banner_type': banner.banner_type,
-        'position': banner.position,
-        'is_active': banner.is_active,
-        'order': banner.order,
-        'created_by': banner.user.username if banner.user else None,
-        'created_date': banner.created_date.isoformat(),
-        'updated_date': banner.updated_date.isoformat(),
-    }
+from board.services.api_request_body_service import ApiRequestBodyService
+from board.services.site_content_api_service import (
+    SiteContentApiError,
+    SiteContentApiService,
+)
 
 
 def global_banners(request, banner_id=None):
-    """
-    GlobalBanner CRUD API endpoint (staff only)
-
-    GET /v1/global-banners - List all global banners
-    POST /v1/global-banners - Create new global banner
-    GET /v1/global-banners/<id> - Get global banner details
-    PUT /v1/global-banners/<id> - Update global banner
-    DELETE /v1/global-banners/<id> - Delete global banner
-    """
     permission_error = ApiPermissionService.require_staff(request.user)
     if permission_error:
         return permission_error
 
-    qs = SiteBanner.objects.filter(
-        scope=SiteContentScope.GLOBAL,
-    )
+    queryset = SiteContentApiService.scoped_banner_queryset(SiteContentScope.GLOBAL)
 
-    # List all global banners
     if request.method == 'GET' and banner_id is None:
-        banners = qs.select_related('user').order_by('order', '-created_date')
-
+        banners = queryset.select_related('user').order_by('order', '-created_date')
         return StatusDone({
-            'banners': list(map(_serialize_global_banner, banners))
+            'banners': [
+                SiteContentApiService.serialize_banner(item, include_created_by=True)
+                for item in banners
+            ]
         })
 
-    # Get single global banner
     if request.method == 'GET' and banner_id:
-        banner = get_object_or_404(qs.select_related('user'), id=banner_id)
+        banner = get_object_or_404(queryset.select_related('user'), id=banner_id)
+        return StatusDone(SiteContentApiService.serialize_banner(banner, include_created_by=True))
 
-        return StatusDone(_serialize_global_banner(banner))
-
-    # Create new global banner
     if request.method == 'POST':
         post_data, body_error = ApiRequestBodyService.parse_json_or_error(request)
         if body_error:
             return body_error
 
-        title = post_data.get('title', '')
-        content_html = post_data.get('content_html', '')
-        banner_type = post_data.get('banner_type', 'horizontal')
-        position = post_data.get('position', 'top')
-        is_active = post_data.get('is_active', True)
-        order = post_data.get('order', 0)
+        try:
+            banner = SiteContentApiService.create_banner(
+                SiteContentScope.GLOBAL,
+                request.user,
+                post_data,
+                sanitize_content=False,
+            )
+        except SiteContentApiError as error:
+            return StatusError(error.code, error.message)
 
-        if not title:
-            return StatusError(ErrorCode.VALIDATE, '배너 이름을 입력해주세요.')
+        return StatusDone(SiteContentApiService.serialize_banner(banner, include_created_by=True))
 
-        if not content_html:
-            return StatusError(ErrorCode.VALIDATE, '배너 내용을 입력해주세요.')
-
-        # Validate banner type and position compatibility
-        if banner_type == 'horizontal' and position not in ['top', 'bottom']:
-            return StatusError(ErrorCode.VALIDATE, '줄배너는 상단 또는 하단에만 배치할 수 있습니다.')
-
-        if banner_type == 'sidebar' and position not in ['left', 'right']:
-            return StatusError(ErrorCode.VALIDATE, '사이드배너는 좌측 또는 우측에만 배치할 수 있습니다.')
-
-        banner = SiteBanner.objects.create(
-            scope=SiteContentScope.GLOBAL,
-            user=request.user,
-            title=title,
-            content_html=content_html,
-            banner_type=banner_type,
-            position=position,
-            is_active=is_active,
-            order=order,
-        )
-
-        return StatusDone(_serialize_global_banner(banner))
-
-    # Update global banner
     if request.method == 'PUT' and banner_id:
-        banner = get_object_or_404(qs.select_related('user'), id=banner_id)
-
+        banner = get_object_or_404(queryset.select_related('user'), id=banner_id)
         put_data = ApiRequestBodyService.parse_json_or_empty_for_legacy_only(request)
 
-        if 'title' in put_data:
-            banner.title = put_data['title']
+        try:
+            SiteContentApiService.update_banner(
+                banner,
+                put_data,
+                sanitize_content=False,
+            )
+        except SiteContentApiError as error:
+            return StatusError(error.code, error.message)
 
-        if 'content_html' in put_data:
-            banner.content_html = put_data['content_html']
+        return StatusDone(SiteContentApiService.serialize_banner(banner, include_created_by=True))
 
-        if 'banner_type' in put_data:
-            banner.banner_type = put_data['banner_type']
-
-        if 'position' in put_data:
-            banner.position = put_data['position']
-
-        if 'is_active' in put_data:
-            banner.is_active = put_data['is_active']
-
-        if 'order' in put_data:
-            banner.order = put_data['order']
-
-        # Validate
-        if banner.banner_type == 'horizontal' and banner.position not in ['top', 'bottom']:
-            return StatusError(ErrorCode.VALIDATE, '줄배너는 상단 또는 하단에만 배치할 수 있습니다.')
-
-        if banner.banner_type == 'sidebar' and banner.position not in ['left', 'right']:
-            return StatusError(ErrorCode.VALIDATE, '사이드배너는 좌측 또는 우측에만 배치할 수 있습니다.')
-
-        banner.save()
-
-        return StatusDone(_serialize_global_banner(banner))
-
-    # Delete global banner
     if request.method == 'DELETE' and banner_id:
-        banner = get_object_or_404(qs, id=banner_id)
+        banner = get_object_or_404(queryset, id=banner_id)
         banner.delete()
-
         return StatusDone({'message': '글로벌 배너가 삭제되었습니다.'})
 
     raise Http404
 
 
 def global_banner_order(request):
-    """
-    Update global banner order
-
-    PUT /v1/global-banners/order
-    Body: { order: [[id1, order1], [id2, order2], ...] }
-    """
     permission_error = ApiPermissionService.require_staff(request.user)
     if permission_error:
         return permission_error
@@ -155,21 +83,9 @@ def global_banner_order(request):
     if body_error:
         return body_error
 
-    order_list = put_data.get('order', [])
-
-    for item in order_list:
-        if len(item) != 2:
-            continue
-
-        banner_id, order = item
-        try:
-            banner = SiteBanner.objects.get(
-                id=banner_id,
-                scope=SiteContentScope.GLOBAL,
-            )
-            banner.order = order
-            banner.save()
-        except SiteBanner.DoesNotExist:
-            continue
-
+    SiteContentApiService.update_banner_order(
+        SiteContentScope.GLOBAL,
+        None,
+        put_data.get('order', []),
+    )
     return StatusDone({'message': '글로벌 배너 순서가 업데이트되었습니다.'})

--- a/backend/src/board/views/api/v1/global_notice.py
+++ b/backend/src/board/views/api/v1/global_notice.py
@@ -1,120 +1,61 @@
 from django.http import Http404
 from django.shortcuts import get_object_or_404
-from board.models import SiteNotice, SiteContentScope
-from board.modules.response import StatusDone, StatusError, ErrorCode
-from board.services.api_request_body_service import ApiRequestBodyService
+
+from board.models import SiteContentScope
+from board.modules.response import StatusDone, StatusError
 from board.services.api_permission_service import ApiPermissionService
+from board.services.api_request_body_service import ApiRequestBodyService
+from board.services.site_content_api_service import (
+    SiteContentApiError,
+    SiteContentApiService,
+)
 
 
 def global_notices(request, notice_id=None):
-    """
-    GlobalNotice CRUD API endpoint (staff only)
-
-    GET /v1/global-notices - List all global notices
-    POST /v1/global-notices - Create new global notice
-    GET /v1/global-notices/<id> - Get global notice details
-    PUT /v1/global-notices/<id> - Update global notice
-    DELETE /v1/global-notices/<id> - Delete global notice
-    """
     permission_error = ApiPermissionService.require_staff(request.user)
     if permission_error:
         return permission_error
 
-    qs = SiteNotice.objects.filter(
-        scope=SiteContentScope.GLOBAL,
-    )
+    queryset = SiteContentApiService.scoped_notice_queryset(SiteContentScope.GLOBAL)
 
-    # List all global notices
     if request.method == 'GET' and notice_id is None:
-        notices = qs.order_by('-created_date')
-
+        notices = queryset.order_by('-created_date')
         return StatusDone({
-            'notices': list(map(lambda notice: {
-                'id': notice.id,
-                'title': notice.title,
-                'url': notice.url,
-                'is_active': notice.is_active,
-                'created_date': notice.created_date.isoformat(),
-                'updated_date': notice.updated_date.isoformat(),
-            }, notices))
+            'notices': [
+                SiteContentApiService.serialize_notice(item)
+                for item in notices
+            ]
         })
 
-    # Get single global notice
     if request.method == 'GET' and notice_id:
-        notice = get_object_or_404(qs, id=notice_id)
+        notice = get_object_or_404(queryset, id=notice_id)
+        return StatusDone(SiteContentApiService.serialize_notice(notice))
 
-        return StatusDone({
-            'id': notice.id,
-            'title': notice.title,
-            'url': notice.url,
-            'is_active': notice.is_active,
-            'created_date': notice.created_date.isoformat(),
-            'updated_date': notice.updated_date.isoformat(),
-        })
-
-    # Create new global notice
     if request.method == 'POST':
         post_data, body_error = ApiRequestBodyService.parse_json_or_error(request)
         if body_error:
             return body_error
 
-        title = post_data.get('title', '')
-        url = post_data.get('url', '')
-        is_active = post_data.get('is_active', True)
+        try:
+            notice = SiteContentApiService.create_notice(
+                SiteContentScope.GLOBAL,
+                None,
+                post_data,
+            )
+        except SiteContentApiError as error:
+            return StatusError(error.code, error.message)
 
-        if not title:
-            return StatusError(ErrorCode.VALIDATE, '공지 제목을 입력해주세요.')
+        return StatusDone(SiteContentApiService.serialize_notice(notice))
 
-        if not url:
-            return StatusError(ErrorCode.VALIDATE, 'URL을 입력해주세요.')
-
-        notice = SiteNotice.objects.create(
-            scope=SiteContentScope.GLOBAL,
-            title=title,
-            url=url,
-            is_active=is_active,
-        )
-
-        return StatusDone({
-            'id': notice.id,
-            'title': notice.title,
-            'url': notice.url,
-            'is_active': notice.is_active,
-            'created_date': notice.created_date.isoformat(),
-            'updated_date': notice.updated_date.isoformat(),
-        })
-
-    # Update global notice
     if request.method == 'PUT' and notice_id:
-        notice = get_object_or_404(qs, id=notice_id)
-
+        notice = get_object_or_404(queryset, id=notice_id)
         put_data = ApiRequestBodyService.parse_json_or_empty_for_legacy_only(request)
+        SiteContentApiService.update_notice(notice, put_data)
+        return StatusDone(SiteContentApiService.serialize_notice(notice))
 
-        if 'title' in put_data:
-            notice.title = put_data['title']
-
-        if 'url' in put_data:
-            notice.url = put_data['url']
-
-        if 'is_active' in put_data:
-            notice.is_active = put_data['is_active']
-
-        notice.save()
-
-        return StatusDone({
-            'id': notice.id,
-            'title': notice.title,
-            'url': notice.url,
-            'is_active': notice.is_active,
-            'created_date': notice.created_date.isoformat(),
-            'updated_date': notice.updated_date.isoformat(),
-        })
-
-    # Delete global notice
     if request.method == 'DELETE' and notice_id:
-        notice = get_object_or_404(qs, id=notice_id)
+        notice = get_object_or_404(queryset, id=notice_id)
         notice.delete()
-
         return StatusDone({'message': '공지가 삭제되었습니다.'})
 
     raise Http404

--- a/backend/src/board/views/api/v1/markdown.py
+++ b/backend/src/board/views/api/v1/markdown.py
@@ -1,9 +1,9 @@
-import json
 from django.http import Http404
 
 from modules import markdown
 from board.decorators import api_editor_required_methods
 from board.modules.response import StatusDone, StatusError, ErrorCode
+from board.services.api_request_body_service import ApiRequestBodyService
 
 
 @api_editor_required_methods(['POST'])
@@ -17,21 +17,23 @@ def markdown_to_html(request):
     """
     if request.method != 'POST':
         raise Http404
-    
-    try:
-        if request.content_type == 'application/json':
-            data = json.loads(request.body)
-            text = data.get('text', '')
-        else:
-            text = request.POST.get('text', '')
-        
-        if not text:
-            return StatusError(ErrorCode.INVALID_PARAMETER, '텍스트가 비어있습니다.')
-        
-        html = markdown.parse_post_to_html(text)
-        
-        return StatusDone({
-            'html': html
-        })
-    except json.JSONDecodeError:
-        return StatusError(ErrorCode.INVALID_PARAMETER)
+
+    if request.content_type == 'application/json':
+        data, body_error = ApiRequestBodyService.parse_json_or_error(
+            request,
+            error_code=ErrorCode.INVALID_PARAMETER,
+        )
+        if body_error:
+            return body_error
+        text = data.get('text', '')
+    else:
+        text = request.POST.get('text', '')
+
+    if not text:
+        return StatusError(ErrorCode.INVALID_PARAMETER, '텍스트가 비어있습니다.')
+
+    html = markdown.parse_post_to_html(text)
+
+    return StatusDone({
+        'html': html
+    })

--- a/backend/src/board/views/api/v1/notice.py
+++ b/backend/src/board/views/api/v1/notice.py
@@ -1,124 +1,64 @@
 from django.http import Http404
 from django.shortcuts import get_object_or_404
-from board.models import SiteNotice, SiteContentScope
-from board.modules.response import StatusDone, StatusError, ErrorCode
-from board.services.api_request_body_service import ApiRequestBodyService
+
+from board.models import SiteContentScope
+from board.modules.response import StatusDone, StatusError
 from board.services.api_permission_service import ApiPermissionService
+from board.services.api_request_body_service import ApiRequestBodyService
+from board.services.site_content_api_service import (
+    SiteContentApiError,
+    SiteContentApiService,
+)
 
 
 def notices(request, notice_id=None):
-    """
-    User Notice CRUD API endpoint (editor only)
-
-    GET /v1/notices - List all notices for current user
-    POST /v1/notices - Create new notice
-    GET /v1/notices/<id> - Get notice details
-    PUT /v1/notices/<id> - Update notice
-    DELETE /v1/notices/<id> - Delete notice
-    """
     permission_error = ApiPermissionService.require_editor(request.user)
     if permission_error:
         return permission_error
 
-    user = request.user
-
-    qs = SiteNotice.objects.filter(
-        scope=SiteContentScope.USER,
-        user=user,
+    queryset = SiteContentApiService.scoped_notice_queryset(
+        SiteContentScope.USER,
+        request.user,
     )
 
-    # List all notices
     if request.method == 'GET' and notice_id is None:
-        notice_list = qs.order_by('-created_date')
-
+        notice_list = queryset.order_by('-created_date')
         return StatusDone({
-            'notices': list(map(lambda notice: {
-                'id': notice.id,
-                'title': notice.title,
-                'url': notice.url,
-                'is_active': notice.is_active,
-                'created_date': notice.created_date.isoformat(),
-                'updated_date': notice.updated_date.isoformat(),
-            }, notice_list))
+            'notices': [
+                SiteContentApiService.serialize_notice(item)
+                for item in notice_list
+            ]
         })
 
-    # Get single notice
     if request.method == 'GET' and notice_id:
-        notice = get_object_or_404(qs, id=notice_id)
+        notice = get_object_or_404(queryset, id=notice_id)
+        return StatusDone(SiteContentApiService.serialize_notice(notice))
 
-        return StatusDone({
-            'id': notice.id,
-            'title': notice.title,
-            'url': notice.url,
-            'is_active': notice.is_active,
-            'created_date': notice.created_date.isoformat(),
-            'updated_date': notice.updated_date.isoformat(),
-        })
-
-    # Create new notice
     if request.method == 'POST':
         post_data, body_error = ApiRequestBodyService.parse_json_or_error(request)
         if body_error:
             return body_error
 
-        title = post_data.get('title', '')
-        url = post_data.get('url', '')
-        is_active = post_data.get('is_active', True)
+        try:
+            notice = SiteContentApiService.create_notice(
+                SiteContentScope.USER,
+                request.user,
+                post_data,
+            )
+        except SiteContentApiError as error:
+            return StatusError(error.code, error.message)
 
-        if not title:
-            return StatusError(ErrorCode.VALIDATE, '공지 제목을 입력해주세요.')
+        return StatusDone(SiteContentApiService.serialize_notice(notice))
 
-        if not url:
-            return StatusError(ErrorCode.VALIDATE, 'URL을 입력해주세요.')
-
-        notice = SiteNotice.objects.create(
-            scope=SiteContentScope.USER,
-            user=user,
-            title=title,
-            url=url,
-            is_active=is_active,
-        )
-
-        return StatusDone({
-            'id': notice.id,
-            'title': notice.title,
-            'url': notice.url,
-            'is_active': notice.is_active,
-            'created_date': notice.created_date.isoformat(),
-            'updated_date': notice.updated_date.isoformat(),
-        })
-
-    # Update notice
     if request.method == 'PUT' and notice_id:
-        notice = get_object_or_404(qs, id=notice_id)
-
+        notice = get_object_or_404(queryset, id=notice_id)
         put_data = ApiRequestBodyService.parse_json_or_empty_for_legacy_only(request)
+        SiteContentApiService.update_notice(notice, put_data)
+        return StatusDone(SiteContentApiService.serialize_notice(notice))
 
-        if 'title' in put_data:
-            notice.title = put_data['title']
-
-        if 'url' in put_data:
-            notice.url = put_data['url']
-
-        if 'is_active' in put_data:
-            notice.is_active = put_data['is_active']
-
-        notice.save()
-
-        return StatusDone({
-            'id': notice.id,
-            'title': notice.title,
-            'url': notice.url,
-            'is_active': notice.is_active,
-            'created_date': notice.created_date.isoformat(),
-            'updated_date': notice.updated_date.isoformat(),
-        })
-
-    # Delete notice
     if request.method == 'DELETE' and notice_id:
-        notice = get_object_or_404(qs, id=notice_id)
+        notice = get_object_or_404(queryset, id=notice_id)
         notice.delete()
-
         return StatusDone({'message': '공지가 삭제되었습니다.'})
 
     raise Http404

--- a/backend/src/board/views/api/v1/pinned_post.py
+++ b/backend/src/board/views/api/v1/pinned_post.py
@@ -1,11 +1,12 @@
 import json
 
-from django.http import Http404, QueryDict
+from django.http import Http404
 from django.shortcuts import get_object_or_404
 
 from board.models import User
 from board.services import PinnedPostService
 from board.services.api_permission_service import ApiPermissionService
+from board.services.api_request_body_service import ApiRequestBodyService
 from board.services.pinned_post_service import PinnedPostError
 from board.modules.response import StatusDone, StatusError, ErrorCode
 
@@ -43,7 +44,7 @@ def pinned_posts(request, username):
             return StatusError(e.code, e.message)
 
     if request.method == 'DELETE':
-        delete = QueryDict(request.body)
+        delete = ApiRequestBodyService.parse_json_or_querydict(request)
         post_url = delete.get('post_url', '')
         if not post_url:
             return StatusError(ErrorCode.INVALID_PARAMETER, '포스트 URL이 필요합니다.')
@@ -70,12 +71,12 @@ def pinned_posts_order(request, username):
         return permission_error
 
     if request.method == 'PUT':
-        put = QueryDict(request.body)
-        post_urls_str = put.get('post_urls', '[]')
+        put = ApiRequestBodyService.parse_json_or_querydict(request)
+        post_urls_data = put.get('post_urls', '[]')
 
         try:
-            post_urls = json.loads(post_urls_str)
-        except json.JSONDecodeError:
+            post_urls = json.loads(post_urls_data) if isinstance(post_urls_data, str) else post_urls_data
+        except (TypeError, json.JSONDecodeError):
             return StatusError(ErrorCode.INVALID_PARAMETER, '잘못된 형식입니다.')
 
         if not isinstance(post_urls, list):

--- a/backend/src/board/views/api/v1/post.py
+++ b/backend/src/board/views/api/v1/post.py
@@ -1,4 +1,4 @@
-from django.http import Http404, QueryDict
+from django.http import Http404
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 
@@ -9,6 +9,7 @@ from board.modules.time import convert_to_localtime, time_since
 from board.decorators import api_editor_required_methods
 from board.services.comment_list_service import CommentListService
 from board.services.api_permission_service import ApiPermissionService
+from board.services.api_request_body_service import ApiRequestBodyService
 from board.services.post_service import PostService, PostValidationError
 from board.services.public_post_service import PublicPostService
 
@@ -101,10 +102,7 @@ def user_posts(request, username, url=None):
                 })
 
             if request.GET.get('mode') == 'view':
-                if post.config.hide and request.user != post.author:
-                    raise Http404
-
-                if not post.is_published() and request.user != post.author:
+                if request.user != post.author and not PublicPostService.is_public(post):
                     raise Http404
 
                 return StatusDone({
@@ -169,7 +167,7 @@ def user_posts(request, username, url=None):
             return StatusDone()
 
         if request.method == 'PUT':
-            put = QueryDict(request.body)
+            put = ApiRequestBodyService.parse_json_or_querydict(request)
 
             if request.GET.get('hide', ''):
                 if not PostService.can_user_edit_post(request.user, post):

--- a/backend/src/board/views/api/v1/series.py
+++ b/backend/src/board/views/api/v1/series.py
@@ -1,5 +1,5 @@
 from django.db.models import F, Q
-from django.http import Http404, QueryDict
+from django.http import Http404
 from django.shortcuts import get_object_or_404
 
 from board.models import User, Post, Series
@@ -17,9 +17,6 @@ from board.modules.response import StatusDone, StatusError, ErrorCode
 @api_editor_required
 def posts_can_add_series(request):
     if request.method == 'GET':
-        if not request.user.is_authenticated:
-            return StatusError(ErrorCode.NEED_LOGIN)
-
         series_id = request.GET.get('series_id')
         if series_id is not None:
             try:
@@ -69,7 +66,7 @@ def user_series(request, username, url=None):
             })
 
         if request.method == 'PUT':
-            body = QueryDict(request.body)
+            body = ApiRequestBodyService.parse_json_or_querydict(request)
             if request.GET.get('kind', '') == 'order':
                 try:
                     items = body.get('series').split(',')

--- a/backend/src/board/views/api/v1/setting.py
+++ b/backend/src/board/views/api/v1/setting.py
@@ -2,9 +2,8 @@ import json
 
 from django.contrib import auth
 from django.db.models import Count
-from django.http import Http404, QueryDict
+from django.http import Http404
 from django.shortcuts import get_object_or_404
-from django.utils import timezone
 from board.models import (
     User, Series, Post, SiteSetting,
     Profile, Notify)
@@ -13,7 +12,9 @@ from board.modules.response import StatusDone, StatusError, ErrorCode
 from board.modules.time import convert_to_localtime
 from board.services.auth_service import AuthService, AuthValidationError
 from board.services.api_permission_service import ApiPermissionService
+from board.services.api_request_body_service import ApiRequestBodyService
 from board.services.pinned_post_service import PinnedPostService, PinnedPostError
+from board.services.post_status_service import PostStatusService
 from board.services.user_heatmap_service import UserHeatmapService
 from board.services.user_notification_service import UserNotificationService
 from board.services.user_social_link_service import UserSocialLinkService
@@ -41,13 +42,7 @@ POST_MANAGEMENT_ORDERS = {
 
 
 def get_post_management_queryset(user, *, scheduled=False):
-    now = timezone.now()
-    published_date_filter = {
-        'published_date__isnull': False,
-        'published_date__gt' if scheduled else 'published_date__lte': now,
-    }
-
-    return Post.objects.select_related(
+    posts = Post.objects.select_related(
         'config', 'series',
     ).prefetch_related(
         'tags'
@@ -56,8 +51,10 @@ def get_post_management_queryset(user, *, scheduled=False):
         count_comments=Count('comments', distinct=True),
     ).filter(
         author=user,
-        **published_date_filter,
     ).order_by('-published_date')
+    if scheduled:
+        return PostStatusService.filter_scheduled(posts)
+    return PostStatusService.filter_published(posts)
 
 
 def apply_post_management_filters(posts, request):
@@ -94,7 +91,7 @@ def apply_post_management_order(posts, request):
     return posts.order_by(order)
 
 
-def paginate_post_management_posts(posts, request):
+def paginate_post_management_posts(posts, request, total_count):
     try:
         page = int(request.GET.get('page', 1))
     except (TypeError, ValueError):
@@ -103,7 +100,7 @@ def paginate_post_management_posts(posts, request):
     if page < 1:
         raise Http404
 
-    if not posts.exists():
+    if total_count == 0:
         if page > 1:
             raise Http404
         return [], 1
@@ -144,7 +141,8 @@ def get_post_management_response(request, user, *, scheduled=False):
     posts = get_post_management_queryset(user, scheduled=scheduled)
     posts = apply_post_management_filters(posts, request)
     posts = apply_post_management_order(posts, request)
-    page_posts, last_page = paginate_post_management_posts(posts, request)
+    total_count = posts.count()
+    page_posts, last_page = paginate_post_management_posts(posts, request, total_count)
     date_format = '%Y-%m-%d %H:%M' if scheduled else '%Y-%m-%d'
 
     return StatusDone({
@@ -154,6 +152,7 @@ def get_post_management_response(request, user, *, scheduled=False):
             for post in page_posts
         ],
         'last_page': last_page,
+        'total_count': total_count,
     })
 
 
@@ -322,7 +321,7 @@ def setting(request, parameter):
             })
 
         if parameter == 'pinned-posts':
-            delete = QueryDict(request.body)
+            delete = ApiRequestBodyService.parse_json_or_querydict(request)
             post_url = delete.get('post_url', '')
             if not post_url:
                 return StatusError(ErrorCode.INVALID_PARAMETER, '포스트 URL이 필요합니다.')
@@ -334,14 +333,7 @@ def setting(request, parameter):
                 return StatusError(e.code, e.message)
 
     if request.method == 'PUT':
-        # Try to parse JSON first, fallback to QueryDict
-        try:
-            put_data = json.loads(request.body.decode('utf-8')) if request.body else {}
-            put = type('QueryDict', (), {
-                'get': lambda self, key, default='': put_data.get(key, default)
-            })()
-        except (json.JSONDecodeError, UnicodeDecodeError):
-            put = QueryDict(request.body)
+        put = ApiRequestBodyService.parse_json_or_querydict(request)
 
         if parameter == 'notify':
             id = put.get('id')

--- a/backend/src/board/views/api/v1/static_page.py
+++ b/backend/src/board/views/api/v1/static_page.py
@@ -1,159 +1,60 @@
 from django.http import Http404
 from django.shortcuts import get_object_or_404
+
 from board.models import StaticPage
-from board.modules.response import StatusDone, StatusError, ErrorCode
+from board.modules.response import StatusDone, StatusError
+from board.services.api_permission_service import ApiPermissionService
 from board.services.api_request_body_service import ApiRequestBodyService
+from board.services.site_content_api_service import (
+    SiteContentApiError,
+    SiteContentApiService,
+)
 
 
 def static_pages(request, page_id=None):
-    """
-    Static Page CRUD API endpoint (staff only)
+    permission_error = ApiPermissionService.require_staff(request.user)
+    if permission_error:
+        return permission_error
 
-    GET /v1/static-pages - List all static pages
-    POST /v1/static-pages - Create new static page
-    GET /v1/static-pages/:id - Get static page details
-    PUT /v1/static-pages/:id - Update static page
-    DELETE /v1/static-pages/:id - Delete static page
-    """
-    if not request.user.is_active:
-        return StatusError(ErrorCode.NEED_LOGIN)
-
-    if not request.user.is_staff:
-        return StatusError(ErrorCode.REJECT, '관리자 권한이 필요합니다.')
-
-    # List all static pages
     if request.method == 'GET' and page_id is None:
         pages = StaticPage.objects.all().order_by('order', '-created_date')
-
         return StatusDone({
-            'pages': list(map(lambda page: {
-                'id': page.id,
-                'title': page.title,
-                'slug': page.slug,
-                'content': page.content,
-                'meta_description': page.meta_description,
-                'is_published': page.is_published,
-                'show_in_footer': page.show_in_footer,
-                'order': page.order,
-                'created_date': page.created_date.isoformat(),
-                'updated_date': page.updated_date.isoformat(),
-            }, pages))
+            'pages': [
+                SiteContentApiService.serialize_static_page(page)
+                for page in pages
+            ]
         })
 
-    # Get single static page
     if request.method == 'GET' and page_id:
         page = get_object_or_404(StaticPage, id=page_id)
+        return StatusDone(SiteContentApiService.serialize_static_page(page))
 
-        return StatusDone({
-            'id': page.id,
-            'title': page.title,
-            'slug': page.slug,
-            'content': page.content,
-            'meta_description': page.meta_description,
-            'is_published': page.is_published,
-            'show_in_footer': page.show_in_footer,
-            'order': page.order,
-            'created_date': page.created_date.isoformat(),
-            'updated_date': page.updated_date.isoformat(),
-        })
-
-    # Create new static page
     if request.method == 'POST':
         post_data, body_error = ApiRequestBodyService.parse_json_or_error(request)
         if body_error:
             return body_error
 
-        title = post_data.get('title', '')
-        slug = post_data.get('slug', '')
-        content = post_data.get('content', '')
-        meta_description = post_data.get('meta_description', '')
-        is_published = post_data.get('is_published', True)
-        show_in_footer = post_data.get('show_in_footer', False)
-        order = post_data.get('order', 0)
+        try:
+            page = SiteContentApiService.create_static_page(request.user, post_data)
+        except SiteContentApiError as error:
+            return StatusError(error.code, error.message)
 
-        if not title:
-            return StatusError(ErrorCode.VALIDATE, '제목을 입력해주세요.')
+        return StatusDone(SiteContentApiService.serialize_static_page(page))
 
-        if not slug:
-            return StatusError(ErrorCode.VALIDATE, 'URL 슬러그를 입력해주세요.')
-
-        if StaticPage.objects.filter(slug=slug).exists():
-            return StatusError(ErrorCode.ALREADY_EXISTS, '이미 사용 중인 슬러그입니다.')
-
-        page = StaticPage.objects.create(
-            title=title,
-            slug=slug,
-            content=content,
-            meta_description=meta_description,
-            is_published=is_published,
-            show_in_footer=show_in_footer,
-            order=order,
-            author=request.user,
-        )
-
-        return StatusDone({
-            'id': page.id,
-            'title': page.title,
-            'slug': page.slug,
-            'content': page.content,
-            'meta_description': page.meta_description,
-            'is_published': page.is_published,
-            'show_in_footer': page.show_in_footer,
-            'order': page.order,
-            'created_date': page.created_date.isoformat(),
-            'updated_date': page.updated_date.isoformat(),
-        })
-
-    # Update static page
     if request.method == 'PUT' and page_id:
         page = get_object_or_404(StaticPage, id=page_id)
-
         put_data = ApiRequestBodyService.parse_json_or_empty_for_legacy_only(request)
 
-        if 'title' in put_data:
-            page.title = put_data['title']
+        try:
+            SiteContentApiService.update_static_page(page, put_data)
+        except SiteContentApiError as error:
+            return StatusError(error.code, error.message)
 
-        if 'slug' in put_data:
-            new_slug = put_data['slug']
-            if new_slug != page.slug and StaticPage.objects.filter(slug=new_slug).exists():
-                return StatusError(ErrorCode.ALREADY_EXISTS, '이미 사용 중인 슬러그입니다.')
-            page.slug = new_slug
+        return StatusDone(SiteContentApiService.serialize_static_page(page))
 
-        if 'content' in put_data:
-            page.content = put_data['content']
-
-        if 'meta_description' in put_data:
-            page.meta_description = put_data['meta_description']
-
-        if 'is_published' in put_data:
-            page.is_published = put_data['is_published']
-
-        if 'show_in_footer' in put_data:
-            page.show_in_footer = put_data['show_in_footer']
-
-        if 'order' in put_data:
-            page.order = put_data['order']
-
-        page.save()
-
-        return StatusDone({
-            'id': page.id,
-            'title': page.title,
-            'slug': page.slug,
-            'content': page.content,
-            'meta_description': page.meta_description,
-            'is_published': page.is_published,
-            'show_in_footer': page.show_in_footer,
-            'order': page.order,
-            'created_date': page.created_date.isoformat(),
-            'updated_date': page.updated_date.isoformat(),
-        })
-
-    # Delete static page
     if request.method == 'DELETE' and page_id:
         page = get_object_or_404(StaticPage, id=page_id)
         page.delete()
-
         return StatusDone({'message': '정적 페이지가 삭제되었습니다.'})
 
     raise Http404

--- a/backend/src/board/views/api/v1/telegram.py
+++ b/backend/src/board/views/api/v1/telegram.py
@@ -1,11 +1,10 @@
-import json
-
 from django.conf import settings
 from django.http import Http404
 from django.utils import timezone
 
 from board.models import TelegramSync
 from board.modules.response import StatusDone, StatusError, ErrorCode
+from board.services.api_request_body_service import ApiRequestBodyService
 from board.services.site_url_service import SiteUrlService
 from modules.sub_task import SubTaskProcessor
 from modules.telegram import TelegramBot
@@ -15,11 +14,10 @@ from modules.randomness import randstr
 def telegram(request, parameter):
     if parameter == 'webHook':
         if request.method == 'POST':
-            print(request.body.decode("utf-8"))
             bot = TelegramBot(settings.TELEGRAM_BOT_TOKEN)
             req_userid = None
             try:
-                req = json.loads(request.body.decode("utf-8"))
+                req = ApiRequestBodyService.parse_json_or_empty_for_legacy_only(request)
                 req_userid = req['message']['from']['id']
                 req_token = req['message']['text']
 

--- a/backend/src/board/views/api/v1/user.py
+++ b/backend/src/board/views/api/v1/user.py
@@ -1,9 +1,10 @@
-from django.http import Http404, QueryDict
+from django.http import Http404
 from django.shortcuts import get_object_or_404
 
 from board.models import User
 from board.services import UserService
 from board.services.user_service import UserValidationError
+from board.services.api_request_body_service import ApiRequestBodyService
 from board.modules.response import StatusDone, StatusError, ErrorCode
 from board.modules.time import convert_to_localtime, time_since
 
@@ -12,7 +13,7 @@ def users(request, username):
     user = get_object_or_404(User, username=username)
 
     if request.method == 'PUT':
-        put = QueryDict(request.body)
+        put = ApiRequestBodyService.parse_json_or_querydict(request)
         if put.get('about'):
             try:
                 UserService.validate_user_permissions(request.user, user)


### PR DESCRIPTION
## 🎯 Goal
- Reduce duplicated request parsing and CRUD policy code across site content APIs.
- Keep settings list counts consistent across posts, forms, series, notices, and banners.

## 🔧 Core Changes
- Added a shared site content API service for notices, banners, forms, static pages, and related admin surfaces.
- Hardened JSON/form body parsing for non-object or invalid request bodies.
- Added total post counts for settings post management and surfaced counts in posts/forms settings headers.

## 🤔 Key Decisions
- Kept legacy form-body fallback where existing endpoints rely on it.
- Added post total counts at the API level so paginated settings lists show the full filtered result count, not only the current page length.

## 🧪 Verification Guide
### How to verify
1. Open settings posts and switch between 발행 포스트, 예약 포스트, and 임시 포스트 tabs.
2. Confirm the 포스트 header count follows the active tab and current filters.
3. Open settings forms and confirm the 서식 header displays its count.

### Expected result
- Site content APIs keep existing behavior while sharing common request and CRUD handling.
- Settings list headers show counts consistently.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)

Verification run:
- `npm run islands:lint`
- `npm run islands:type-check`
- `npm run server:test`
- `git diff --check`