### PR TITLE
♻️ Improve pinned post management UX

### DIFF
--- a/backend/islands/apps/remotes/src/components/remotes/Author/PinnedPostQuickAction.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/Author/PinnedPostQuickAction.tsx
@@ -1,26 +1,84 @@
-import { lazy, Suspense, useState } from 'react';
+import {
+    lazy,
+    Suspense,
+    useCallback,
+    useEffect,
+    useRef,
+    useState
+} from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { Modal } from '~/components/shared';
+import { getPinnedPosts } from '~/lib/api/settings';
+import { refreshPartialElement } from '~/utils/partialRefresh';
 
-const PinnedPostsPanel = lazy(() =>
+const loadPinnedPostsPanel = () =>
     import('~/components/remotes/SettingsApp/pages/PinnedPostsSetting/components/PinnedPostsPanel')
-        .then(module => ({ default: module.PinnedPostsPanel }))
-);
+        .then(module => ({ default: module.PinnedPostsPanel }));
 
-const PinnedPostQuickAction = () => {
+const PinnedPostsPanel = lazy(loadPinnedPostsPanel);
+
+const FEATURED_POSTS_SELECTOR = '[data-featured-posts-section]';
+const MODAL_CLOSE_REFRESH_DELAY_MS = 300;
+
+interface PinnedPostQuickActionProps {
+    partialUrl?: string;
+}
+
+const PinnedPostQuickAction = ({ partialUrl }: PinnedPostQuickActionProps) => {
+    const queryClient = useQueryClient();
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [hasChanges, setHasChanges] = useState(false);
+    const isRefreshingRef = useRef(false);
+    const refreshTimeoutRef = useRef<number | null>(null);
+
+    const cancelScheduledRefresh = useCallback(() => {
+        if (refreshTimeoutRef.current === null) return;
+
+        window.clearTimeout(refreshTimeoutRef.current);
+        refreshTimeoutRef.current = null;
+        isRefreshingRef.current = false;
+    }, []);
+
+    const preloadPinnedPostsPanel = useCallback(() => {
+        void loadPinnedPostsPanel();
+        void queryClient.prefetchQuery({
+            queryKey: ['pinned-posts-setting'],
+            queryFn: async () => {
+                const { data } = await getPinnedPosts();
+                if (data.status === 'DONE') {
+                    return data.body;
+                }
+                throw new Error('고정 포스트 목록을 불러오는데 실패했습니다.');
+            },
+            staleTime: 30_000
+        });
+    }, [queryClient]);
+
+    useEffect(() => {
+        return () => cancelScheduledRefresh();
+    }, [cancelScheduledRefresh]);
 
     const handleOpen = () => {
+        cancelScheduledRefresh();
         setHasChanges(false);
+        preloadPinnedPostsPanel();
         setIsModalOpen(true);
     };
 
     const handleClose = () => {
         setIsModalOpen(false);
-        if (hasChanges) {
-            window.setTimeout(() => {
-                window.location.reload();
-            }, 150);
+        if (hasChanges && !isRefreshingRef.current) {
+            setHasChanges(false);
+            isRefreshingRef.current = true;
+            refreshTimeoutRef.current = window.setTimeout(() => {
+                refreshTimeoutRef.current = null;
+                void refreshPartialElement({
+                    selector: FEATURED_POSTS_SELECTOR,
+                    url: partialUrl
+                }).finally(() => {
+                    isRefreshingRef.current = false;
+                });
+            }, MODAL_CLOSE_REFRESH_DELAY_MS);
         }
     };
 
@@ -29,6 +87,8 @@ const PinnedPostQuickAction = () => {
             <button
                 type="button"
                 onClick={handleOpen}
+                onFocus={preloadPinnedPostsPanel}
+                onPointerEnter={preloadPinnedPostsPanel}
                 className="inline-flex w-fit items-center justify-center rounded-lg bg-surface-subtle px-4 py-2 text-sm font-semibold text-content-secondary transition-colors hover:bg-surface-subtle/80 hover:text-content">
                 <i className="fas fa-thumbtack mr-2 text-xs" />
                 고정 포스트 설정
@@ -39,21 +99,19 @@ const PinnedPostQuickAction = () => {
                 onClose={handleClose}
                 title="고정 포스트 설정"
                 maxWidth="3xl">
-                <Modal.Body className="max-h-[70vh] overflow-y-auto">
-                    {isModalOpen && (
-                        <Suspense
-                            fallback={
-                                <div className="flex h-48 items-center justify-center text-content-secondary">
-                                    <i className="fas fa-spinner fa-spin mr-2" />
-                                    고정 포스트를 불러오는 중...
-                                </div>
-                            }>
-                            <PinnedPostsPanel
-                                embedded
-                                onPinnedPostsChange={() => setHasChanges(true)}
-                            />
-                        </Suspense>
-                    )}
+                <Modal.Body className="h-[70vh] overflow-y-auto">
+                    <Suspense
+                        fallback={
+                            <div className="flex h-full min-h-48 items-center justify-center text-content-secondary">
+                                <i className="fas fa-spinner fa-spin mr-2" />
+                                고정 포스트를 불러오는 중...
+                            </div>
+                        }>
+                        <PinnedPostsPanel
+                            embedded
+                            onPinnedPostsChange={() => setHasChanges(true)}
+                        />
+                    </Suspense>
                 </Modal.Body>
             </Modal>
         </>

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PinnedPostsSetting/components/AddPinnedPostModal.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PinnedPostsSetting/components/AddPinnedPostModal.tsx
@@ -1,47 +1,221 @@
-import { useState, useMemo } from 'react';
+import { useEffect, useState } from 'react';
 import { Modal } from '~/components/shared';
 import { getMediaPath } from '~/modules/static.module';
-import type { PinnablePostData } from '~/lib/api/settings';
+import type { PinnablePostData, PinnablePostsPaginationData } from '~/lib/api/settings';
+import { PinnablePostsPager } from './PinnablePostsPager';
 
 interface AddPinnedPostModalProps {
     open: boolean;
     onOpenChange: (open: boolean) => void;
     pinnablePosts: PinnablePostData[];
+    searchQuery?: string;
+    onSearchQueryChange?: (query: string) => void;
+    pagination: PinnablePostsPaginationData;
+    onPageChange: (page: number) => void;
     onAdd: (postUrl: string) => void;
     isLoading: boolean;
+    isFetchingPosts?: boolean;
+    presentation?: 'modal' | 'inline';
 }
 
 export const AddPinnedPostModal = ({
     open,
     onOpenChange,
     pinnablePosts,
+    searchQuery = '',
+    onSearchQueryChange,
+    pagination,
+    onPageChange,
     onAdd,
-    isLoading
+    isLoading,
+    isFetchingPosts = false,
+    presentation = 'modal'
 }: AddPinnedPostModalProps) => {
     const [selectedPost, setSelectedPost] = useState<string | null>(null);
-    const [searchQuery, setSearchQuery] = useState('');
 
-    const filteredPosts = useMemo(() => {
-        if (!searchQuery.trim()) return pinnablePosts;
-        const lowerQuery = searchQuery.toLowerCase();
-        return pinnablePosts.filter(post =>
-            post.title.toLowerCase().includes(lowerQuery)
-        );
-    }, [pinnablePosts, searchQuery]);
+    useEffect(() => {
+        setSelectedPost(null);
+    }, [searchQuery]);
 
     const handleAdd = () => {
         if (selectedPost) {
             onAdd(selectedPost);
             setSelectedPost(null);
-            setSearchQuery('');
+            onSearchQueryChange?.('');
         }
     };
 
     const handleClose = () => {
         onOpenChange(false);
         setSelectedPost(null);
-        setSearchQuery('');
+        onSearchQueryChange?.('');
     };
+
+    const handlePageChange = (page: number) => {
+        setSelectedPost(null);
+        onPageChange(page);
+    };
+
+    const content = (
+        <div className={`flex flex-col ${presentation === 'inline' ? 'max-h-[68vh] rounded-2xl border border-line bg-surface-elevated shadow-subtle' : 'h-[70vh]'}`}>
+            {presentation === 'inline' && (
+                <div className="flex items-start justify-between gap-3 border-b border-line px-5 py-4">
+                    <div className="space-y-1">
+                        <h3 className="text-lg font-semibold tracking-tight text-content">
+                            고정할 포스트 선택
+                        </h3>
+                        <p className="text-sm text-content-secondary">
+                            프로필에 보여줄 포스트를 하나 선택하세요.
+                        </p>
+                    </div>
+                    <div>
+                        <button
+                            type="button"
+                            onClick={handleClose}
+                            className="inline-flex min-h-10 items-center justify-center rounded-lg px-3 text-sm font-semibold text-content-secondary transition-colors duration-150 hover:bg-surface-subtle hover:text-content active:scale-95">
+                            선택 취소
+                        </button>
+                    </div>
+                </div>
+            )}
+
+            <div className={`space-y-3 border-b border-line ${presentation === 'inline' ? 'px-5 py-4' : 'px-6 py-4'}`}>
+                {presentation === 'modal' && (
+                    <p className="text-sm text-content-secondary">
+                        프로필에 표시할 포스트를 선택하세요.
+                    </p>
+                )}
+                <div className="relative">
+                    <i className="fas fa-search absolute left-4 top-1/2 -translate-y-1/2 text-content-hint" />
+                    <input
+                        type="text"
+                        aria-label="고정할 포스트 검색"
+                        placeholder="포스트 제목 검색..."
+                        value={searchQuery}
+                        onChange={(e) => onSearchQueryChange?.(e.target.value)}
+                        className="w-full rounded-xl border border-line bg-surface-subtle py-3 pl-10 pr-4 transition-all focus:border-line-strong focus:outline-none focus:ring-2 focus:ring-line/5"
+                    />
+                </div>
+            </div>
+
+            <div className={`flex-1 overflow-y-auto bg-surface-subtle/30 ${presentation === 'inline' ? 'min-h-0 px-4 py-4' : 'p-4'}`}>
+                {isFetchingPosts && pinnablePosts.length === 0 ? (
+                    <div className="grid grid-cols-1 gap-2">
+                        {Array.from({ length: 4 }).map((_, index) => (
+                            <div
+                                key={index}
+                                className="animate-pulse rounded-xl border border-line bg-surface p-4">
+                                <div className="flex items-center gap-4">
+                                    <div className="h-16 w-16 rounded-lg bg-surface-subtle" />
+                                    <div className="min-w-0 flex-1 space-y-2">
+                                        <div className="h-5 w-2/3 rounded bg-surface-subtle" />
+                                        <div className="h-4 w-1/3 rounded bg-surface-subtle" />
+                                    </div>
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                ) : pinnablePosts.length === 0 ? (
+                    <div className="flex h-full flex-col items-center justify-center py-20 text-center">
+                        <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-surface-subtle">
+                            <i className="fas fa-search text-2xl text-content-hint" />
+                        </div>
+                        <p className="mb-1 text-lg font-medium text-content">검색 결과가 없습니다</p>
+                        <p className="text-content-secondary">다른 검색어로 다시 시도해보세요.</p>
+                    </div>
+                ) : (
+                    <div
+                        className="grid grid-cols-1 gap-2"
+                        role="radiogroup"
+                        aria-label="고정할 포스트 선택">
+                        {pinnablePosts.map((post) => {
+                            const isSelected = selectedPost === post.url;
+                            return (
+                                <button
+                                    key={post.url}
+                                    type="button"
+                                    role="radio"
+                                    aria-checked={isSelected}
+                                    aria-label={`고정할 포스트 선택: ${post.title}`}
+                                    onClick={() => setSelectedPost(post.url)}
+                                    className={`group relative flex w-full items-center gap-4 rounded-xl border p-4 text-left transition-all duration-150 active:scale-[0.99] ${
+                                        isSelected
+                                            ? 'z-10 border-line-strong bg-surface shadow-subtle ring-1 ring-line-strong'
+                                            : 'border-line bg-surface hover:border-line-strong hover:shadow-subtle'
+                                    }`}>
+
+                                    {post.image ? (
+                                        <div className="h-16 w-16 flex-shrink-0 overflow-hidden rounded-lg border border-line bg-surface-subtle">
+                                            <img
+                                                src={getMediaPath(post.image)}
+                                                alt={post.title}
+                                                className="h-full w-full object-cover"
+                                            />
+                                        </div>
+                                    ) : (
+                                        <div className="flex h-16 w-16 flex-shrink-0 items-center justify-center rounded-lg border border-line bg-surface-subtle text-content-hint">
+                                            <i className="fas fa-file-alt text-xl" />
+                                        </div>
+                                    )}
+
+                                    <div className="min-w-0 flex-1">
+                                        <h4 className="mb-1 truncate text-lg font-bold text-content">
+                                            {post.title}
+                                        </h4>
+                                        <p className="flex items-center gap-2 text-sm text-content-secondary">
+                                            <i className="far fa-calendar" />
+                                            {new Date(post.createdDate).toLocaleDateString('ko-KR')}
+                                        </p>
+                                    </div>
+
+                                    <div
+                                        className={`absolute right-4 top-1/2 flex h-6 w-6 -translate-y-1/2 items-center justify-center rounded-full border transition-all ${
+                                        isSelected
+                                            ? 'scale-100 border-line-strong bg-action text-content-inverted opacity-100'
+                                            : 'border-line bg-surface text-transparent group-hover:border-line-strong'
+                                    }`}>
+                                        <i className="fas fa-check text-xs" />
+                                    </div>
+                                </button>
+                            );
+                        })}
+                        <PinnablePostsPager
+                            pagination={pagination}
+                            onPageChange={handlePageChange}
+                            isLoading={isFetchingPosts}
+                        />
+                    </div>
+                )}
+            </div>
+
+            <div className="flex items-center justify-end gap-3 border-t border-line bg-surface-subtle px-6 py-4">
+                <Modal.FooterAction variant="secondary" onClick={handleClose}>
+                    취소
+                </Modal.FooterAction>
+                <Modal.FooterAction
+                    variant="primary"
+                    onClick={handleAdd}
+                    disabled={!selectedPost || isLoading}>
+                    {isLoading ? (
+                        <span className="flex items-center gap-2">
+                            <i className="fas fa-spinner fa-spin" />
+                            추가 중...
+                        </span>
+                    ) : (
+                        '포스트 고정'
+                    )}
+                </Modal.FooterAction>
+            </div>
+        </div>
+    );
+
+    if (presentation === 'inline' && !open) {
+        return null;
+    }
+
+    if (presentation === 'inline') {
+        return content;
+    }
 
     return (
         <Modal
@@ -49,107 +223,7 @@ export const AddPinnedPostModal = ({
             onClose={handleClose}
             title="포스트 고정하기"
             maxWidth="2xl">
-            <div className="flex flex-col h-[70vh]">
-                <div className="px-6 py-4 border-b border-line-light space-y-3">
-                    <p className="text-sm text-content-secondary">
-                        프로필에 표시할 포스트를 선택하세요.
-                    </p>
-                    <div className="relative">
-                        <i className="fas fa-search absolute left-4 top-1/2 -translate-y-1/2 text-content-hint" />
-                        <input
-                            type="text"
-                            placeholder="포스트 제목 검색..."
-                            value={searchQuery}
-                            onChange={(e) => setSearchQuery(e.target.value)}
-                            className="w-full pl-10 pr-4 py-3 bg-surface-subtle border border-line rounded-xl focus:outline-none focus:ring-2 focus:ring-line/5 focus:border-line-strong transition-all"
-                        />
-                    </div>
-                </div>
-
-                <div className="flex-1 overflow-y-auto p-4 bg-surface-subtle/30">
-                    {filteredPosts.length === 0 ? (
-                        <div className="text-center py-20 flex flex-col items-center justify-center h-full">
-                            <div className="w-16 h-16 bg-surface-subtle rounded-full flex items-center justify-center mb-4">
-                                <i className="fas fa-search text-2xl text-content-hint" />
-                            </div>
-                            <p className="text-content font-medium text-lg mb-1">검색 결과가 없습니다</p>
-                            <p className="text-content-secondary">다른 검색어로 다시 시도해보세요.</p>
-                        </div>
-                    ) : (
-                        <div className="grid grid-cols-1 gap-2">
-                            {filteredPosts.map((post) => {
-                                const isSelected = selectedPost === post.url;
-                                return (
-                                    <button
-                                        key={post.url}
-                                        onClick={() => setSelectedPost(post.url)}
-                                        className={`w-full text-left p-4 rounded-xl border transition-all duration-200 group relative flex items-center gap-4 ${
-                                            isSelected
-                                                ? 'border-line-strong bg-surface ring-1 ring-line-strong shadow-md z-10'
-                                                : 'border-line bg-surface hover:border-line-strong hover:shadow-sm'
-                                        }`}>
-
-                                        {/* Image */}
-                                        {post.image ? (
-                                            <div className="w-16 h-16 rounded-lg overflow-hidden flex-shrink-0 bg-surface-subtle border border-line-light">
-                                                <img
-                                                    src={getMediaPath(post.image)}
-                                                    alt={post.title}
-                                                    className="w-full h-full object-cover"
-                                                />
-                                            </div>
-                                        ) : (
-                                            <div className="w-16 h-16 rounded-lg bg-surface-subtle flex items-center justify-center flex-shrink-0 border border-line-light text-content-hint">
-                                                <i className="fas fa-file-alt text-xl" />
-                                            </div>
-                                        )}
-
-                                        {/* Content */}
-                                        <div className="flex-1 min-w-0">
-                                            <h4 className={`font-bold text-lg truncate mb-1 ${isSelected ? 'text-content' : 'text-content'}`}>
-                                                {post.title}
-                                            </h4>
-                                            <p className="text-sm text-content-secondary flex items-center gap-2">
-                                                <i className="far fa-calendar" />
-                                                {new Date(post.createdDate).toLocaleDateString('ko-KR')}
-                                            </p>
-                                        </div>
-
-                                        {/* Check Icon */}
-                                        <div
-                                            className={`absolute right-4 top-1/2 -translate-y-1/2 w-6 h-6 rounded-full border flex items-center justify-center transition-all ${
-                                            isSelected
-                                                ? 'border-line-strong bg-action text-content-inverted scale-100 opacity-100'
-                                                : 'border-line bg-surface text-transparent group-hover:border-line-strong'
-                                        }`}>
-                                            <i className="fas fa-check text-xs" />
-                                        </div>
-                                    </button>
-                                );
-                            })}
-                        </div>
-                    )}
-                </div>
-
-                <Modal.Footer>
-                    <Modal.FooterAction variant="secondary" onClick={handleClose}>
-                        취소
-                    </Modal.FooterAction>
-                    <Modal.FooterAction
-                        variant="primary"
-                        onClick={handleAdd}
-                        disabled={!selectedPost || isLoading}>
-                        {isLoading ? (
-                            <span className="flex items-center gap-2">
-                                <i className="fas fa-spinner fa-spin" />
-                                추가 중...
-                            </span>
-                        ) : (
-                            '포스트 고정'
-                        )}
-                    </Modal.FooterAction>
-                </Modal.Footer>
-            </div>
+            {content}
         </Modal>
     );
 };

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PinnedPostsSetting/components/PinnablePostInlineList.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PinnedPostsSetting/components/PinnablePostInlineList.tsx
@@ -1,0 +1,140 @@
+import {
+    Button,
+    SUBTITLE,
+    TITLE,
+    getIconClass
+} from '~/components/shared';
+import SettingsListItem from '../../../components/SettingsListItem';
+import { getMediaPath } from '~/modules/static.module';
+import type { PinnablePostData, PinnablePostsPaginationData } from '~/lib/api/settings';
+import { PinnablePostsPager } from './PinnablePostsPager';
+
+interface PinnablePostInlineListProps {
+    posts: PinnablePostData[];
+    searchQuery: string;
+    onSearchQueryChange: (query: string) => void;
+    pagination: PinnablePostsPaginationData;
+    onPageChange: (page: number) => void;
+    onAdd: (postUrl: string) => void;
+    canAddMore: boolean;
+    isLoading?: boolean;
+    isAdding?: boolean;
+    loadingPostUrl?: string | null;
+}
+
+export const PinnablePostInlineList = ({
+    posts,
+    searchQuery,
+    onSearchQueryChange,
+    pagination,
+    onPageChange,
+    onAdd,
+    canAddMore,
+    isLoading = false,
+    isAdding = false,
+    loadingPostUrl = null
+}: PinnablePostInlineListProps) => {
+    const isActionDisabled = !canAddMore || isAdding || isLoading;
+
+    return (
+        <div className="space-y-3">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div className="space-y-1">
+                    <h4 className="text-sm font-semibold text-content">고정 가능한 포스트</h4>
+                    <p className="text-xs text-content-secondary">
+                        오른쪽의 고정 버튼을 누르면 바로 프로필에 추가됩니다.
+                    </p>
+                </div>
+                <div className="relative w-full sm:w-72">
+                    <i className="fas fa-search absolute left-3 top-1/2 -translate-y-1/2 text-xs text-content-hint" />
+                    <input
+                        type="text"
+                        aria-label="고정 가능한 포스트 검색"
+                        placeholder="포스트 검색"
+                        value={searchQuery}
+                        onChange={(event) => onSearchQueryChange(event.target.value)}
+                        className="h-11 w-full rounded-lg border border-line bg-surface-subtle pl-9 pr-3 text-sm text-content transition-colors duration-150 placeholder:text-content-hint focus:border-line-strong focus:outline-none focus:ring-2 focus:ring-line/50"
+                    />
+                </div>
+            </div>
+
+            {!canAddMore && (
+                <div className="rounded-xl border border-line bg-surface-subtle px-4 py-3 text-sm text-content-secondary">
+                    고정 가능한 최대 개수에 도달했습니다. 새 포스트를 고정하려면 기존 고정을 먼저 해제하세요.
+                </div>
+            )}
+
+            {isLoading && posts.length === 0 ? (
+                <div className="space-y-3" aria-label="고정 가능한 포스트를 불러오는 중">
+                    {Array.from({ length: 3 }).map((_, index) => (
+                        <div
+                            key={index}
+                            className="animate-pulse rounded-xl border border-line bg-surface px-4 py-3">
+                            <div className="flex items-center gap-4">
+                                <div className="h-12 w-12 rounded-lg bg-surface-subtle" />
+                                <div className="min-w-0 flex-1 space-y-2">
+                                    <div className="h-4 w-2/3 rounded bg-surface-subtle" />
+                                    <div className="h-3 w-1/3 rounded bg-surface-subtle" />
+                                </div>
+                                <div className="h-9 w-14 rounded-lg bg-surface-subtle" />
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            ) : posts.length === 0 ? (
+                <div className="rounded-xl border border-dashed border-line bg-surface-subtle px-4 py-8 text-center text-sm text-content-secondary">
+                    {searchQuery.trim() ? '검색 결과가 없습니다.' : '더 고정할 수 있는 포스트가 없습니다.'}
+                </div>
+            ) : (
+                <div className="space-y-3" aria-busy={isLoading}>
+                    {posts.map((post) => {
+                        const isLoading = loadingPostUrl === post.url;
+
+                        return (
+                            <SettingsListItem
+                                key={post.url}
+                                left={
+                                    post.image ? (
+                                        <div className={`${getIconClass('default')} overflow-hidden`}>
+                                            <img
+                                                src={getMediaPath(post.image)}
+                                                alt={post.title}
+                                                className="h-full w-full object-cover"
+                                            />
+                                        </div>
+                                    ) : (
+                                        <div className={getIconClass('default')}>
+                                            <i className="fas fa-file-alt text-sm" />
+                                        </div>
+                                    )
+                                }
+                                actions={
+                                    <Button
+                                        variant="secondary"
+                                        size="sm"
+                                        onClick={() => onAdd(post.url)}
+                                        disabled={isActionDisabled || isLoading}
+                                        isLoading={isLoading}>
+                                        고정
+                                    </Button>
+                                }>
+                                <h3 className={`${TITLE} mb-1 truncate text-content`}>{post.title}</h3>
+                                <div className={`${SUBTITLE} flex items-center gap-2 text-xs`}>
+                                    <span className="flex items-center gap-1">
+                                        <i className="far fa-calendar text-content-hint" />
+                                        {new Date(post.createdDate).toLocaleDateString('ko-KR')}
+                                    </span>
+                                </div>
+                            </SettingsListItem>
+                        );
+                    })}
+                    <PinnablePostsPager
+                        pagination={pagination}
+                        onPageChange={onPageChange}
+                        isLoading={isLoading}
+                    />
+                </div>
+            )}
+        </div>
+    );
+};

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PinnedPostsSetting/components/PinnablePostsPager.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PinnedPostsSetting/components/PinnablePostsPager.tsx
@@ -1,0 +1,101 @@
+import { Button } from '~/components/shared';
+import type { PinnablePostsPaginationData } from '~/lib/api/settings';
+
+interface PinnablePostsPagerProps {
+    pagination: PinnablePostsPaginationData;
+    onPageChange: (page: number) => void;
+    isLoading?: boolean;
+}
+
+const getVisiblePages = (currentPage: number, lastPage: number) => {
+    if (lastPage <= 5) {
+        return Array.from({ length: lastPage }, (_, index) => index + 1);
+    }
+
+    if (currentPage <= 3) {
+        return [1, 2, 3, 4, 5];
+    }
+
+    if (currentPage >= lastPage - 2) {
+        return [lastPage - 4, lastPage - 3, lastPage - 2, lastPage - 1, lastPage];
+    }
+
+    return [currentPage - 2, currentPage - 1, currentPage, currentPage + 1, currentPage + 2];
+};
+
+export const PinnablePostsPager = ({
+    pagination,
+    onPageChange,
+    isLoading = false
+}: PinnablePostsPagerProps) => {
+    if (pagination.totalCount === 0) {
+        return null;
+    }
+
+    const currentPage = pagination.page;
+    const start = (currentPage - 1) * pagination.limit + 1;
+    const end = Math.min(currentPage * pagination.limit, pagination.totalCount);
+    const visiblePages = getVisiblePages(currentPage, pagination.lastPage);
+
+    const handlePageMove = (page: number) => {
+        if (page < 1 || page > pagination.lastPage || page === currentPage || isLoading) return;
+        onPageChange(page);
+    };
+
+    return (
+        <nav
+            className="flex flex-col gap-3 pt-1 sm:flex-row sm:items-center sm:justify-between"
+            aria-label="고정 가능한 포스트 페이지">
+            <p className="text-xs text-content-secondary">
+                총 {pagination.totalCount}개 중 {start}-{end}개 표시
+            </p>
+            {pagination.lastPage > 1 && (
+                <div className="flex flex-wrap items-center gap-1.5">
+                    <Button
+                        variant="secondary"
+                        size="sm"
+                        disabled={!pagination.hasPrevious || isLoading}
+                        onClick={() => handlePageMove(1)}
+                        aria-label="첫 페이지">
+                        <i className="fas fa-angle-double-left" />
+                    </Button>
+                    <Button
+                        variant="secondary"
+                        size="sm"
+                        disabled={!pagination.hasPrevious || isLoading}
+                        onClick={() => handlePageMove(currentPage - 1)}
+                        aria-label="이전 페이지">
+                        <i className="fas fa-angle-left" />
+                    </Button>
+                    {visiblePages.map(page => (
+                        <Button
+                            key={page}
+                            variant={page === currentPage ? 'primary' : 'secondary'}
+                            size="sm"
+                            disabled={isLoading}
+                            onClick={() => handlePageMove(page)}
+                            aria-current={page === currentPage ? 'page' : undefined}>
+                            {page}
+                        </Button>
+                    ))}
+                    <Button
+                        variant="secondary"
+                        size="sm"
+                        disabled={!pagination.hasNext || isLoading}
+                        onClick={() => handlePageMove(currentPage + 1)}
+                        aria-label="다음 페이지">
+                        <i className="fas fa-angle-right" />
+                    </Button>
+                    <Button
+                        variant="secondary"
+                        size="sm"
+                        disabled={!pagination.hasNext || isLoading}
+                        onClick={() => handlePageMove(pagination.lastPage)}
+                        aria-label="마지막 페이지">
+                        <i className="fas fa-angle-double-right" />
+                    </Button>
+                </div>
+            )}
+        </nav>
+    );
+};

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PinnedPostsSetting/components/PinnedPostItem.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PinnedPostsSetting/components/PinnedPostItem.tsx
@@ -1,13 +1,13 @@
 import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import {
+    Button,
     TITLE,
     SUBTITLE,
-    Dropdown,
     getIconClass
 } from '~/components/shared';
 import { SettingsListItem } from '../../../components';
 import { getMediaPath } from '~/modules/static.module';
-import { useConfirm } from '~/hooks/useConfirm';
 import type { PinnedPostData } from '~/lib/api/settings';
 
 interface PinnedPostItemProps {
@@ -21,35 +21,29 @@ export const PinnedPostItem = ({
     username,
     onRemove
 }: PinnedPostItemProps) => {
-    const { confirm } = useConfirm();
     const {
         attributes,
         listeners,
         setNodeRef,
+        transform,
         transition,
         isDragging
     } = useSortable({ id: pinnedPost.post.url });
 
     const style = {
+        transform: CSS.Transform.toString(transform),
         transition,
-        opacity: isDragging ? 0.5 : 1
+        opacity: isDragging ? 0.5 : 1,
+        position: 'relative' as const,
+        zIndex: isDragging ? 999 : 1
     };
 
     const handleView = () => {
         window.location.assign(`/@${username}/${pinnedPost.post.url}`);
     };
 
-    const handleRemove = async () => {
-        const confirmed = await confirm({
-            title: '포스트 고정 해제',
-            message: `"${pinnedPost.post.title}" 포스트 고정을 해제하시겠습니까?`,
-            confirmText: '해제',
-            variant: 'danger'
-        });
-
-        if (confirmed) {
-            onRemove(pinnedPost.post.url);
-        }
+    const handleRemove = () => {
+        onRemove(pinnedPost.post.url);
     };
 
     return (
@@ -76,15 +70,12 @@ export const PinnedPostItem = ({
                     )
                 }
                 actions={
-                    <Dropdown
-                        items={[
-                            {
-                                label: '고정 해제',
-                                icon: 'fas fa-thumbtack',
-                                onClick: handleRemove
-                            }
-                        ]}
-                    />
+                    <Button
+                        variant="secondary"
+                        size="sm"
+                        onClick={handleRemove}>
+                        해제
+                    </Button>
                 }>
                 <h3 className={`${TITLE} mb-1 truncate text-content`}>{pinnedPost.post.title}</h3>
                 <div className={`${SUBTITLE} text-xs flex items-center gap-2`}>

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PinnedPostsSetting/components/PinnedPostList.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PinnedPostsSetting/components/PinnedPostList.tsx
@@ -75,7 +75,7 @@ export const PinnedPostList = ({
             <SortableContext
                 items={pinnedPosts.map((item) => item.post.url)}
                 strategy={verticalListSortingStrategy}>
-                <div className="space-y-3">
+                <div>
                     {pinnedPosts.map((item) => (
                         <PinnedPostItem
                             key={item.post.url}

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PinnedPostsSetting/components/PinnedPostsPanel.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PinnedPostsSetting/components/PinnedPostsPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 import { SettingsHeader } from '../../../components';
 import { Button } from '~/components/shared';
@@ -10,9 +10,11 @@ import {
     removePinnedPost,
     updatePinnedPostsOrder,
     type PinnablePostData,
+    type PinnablePostsPaginationData,
     type PinnedPostData
 } from '~/lib/api/settings';
 import { AddPinnedPostModal } from './AddPinnedPostModal';
+import { PinnablePostInlineList } from './PinnablePostInlineList';
 import { PinnedPostList } from './PinnedPostList';
 
 interface PinnedPostsPanelProps {
@@ -20,18 +22,22 @@ interface PinnedPostsPanelProps {
     onPinnedPostsChange?: () => void;
 }
 
+const PINNABLE_POSTS_PAGE_SIZE = 30;
+
+const DEFAULT_PINNABLE_POSTS_PAGINATION: PinnablePostsPaginationData = {
+    page: 1,
+    limit: PINNABLE_POSTS_PAGE_SIZE,
+    lastPage: 1,
+    totalCount: 0,
+    hasNext: false,
+    hasPrevious: false
+};
+
 export const PinnedPostsPanel = ({
     embedded = false,
     onPinnedPostsChange
 }: PinnedPostsPanelProps) => {
     const queryClient = useQueryClient();
-    const [pinnedPosts, setPinnedPosts] = useState<PinnedPostData[]>([]);
-    const [pinnablePosts, setPinnablePosts] = useState<PinnablePostData[]>([]);
-    const [username, setUsername] = useState<string>('');
-    const [maxCount, setMaxCount] = useState<number>(6);
-    const [isModalOpen, setIsModalOpen] = useState(false);
-    const [isAddingPost, setIsAddingPost] = useState(false);
-
     const { data: pinnedPostsData } = useSuspenseQuery({
         queryKey: ['pinned-posts-setting'],
         queryFn: async () => {
@@ -43,6 +49,22 @@ export const PinnedPostsPanel = ({
         }
     });
 
+    const [pinnedPosts, setPinnedPosts] = useState<PinnedPostData[]>(
+        pinnedPostsData.pinnedPosts
+    );
+    const [pinnablePosts, setPinnablePosts] = useState<PinnablePostData[]>([]);
+    const [username, setUsername] = useState<string>(pinnedPostsData.username);
+    const [maxCount, setMaxCount] = useState<number>(pinnedPostsData.maxCount);
+    const [isModalOpen, setIsModalOpen] = useState(false);
+    const [isAddingPost, setIsAddingPost] = useState(false);
+    const [addingPostUrl, setAddingPostUrl] = useState<string | null>(null);
+    const [pinnableSearchQuery, setPinnableSearchQuery] = useState('');
+    const [pinnablePage, setPinnablePage] = useState(1);
+    const [pinnablePagination, setPinnablePagination] =
+        useState<PinnablePostsPaginationData>(DEFAULT_PINNABLE_POSTS_PAGINATION);
+    const [isPinnableLoading, setIsPinnableLoading] = useState(embedded);
+    const pinnableRequestSeq = useRef(0);
+
     useEffect(() => {
         if (pinnedPostsData) {
             setPinnedPosts(pinnedPostsData.pinnedPosts);
@@ -51,23 +73,79 @@ export const PinnedPostsPanel = ({
         }
     }, [pinnedPostsData]);
 
-    const fetchPinnablePosts = async () => {
+    const fetchPinnablePosts = useCallback(async (query = '', page = 1) => {
+        const requestSeq = pinnableRequestSeq.current + 1;
+        pinnableRequestSeq.current = requestSeq;
+        setIsPinnableLoading(true);
         try {
-            const { data } = await getPinnablePosts();
+            const { data } = await getPinnablePosts({
+                query,
+                limit: PINNABLE_POSTS_PAGE_SIZE,
+                page
+            });
+
+            if (requestSeq !== pinnableRequestSeq.current) {
+                return;
+            }
+
             if (data.status === 'DONE') {
                 setPinnablePosts(data.body.posts);
+                setPinnablePagination({
+                    page: data.body.page,
+                    limit: data.body.limit,
+                    lastPage: data.body.lastPage,
+                    totalCount: data.body.totalCount,
+                    hasNext: data.body.hasNext,
+                    hasPrevious: data.body.hasPrevious
+                });
+                setPinnablePage(data.body.page);
             }
         } catch {
-            toast.error('포스트 목록을 불러오는데 실패했습니다.');
+            if (requestSeq === pinnableRequestSeq.current) {
+                toast.error('포스트 목록을 불러오는데 실패했습니다.');
+            }
+        } finally {
+            if (requestSeq === pinnableRequestSeq.current) {
+                setIsPinnableLoading(false);
+            }
         }
+    }, []);
+
+    useEffect(() => {
+        if (!embedded && !isModalOpen) return;
+
+        const timeoutId = window.setTimeout(
+            () => {
+                fetchPinnablePosts(pinnableSearchQuery, pinnablePage);
+            },
+            pinnableSearchQuery ? 250 : 0
+        );
+
+        return () => window.clearTimeout(timeoutId);
+    }, [embedded, fetchPinnablePosts, isModalOpen, pinnablePage, pinnableSearchQuery]);
+
+    const handlePinnableSearchQueryChange = (query: string) => {
+        setPinnableSearchQuery(query);
+        setPinnablePage(1);
+        setIsPinnableLoading(true);
     };
 
-    const handleOpenModal = async () => {
-        await fetchPinnablePosts();
+    const handlePinnablePageChange = (page: number) => {
+        setPinnablePage(page);
+        setIsPinnableLoading(true);
+    };
+
+    const handleOpenModal = () => {
+        setPinnableSearchQuery('');
+        setPinnablePage(1);
+        setPinnablePagination(DEFAULT_PINNABLE_POSTS_PAGINATION);
+        setPinnablePosts([]);
+        setIsPinnableLoading(true);
         setIsModalOpen(true);
     };
 
     const handleReorder = async (newPinnedPosts: PinnedPostData[]) => {
+        const previousPinnedPosts = pinnedPosts;
         setPinnedPosts(newPinnedPosts);
 
         try {
@@ -79,21 +157,26 @@ export const PinnedPostsPanel = ({
             }
 
             toast.success('순서가 변경되었습니다.');
+            await queryClient.invalidateQueries({ queryKey: ['pinned-posts-setting'] });
             onPinnedPostsChange?.();
         } catch {
-            setPinnedPosts(pinnedPosts);
+            setPinnedPosts(previousPinnedPosts);
             toast.error('순서 변경에 실패했습니다.');
         }
     };
 
     const handleAddPinnedPost = async (postUrl: string) => {
         setIsAddingPost(true);
+        setAddingPostUrl(postUrl);
         try {
             const { data } = await addPinnedPost(postUrl);
 
             if (data.status === 'DONE') {
-                queryClient.invalidateQueries({ queryKey: ['pinned-posts-setting'] });
+                await queryClient.invalidateQueries({ queryKey: ['pinned-posts-setting'] });
+                pinnableRequestSeq.current += 1;
                 setIsModalOpen(false);
+                setPinnablePosts((posts) => posts.filter((post) => post.url !== postUrl));
+                fetchPinnablePosts(pinnableSearchQuery, pinnablePage);
                 toast.success('포스트가 고정되었습니다.');
                 onPinnedPostsChange?.();
             } else {
@@ -103,6 +186,7 @@ export const PinnedPostsPanel = ({
             toast.error(error instanceof Error ? error.message : '포스트 고정에 실패했습니다.');
         } finally {
             setIsAddingPost(false);
+            setAddingPostUrl(null);
         }
     };
 
@@ -111,7 +195,9 @@ export const PinnedPostsPanel = ({
             const { data } = await removePinnedPost(postUrl);
 
             if (data.status === 'DONE') {
-                setPinnedPosts(pinnedPosts.filter(p => p.post.url !== postUrl));
+                setPinnedPosts((posts) => posts.filter(p => p.post.url !== postUrl));
+                await queryClient.invalidateQueries({ queryKey: ['pinned-posts-setting'] });
+                fetchPinnablePosts(pinnableSearchQuery, pinnablePage);
                 toast.success('고정이 해제되었습니다.');
                 onPinnedPostsChange?.();
             } else {
@@ -143,13 +229,20 @@ export const PinnedPostsPanel = ({
                 maxCount={maxCount}
             />
 
-            <AddPinnedPostModal
-                open={isModalOpen}
-                onOpenChange={setIsModalOpen}
-                pinnablePosts={pinnablePosts}
-                onAdd={handleAddPinnedPost}
-                isLoading={isAddingPost}
-            />
+            {!embedded && (
+                <AddPinnedPostModal
+                    open={isModalOpen}
+                    onOpenChange={setIsModalOpen}
+                    pinnablePosts={pinnablePosts}
+                    searchQuery={pinnableSearchQuery}
+                    onSearchQueryChange={handlePinnableSearchQueryChange}
+                    pagination={pinnablePagination}
+                    onPageChange={handlePinnablePageChange}
+                    onAdd={handleAddPinnedPost}
+                    isLoading={isAddingPost}
+                    isFetchingPosts={isPinnableLoading}
+                />
+            )}
         </>
     );
 
@@ -182,10 +275,24 @@ export const PinnedPostsPanel = ({
                     </p>
                 </div>
                 <div className="flex-shrink-0">
-                    {action}
+                    {!embedded && action}
                 </div>
             </div>
             {list}
+            <div className="border-t border-line pt-4">
+                <PinnablePostInlineList
+                    posts={pinnablePosts}
+                    searchQuery={pinnableSearchQuery}
+                    onSearchQueryChange={handlePinnableSearchQueryChange}
+                    pagination={pinnablePagination}
+                    onPageChange={handlePinnablePageChange}
+                    onAdd={handleAddPinnedPost}
+                    canAddMore={canAddMore}
+                    isLoading={isPinnableLoading}
+                    isAdding={isAddingPost}
+                    loadingPostUrl={addingPostUrl}
+                />
+            </div>
         </section>
     );
 };

--- a/backend/islands/apps/remotes/src/lib/api/settings.ts
+++ b/backend/islands/apps/remotes/src/lib/api/settings.ts
@@ -322,12 +322,29 @@ export interface PinnablePostData {
     createdDate: string;
 }
 
+export interface PinnablePostsPaginationData {
+    page: number;
+    limit: number;
+    lastPage: number;
+    totalCount: number;
+    hasNext: boolean;
+    hasPrevious: boolean;
+}
+
 export const getPinnedPosts = async () => {
     return http.get<Response<{ pinnedPosts: PinnedPostData[]; username: string; maxCount: number }>>('v1/setting/pinned-posts');
 };
 
-export const getPinnablePosts = async () => {
-    return http.get<Response<{ posts: PinnablePostData[] }>>('v1/setting/pinnable-posts');
+export const getPinnablePosts = async (
+    options: { query?: string; limit?: number; page?: number } = {}
+) => {
+    return http.get<Response<{ posts: PinnablePostData[] } & PinnablePostsPaginationData>>('v1/setting/pinnable-posts', {
+        params: {
+            q: options.query || undefined,
+            limit: options.limit,
+            page: options.page
+        }
+    });
 };
 
 export const addPinnedPost = async (postUrl: string) => {

--- a/backend/islands/apps/remotes/src/utils/partialRefresh.ts
+++ b/backend/islands/apps/remotes/src/utils/partialRefresh.ts
@@ -1,0 +1,66 @@
+interface RefreshPartialElementOptions {
+    selector: string;
+    url?: string;
+    fallbackToReload?: boolean;
+}
+
+const readPartialUrl = (element: HTMLElement, url?: string) => url || element.dataset.partialUrl;
+
+const reloadOrReturnFalse = (fallbackToReload: boolean) => {
+    if (fallbackToReload) {
+        window.location.reload();
+    }
+
+    return false;
+};
+
+export const refreshPartialElement = async ({
+    selector,
+    url,
+    fallbackToReload = true
+}: RefreshPartialElementOptions) => {
+    const currentElement = document.querySelector<HTMLElement>(selector);
+
+    if (!currentElement) {
+        return reloadOrReturnFalse(fallbackToReload);
+    }
+
+    const partialUrl = readPartialUrl(currentElement, url);
+
+    if (!partialUrl) {
+        return reloadOrReturnFalse(fallbackToReload);
+    }
+
+    currentElement.setAttribute('aria-busy', 'true');
+    currentElement.classList.add('opacity-60', 'transition-opacity', 'duration-150');
+
+    try {
+        const response = await fetch(partialUrl, {
+            credentials: 'same-origin',
+            headers: { 'X-Requested-With': 'XMLHttpRequest' }
+        });
+
+        if (!response.ok) {
+            throw new Error('Failed to refresh partial element');
+        }
+
+        const html = (await response.text()).trim();
+
+        if (!html) {
+            currentElement.remove();
+            return true;
+        }
+
+        const nextDocument = new DOMParser().parseFromString(html, 'text/html');
+        const nextElement = nextDocument.querySelector<HTMLElement>(selector);
+
+        if (!nextElement) {
+            throw new Error('Partial element was not found');
+        }
+
+        currentElement.replaceWith(nextElement);
+        return true;
+    } catch {
+        return reloadOrReturnFalse(fallbackToReload);
+    }
+};

--- a/backend/islands/packages/ui/src/components/Modal.tsx
+++ b/backend/islands/packages/ui/src/components/Modal.tsx
@@ -136,28 +136,23 @@ const ModalRoot = ({
                 <Dialog.Content
                     className={cx(
                         // Base styles
-                        `fixed z-[61] bg-surface-elevated shadow-2xl ${INTERACTION_DURATION} focus:outline-none flex flex-col`,
-                        'max-h-[85vh] overflow-y-auto',
+                        `fixed z-[61] flex max-h-[85vh] flex-col overflow-y-auto bg-surface-elevated shadow-2xl ${INTERACTION_DURATION} focus:outline-none`,
+
+                        // Mobile: Bottom Sheet
+                        'bottom-0 left-0 w-full translate-x-0 translate-y-0 rounded-t-2xl rounded-b-none',
+
+                        // Desktop: Centered Modal
+                        'sm:bottom-auto sm:left-[50%] sm:top-[50%] sm:w-full',
+                        'sm:translate-x-[-50%] sm:translate-y-[-50%] sm:rounded-2xl',
+                        getMaxWidthClass(),
 
                         // Animations
                         'data-[state=open]:animate-in data-[state=closed]:animate-out',
                         'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
-
-                        // Mobile: Bottom Sheet
-                        'bottom-0 left-0 w-full',
-                        'translate-x-0 translate-y-0',
-                        'rounded-t-2xl rounded-b-none',
-                        'data-[state=closed]:slide-out-to-bottom hover:data-[state=closed]:slide-out-to-bottom',
-                        'data-[state=open]:slide-in-from-bottom',
-
-                        // Desktop: Centered Modal
-                        'sm:top-[50%] sm:left-[50%] sm:bottom-auto',
-                        'sm:w-full',
-                        getMaxWidthClass(),
-                        'sm:translate-x-[-50%] sm:translate-y-[-50%]',
-                        'sm:rounded-2xl',
-                        'sm:data-[state=closed]:slide-out-to-bottom-[48%]',
-                        'sm:data-[state=open]:slide-in-from-bottom-[48%]'
+                        'motion-safe:max-sm:data-[state=closed]:slide-out-to-bottom motion-safe:max-sm:data-[state=open]:slide-in-from-bottom',
+                        'motion-safe:sm:data-[state=closed]:zoom-out-95 motion-safe:sm:data-[state=open]:zoom-in-95',
+                        'motion-reduce:data-[state=open]:animate-none motion-reduce:data-[state=closed]:animate-none motion-reduce:transition-none',
+                        'duration-150 motion-reduce:duration-0'
                     )}>
 
                     {!title && (

--- a/backend/src/board/services/pinned_post_service.py
+++ b/backend/src/board/services/pinned_post_service.py
@@ -5,7 +5,9 @@ Business logic for managing user's pinned posts on their profile.
 Users can pin up to 6 posts to showcase on their profile page.
 """
 
-from typing import List, Dict, Any
+import math
+
+from typing import List, Dict, Any, Optional, Tuple, Union
 
 from django.contrib.auth.models import User
 from django.db import transaction
@@ -29,6 +31,9 @@ class PinnedPostService:
     """Service class for handling pinned post operations"""
 
     MAX_PINNED_POSTS = 6
+    DEFAULT_PINNABLE_POSTS_LIMIT = 30
+    MAX_PINNABLE_POSTS_LIMIT = 100
+    MAX_PINNABLE_SEARCH_QUERY_LENGTH = 100
 
     @staticmethod
     def _is_published_post(post: Post) -> bool:
@@ -42,6 +47,44 @@ class PinnedPostService:
                 ErrorCode.REJECT,
                 '작가 권한이 필요합니다.',
             )
+
+    @staticmethod
+    def normalize_pinnable_post_filters(
+        query: Optional[str] = '',
+        limit: Optional[Union[int, str]] = None,
+        page: Optional[Union[int, str]] = None,
+    ) -> Tuple[str, Optional[int], int, bool]:
+        normalized_query = (query or '').strip()[:PinnedPostService.MAX_PINNABLE_SEARCH_QUERY_LENGTH]
+        has_pagination = limit is not None or page is not None
+
+        if has_pagination:
+            try:
+                normalized_limit = int(limit) if limit is not None else PinnedPostService.DEFAULT_PINNABLE_POSTS_LIMIT
+            except (TypeError, ValueError):
+                normalized_limit = PinnedPostService.DEFAULT_PINNABLE_POSTS_LIMIT
+
+            normalized_limit = max(
+                1,
+                min(normalized_limit, PinnedPostService.MAX_PINNABLE_POSTS_LIMIT),
+            )
+        else:
+            normalized_limit = None
+
+        try:
+            normalized_page = int(page) if page is not None else 1
+        except (TypeError, ValueError):
+            raise PinnedPostError(
+                ErrorCode.INVALID_PARAMETER,
+                '잘못된 페이지입니다.',
+            )
+
+        if normalized_page < 1:
+            raise PinnedPostError(
+                ErrorCode.INVALID_PARAMETER,
+                '잘못된 페이지입니다.',
+            )
+
+        return normalized_query, normalized_limit, normalized_page, has_pagination
 
     @staticmethod
     def get_user_pinned_posts(user: User) -> List[Dict[str, Any]]:
@@ -73,18 +116,31 @@ class PinnedPostService:
         } for pinned in pinned_posts]
 
     @staticmethod
-    def get_pinnable_posts(user: User) -> List[Dict[str, Any]]:
+    def get_pinnable_posts(
+        user: User,
+        query: Optional[str] = '',
+        limit: Optional[Union[int, str]] = None,
+        page: Optional[Union[int, str]] = None,
+    ) -> Dict[str, Any]:
         """
         Get all posts that can be pinned by the user.
         Excludes hidden posts and already pinned posts.
 
         Args:
             user: User instance
+            query: Optional post title search query
+            limit: Maximum number of posts to return
+            page: Page number to return
 
         Returns:
-            List of pinnable post dictionaries
+            Paginated pinnable post dictionaries
         """
         PinnedPostService.validate_user_permissions(user)
+        query, limit, page, has_pagination = PinnedPostService.normalize_pinnable_post_filters(
+            query,
+            limit,
+            page,
+        )
 
         pinned_post_ids = PinnedPost.objects.filter(
             user=user
@@ -94,14 +150,47 @@ class PinnedPostService:
             Post.objects.filter(author=user)
         ).exclude(
             id__in=pinned_post_ids
-        ).order_by('-published_date')
+        ).order_by('-published_date', '-id')
 
-        return [{
-            'url': post.url,
-            'title': post.title,
-            'image': str(post.image) if post.image else None,
-            'created_date': post.published_date.strftime('%Y-%m-%d') if post.published_date else '',
-        } for post in posts]
+        if query:
+            posts = posts.filter(title__icontains=query)
+
+        total_count = posts.count()
+        if not has_pagination:
+            return {
+                'posts': [{
+                    'url': post.url,
+                    'title': post.title,
+                    'image': str(post.image) if post.image else None,
+                    'created_date': post.published_date.strftime('%Y-%m-%d') if post.published_date else '',
+                } for post in posts],
+                'page': 1,
+                'limit': total_count,
+                'last_page': 1,
+                'total_count': total_count,
+                'has_next': False,
+                'has_previous': False,
+            }
+
+        last_page = max(1, math.ceil(total_count / limit))
+        page = min(page, last_page)
+        offset = (page - 1) * limit
+        page_posts = posts[offset:offset + limit]
+
+        return {
+            'posts': [{
+                'url': post.url,
+                'title': post.title,
+                'image': str(post.image) if post.image else None,
+                'created_date': post.published_date.strftime('%Y-%m-%d') if post.published_date else '',
+            } for post in page_posts],
+            'page': page,
+            'limit': limit,
+            'last_page': last_page,
+            'total_count': total_count,
+            'has_next': page < last_page,
+            'has_previous': page > 1,
+        }
 
     @staticmethod
     @transaction.atomic

--- a/backend/src/board/templates/board/author/author_overview.html
+++ b/backend/src/board/templates/board/author/author_overview.html
@@ -29,67 +29,7 @@
             {% include 'board/author/components/readme_section.html' %}
 
             <!-- Featured Posts Section -->
-            {% if featured_posts_section.posts or request.user == author %}
-            <section>
-                <div class="mb-4 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
-                    <div>
-                        <p class="mb-2 text-xs font-bold uppercase tracking-[0.18em] text-content-hint">Posts</p>
-                        <h2 class="text-2xl font-bold text-content">{{ featured_posts_section.title }}</h2>
-                    </div>
-                    {% if request.user == author %}
-                    {% island_component 'PinnedPostQuickAction' %}
-                    {% endif %}
-                </div>
-
-                {% if featured_posts_section.posts %}
-                <div class="grid grid-cols-1 gap-5 sm:grid-cols-2">
-                    {% for post in featured_posts_section.posts %}
-                    <a href="/@{{ post.author }}/{{ post.url }}" class="group block h-full">
-                        <article class="flex h-full flex-col overflow-hidden rounded-2xl bg-surface ring-1 ring-line/60 transition-all duration-150 hover:ring-line-strong/70 active:scale-[0.99]">
-                            <div class="overflow-hidden bg-surface-subtle aspect-[16/9]">
-                                {% if post.image %}
-                                    <img
-                                        src="{% resource 'media/'|add:post.image %}"
-                                        alt="{{ post.title }}"
-                                        class="h-full w-full object-cover motion-safe:transition-transform motion-safe:duration-500 motion-safe:group-hover:scale-[1.03]">
-                                {% else %}
-                                    <img
-                                        src="{% resource post.default_cover_path %}"
-                                        alt="{{ post.title }}"
-                                        class="h-full w-full object-cover motion-safe:transition-transform motion-safe:duration-500 motion-safe:group-hover:scale-[1.03]">
-                                {% endif %}
-                            </div>
-                            <div class="flex flex-1 flex-col p-5">
-                                <h3 class="line-clamp-2 text-md font-bold leading-snug text-content transition-colors group-hover:text-content-secondary">
-                                    {{ post.title }}
-                                </h3>
-                                <div class="mt-auto flex items-center gap-3 pt-4 text-xs text-content-hint">
-                                    <time class="flex items-center gap-1.5">
-                                        <i class="far fa-calendar text-xs"></i>
-                                        {{ post.published_date|date:"Y년 n월 j일" }}
-                                    </time>
-                                    <span class="h-1 w-1 rounded-full bg-content-hint/70"></span>
-                                    <span class="flex items-center gap-1.5">
-                                        <i class="far fa-clock text-xs"></i>
-                                        {{ post.read_time }}분
-                                    </span>
-                                </div>
-                            </div>
-                        </article>
-                    </a>
-                    {% endfor %}
-                </div>
-                {% elif request.user == author %}
-                <div class="rounded-2xl border border-dashed border-line bg-surface px-6 py-8 text-center">
-                    <p class="text-sm font-semibold text-content">아직 공개된 포스트가 없습니다.</p>
-                    <p class="mt-1 text-sm text-content-secondary">첫 포스트를 발행하면 이 영역에 표시됩니다.</p>
-                    <a href="/write" class="mt-4 inline-flex items-center justify-center rounded-lg bg-action px-4 py-2 text-sm font-semibold text-content-inverted transition-colors hover:bg-action-hover">
-                        포스트 작성하기
-                    </a>
-                </div>
-                {% endif %}
-            </section>
-            {% endif %}
+            {% include 'board/author/components/featured_posts_section.html' %}
 
             {% with is_editor_view=True %}
                 {% include 'board/author/components/activity_section.html' %}

--- a/backend/src/board/templates/board/author/components/featured_posts_section.html
+++ b/backend/src/board/templates/board/author/components/featured_posts_section.html
@@ -1,0 +1,65 @@
+{% load island %}
+{% load resource %}
+
+{% if featured_posts_section.posts or request.user == author %}
+<section data-featured-posts-section data-partial-url="{% url 'user_featured_posts_partial' username=author.username %}">
+    <div class="mb-4 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+            <p class="mb-2 text-xs font-bold uppercase tracking-[0.18em] text-content-hint">Posts</p>
+            <h2 class="text-2xl font-bold text-content">{{ featured_posts_section.title }}</h2>
+        </div>
+        {% if request.user == author %}
+        {% url 'user_featured_posts_partial' username=author.username as featured_posts_partial_url %}
+        {% island_component 'PinnedPostQuickAction' partialUrl=featured_posts_partial_url %}
+        {% endif %}
+    </div>
+
+    {% if featured_posts_section.posts %}
+    <div class="grid grid-cols-1 gap-5 sm:grid-cols-2">
+        {% for post in featured_posts_section.posts %}
+        <a href="/@{{ post.author }}/{{ post.url }}" class="group block h-full">
+            <article class="flex h-full flex-col overflow-hidden rounded-2xl bg-surface ring-1 ring-line/60 transition-all duration-150 hover:ring-line-strong/70 active:scale-[0.99]">
+                <div class="overflow-hidden bg-surface-subtle aspect-[16/9]">
+                    {% if post.image %}
+                        <img
+                            src="{% resource 'media/'|add:post.image %}"
+                            alt="{{ post.title }}"
+                            class="h-full w-full object-cover motion-safe:transition-transform motion-safe:duration-500 motion-safe:group-hover:scale-[1.03]">
+                    {% else %}
+                        <img
+                            src="{% resource post.default_cover_path %}"
+                            alt="{{ post.title }}"
+                            class="h-full w-full object-cover motion-safe:transition-transform motion-safe:duration-500 motion-safe:group-hover:scale-[1.03]">
+                    {% endif %}
+                </div>
+                <div class="flex flex-1 flex-col p-5">
+                    <h3 class="line-clamp-2 text-md font-bold leading-snug text-content transition-colors group-hover:text-content-secondary">
+                        {{ post.title }}
+                    </h3>
+                    <div class="mt-auto flex items-center gap-3 pt-4 text-xs text-content-hint">
+                        <time class="flex items-center gap-1.5">
+                            <i class="far fa-calendar text-xs"></i>
+                            {{ post.published_date|date:"Y년 n월 j일" }}
+                        </time>
+                        <span class="h-1 w-1 rounded-full bg-content-hint/70"></span>
+                        <span class="flex items-center gap-1.5">
+                            <i class="far fa-clock text-xs"></i>
+                            {{ post.read_time }}분
+                        </span>
+                    </div>
+                </div>
+            </article>
+        </a>
+        {% endfor %}
+    </div>
+    {% elif request.user == author %}
+    <div class="rounded-2xl border border-dashed border-line bg-surface px-6 py-8 text-center">
+        <p class="text-sm font-semibold text-content">아직 공개된 포스트가 없습니다.</p>
+        <p class="mt-1 text-sm text-content-secondary">첫 포스트를 발행하면 이 영역에 표시됩니다.</p>
+        <a href="/write" class="mt-4 inline-flex items-center justify-center rounded-lg bg-action px-4 py-2 text-sm font-semibold text-content-inverted transition-colors hover:bg-action-hover">
+            포스트 작성하기
+        </a>
+    </div>
+    {% endif %}
+</section>
+{% endif %}

--- a/backend/src/board/tests/api/test_pinned_post.py
+++ b/backend/src/board/tests/api/test_pinned_post.py
@@ -381,6 +381,87 @@ class PinnedPostAPITestCase(TestCase):
         self.assertNotIn('draft-post', urls)  # Draft
         self.assertIn('test-post-1', urls)
 
+    def test_get_pinnable_posts_supports_limit(self):
+        """고정 가능한 글 목록은 limit 개수만 반환"""
+        self.client.login(username='testuser', password='testpass')
+
+        response = self.client.get('/v1/users/@testuser/pinnable-posts?limit=3')
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'DONE')
+        self.assertEqual(len(content['body']['posts']), 3)
+        self.assertEqual(content['body']['limit'], 3)
+        self.assertEqual(content['body']['totalCount'], 8)
+        self.assertEqual(content['body']['lastPage'], 3)
+
+    def test_get_pinnable_posts_without_limit_returns_all_posts(self):
+        """limit 없는 고정 가능 글 목록은 기존처럼 전체 글을 반환"""
+        for index in range(31):
+            post = Post.objects.create(
+                author=self.user,
+                title=f'Compatibility Post {index}',
+                url=f'compatibility-post-{index}',
+                published_date=timezone.now(),
+            )
+            PostContent.objects.create(post=post, content_html='')
+            PostConfig.objects.create(post=post)
+
+        self.client.login(username='testuser', password='testpass')
+
+        response = self.client.get('/v1/users/@testuser/pinnable-posts')
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'DONE')
+
+        self.assertEqual(len(content['body']['posts']), 39)
+        self.assertEqual(content['body']['totalCount'], 39)
+        self.assertFalse(content['body']['hasNext'])
+
+    def test_get_pinnable_posts_supports_title_search(self):
+        """고정 가능한 글 목록은 제목 검색을 지원"""
+        self.client.login(username='testuser', password='testpass')
+
+        response = self.client.get('/v1/users/@testuser/pinnable-posts?q=Post%201')
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'DONE')
+
+        urls = [p['url'] for p in content['body']['posts']]
+        self.assertEqual(urls, ['test-post-1'])
+
+    def test_get_pinnable_posts_supports_page(self):
+        """고정 가능한 글 목록은 페이지 이동을 지원"""
+        self.client.login(username='testuser', password='testpass')
+
+        first_response = self.client.get('/v1/users/@testuser/pinnable-posts?limit=3&page=1')
+        second_response = self.client.get('/v1/users/@testuser/pinnable-posts?limit=3&page=2')
+
+        self.assertEqual(first_response.status_code, 200)
+        self.assertEqual(second_response.status_code, 200)
+        first_content = json.loads(first_response.content)
+        second_content = json.loads(second_response.content)
+        first_urls = [post['url'] for post in first_content['body']['posts']]
+        second_urls = [post['url'] for post in second_content['body']['posts']]
+
+        self.assertEqual(second_content['body']['page'], 2)
+        self.assertEqual(second_content['body']['limit'], 3)
+        self.assertEqual(second_content['body']['lastPage'], 3)
+        self.assertTrue(second_content['body']['hasPrevious'])
+        self.assertTrue(second_content['body']['hasNext'])
+        self.assertEqual(len(second_urls), 3)
+        self.assertTrue(set(first_urls).isdisjoint(second_urls))
+
+    def test_get_pinnable_posts_rejects_invalid_page(self):
+        """고정 가능한 글 목록은 잘못된 page를 거부"""
+        self.client.login(username='testuser', password='testpass')
+
+        response = self.client.get('/v1/users/@testuser/pinnable-posts?limit=3&page=abc')
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'ERROR')
+        self.assertEqual(content['errorCode'], 'error:IP')
+
     def test_get_pinnable_posts_requires_login(self):
         """고정 가능한 글 목록은 로그인 필요"""
         response = self.client.get('/v1/users/@testuser/pinnable-posts')

--- a/backend/src/board/tests/api/test_setting.py
+++ b/backend/src/board/tests/api/test_setting.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 from board.constants.config_meta import CONFIG_TYPE
 from board.models import (
     Comment, Config, Notify, Post, PostConfig, PostContent,
-    PostLikes, Profile, User, UserLinkMeta
+    PinnedPost, PostLikes, Profile, User, UserLinkMeta
 )
 
 
@@ -60,6 +60,93 @@ class SettingTestCase(TestCase):
         content = json.loads(response.content)
         self.assertEqual(len(content['body']['notify']), 2)
         self.assertEqual(content['body']['isTelegramSync'], False)
+
+    def test_get_setting_pinnable_posts_supports_limit(self):
+        """설정 고정 가능 포스트 목록은 limit 개수만 반환"""
+        user = User.objects.get(username='test')
+        posts = []
+        for index in range(4):
+            post = Post.objects.create(
+                author=user,
+                title=f'Setting Pinnable Post {index}',
+                url=f'setting-pinnable-post-{index}',
+                published_date=timezone.now(),
+            )
+            PostContent.objects.create(post=post, content_html='')
+            PostConfig.objects.create(post=post)
+            posts.append(post)
+        PinnedPost.objects.create(user=user, post=posts[0], order=0)
+
+        self.client.login(username='test', password='test')
+        response = self.client.get('/v1/setting/pinnable-posts?limit=2')
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'DONE')
+        urls = [post['url'] for post in content['body']['posts']]
+        self.assertEqual(len(urls), 2)
+        self.assertNotIn('setting-pinnable-post-0', urls)
+        self.assertEqual(content['body']['limit'], 2)
+        self.assertEqual(content['body']['totalCount'], 3)
+        self.assertEqual(content['body']['lastPage'], 2)
+
+    def test_get_setting_pinnable_posts_supports_title_search(self):
+        """설정 고정 가능 포스트 목록은 제목 검색을 지원"""
+        user = User.objects.get(username='test')
+        for title, url in [
+            ('Needle Setting Post', 'needle-setting-post'),
+            ('Regular Setting Post', 'regular-setting-post'),
+        ]:
+            post = Post.objects.create(
+                author=user,
+                title=title,
+                url=url,
+                published_date=timezone.now(),
+            )
+            PostContent.objects.create(post=post, content_html='')
+            PostConfig.objects.create(post=post)
+
+        self.client.login(username='test', password='test')
+        response = self.client.get('/v1/setting/pinnable-posts?q=Needle')
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'DONE')
+        urls = [post['url'] for post in content['body']['posts']]
+        self.assertEqual(urls, ['needle-setting-post'])
+
+    def test_get_setting_pinnable_posts_supports_page(self):
+        """설정 고정 가능 포스트 목록은 페이지 이동을 지원"""
+        user = User.objects.get(username='test')
+        for index in range(5):
+            post = Post.objects.create(
+                author=user,
+                title=f'Setting Page Post {index}',
+                url=f'setting-page-post-{index}',
+                published_date=timezone.now(),
+            )
+            PostContent.objects.create(post=post, content_html='')
+            PostConfig.objects.create(post=post)
+
+        self.client.login(username='test', password='test')
+        first_response = self.client.get('/v1/setting/pinnable-posts?limit=2&page=1')
+        second_response = self.client.get('/v1/setting/pinnable-posts?limit=2&page=2')
+
+        self.assertEqual(first_response.status_code, 200)
+        self.assertEqual(second_response.status_code, 200)
+        first_content = json.loads(first_response.content)
+        second_content = json.loads(second_response.content)
+        first_urls = [post['url'] for post in first_content['body']['posts']]
+        second_urls = [post['url'] for post in second_content['body']['posts']]
+
+        self.assertEqual(second_content['body']['page'], 2)
+        self.assertEqual(second_content['body']['limit'], 2)
+        self.assertEqual(second_content['body']['lastPage'], 3)
+        self.assertEqual(second_content['body']['totalCount'], 5)
+        self.assertTrue(second_content['body']['hasPrevious'])
+        self.assertTrue(second_content['body']['hasNext'])
+        self.assertEqual(len(second_urls), 2)
+        self.assertTrue(set(first_urls).isdisjoint(second_urls))
 
     def test_update_setting_notify_marks_as_read(self):
         """알림 읽음 처리 테스트"""

--- a/backend/src/board/tests/templates/test_author.py
+++ b/backend/src/board/tests/templates/test_author.py
@@ -303,6 +303,85 @@ class AuthorPostsPageTestCase(TestCase):
         self.assertContains(owner_response, 'PinnedPostQuickAction')
         self.assertNotContains(owner_response, '/settings/posts?section=pinned')
 
+    def test_author_featured_posts_partial_renders_section_only(self):
+        """대표 포스트 partial은 전체 페이지가 아니라 해당 섹션만 렌더링한다."""
+        partial_url = reverse(
+            'user_featured_posts_partial',
+            kwargs={'username': self.user.username},
+        )
+
+        response = self.client.get(partial_url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(
+            response,
+            'board/author/components/featured_posts_section.html',
+        )
+        self.assertEqual(response['Cache-Control'], 'no-store')
+        self.assertEqual(response['X-Robots-Tag'], 'noindex')
+        self.assertContains(response, 'data-featured-posts-section')
+        self.assertContains(response, 'Author Test Post')
+        self.assertNotContains(response, '<html')
+
+    def test_author_featured_posts_partial_action_is_owner_only(self):
+        """대표 포스트 partial의 고정 설정 액션은 작성자 본인에게만 노출한다."""
+        partial_url = reverse(
+            'user_featured_posts_partial',
+            kwargs={'username': self.user.username},
+        )
+
+        visitor_response = self.client.get(partial_url)
+        self.assertEqual(visitor_response.status_code, 200)
+        self.assertNotContains(visitor_response, 'PinnedPostQuickAction')
+
+        self.client.login(username='testauthor', password='testpass123')
+        owner_response = self.client.get(partial_url)
+
+        self.assertEqual(owner_response.status_code, 200)
+        self.assertContains(owner_response, 'PinnedPostQuickAction')
+        self.assertContains(owner_response, partial_url)
+
+    def test_author_featured_posts_partial_hides_empty_section_from_visitors(self):
+        """공개 포스트가 없는 대표 포스트 partial은 방문자에게 빈 응답을 준다."""
+        empty_author = User.objects.create_user(
+            username='emptyfeaturedauthor',
+            email='empty-featured@example.com',
+            password='testpass123',
+        )
+        Profile.objects.create(user=empty_author, role=Profile.Role.EDITOR)
+
+        response = self.client.get(
+            reverse(
+                'user_featured_posts_partial',
+                kwargs={'username': empty_author.username},
+            )
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, 'data-featured-posts-section')
+        self.assertNotContains(response, '포스트 작성하기')
+
+    def test_author_featured_posts_partial_returns_empty_for_reader(self):
+        """독자 권한 사용자의 대표 포스트 partial은 빈 응답을 반환한다."""
+        reader = User.objects.create_user(
+            username='readerfeatured',
+            email='reader-featured@example.com',
+            password='testpass123',
+        )
+        Profile.objects.create(user=reader, role=Profile.Role.READER)
+
+        response = self.client.get(
+            reverse(
+                'user_featured_posts_partial',
+                kwargs={'username': reader.username},
+            )
+        )
+
+        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.content, b'')
+        self.assertEqual(response['Cache-Control'], 'no-store')
+        self.assertEqual(response['X-Robots-Tag'], 'noindex')
+
     def test_author_overview_social_link_add_entrypoint_uses_existing_empty_state(self):
         """소셜 링크가 없을 때는 기존 빈 상태 추가 링크만 노출한다."""
         self.client.login(username='testauthor', password='testpass123')

--- a/backend/src/board/urls.py
+++ b/backend/src/board/urls.py
@@ -8,7 +8,14 @@ from board.views.api.developer.v1.api import api as developer_api_v1
 from board.views import agent
 from board.views import main
 from board.views.post_actions import like_post
-from board.views.author import author_posts, author_series, author_about, author_about_edit, author_overview
+from board.views.author import (
+    author_about,
+    author_about_edit,
+    author_featured_posts_partial,
+    author_overview,
+    author_posts,
+    author_series,
+)
 from board.views.post import post_detail, post_editor
 from board.views.series import series_detail
 from board.views.search import search_page
@@ -58,6 +65,11 @@ urlpatterns = [
     path('@<username>/series', author_series, name='user_series'),
     path('@<username>/about', author_about, name='user_about'),
     path('@<username>/about/edit', author_about_edit, name='user_about_edit'),
+    path(
+        '@<username>/partials/featured-posts',
+        author_featured_posts_partial,
+        name='user_featured_posts_partial',
+    ),
     path('@<username>/series/<series_url>.md', agent.series_markdown, name='series_markdown'),
     path('@<username>/series/<series_url>', series_detail, name='series_detail'),
     path('@<username>/posts', author_posts, name='user_posts'),

--- a/backend/src/board/views/api/v1/pinned_post.py
+++ b/backend/src/board/views/api/v1/pinned_post.py
@@ -95,7 +95,7 @@ def pinnable_posts(request, username):
     """
     Get posts that can be pinned by the user.
 
-    GET: Get all pinnable posts (non-hidden, not already pinned)
+    GET: Get recent/searchable pinnable posts (non-hidden, not already pinned)
     """
     user = get_object_or_404(User, username=username)
 
@@ -104,9 +104,15 @@ def pinnable_posts(request, username):
         return permission_error
 
     if request.method == 'GET':
-        posts = PinnedPostService.get_pinnable_posts(user)
-        return StatusDone({
-            'posts': posts,
-        })
+        try:
+            pinnable_posts = PinnedPostService.get_pinnable_posts(
+                user,
+                query=request.GET.get('q', ''),
+                limit=request.GET.get('limit'),
+                page=request.GET.get('page'),
+            )
+            return StatusDone(pinnable_posts)
+        except PinnedPostError as e:
+            return StatusError(e.code, e.message)
 
     raise Http404

--- a/backend/src/board/views/api/v1/setting.py
+++ b/backend/src/board/views/api/v1/setting.py
@@ -275,10 +275,16 @@ def setting(request, parameter):
             })
 
         if parameter == 'pinnable-posts':
-            posts = PinnedPostService.get_pinnable_posts(user)
-            return StatusDone({
-                'posts': posts,
-            })
+            try:
+                pinnable_posts = PinnedPostService.get_pinnable_posts(
+                    user,
+                    query=request.GET.get('q', ''),
+                    limit=request.GET.get('limit'),
+                    page=request.GET.get('page'),
+                )
+                return StatusDone(pinnable_posts)
+            except PinnedPostError as e:
+                return StatusError(e.code, e.message)
 
     if request.method == 'POST':
         if parameter == 'avatar':
@@ -408,11 +414,11 @@ def setting(request, parameter):
             return StatusDone(UserSocialLinkService.update_user_social_links(user, put))
 
         if parameter == 'pinned-posts/order':
-            post_urls_str = put.get('post_urls', '[]')
+            post_urls_data = put.get('post_urls', '[]')
 
             try:
-                post_urls = json.loads(post_urls_str)
-            except json.JSONDecodeError:
+                post_urls = json.loads(post_urls_data) if isinstance(post_urls_data, str) else post_urls_data
+            except (TypeError, json.JSONDecodeError):
                 return StatusError(ErrorCode.INVALID_PARAMETER, '잘못된 형식입니다.')
 
             if not isinstance(post_urls, list):

--- a/backend/src/board/views/author.py
+++ b/backend/src/board/views/author.py
@@ -4,8 +4,9 @@ from django.contrib.auth.models import User
 from django.contrib.auth.decorators import login_required
 from django.db.models import Count, Q
 from django.shortcuts import render, get_object_or_404, redirect
-from django.http import JsonResponse
+from django.http import HttpResponse, JsonResponse
 from django.urls import reverse
+from django.views.decorators.http import require_GET
 
 from board.modules.paginator import Paginator
 from board.modules.time import time_since
@@ -15,6 +16,12 @@ from board.services.discovery_metadata_service import DiscoveryMetadataService
 from board.services.public_post_service import PublicPostService
 from board.services.public_series_service import PublicSeriesService
 from board.models import Comment, Post, Series, PostLikes, Tag, Profile, SiteNotice, SiteContentScope
+
+
+def apply_partial_response_headers(response):
+    response['Cache-Control'] = 'no-store'
+    response['X-Robots-Tag'] = 'noindex'
+    return response
 
 
 def author_overview(request, username):
@@ -85,6 +92,30 @@ def author_overview(request, username):
             'author_activity_props': json.dumps({'username': author.username})
         }
         return render(request, 'board/author/author_overview.html', context)
+
+
+@require_GET
+def author_featured_posts_partial(request, username):
+    """
+    Render only the author's featured posts section for server-side partial refresh.
+    """
+    author = get_object_or_404(User.objects.select_related('profile'), username=username)
+
+    if not AuthoringPermissionService.is_active_editor(author):
+        return apply_partial_response_headers(HttpResponse('', status=204))
+
+    featured_posts_section = UserService.get_user_profile_featured_posts(author)
+
+    response = render(
+        request,
+        'board/author/components/featured_posts_section.html',
+        {
+            'author': author,
+            'featured_posts_section': featured_posts_section,
+            'pinned_posts': featured_posts_section['posts'],
+        },
+    )
+    return apply_partial_response_headers(response)
 
 
 def author_about(request, username):


### PR DESCRIPTION
## 🎯 Goal
- Improve the pinned post management flow on author profiles.
- Let authors manage pinned posts without navigating away from the profile context.
- Reduce unnecessary payload size when browsing pinnable posts.

## 🔧 Core Changes
- Added inline pinned post management for profile quick actions.
- Added server-side search and pagination for pinnable posts.
- Added a scoped featured-posts partial refresh after pinning changes.
- Improved modal behavior across mobile and desktop, including reduced-motion handling.
- Added tests for pinnable post pagination, API compatibility, and featured-posts partial rendering.

## 🤔 Key Decisions
- Kept the partial refresh scoped to the featured posts section instead of introducing a broader partial-rendering system.
- Preserved the existing v1 pinnable-posts behavior when `limit` and `page` are omitted.
- Used pagination only when the client explicitly requests paged data.
- Kept mobile bottom-sheet behavior while preserving centered desktop modal behavior.

## 🧪 Verification Guide
### How to verify
1. Open an author profile as the owner and open pinned post settings.
2. Add, remove, and reorder pinned posts.
3. Confirm the featured posts section updates after closing the modal.
4. Search and paginate through pinnable posts.
5. Check the same modal behavior on mobile and desktop viewport sizes.

### Expected result
- Pinned posts can be added, removed, and reordered without component errors.
- Pinnable post lists load in pages and preserve existing API compatibility.
- The profile featured posts section refreshes without a full page reload.
- Modal presentation is stable and consistent across mobile and desktop.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)
