### PR TITLE
✨ Add admin-managed social login providers

### DIFF
--- a/backend/islands/apps/remotes/src/components/remotes/Login/components/LoginForm.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/Login/components/LoginForm.tsx
@@ -179,21 +179,7 @@ const LoginForm = ({
                 </button>
             </form>
 
-            {/* Divider */}
-            <div className="relative py-4">
-                <div className="absolute inset-0 flex items-center">
-                    <div className="w-full border-t border-line" />
-                </div>
-                <div className="relative flex justify-center text-xs uppercase tracking-wider">
-                    <span className="px-4 bg-surface/50 backdrop-blur-sm text-content-hint font-medium">
-                        또는 간편하게
-                    </span>
-                </div>
-            </div>
-
-            <div className="space-y-3">
-                <SocialLogin />
-            </div>
+            <SocialLogin />
         </>
     );
 };

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/SettingsApp.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/SettingsApp.tsx
@@ -30,6 +30,7 @@ const GlobalWebhookSetting = lazy(() => import('./pages/GlobalWebhookSetting'));
 const GlobalNoticeSetting = lazy(() => import('./pages/GlobalNoticeSetting'));
 const GlobalBannerSetting = lazy(() => import('./pages/GlobalBannerSetting'));
 const SiteSettingSetting = lazy(() => import('./pages/SiteSettingSetting'));
+const SocialLoginSetting = lazy(() => import('./pages/SocialLoginSetting'));
 const SeoAeoSetting = lazy(() => import('./pages/SeoAeoSetting'));
 const StaticPagesSetting = lazy(() => import('./pages/StaticPagesSetting'));
 const UtilitySetting = lazy(() => import('./pages/UtilitySetting'));
@@ -216,6 +217,12 @@ const siteSettingsRoute = createRoute({
     component: SiteSettingSetting
 });
 
+const socialLoginRoute = createRoute({
+    getParentRoute: () => settingsRoute,
+    path: '/social-login',
+    component: SocialLoginSetting
+});
+
 const seoAeoRoute = createRoute({
     getParentRoute: () => settingsRoute,
     path: '/seo-aeo',
@@ -339,6 +346,7 @@ const routeTree = rootRoute.addChildren([
         globalNoticesRoute,
         globalBannersRoute,
         siteSettingsRoute,
+        socialLoginRoute,
         seoAeoRoute,
         staticPagesRoute,
         utilitiesRoute,

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/SettingsNavigation.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/SettingsNavigation.tsx
@@ -12,7 +12,6 @@ interface NavigationItem {
     name: string;
     path: string;
     icon: string;
-    risk?: 'external' | 'danger';
     requiresEditor?: boolean;
     requiresStaff?: boolean;
 }
@@ -52,8 +51,7 @@ const userNavigationSections: NavigationSection[] = [
             {
                 name: '계정',
                 path: '/account',
-                icon: 'fa-user-cog',
-                risk: 'danger'
+                icon: 'fa-user-cog'
             },
             {
                 name: '프로필',
@@ -123,7 +121,6 @@ const userNavigationSections: NavigationSection[] = [
                 name: '개발자 API',
                 path: '/developer-api',
                 icon: 'fa-code',
-                risk: 'danger',
                 requiresEditor: true
             }
         ]
@@ -137,17 +134,21 @@ const adminNavigationSections: NavigationSection[] = [
         requiresStaff: true,
         items: [
             {
-                name: '사이트 설정',
+                name: '블로그 커스텀',
                 path: '/site-settings',
-                icon: 'fa-gear',
-                risk: 'danger',
+                icon: 'fa-palette',
+                requiresStaff: true
+            },
+            {
+                name: '소셜 로그인',
+                path: '/social-login',
+                icon: 'fa-right-to-bracket',
                 requiresStaff: true
             },
             {
                 name: 'SEO/AEO',
                 path: '/seo-aeo',
                 icon: 'fa-robot',
-                risk: 'danger',
                 requiresStaff: true
             },
             {
@@ -179,7 +180,6 @@ const adminNavigationSections: NavigationSection[] = [
                 name: '전역 웹훅 연동',
                 path: '/global-webhook',
                 icon: 'fa-bolt',
-                risk: 'danger',
                 requiresStaff: true
             }
         ]
@@ -193,21 +193,18 @@ const adminNavigationSections: NavigationSection[] = [
                 name: '사용자 권한',
                 path: '/users',
                 icon: 'fa-users',
-                risk: 'danger',
                 requiresStaff: true
             },
             {
                 name: '유틸리티',
                 path: '/utilities',
                 icon: 'fa-toolbox',
-                risk: 'danger',
                 requiresStaff: true
             },
             {
                 name: '관리자 패널',
                 path: 'admin',
                 icon: 'fa-shield-alt',
-                risk: 'external',
                 requiresStaff: true
             }
         ]
@@ -230,21 +227,6 @@ const normalizePath = (path: string, basePath: string) => {
     const withoutBase = path.startsWith(basePath) ? path.slice(basePath.length) : path;
     const normalized = withoutBase.replace(/\/+$/, '');
     return normalized || '/';
-};
-
-const RiskBadge = ({ risk }: { risk?: NavigationItem['risk'] }) => {
-    if (!risk) return null;
-
-    const label = risk === 'external' ? '외부' : '주의';
-    const className = risk === 'external'
-        ? 'border-line bg-surface text-content-hint'
-        : 'border-warning-line bg-warning-surface text-warning';
-
-    return (
-        <span className={`rounded-md border px-1.5 py-0.5 text-[10px] font-semibold ${className}`}>
-            {label}
-        </span>
-    );
 };
 
 const SettingsModeLink = ({ settingsMode, isStaff }: { settingsMode: SettingsMode; isStaff: boolean }) => {
@@ -304,10 +286,7 @@ export const SettingsMobileNavigation = ({ currentPath }: SettingsNavigationProp
                         className={`${baseClasses} ${activeClasses}`}
                         onClick={() => handleNavClick(item)}>
                         <i className={`fas ${item.icon} w-6 text-center mr-3 transition-colors ${iconClasses} group-hover:text-content-secondary`} />
-                        <span className="flex min-w-0 flex-1 items-center gap-2">
-                            <span>{item.name}</span>
-                            <RiskBadge risk={item.risk} />
-                        </span>
+                        <span className="min-w-0 flex-1">{item.name}</span>
                     </a>
                 </li>
             );
@@ -320,10 +299,7 @@ export const SettingsMobileNavigation = ({ currentPath }: SettingsNavigationProp
                     className={`${baseClasses} ${activeClasses}`}
                     onClick={() => handleNavClick(item)}>
                     <i className={`fas ${item.icon} w-6 text-center mr-3 transition-colors ${iconClasses} group-hover:text-content-secondary`} />
-                    <span className="flex min-w-0 flex-1 items-center gap-2">
-                        <span>{item.name}</span>
-                        <RiskBadge risk={item.risk} />
-                    </span>
+                    <span className="min-w-0 flex-1">{item.name}</span>
                 </Link>
             </li>
         );
@@ -437,10 +413,7 @@ export const SettingsDesktopNavigation = ({ currentPath }: SettingsNavigationPro
                         className={`${baseClasses} ${activeClasses} ${desktopClasses}`}
                         onClick={() => handleNavClick(item)}>
                         <i className={`fas ${item.icon} w-7 text-center mr-4 transition-colors ${iconClasses} group-hover:text-content-secondary`} />
-                        <span className="flex min-w-0 flex-1 items-center gap-2">
-                            <span>{item.name}</span>
-                            <RiskBadge risk={item.risk} />
-                        </span>
+                        <span className="min-w-0 flex-1">{item.name}</span>
                     </a>
                 </li>
             );
@@ -453,10 +426,7 @@ export const SettingsDesktopNavigation = ({ currentPath }: SettingsNavigationPro
                     className={`${baseClasses} ${activeClasses} ${desktopClasses}`}
                     onClick={() => handleNavClick(item)}>
                     <i className={`fas ${item.icon} w-7 text-center mr-4 transition-colors ${iconClasses} group-hover:text-content-secondary`} />
-                    <span className="flex min-w-0 flex-1 items-center gap-2">
-                        <span>{item.name}</span>
-                        <RiskBadge risk={item.risk} />
-                    </span>
+                    <span className="min-w-0 flex-1">{item.name}</span>
                 </Link>
             </li>
         );

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SiteSettingSetting/SiteSettingSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SiteSettingSetting/SiteSettingSetting.tsx
@@ -1,4 +1,10 @@
-import { type ChangeEvent, useEffect, useRef, useState } from 'react';
+import {
+    type ChangeEvent,
+    type FormEvent,
+    useEffect,
+    useRef,
+    useState
+} from 'react';
 import { toast } from '~/utils/toast';
 import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 import { SettingsHeader } from '../../components';
@@ -13,8 +19,7 @@ import {
     type BrandAssetTheme,
     type BrandAssetType,
     type SiteSettingData,
-    type SiteSettingUpdateData,
-    type SocialAuthProviderSetting
+    type SiteSettingUpdateData
 } from '~/lib/api/settings';
 import {
     createIconBrandAssetFormData,
@@ -32,9 +37,13 @@ interface BrandAssetDeletePayload {
     theme: BrandAssetTheme;
 }
 
-interface SocialAuthProviderForm extends SocialAuthProviderSetting {
-    clientSecret: string;
-    clearClientSecret: boolean;
+interface EditableSiteSettings {
+    siteName: string;
+    headerScript: string;
+    footerScript: string;
+    welcomeMessage: string;
+    welcomeUrl: string;
+    deletionRedirectUrl: string;
 }
 
 interface AssetUploadButtonProps {
@@ -89,6 +98,23 @@ const syncSettingsDocumentTitle = (siteName: string) => {
     document.title = `${titlePrefix?.trim() || '설정'} | ${siteName}`;
 };
 
+const getEditableSiteSettings = (data: SiteSettingData): EditableSiteSettings => ({
+    siteName: data.siteName,
+    headerScript: data.headerScript,
+    footerScript: data.footerScript,
+    welcomeMessage: data.welcomeNotificationMessage,
+    welcomeUrl: data.welcomeNotificationUrl,
+    deletionRedirectUrl: data.accountDeletionRedirectUrl
+});
+
+const hasSiteSettingsChanged = (current: EditableSiteSettings, saved: EditableSiteSettings | null) => {
+    if (!saved) return false;
+
+    return Object.keys(current).some((key) => (
+        current[key as keyof EditableSiteSettings] !== saved[key as keyof EditableSiteSettings]
+    ));
+};
+
 const AssetUploadButton = ({ label, disabled, onUpload }: AssetUploadButtonProps) => {
     const inputRef = useRef<HTMLInputElement>(null);
 
@@ -124,7 +150,7 @@ const BrandAssetSlot = ({
     onUpload,
     onDelete
 }: BrandAssetSlotProps) => (
-    <div className="space-y-3 rounded-lg border border-line bg-surface p-3">
+    <div className="space-y-3 rounded-xl bg-surface-subtle p-4">
         <div className="flex items-center justify-between gap-3">
             <div className="text-xs font-semibold text-content-secondary">{label}</div>
             <div className="text-[11px] font-medium text-content-hint">
@@ -133,7 +159,7 @@ const BrandAssetSlot = ({
         </div>
         <div
             data-theme={dark ? 'dark' : 'light'}
-            className="flex h-24 items-center justify-center rounded-xl border border-line bg-surface-subtle p-4">
+            className="flex h-24 items-center justify-center rounded-xl bg-surface p-4">
             <img
                 src={url}
                 alt=""
@@ -174,12 +200,10 @@ const BrandAssetPanel = ({
     onUpload,
     onDelete
 }: BrandAssetPanelProps) => (
-    <section className="space-y-4 rounded-xl border border-line bg-surface-subtle p-4">
-        <div className="space-y-1">
-            <h4 className="text-sm font-semibold text-content">{title}</h4>
-            <p className="text-xs leading-relaxed text-content-secondary">{description}</p>
-        </div>
-
+    <Card
+        title={title}
+        subtitle={description}
+        icon={<i className={`fas ${assetType === 'logo' ? 'fa-signature' : 'fa-icons'}`} />}>
         <div className="grid gap-3 sm:grid-cols-2">
             <BrandAssetSlot
                 label="기본"
@@ -203,13 +227,14 @@ const BrandAssetPanel = ({
                 onDelete={() => onDelete(assetType, 'dark')}
             />
         </div>
-    </section>
+    </Card>
 );
 
 const SiteSettingSetting = () => {
     const queryClient = useQueryClient();
     const { confirm } = useConfirm();
     const hasHydratedFormRef = useRef(false);
+    const savedSettingsRef = useRef<EditableSiteSettings | null>(null);
     const { data: settingData } = useSuspenseQuery({
         queryKey: ['site-settings'],
         queryFn: async () => {
@@ -227,21 +252,17 @@ const SiteSettingSetting = () => {
     const [welcomeMessage, setWelcomeMessage] = useState('');
     const [welcomeUrl, setWelcomeUrl] = useState('');
     const [deletionRedirectUrl, setDeletionRedirectUrl] = useState('');
-    const [socialAuthProviders, setSocialAuthProviders] = useState<SocialAuthProviderForm[]>([]);
 
     useEffect(() => {
         if (!hasHydratedFormRef.current) {
-            setSiteName(settingData.siteName);
-            setHeaderScript(settingData.headerScript);
-            setFooterScript(settingData.footerScript);
-            setWelcomeMessage(settingData.welcomeNotificationMessage);
-            setWelcomeUrl(settingData.welcomeNotificationUrl);
-            setDeletionRedirectUrl(settingData.accountDeletionRedirectUrl);
-            setSocialAuthProviders(settingData.socialAuthProviders.map((provider) => ({
-                ...provider,
-                clientSecret: '',
-                clearClientSecret: false
-            })));
+            const editableSettings = getEditableSiteSettings(settingData);
+            setSiteName(editableSettings.siteName);
+            setHeaderScript(editableSettings.headerScript);
+            setFooterScript(editableSettings.footerScript);
+            setWelcomeMessage(editableSettings.welcomeMessage);
+            setWelcomeUrl(editableSettings.welcomeUrl);
+            setDeletionRedirectUrl(editableSettings.deletionRedirectUrl);
+            savedSettingsRef.current = editableSettings;
             hasHydratedFormRef.current = true;
         }
         syncSettingsDocumentTitle(settingData.siteName);
@@ -253,17 +274,14 @@ const SiteSettingSetting = () => {
             return assertDone(response, '사이트 설정 저장에 실패했습니다.');
         },
         onSuccess: (body: SiteSettingData) => {
-            setSiteName(body.siteName);
-            setHeaderScript(body.headerScript);
-            setFooterScript(body.footerScript);
-            setWelcomeMessage(body.welcomeNotificationMessage);
-            setWelcomeUrl(body.welcomeNotificationUrl);
-            setDeletionRedirectUrl(body.accountDeletionRedirectUrl);
-            setSocialAuthProviders(body.socialAuthProviders.map((provider) => ({
-                ...provider,
-                clientSecret: '',
-                clearClientSecret: false
-            })));
+            const editableSettings = getEditableSiteSettings(body);
+            setSiteName(editableSettings.siteName);
+            setHeaderScript(editableSettings.headerScript);
+            setFooterScript(editableSettings.footerScript);
+            setWelcomeMessage(editableSettings.welcomeMessage);
+            setWelcomeUrl(editableSettings.welcomeUrl);
+            setDeletionRedirectUrl(editableSettings.deletionRedirectUrl);
+            savedSettingsRef.current = editableSettings;
             syncSettingsDocumentTitle(body.siteName);
             void queryClient.invalidateQueries({ queryKey: ['site-settings'] });
             toast.success('사이트 설정이 저장되었습니다.');
@@ -304,33 +322,16 @@ const SiteSettingSetting = () => {
         }
     });
 
-    const handleSave = () => {
+    const handleSave = (event?: FormEvent<HTMLFormElement>) => {
+        event?.preventDefault();
         updateMutation.mutate({
             site_name: siteName,
             header_script: headerScript,
             footer_script: footerScript,
             welcome_notification_message: welcomeMessage,
             welcome_notification_url: welcomeUrl,
-            account_deletion_redirect_url: deletionRedirectUrl,
-            social_auth_providers: socialAuthProviders.map((provider) => ({
-                key: provider.key,
-                is_enabled: provider.isEnabled,
-                client_id: provider.clientId,
-                ...(provider.clientSecret ? { client_secret: provider.clientSecret } : {}),
-                ...(provider.clearClientSecret ? { clear_client_secret: true } : {})
-            }))
+            account_deletion_redirect_url: deletionRedirectUrl
         });
-    };
-
-    const updateSocialProvider = (key: string, patch: Partial<SocialAuthProviderForm>) => {
-        setSocialAuthProviders((providers) => providers.map((provider) => (
-            provider.key === key
-                ? {
-                    ...provider,
-                    ...patch
-                }
-                : provider
-        )));
     };
 
     const handleBrandAssetUpload = (assetType: BrandAssetType, theme: BrandAssetTheme) => (
@@ -380,221 +381,152 @@ const SiteSettingSetting = () => {
     };
 
     const assetMutationPending = uploadMutation.isPending || deleteMutation.isPending;
+    const currentSettings: EditableSiteSettings = {
+        siteName,
+        headerScript,
+        footerScript,
+        welcomeMessage,
+        welcomeUrl,
+        deletionRedirectUrl
+    };
+    const isDirty = hasSiteSettingsChanged(currentSettings, savedSettingsRef.current);
+    const saveDisabled = !isDirty || assetMutationPending || updateMutation.isPending;
 
     return (
-        <div className="space-y-8">
+        <form className="space-y-8" onSubmit={handleSave}>
             <SettingsHeader
-                title="사이트 설정"
-                description="사이트 이름, 브랜드 자산, 전역 코드 및 알림 설정을 관리합니다."
+                title="블로그 커스텀"
+                description="사이트 이름, 브랜드 자산, 회원 안내, 전역 코드를 관리합니다."
             />
 
-            <Card
-                title="브랜드"
-                subtitle="공개 화면, RSS, llms.txt, favicon에 쓰이는 사이트 이름과 브랜드 자산입니다."
-                icon={<i className="fas fa-building" />}>
-                <div className="space-y-6">
-                    <div>
+            <section className="space-y-4">
+                <Card
+                    title="사이트 이름"
+                    subtitle="공개 화면, RSS, llms.txt에 표시되는 블로그 이름입니다."
+                    icon={<i className="fas fa-building" />}>
+                    <Input
+                        label="사이트 이름"
+                        maxLength={80}
+                        placeholder="BLEX"
+                        value={siteName}
+                        onChange={(event) => setSiteName(event.target.value)}
+                        helperText="브라우저 제목, RSS, 검색 결과, 공개 문서에 표시됩니다."
+                    />
+                </Card>
+
+                <div className="grid gap-4 xl:grid-cols-2">
+                    <BrandAssetPanel
+                        title="로고"
+                        description="헤더와 푸터에 쓰입니다. 다크 모드 SVG는 기본 로고를 올린 뒤 선택적으로 지정합니다."
+                        assetType="logo"
+                        defaultUrl={settingData.logoSvgUrl}
+                        darkUrl={settingData.logoSvgDarkUrl}
+                        hasDefaultAsset={settingData.hasCustomLogo}
+                        hasDarkAsset={settingData.hasCustomLogoDark}
+                        darkUploadDisabled={!settingData.hasCustomLogo}
+                        isPending={assetMutationPending}
+                        previewShape="logo"
+                        onUpload={handleBrandAssetUpload}
+                        onDelete={handleBrandAssetDelete}
+                    />
+                    <BrandAssetPanel
+                        title="아이콘"
+                        description="기본 아이콘 SVG를 올리면 브라우저에서 favicon과 PNG 아이콘을 함께 생성합니다."
+                        assetType="icon"
+                        defaultUrl={settingData.iconSvgUrl}
+                        darkUrl={settingData.iconSvgDarkUrl}
+                        hasDefaultAsset={settingData.hasCustomIcon}
+                        hasDarkAsset={settingData.hasCustomIconDark}
+                        darkUploadDisabled={!settingData.hasCustomIcon}
+                        isPending={assetMutationPending}
+                        previewShape="icon"
+                        onUpload={handleBrandAssetUpload}
+                        onDelete={handleBrandAssetDelete}
+                    />
+                </div>
+
+                <Card
+                    title="회원 안내"
+                    subtitle="회원 가입과 탈퇴 흐름에서 보여줄 안내를 설정합니다."
+                    icon={<i className="fas fa-user-gear" />}>
+                    <div className="space-y-4">
                         <Input
-                            label="사이트 이름"
-                            maxLength={80}
-                            placeholder="BLEX"
-                            value={siteName}
-                            onChange={(event) => setSiteName(event.target.value)}
-                            helperText="브라우저 제목, RSS, 검색 결과, 공개 문서에 표시됩니다."
-                        />
-                    </div>
-
-                    <div className="grid gap-4 xl:grid-cols-2">
-                        <BrandAssetPanel
-                            title="로고"
-                            description="헤더와 푸터에 쓰입니다. 다크 모드 SVG는 기본 로고를 올린 뒤 선택적으로 지정합니다."
-                            assetType="logo"
-                            defaultUrl={settingData.logoSvgUrl}
-                            darkUrl={settingData.logoSvgDarkUrl}
-                            hasDefaultAsset={settingData.hasCustomLogo}
-                            hasDarkAsset={settingData.hasCustomLogoDark}
-                            darkUploadDisabled={!settingData.hasCustomLogo}
-                            isPending={assetMutationPending}
-                            previewShape="logo"
-                            onUpload={handleBrandAssetUpload}
-                            onDelete={handleBrandAssetDelete}
-                        />
-                        <BrandAssetPanel
-                            title="아이콘"
-                            description="기본 아이콘 SVG를 올리면 브라우저에서 favicon과 PNG 아이콘을 함께 생성합니다."
-                            assetType="icon"
-                            defaultUrl={settingData.iconSvgUrl}
-                            darkUrl={settingData.iconSvgDarkUrl}
-                            hasDefaultAsset={settingData.hasCustomIcon}
-                            hasDarkAsset={settingData.hasCustomIconDark}
-                            darkUploadDisabled={!settingData.hasCustomIcon}
-                            isPending={assetMutationPending}
-                            previewShape="icon"
-                            onUpload={handleBrandAssetUpload}
-                            onDelete={handleBrandAssetDelete}
-                        />
-                    </div>
-                </div>
-            </Card>
-
-            <Card
-                title="커스텀 코드"
-                subtitle="스크립트나 메타 태그와 같은 코드를 전역에 삽입할 수 있습니다."
-                icon={<i className="fas fa-code" />}>
-                <div className="space-y-4">
-                    <div className="space-y-2">
-                        <label className="block text-sm font-semibold text-content">
-                            Head 영역 코드
-                        </label>
-                        <CodeEditor
-                            language="html"
-                            value={headerScript}
-                            onChange={setHeaderScript}
-                            height="200px"
-                        />
-                        <p className="text-xs text-content-secondary">{'<head>'} 태그 안에 삽입됩니다.</p>
-                    </div>
-                    <div className="space-y-2">
-                        <label className="block text-sm font-semibold text-content">
-                            Body 하단 코드
-                        </label>
-                        <CodeEditor
-                            language="html"
-                            value={footerScript}
-                            onChange={setFooterScript}
-                            height="200px"
-                        />
-                        <p className="text-xs text-content-secondary">{'</body>'} 태그 직전에 삽입됩니다.</p>
-                    </div>
-                </div>
-            </Card>
-
-            <Card
-                title="소셜 로그인"
-                subtitle="설치형 블로그에서 사용할 OAuth 제공자를 설정합니다. 현재 Google과 GitHub를 지원합니다."
-                icon={<i className="fas fa-right-to-bracket" />}>
-                <div className="space-y-4">
-                    {socialAuthProviders.map((provider) => (
-                        <div
-                            key={provider.key}
-                            className="rounded-2xl border border-line bg-surface-subtle p-4 space-y-4">
-                            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                                <div>
-                                    <h3 className="font-semibold text-content">{provider.name}</h3>
-                                    <p className="text-xs text-content-secondary">
-                                        콜백 URL: /login/callback/{provider.key}
-                                    </p>
-                                </div>
-                                <label className="inline-flex items-center gap-2 text-sm font-semibold text-content">
-                                    <input
-                                        type="checkbox"
-                                        checked={provider.isEnabled}
-                                        onChange={(event) => updateSocialProvider(provider.key, { isEnabled: event.target.checked })}
-                                    />
-                                    사용
-                                </label>
-                            </div>
-                            <div className="grid gap-4 lg:grid-cols-2">
-                                <Input
-                                    label="Client ID"
-                                    placeholder={`${provider.name} OAuth Client ID`}
-                                    value={provider.clientId}
-                                    onChange={(event) => updateSocialProvider(provider.key, { clientId: event.target.value })}
-                                />
-                                <Input
-                                    label="Client Secret"
-                                    type="password"
-                                    placeholder={provider.hasClientSecret ? '저장된 값 유지' : `${provider.name} OAuth Client Secret`}
-                                    value={provider.clientSecret}
-                                    onChange={(event) => updateSocialProvider(provider.key, {
-                                        clientSecret: event.target.value,
-                                        clearClientSecret: false
-                                    })}
-                                    helperText={provider.hasClientSecret ? '새 값을 입력하지 않으면 기존 secret을 유지합니다.' : undefined}
-                                />
-                            </div>
-                            {provider.hasClientSecret && (
-                                <label className="inline-flex items-center gap-2 text-xs text-content-secondary">
-                                    <input
-                                        type="checkbox"
-                                        checked={provider.clearClientSecret}
-                                        onChange={(event) => updateSocialProvider(provider.key, {
-                                            clearClientSecret: event.target.checked,
-                                            clientSecret: event.target.checked ? '' : provider.clientSecret
-                                        })}
-                                    />
-                                    저장된 Client Secret 삭제
-                                </label>
-                            )}
-                        </div>
-                    ))}
-                </div>
-            </Card>
-
-            <Card
-                title="회원가입 알림"
-                subtitle="새로운 회원 가입 시 발송되는 환영 알림을 설정합니다."
-                icon={<i className="fas fa-bell" />}>
-                <div className="space-y-4">
-                    <div className="space-y-2">
-                        <label className="block text-sm font-semibold text-content">
-                            환영 메시지
-                        </label>
-                        <Input
+                            label="가입 환영 메시지"
                             multiline
                             rows={3}
                             placeholder="환영합니다, {name}님! BLEX에 오신 것을 환영합니다."
                             value={welcomeMessage}
                             onChange={(e) => setWelcomeMessage(e.target.value)}
                             className="text-sm"
+                            helperText="{name}을 사용하면 사용자 이름으로 치환됩니다."
                         />
-                        <p className="text-xs text-content-secondary">{'{name}'}을 사용하면 사용자 이름으로 치환됩니다.</p>
-                    </div>
-                    <div className="space-y-2">
-                        <label className="block text-sm font-semibold text-content">
-                            알림 클릭 URL
-                        </label>
                         <Input
+                            label="환영 알림 클릭 URL"
                             placeholder="/"
                             value={welcomeUrl}
                             onChange={(e) => setWelcomeUrl(e.target.value)}
                             className="text-sm"
+                            helperText="환영 알림 클릭 시 이동할 URL입니다."
                         />
-                        <p className="text-xs text-content-secondary">환영 알림 클릭 시 이동할 URL입니다.</p>
+                        <Input
+                            label="탈퇴 후 리다이렉트 URL"
+                            placeholder="https://forms.example.com/exit-survey"
+                            value={deletionRedirectUrl}
+                            onChange={(e) => setDeletionRedirectUrl(e.target.value)}
+                            className="text-sm"
+                            helperText="비워두면 메인 페이지로 이동합니다. 설문 링크 등을 설정할 수 있습니다."
+                        />
                     </div>
-                </div>
-            </Card>
+                </Card>
 
-            <Card
-                title="회원 탈퇴 설정"
-                subtitle="회원 탈퇴 시 리다이렉트 설정입니다."
-                icon={<i className="fas fa-user-minus" />}>
-                <div className="space-y-2">
-                    <label className="block text-sm font-semibold text-content">
-                        탈퇴 후 리다이렉트 URL
-                    </label>
-                    <Input
-                        placeholder="https://forms.example.com/exit-survey"
-                        value={deletionRedirectUrl}
-                        onChange={(e) => setDeletionRedirectUrl(e.target.value)}
-                        className="text-sm"
-                    />
-                    <p className="text-xs text-content-secondary">비워두면 메인 페이지로 이동합니다. 설문 링크 등을 설정할 수 있습니다.</p>
-                </div>
-            </Card>
+                <Card
+                    title="커스텀 코드"
+                    subtitle="스크립트나 메타 태그와 같은 코드를 전역에 삽입할 수 있습니다."
+                    icon={<i className="fas fa-code" />}>
+                    <div className="space-y-4">
+                        <p className="text-xs leading-relaxed text-content-secondary">
+                            모든 공개 페이지에 영향을 줍니다. 분석 스크립트나 검증 메타 태그처럼 꼭 필요한 코드만 넣어주세요.
+                        </p>
+                        <div className="space-y-2">
+                            <label className="block text-sm font-semibold text-content">
+                                Head 영역 코드
+                            </label>
+                            <CodeEditor
+                                language="html"
+                                value={headerScript}
+                                onChange={setHeaderScript}
+                                height="220px"
+                            />
+                            <p className="text-xs text-content-secondary">{'<head>'} 태그 안에 삽입됩니다.</p>
+                        </div>
+                        <div className="space-y-2">
+                            <label className="block text-sm font-semibold text-content">
+                                Body 하단 코드
+                            </label>
+                            <CodeEditor
+                                language="html"
+                                value={footerScript}
+                                onChange={setFooterScript}
+                                height="220px"
+                            />
+                            <p className="text-xs text-content-secondary">{'</body>'} 태그 직전에 삽입됩니다.</p>
+                        </div>
+                    </div>
+                </Card>
+            </section>
 
-            <div className="flex justify-end">
+            <div className="sticky bottom-0 z-10 -mx-4 flex justify-end bg-surface-page/95 px-4 py-3 backdrop-blur md:mx-0 md:px-0">
                 <Button
+                    type="submit"
                     variant="primary"
                     size="md"
                     isLoading={updateMutation.isPending}
-                    disabled={assetMutationPending}
-                    onClick={handleSave}
+                    disabled={saveDisabled}
                     leftIcon={!updateMutation.isPending ? <i className="fas fa-check" /> : undefined}>
-                    {updateMutation.isPending ? '저장 중...' : '저장'}
+                    {updateMutation.isPending ? '저장 중...' : '사이트 설정 저장'}
                 </Button>
             </div>
-        </div>
+        </form>
     );
 };
 

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SiteSettingSetting/SiteSettingSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SiteSettingSetting/SiteSettingSetting.tsx
@@ -13,7 +13,8 @@ import {
     type BrandAssetTheme,
     type BrandAssetType,
     type SiteSettingData,
-    type SiteSettingUpdateData
+    type SiteSettingUpdateData,
+    type SocialAuthProviderSetting
 } from '~/lib/api/settings';
 import {
     createIconBrandAssetFormData,
@@ -29,6 +30,11 @@ interface BrandAssetUploadPayload {
 interface BrandAssetDeletePayload {
     assetType: BrandAssetType;
     theme: BrandAssetTheme;
+}
+
+interface SocialAuthProviderForm extends SocialAuthProviderSetting {
+    clientSecret: string;
+    clearClientSecret: boolean;
 }
 
 interface AssetUploadButtonProps {
@@ -221,6 +227,7 @@ const SiteSettingSetting = () => {
     const [welcomeMessage, setWelcomeMessage] = useState('');
     const [welcomeUrl, setWelcomeUrl] = useState('');
     const [deletionRedirectUrl, setDeletionRedirectUrl] = useState('');
+    const [socialAuthProviders, setSocialAuthProviders] = useState<SocialAuthProviderForm[]>([]);
 
     useEffect(() => {
         if (!hasHydratedFormRef.current) {
@@ -230,6 +237,11 @@ const SiteSettingSetting = () => {
             setWelcomeMessage(settingData.welcomeNotificationMessage);
             setWelcomeUrl(settingData.welcomeNotificationUrl);
             setDeletionRedirectUrl(settingData.accountDeletionRedirectUrl);
+            setSocialAuthProviders(settingData.socialAuthProviders.map((provider) => ({
+                ...provider,
+                clientSecret: '',
+                clearClientSecret: false
+            })));
             hasHydratedFormRef.current = true;
         }
         syncSettingsDocumentTitle(settingData.siteName);
@@ -247,6 +259,11 @@ const SiteSettingSetting = () => {
             setWelcomeMessage(body.welcomeNotificationMessage);
             setWelcomeUrl(body.welcomeNotificationUrl);
             setDeletionRedirectUrl(body.accountDeletionRedirectUrl);
+            setSocialAuthProviders(body.socialAuthProviders.map((provider) => ({
+                ...provider,
+                clientSecret: '',
+                clearClientSecret: false
+            })));
             syncSettingsDocumentTitle(body.siteName);
             void queryClient.invalidateQueries({ queryKey: ['site-settings'] });
             toast.success('사이트 설정이 저장되었습니다.');
@@ -294,8 +311,26 @@ const SiteSettingSetting = () => {
             footer_script: footerScript,
             welcome_notification_message: welcomeMessage,
             welcome_notification_url: welcomeUrl,
-            account_deletion_redirect_url: deletionRedirectUrl
+            account_deletion_redirect_url: deletionRedirectUrl,
+            social_auth_providers: socialAuthProviders.map((provider) => ({
+                key: provider.key,
+                is_enabled: provider.isEnabled,
+                client_id: provider.clientId,
+                ...(provider.clientSecret ? { client_secret: provider.clientSecret } : {}),
+                ...(provider.clearClientSecret ? { clear_client_secret: true } : {})
+            }))
         });
+    };
+
+    const updateSocialProvider = (key: string, patch: Partial<SocialAuthProviderForm>) => {
+        setSocialAuthProviders((providers) => providers.map((provider) => (
+            provider.key === key
+                ? {
+                    ...provider,
+                    ...patch
+                }
+                : provider
+        )));
     };
 
     const handleBrandAssetUpload = (assetType: BrandAssetType, theme: BrandAssetTheme) => (
@@ -431,6 +466,68 @@ const SiteSettingSetting = () => {
                         />
                         <p className="text-xs text-content-secondary">{'</body>'} 태그 직전에 삽입됩니다.</p>
                     </div>
+                </div>
+            </Card>
+
+            <Card
+                title="소셜 로그인"
+                subtitle="설치형 블로그에서 사용할 OAuth 제공자를 설정합니다. 현재 Google과 GitHub를 지원합니다."
+                icon={<i className="fas fa-right-to-bracket" />}>
+                <div className="space-y-4">
+                    {socialAuthProviders.map((provider) => (
+                        <div
+                            key={provider.key}
+                            className="rounded-2xl border border-line bg-surface-subtle p-4 space-y-4">
+                            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                                <div>
+                                    <h3 className="font-semibold text-content">{provider.name}</h3>
+                                    <p className="text-xs text-content-secondary">
+                                        콜백 URL: /login/callback/{provider.key}
+                                    </p>
+                                </div>
+                                <label className="inline-flex items-center gap-2 text-sm font-semibold text-content">
+                                    <input
+                                        type="checkbox"
+                                        checked={provider.isEnabled}
+                                        onChange={(event) => updateSocialProvider(provider.key, { isEnabled: event.target.checked })}
+                                    />
+                                    사용
+                                </label>
+                            </div>
+                            <div className="grid gap-4 lg:grid-cols-2">
+                                <Input
+                                    label="Client ID"
+                                    placeholder={`${provider.name} OAuth Client ID`}
+                                    value={provider.clientId}
+                                    onChange={(event) => updateSocialProvider(provider.key, { clientId: event.target.value })}
+                                />
+                                <Input
+                                    label="Client Secret"
+                                    type="password"
+                                    placeholder={provider.hasClientSecret ? '저장된 값 유지' : `${provider.name} OAuth Client Secret`}
+                                    value={provider.clientSecret}
+                                    onChange={(event) => updateSocialProvider(provider.key, {
+                                        clientSecret: event.target.value,
+                                        clearClientSecret: false
+                                    })}
+                                    helperText={provider.hasClientSecret ? '새 값을 입력하지 않으면 기존 secret을 유지합니다.' : undefined}
+                                />
+                            </div>
+                            {provider.hasClientSecret && (
+                                <label className="inline-flex items-center gap-2 text-xs text-content-secondary">
+                                    <input
+                                        type="checkbox"
+                                        checked={provider.clearClientSecret}
+                                        onChange={(event) => updateSocialProvider(provider.key, {
+                                            clearClientSecret: event.target.checked,
+                                            clientSecret: event.target.checked ? '' : provider.clientSecret
+                                        })}
+                                    />
+                                    저장된 Client Secret 삭제
+                                </label>
+                            )}
+                        </div>
+                    ))}
                 </div>
             </Card>
 

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SocialLoginSetting/SocialLoginSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SocialLoginSetting/SocialLoginSetting.tsx
@@ -1,0 +1,247 @@
+import { type FormEvent, useEffect, useRef, useState } from 'react';
+import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
+import { SettingsHeader } from '../../components';
+import { Toggle } from '@blex/ui/toggle';
+import { Button, Card, Input } from '~/components/shared';
+import { toast } from '~/utils/toast';
+import {
+    getSiteSettings,
+    updateSiteSettings,
+    type SiteSettingData,
+    type SiteSettingUpdateData,
+    type SocialAuthProviderSetting
+} from '~/lib/api/settings';
+
+interface SocialAuthProviderForm extends SocialAuthProviderSetting {
+    clientSecret: string;
+    clearClientSecret: boolean;
+}
+
+interface SavedSocialAuthProviderForm {
+    key: string;
+    isEnabled: boolean;
+    clientId: string;
+    hasClientSecret: boolean;
+}
+
+const assertDone = (response: Awaited<ReturnType<typeof updateSiteSettings>>, fallbackMessage: string) => {
+    if (response.data.status !== 'DONE') {
+        throw new Error(response.data.errorMessage || fallbackMessage);
+    }
+    return response.data.body;
+};
+
+const getErrorMessage = (error: unknown, fallbackMessage: string) => {
+    if (error instanceof Error && error.message) {
+        return error.message;
+    }
+    return fallbackMessage;
+};
+
+const toSocialAuthProviderForms = (providers: SocialAuthProviderSetting[] | undefined): SocialAuthProviderForm[] => (
+    providers ?? []
+).map((provider) => ({
+    ...provider,
+    clientSecret: '',
+    clearClientSecret: false
+}));
+
+const toSavedSocialAuthProviderForms = (providers: SocialAuthProviderForm[]): SavedSocialAuthProviderForm[] => (
+    providers.map((provider) => ({
+        key: provider.key,
+        isEnabled: provider.isEnabled,
+        clientId: provider.clientId,
+        hasClientSecret: provider.hasClientSecret
+    }))
+);
+
+const hasSocialAuthProvidersChanged = (
+    current: SocialAuthProviderForm[],
+    saved: SavedSocialAuthProviderForm[] | null
+) => {
+    if (!saved || current.length !== saved.length) return Boolean(saved);
+
+    return current.some((provider) => {
+        const savedProvider = saved.find((item) => item.key === provider.key);
+        if (!savedProvider) return true;
+        return provider.isEnabled !== savedProvider.isEnabled
+            || provider.clientId !== savedProvider.clientId
+            || provider.hasClientSecret !== savedProvider.hasClientSecret
+            || provider.clientSecret.length > 0
+            || provider.clearClientSecret;
+    });
+};
+
+const SocialLoginSetting = () => {
+    const queryClient = useQueryClient();
+    const hasHydratedFormRef = useRef(false);
+    const savedSocialAuthProvidersRef = useRef<SavedSocialAuthProviderForm[] | null>(null);
+    const { data: settingData } = useSuspenseQuery({
+        queryKey: ['site-settings'],
+        queryFn: async () => {
+            const { data } = await getSiteSettings();
+            if (data.status === 'DONE') {
+                return data.body;
+            }
+            throw new Error('사이트 설정을 불러오는데 실패했습니다.');
+        }
+    });
+
+    const [socialAuthProviders, setSocialAuthProviders] = useState<SocialAuthProviderForm[]>([]);
+
+    useEffect(() => {
+        if (!hasHydratedFormRef.current) {
+            const providerForms = toSocialAuthProviderForms(settingData.socialAuthProviders);
+            setSocialAuthProviders(providerForms);
+            savedSocialAuthProvidersRef.current = toSavedSocialAuthProviderForms(providerForms);
+            hasHydratedFormRef.current = true;
+        }
+    }, [settingData]);
+
+    const updateMutation = useMutation({
+        mutationFn: async (data: SiteSettingUpdateData) => {
+            const response = await updateSiteSettings(data);
+            return assertDone(response, '소셜 로그인 설정 저장에 실패했습니다.');
+        },
+        onSuccess: (body: SiteSettingData) => {
+            const providerForms = toSocialAuthProviderForms(body.socialAuthProviders);
+            setSocialAuthProviders(providerForms);
+            savedSocialAuthProvidersRef.current = toSavedSocialAuthProviderForms(providerForms);
+            void queryClient.invalidateQueries({ queryKey: ['site-settings'] });
+            toast.success('소셜 로그인 설정이 저장되었습니다.');
+        },
+        onError: (error) => {
+            toast.error(getErrorMessage(error, '소셜 로그인 설정 저장에 실패했습니다.'));
+        }
+    });
+
+    const updateSocialProvider = (key: string, patch: Partial<SocialAuthProviderForm>) => {
+        setSocialAuthProviders((providers) => providers.map((provider) => (
+            provider.key === key
+                ? {
+                    ...provider,
+                    ...patch
+                }
+                : provider
+        )));
+    };
+
+    const handleSave = (event?: FormEvent<HTMLFormElement>) => {
+        event?.preventDefault();
+        updateMutation.mutate({
+            social_auth_providers: socialAuthProviders.map((provider) => ({
+                key: provider.key,
+                is_enabled: provider.isEnabled,
+                client_id: provider.clientId,
+                ...(provider.clientSecret ? { client_secret: provider.clientSecret } : {}),
+                ...(provider.clearClientSecret ? { clear_client_secret: true } : {})
+            }))
+        });
+    };
+
+    const isDirty = hasSocialAuthProvidersChanged(socialAuthProviders, savedSocialAuthProvidersRef.current);
+
+    return (
+        <form className="space-y-8" onSubmit={handleSave}>
+            <SettingsHeader
+                title="소셜 로그인"
+                description="Google, GitHub OAuth 로그인 사용 여부와 앱 키를 관리합니다."
+            />
+
+            <Card
+                title="설정 방법"
+                subtitle="OAuth 앱을 만든 뒤 콜백 URL과 앱 키를 등록합니다."
+                icon={<i className="fas fa-circle-info" />}>
+                <ol className="space-y-2 text-sm leading-relaxed text-content-secondary">
+                    <li>1. Google/GitHub에서 OAuth 앱을 생성합니다.</li>
+                    <li>
+                        2. 콜백 URL을{' '}
+                        <code className="rounded-md bg-surface-subtle px-2 py-1 text-xs text-content-secondary">
+                            /login/callback/provider
+                        </code>
+                        {' '}형태로 등록합니다.
+                    </li>
+                    <li>3. Client ID와 Secret을 입력하고 사용을 켭니다.</li>
+                </ol>
+            </Card>
+
+            {socialAuthProviders.map((provider) => (
+                <Card
+                    key={provider.key}
+                    title={provider.name}
+                    subtitle={`콜백 URL: /login/callback/${provider.key}`}
+                    icon={<i className="fas fa-right-to-bracket" />}>
+                    <div className="space-y-6">
+                        <div className="flex flex-col gap-3 border-b border-line pb-5 sm:flex-row sm:items-center sm:justify-between">
+                            <div>
+                                <div className="text-sm font-semibold text-content">로그인 사용</div>
+                                <p className="mt-1 text-xs leading-relaxed text-content-secondary">
+                                    켜면 로그인/회원가입 화면에 {provider.name} 버튼이 표시됩니다.
+                                </p>
+                            </div>
+                            <div className="flex items-center gap-3">
+                                <span className="text-xs font-medium text-content-secondary">
+                                    {provider.isEnabled ? 'ON' : 'OFF'}
+                                </span>
+                                <Toggle
+                                    checked={provider.isEnabled}
+                                    disabled={updateMutation.isPending}
+                                    onCheckedChange={(checked) => updateSocialProvider(provider.key, { isEnabled: checked })}
+                                    aria-label={`${provider.name} 소셜 로그인 사용`}
+                                />
+                            </div>
+                        </div>
+
+                        <div className="grid gap-4 md:grid-cols-2">
+                            <Input
+                                label="Client ID"
+                                placeholder={`${provider.name} OAuth Client ID`}
+                                value={provider.clientId}
+                                onChange={(event) => updateSocialProvider(provider.key, { clientId: event.target.value })}
+                            />
+                            <Input
+                                label="Client Secret"
+                                type="password"
+                                placeholder={provider.hasClientSecret ? '저장된 값 유지' : `${provider.name} OAuth Client Secret`}
+                                value={provider.clientSecret}
+                                onChange={(event) => updateSocialProvider(provider.key, {
+                                    clientSecret: event.target.value,
+                                    clearClientSecret: false
+                                })}
+                                helperText={provider.hasClientSecret ? '새 값을 입력하지 않으면 기존 secret을 유지합니다.' : undefined}
+                            />
+                        </div>
+
+                        {provider.hasClientSecret && (
+                            <label className="inline-flex min-h-11 items-center gap-2 text-xs text-content-secondary">
+                                <input
+                                    type="checkbox"
+                                    checked={provider.clearClientSecret}
+                                    onChange={(event) => updateSocialProvider(provider.key, {
+                                        clearClientSecret: event.target.checked,
+                                        clientSecret: event.target.checked ? '' : provider.clientSecret
+                                    })}
+                                />
+                                저장된 Client Secret 삭제
+                            </label>
+                        )}
+                    </div>
+                </Card>
+            ))}
+
+            <div className="sticky bottom-0 z-10 -mx-4 flex justify-end bg-surface-page/95 px-4 py-3 backdrop-blur md:mx-0 md:px-0">
+                <Button
+                    type="submit"
+                    variant="primary"
+                    size="md"
+                    isLoading={updateMutation.isPending}
+                    disabled={!isDirty || updateMutation.isPending}
+                    leftIcon={!updateMutation.isPending ? <i className="fas fa-check" /> : undefined}>
+                    {updateMutation.isPending ? '저장 중...' : '소셜 로그인 설정 저장'}
+                </Button>
+            </div>
+        </form>
+    );
+};
+
+export default SocialLoginSetting;

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SocialLoginSetting/index.ts
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SocialLoginSetting/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SocialLoginSetting';

--- a/backend/islands/apps/remotes/src/components/remotes/Signup/Signup.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/Signup/Signup.tsx
@@ -397,21 +397,7 @@ const Signup = () => {
                         </button>
                     </form>
 
-                    {/* Divider */}
-                    <div className="relative py-4">
-                        <div className="absolute inset-0 flex items-center">
-                            <div className="w-full border-t border-line" />
-                        </div>
-                        <div className="relative flex justify-center text-xs uppercase tracking-wider">
-                            <span className="px-4 bg-surface/50 backdrop-blur-sm text-content-hint font-medium">
-                                또는 간편하게
-                            </span>
-                        </div>
-                    </div>
-
-                    <div className="space-y-3">
-                        <SocialLogin />
-                    </div>
+                    <SocialLogin />
 
                     {/* Footer Links */}
                     <div className="text-center pt-6 border-t border-line-light/50">

--- a/backend/islands/apps/remotes/src/components/remotes/SocialLogin/SocialLogin.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SocialLogin/SocialLogin.tsx
@@ -4,18 +4,13 @@ import { toast } from '~/utils/toast';
 interface SocialProvider {
     key: string;
     name: string;
-    color: string;
+    clientId?: string;
 }
 
 const SocialLogin = () => {
     const { providers, loading } = useSocialProviders();
 
     const handleSocialLogin = (provider: SocialProvider) => {
-        const clientIds: Record<string, string | undefined> = {
-            google: window.configuration?.googleClientId,
-            github: window.configuration?.githubClientId
-        };
-
         const nextUrl = window.NEXT_URL || '';
 
         const redirectUris: Record<string, string> = {
@@ -30,7 +25,7 @@ const SocialLogin = () => {
                 `https://github.com/login/oauth/authorize?client_id=${clientId}&redirect_uri=${encodeURIComponent(redirectUri)}&scope=user:email`
         };
 
-        const clientId = clientIds[provider.key];
+        const clientId = provider.clientId;
         const redirectUri = redirectUris[provider.key];
         const authUrlBuilder = authUrls[provider.key];
 
@@ -84,28 +79,41 @@ const SocialLogin = () => {
         </svg>
     );
 
-    if (loading) {
+    if (loading || !Array.isArray(providers) || providers.length === 0) {
         return null;
     }
 
     return (
-        <div className="grid grid-cols-1 gap-3">
-            {Array.isArray(providers) && providers.map((provider) => (
-                <button
-                    key={provider.key}
-                    onClick={() => handleSocialLogin(provider)}
-                    className="relative w-full flex items-center justify-center gap-3 px-4 py-3.5 border border-line rounded-2xl text-content bg-surface hover:bg-surface-subtle hover:border-line transition-all duration-150 group active:scale-[0.98]">
-                    <span className="absolute left-5 flex items-center justify-center transition-transform duration-150 group-hover:scale-110">
-                        {provider.key === 'google' && <GoogleIcon />}
-                        {provider.key === 'github' && <GitHubIcon />}
-                        {provider.key !== 'google' && provider.key !== 'github' && (
+        <>
+            <div className="relative py-4">
+                <div className="absolute inset-0 flex items-center">
+                    <div className="w-full border-t border-line" />
+                </div>
+                <div className="relative flex justify-center text-xs uppercase tracking-wider">
+                    <span className="px-4 bg-surface/50 backdrop-blur-sm text-content-hint font-medium">
+                        또는 간편하게
+                    </span>
+                </div>
+            </div>
+
+            <div className="grid grid-cols-1 gap-3">
+                {providers.map((provider) => (
+                    <button
+                        key={provider.key}
+                        onClick={() => handleSocialLogin(provider)}
+                        className="relative w-full flex items-center justify-center gap-3 px-4 py-3.5 border border-line rounded-2xl text-content bg-surface hover:bg-surface-subtle hover:border-line transition-all duration-150 group active:scale-[0.98]">
+                        <span className="absolute left-5 flex items-center justify-center transition-transform duration-150 group-hover:scale-110">
+                            {provider.key === 'google' && <GoogleIcon />}
+                            {provider.key === 'github' && <GitHubIcon />}
+                            {provider.key !== 'google' && provider.key !== 'github' && (
                             <DefaultIcon />
                         )}
-                    </span>
-                    <span className="font-semibold text-sm">{provider.name}으로 계속하기</span>
-                </button>
-            ))}
-        </div>
+                        </span>
+                        <span className="font-semibold text-sm">{provider.name}으로 계속하기</span>
+                    </button>
+                ))}
+            </div>
+        </>
     );
 };
 

--- a/backend/islands/apps/remotes/src/lib/api/auth.ts
+++ b/backend/islands/apps/remotes/src/lib/api/auth.ts
@@ -23,7 +23,7 @@ export interface SecurityCodeRequest {
 export interface SocialProvider {
     key: string;
     name: string;
-    color: string;
+    clientId: string;
 }
 
 export type SocialProvidersResponse = Response<SocialProvider[]>;

--- a/backend/islands/apps/remotes/src/lib/api/settings.ts
+++ b/backend/islands/apps/remotes/src/lib/api/settings.ts
@@ -632,6 +632,14 @@ export const updateGlobalBannerOrder = async (order: [number, number][]) => {
 };
 
 // Site Setting API
+export interface SocialAuthProviderSetting {
+    key: string;
+    name: string;
+    isEnabled: boolean;
+    clientId: string;
+    hasClientSecret: boolean;
+}
+
 export interface SiteSettingData {
     siteName: string;
     siteDescription: string;
@@ -655,6 +663,15 @@ export interface SiteSettingData {
     robotsTxtDefault: string;
     aeoEnabled: boolean;
     updatedDate: string;
+    socialAuthProviders: SocialAuthProviderSetting[];
+}
+
+export interface SocialAuthProviderUpdateData {
+    key: string;
+    is_enabled?: boolean;
+    client_id?: string;
+    client_secret?: string;
+    clear_client_secret?: boolean;
 }
 
 export interface SiteSettingUpdateData {
@@ -667,6 +684,7 @@ export interface SiteSettingUpdateData {
     seo_enabled?: boolean;
     robots_txt_extra_rules?: string;
     aeo_enabled?: boolean;
+    social_auth_providers?: SocialAuthProviderUpdateData[];
 }
 
 export const getSiteSettings = async () => {

--- a/backend/src/board/admin/auth.py
+++ b/backend/src/board/admin/auth.py
@@ -1,6 +1,8 @@
 from django.contrib import admin
 
+from board.constants.social_auth import SUPPORTED_SOCIAL_AUTH_PROVIDERS
 from board.models import TwoFactorAuth, SocialAuth, SocialAuthProvider
+from board.services.social_auth_provider_service import SocialAuthProviderService
 
 
 @admin.register(TwoFactorAuth)
@@ -18,7 +20,7 @@ class TwoFactorAuthAdmin(admin.ModelAdmin):
 @admin.register(SocialAuth)
 class SocialAuthAdmin(admin.ModelAdmin):
     list_display = ['user', 'provider', 'created_date']
-    search_fields = ['user__username', 'provider__name']
+    search_fields = ['user__username', 'provider__key']
     list_filter = ['provider', ('created_date', admin.DateFieldListFilter)]
     list_per_page = 30
 
@@ -29,5 +31,27 @@ class SocialAuthAdmin(admin.ModelAdmin):
 
 @admin.register(SocialAuthProvider)
 class SocialAuthProviderAdmin(admin.ModelAdmin):
-    list_display = ['key', 'name', 'icon', 'color']
-    list_editable = ['name', 'icon', 'color']
+    list_display = ['key', 'is_enabled', 'has_client_id', 'has_client_secret']
+    list_editable = ['is_enabled']
+    readonly_fields = ['key']
+    fields = ['key', 'is_enabled', 'client_id', 'client_secret']
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+    def get_queryset(self, request):
+        SocialAuthProviderService.ensure_supported_providers()
+        return super().get_queryset(request).filter(
+            key__in=SUPPORTED_SOCIAL_AUTH_PROVIDERS.keys()
+        )
+
+    @admin.display(boolean=True, description='Client ID')
+    def has_client_id(self, obj):
+        return bool(obj.client_id)
+
+    @admin.display(boolean=True, description='Client Secret')
+    def has_client_secret(self, obj):
+        return bool(obj.client_secret)

--- a/backend/src/board/constants/social_auth.py
+++ b/backend/src/board/constants/social_auth.py
@@ -1,0 +1,13 @@
+SUPPORTED_SOCIAL_AUTH_PROVIDERS = {
+    'google': {
+        'name': 'Google',
+    },
+    'github': {
+        'name': 'GitHub',
+    },
+}
+
+SUPPORTED_SOCIAL_AUTH_PROVIDER_CHOICES = tuple(
+    (key, provider['name'])
+    for key, provider in SUPPORTED_SOCIAL_AUTH_PROVIDERS.items()
+)

--- a/backend/src/board/context_processors.py
+++ b/backend/src/board/context_processors.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 from board.models import SiteSetting, SiteNotice, SiteContentScope, StaticPage
 from board.services.brand_asset_service import BrandAssetService
 from board.services.site_url_service import SiteUrlService
+from board.services.social_auth_provider_service import SocialAuthProviderService
 
 
 def oauth_settings(request):
@@ -11,8 +12,8 @@ def oauth_settings(request):
     Add OAuth client IDs to template context
     """
     return {
-        'GOOGLE_OAUTH_CLIENT_ID': getattr(settings, 'GOOGLE_OAUTH_CLIENT_ID', ''),
-        'GITHUB_OAUTH_CLIENT_ID': getattr(settings, 'GITHUB_OAUTH_CLIENT_ID', ''),
+        'GOOGLE_OAUTH_CLIENT_ID': SocialAuthProviderService.get_client_id('google'),
+        'GITHUB_OAUTH_CLIENT_ID': SocialAuthProviderService.get_client_id('github'),
     }
 
 

--- a/backend/src/board/migrations/0050_socialauthprovider_credentials.py
+++ b/backend/src/board/migrations/0050_socialauthprovider_credentials.py
@@ -1,0 +1,132 @@
+from django.db import migrations, models
+
+from board.services.social_auth_provider_secret_service import SocialAuthProviderSecretService
+
+
+SUPPORTED_PROVIDER_NAMES = {
+    'google': 'Google',
+    'github': 'GitHub',
+}
+
+
+def create_supported_social_providers(apps, schema_editor):
+    SocialAuthProvider = apps.get_model('board', 'SocialAuthProvider')
+    for key in SUPPORTED_PROVIDER_NAMES:
+        SocialAuthProvider.objects.get_or_create(
+            key=key,
+            defaults={
+                'is_enabled': False,
+            },
+        )
+
+def encrypt_existing_client_secrets(apps, schema_editor):
+    SocialAuthProvider = apps.get_model('board', 'SocialAuthProvider')
+    for provider in SocialAuthProvider.objects.exclude(client_secret=''):
+        encrypted_secret = SocialAuthProviderSecretService.encrypt_secret(provider.client_secret)
+        if encrypted_secret != provider.client_secret:
+            provider.client_secret = encrypted_secret
+            provider.save(update_fields=['client_secret'])
+
+
+def migrate_legacy_last_name_social_auth(apps, schema_editor):
+    User = apps.get_model('auth', 'User')
+    SocialAuth = apps.get_model('board', 'SocialAuth')
+    SocialAuthProvider = apps.get_model('board', 'SocialAuthProvider')
+
+    provider_map = {
+        key: SocialAuthProvider.objects.get_or_create(key=key)[0]
+        for key in SUPPORTED_PROVIDER_NAMES
+    }
+
+    seen = set()
+    owner_by_key = {}
+    for social_auth in SocialAuth.objects.order_by('id'):
+        key = (social_auth.provider_id, social_auth.uid)
+        if key in seen:
+            if owner_by_key[key] == social_auth.user_id:
+                social_auth.delete()
+                continue
+            raise RuntimeError(
+                'Duplicate SocialAuth provider/uid points to multiple users. '
+                'Resolve duplicate social auth rows before applying migration.'
+            )
+            continue
+        seen.add(key)
+        owner_by_key[key] = social_auth.user_id
+
+    for user in User.objects.exclude(last_name=''):
+        provider_key, separator, uid = user.last_name.partition(':')
+        if separator != ':' or provider_key not in provider_map or not uid:
+            continue
+
+        social_auth, created = SocialAuth.objects.get_or_create(
+            provider=provider_map[provider_key],
+            uid=uid,
+            defaults={
+                'user': user,
+                'extra_data': '{}',
+            },
+        )
+        if not created and social_auth.user_id != user.id:
+            continue
+        user.last_name = ''
+        user.save(update_fields=['last_name'])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('board', '0049_sitesetting_brand_fields'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='socialauthprovider',
+            name='client_id',
+            field=models.CharField(blank=True, max_length=255),
+        ),
+        migrations.AddField(
+            model_name='socialauthprovider',
+            name='client_secret',
+            field=models.TextField(blank=True),
+        ),
+        migrations.AddField(
+            model_name='socialauthprovider',
+            name='is_enabled',
+            field=models.BooleanField(default=False),
+        ),
+        migrations.RemoveField(
+            model_name='socialauthprovider',
+            name='color',
+        ),
+        migrations.RemoveField(
+            model_name='socialauthprovider',
+            name='icon',
+        ),
+        migrations.RemoveField(
+            model_name='socialauthprovider',
+            name='name',
+        ),
+        migrations.AlterField(
+            model_name='socialauthprovider',
+            name='key',
+            field=models.CharField(
+                choices=[
+                    ('google', 'Google'),
+                    ('github', 'GitHub'),
+                ],
+                max_length=20,
+                unique=True,
+            ),
+        ),
+        migrations.RunPython(create_supported_social_providers, migrations.RunPython.noop),
+        migrations.RunPython(encrypt_existing_client_secrets, migrations.RunPython.noop),
+        migrations.RunPython(migrate_legacy_last_name_social_auth, migrations.RunPython.noop),
+        migrations.AddConstraint(
+            model_name='socialauth',
+            constraint=models.UniqueConstraint(
+                fields=('provider', 'uid'),
+                name='unique_social_auth_provider_uid',
+            ),
+        ),
+    ]

--- a/backend/src/board/models.py
+++ b/backend/src/board/models.py
@@ -26,6 +26,10 @@ from board.services.webhook_subscription_state_service import WebhookSubscriptio
 from board.services.user_config_meta_service import UserConfigMetaService
 from board.services.series_save_service import SeriesSaveService
 from board.services.telegram_sync_encryption_service import TelegramSyncEncryptionService
+from board.constants.social_auth import (
+    SUPPORTED_SOCIAL_AUTH_PROVIDERS,
+    SUPPORTED_SOCIAL_AUTH_PROVIDER_CHOICES,
+)
 
 
 def get_user_hex(username):
@@ -802,16 +806,36 @@ class UsernameChangeLog(models.Model):
 
 
 class SocialAuthProvider(models.Model):
-    key = models.CharField(max_length=20, unique=True)
-    name = models.CharField(max_length=20)
-    icon = models.CharField(max_length=20)
-    color = models.CharField(max_length=20)
+    key = models.CharField(max_length=20, unique=True, choices=SUPPORTED_SOCIAL_AUTH_PROVIDER_CHOICES)
+    client_id = models.CharField(max_length=255, blank=True)
+    client_secret = models.TextField(blank=True)
+    is_enabled = models.BooleanField(default=False)
+
+    def clean(self):
+        super().clean()
+        if self.key not in SUPPORTED_SOCIAL_AUTH_PROVIDERS:
+            raise ValidationError({'key': '지원하지 않는 소셜 로그인 제공자입니다.'})
+
+    def save(self, *args, **kwargs):
+        if self.client_secret:
+            from board.services.social_auth_provider_secret_service import SocialAuthProviderSecretService
+            self.client_secret = SocialAuthProviderSecretService.encrypt_secret(self.client_secret)
+        self.full_clean()
+        return super().save(*args, **kwargs)
 
     def __str__(self):
-        return self.name
+        return self.key
 
 
 class SocialAuth(models.Model):
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=['provider', 'uid'],
+                name='unique_social_auth_provider_uid',
+            ),
+        ]
+
     user = models.ForeignKey('auth.User', on_delete=models.CASCADE)
     provider = models.ForeignKey('board.SocialAuthProvider', on_delete=models.CASCADE)
     uid = models.CharField(max_length=50)
@@ -819,7 +843,7 @@ class SocialAuth(models.Model):
     created_date = models.DateTimeField(default=timezone.now)
 
     def __str__(self):
-        return f'{self.provider.name} - {self.user.username}'
+        return f'{self.provider.key} - {self.user.username}'
 
 
 class SiteSetting(models.Model):

--- a/backend/src/board/services/auth_service.py
+++ b/backend/src/board/services/auth_service.py
@@ -167,8 +167,7 @@ class AuthService:
         name: str,
         email: str,
         password: Optional[str] = None,
-        avatar_url: Optional[str] = None,
-        token: Optional[str] = None
+        avatar_url: Optional[str] = None
     ) -> Tuple[User, Profile, Config]:
         """
         Create new user with profile and config.
@@ -179,7 +178,6 @@ class AuthService:
             email: User's email
             password: Password for the user (optional, for regular signup)
             avatar_url: URL to download avatar from (optional)
-            token: Token to store in last_name field (optional)
 
         Returns:
             Tuple of (User, Profile, Config)
@@ -193,9 +191,6 @@ class AuthService:
             first_name=name,
         )
 
-        if token:
-            user.last_name = token
-            user.save()
 
         user_profile = Profile.objects.create(user=user)
 

--- a/backend/src/board/services/social_auth_provider_secret_service.py
+++ b/backend/src/board/services/social_auth_provider_secret_service.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from cryptography.fernet import InvalidToken
+
+from modules.cipher import decrypt_value, encrypt_value
+
+
+class SocialAuthProviderSecretService:
+    """Encrypt/decrypt OAuth client secrets stored in the database."""
+
+    @staticmethod
+    def is_encrypted(value: str) -> bool:
+        if not value:
+            return False
+        try:
+            decrypt_value(value)
+            return True
+        except Exception:
+            return False
+
+    @staticmethod
+    def encrypt_secret(value: str) -> str:
+        value = (value or '').strip()
+        if not value:
+            return ''
+        if SocialAuthProviderSecretService.is_encrypted(value):
+            return value
+        return encrypt_value(value).decode()
+
+    @staticmethod
+    def decrypt_secret(value: str) -> str:
+        value = value or ''
+        if not value:
+            return ''
+        try:
+            return decrypt_value(value)
+        except (InvalidToken, Exception):
+            return ''

--- a/backend/src/board/services/social_auth_provider_service.py
+++ b/backend/src/board/services/social_auth_provider_service.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from django.db import transaction
+
+from board.constants.social_auth import SUPPORTED_SOCIAL_AUTH_PROVIDERS
+from board.models import SocialAuthProvider
+from board.services.social_auth_provider_secret_service import SocialAuthProviderSecretService
+
+
+class SocialAuthProviderService:
+    SUPPORTED_PROVIDERS = SUPPORTED_SOCIAL_AUTH_PROVIDERS
+
+    @classmethod
+    def ensure_supported_providers(cls) -> None:
+        for key in cls.SUPPORTED_PROVIDERS:
+            SocialAuthProvider.objects.get_or_create(
+                key=key,
+                defaults={
+                    'is_enabled': False,
+                },
+            )
+
+    @classmethod
+    def supported_keys(cls) -> list[str]:
+        return list(cls.SUPPORTED_PROVIDERS.keys())
+
+    @classmethod
+    def is_enabled(cls, key: str) -> bool:
+        provider = cls.get_provider(key)
+        return bool(provider and provider.is_enabled)
+
+    @classmethod
+    def get_client_id(cls, key: str) -> str:
+        provider = cls.get_provider(key)
+        if not provider or not provider.is_enabled:
+            return ''
+        return provider.client_id
+
+    @classmethod
+    def get_client_secret(cls, key: str) -> str:
+        provider = cls.get_provider(key)
+        if not provider or not provider.is_enabled:
+            return ''
+        return SocialAuthProviderSecretService.decrypt_secret(provider.client_secret)
+
+    @classmethod
+    def get_provider(cls, key: str) -> SocialAuthProvider | None:
+        if key not in cls.SUPPORTED_PROVIDERS:
+            return None
+        cls.ensure_supported_providers()
+        return SocialAuthProvider.objects.filter(key=key).first()
+
+    @classmethod
+    def serialize_public_providers(cls) -> list[dict[str, str]]:
+        cls.ensure_supported_providers()
+        providers = []
+        for provider in SocialAuthProvider.objects.filter(
+            key__in=cls.supported_keys(),
+            is_enabled=True,
+        ).order_by('id'):
+            client_id = cls.get_client_id(provider.key)
+            if not client_id:
+                continue
+            providers.append({
+                'key': provider.key,
+                'name': cls.SUPPORTED_PROVIDERS[provider.key]['name'],
+                'client_id': client_id,
+            })
+        return providers
+
+    @classmethod
+    def serialize_admin_providers(cls) -> list[dict[str, object]]:
+        cls.ensure_supported_providers()
+        providers = []
+        for provider in SocialAuthProvider.objects.filter(key__in=cls.supported_keys()).order_by('id'):
+            providers.append({
+                'key': provider.key,
+                'name': cls.SUPPORTED_PROVIDERS[provider.key]['name'],
+                'is_enabled': provider.is_enabled,
+                'client_id': provider.client_id,
+                'has_client_secret': bool(provider.client_secret),
+            })
+        return providers
+
+    @classmethod
+    @transaction.atomic
+    def update_admin_providers(cls, payload: object) -> None:
+        if not isinstance(payload, list):
+            return
+
+        cls.ensure_supported_providers()
+        provider_map = {
+            provider.key: provider
+            for provider in SocialAuthProvider.objects.filter(key__in=cls.supported_keys())
+        }
+        for item in payload:
+            if not isinstance(item, dict):
+                continue
+            key = item.get('key')
+            provider = provider_map.get(key)
+            if provider is None:
+                continue
+
+            if 'is_enabled' in item:
+                provider.is_enabled = item.get('is_enabled') is True
+            if isinstance(item.get('client_id'), str):
+                provider.client_id = item['client_id'].strip()
+            if isinstance(item.get('client_secret'), str) and item['client_secret']:
+                provider.client_secret = SocialAuthProviderSecretService.encrypt_secret(item['client_secret'])
+            if item.get('clear_client_secret') is True:
+                provider.client_secret = ''
+            provider.save(update_fields=['is_enabled', 'client_id', 'client_secret'])

--- a/backend/src/board/tests/api/test_auth.py
+++ b/backend/src/board/tests/api/test_auth.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 from django.test import TestCase, override_settings
 from django.utils import timezone
 
-from board.models import User, UsernameChangeLog, Profile, Config
+from board.models import User, UsernameChangeLog, Profile, Config, SocialAuth, SocialAuthProvider
 from modules import oauth
 
 
@@ -30,6 +30,16 @@ class AuthTestCase(TestCase):
         )
         Profile.objects.create(user=admin, role=Profile.Role.EDITOR)
         Config.objects.create(user=admin)
+
+        for key in ['google', 'github']:
+            SocialAuthProvider.objects.update_or_create(
+                key=key,
+                defaults={
+                    'is_enabled': True,
+                    'client_id': f'{key}-client-id',
+                    'client_secret': f'{key}-secret',
+                }
+            )
 
     def test_login_not_logged_in_user(self):
         """로그인하지 않은 사용자 테스트"""
@@ -141,6 +151,20 @@ class AuthTestCase(TestCase):
         content = json.loads(response.content)
         self.assertEqual(content['status'], 'ERROR')
 
+
+    def test_disabled_social_provider_blocks_direct_signup_api(self):
+        """관리자가 제공자를 끄면 v1/sign 직접 호출도 막는다."""
+        SocialAuthProvider.objects.filter(key='github').update(is_enabled=False)
+
+        response = self.client.post('/v1/sign/github', {
+            'code': 'SECRET_TOKEN_VALUE',
+        })
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'ERROR')
+        self.assertEqual(content['errorCode'], 'error:RJ')
+
     @patch('modules.oauth.auth_github', return_value=oauth.State(success=True, user={
         'node_id': 'SECRET_TOKEN_VALUE',
         'login': 'test3',
@@ -156,6 +180,9 @@ class AuthTestCase(TestCase):
         self.assertEqual(content['status'], 'DONE')
         self.assertEqual(content['body']['username'], 'test3')
         self.assertEqual(content['body']['isFirstLogin'], True)
+        user = User.objects.get(username='test3')
+        self.assertEqual(user.last_name, '')
+        self.assertTrue(SocialAuth.objects.filter(user=user, provider__key='github', uid='SECRET_TOKEN_VALUE').exists())
 
         self.client.logout()
 
@@ -183,6 +210,9 @@ class AuthTestCase(TestCase):
         self.assertEqual(content['status'], 'DONE')
         self.assertEqual(content['body']['username'], 'test3')
         self.assertEqual(content['body']['isFirstLogin'], True)
+        user = User.objects.get(username='test3')
+        self.assertEqual(user.last_name, '')
+        self.assertTrue(SocialAuth.objects.filter(user=user, provider__key='google', uid='SECRET_TOKEN_VALUE').exists())
 
         self.client.logout()
 

--- a/backend/src/board/tests/api/test_site_setting.py
+++ b/backend/src/board/tests/api/test_site_setting.py
@@ -9,7 +9,8 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.files.storage import default_storage
 from PIL import Image
 
-from board.models import User, Profile, SiteSetting
+from board.models import User, Profile, SiteSetting, SocialAuthProvider
+from board.services.social_auth_provider_service import SocialAuthProviderService
 from board.services.brand_asset_service import BrandAssetService
 
 
@@ -137,6 +138,9 @@ class SiteSettingAPITestCase(TestCase):
         self.assertIn('256', body['iconPngUrls'])
         self.assertIn('512', body['iconPngUrls'])
         self.assertIn('updatedDate', body)
+        self.assertIn('socialAuthProviders', body)
+        provider_keys = {provider['key'] for provider in body['socialAuthProviders']}
+        self.assertEqual(provider_keys, {'google', 'github'})
 
     def test_update_single_field(self):
         """사이트 설정 개별 필드 업데이트 테스트"""
@@ -199,6 +203,110 @@ class SiteSettingAPITestCase(TestCase):
         self.assertEqual(setting.robots_txt_extra_rules, 'User-agent: ExampleBot\nDisallow: /private/')
         self.assertTrue(setting.aeo_enabled)
 
+
+
+    def test_update_social_auth_provider_settings(self):
+        """관리자 사이트 설정에서 소셜 로그인 제공자 값을 저장한다."""
+        data = {
+            'social_auth_providers': [
+                {
+                    'key': 'google',
+                    'is_enabled': True,
+                    'client_id': 'google-client-id',
+                    'client_secret': 'google-secret',
+                },
+                {
+                    'key': 'github',
+                    'is_enabled': False,
+                    'client_id': 'github-client-id',
+                },
+            ]
+        }
+
+        response = self.client.put(
+            '/v1/site-settings',
+            json.dumps(data),
+            content_type='application/json'
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'DONE')
+
+        google = SocialAuthProvider.objects.get(key='google')
+        self.assertTrue(google.is_enabled)
+        self.assertEqual(google.client_id, 'google-client-id')
+        self.assertNotEqual(google.client_secret, 'google-secret')
+        self.assertEqual(SocialAuthProviderService.get_client_secret('google'), 'google-secret')
+
+        body_google = next(
+            provider for provider in content['body']['socialAuthProviders']
+            if provider['key'] == 'google'
+        )
+        self.assertEqual(body_google['clientId'], 'google-client-id')
+        self.assertTrue(body_google['hasClientSecret'])
+        self.assertNotIn('clientSecret', body_google)
+
+    def test_update_social_auth_provider_keeps_existing_secret_when_blank(self):
+        """Client Secret 입력값이 비어 있으면 기존 secret을 유지한다."""
+        SocialAuthProvider.objects.update_or_create(
+            key='github',
+            defaults={
+                'is_enabled': True,
+                'client_id': 'old-client-id',
+                'client_secret': 'old-secret',
+            }
+        )
+
+        response = self.client.put(
+            '/v1/site-settings',
+            json.dumps({
+                'social_auth_providers': [{
+                    'key': 'github',
+                    'is_enabled': True,
+                    'client_id': 'new-client-id',
+                }]
+            }),
+            content_type='application/json'
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'DONE')
+
+        github = SocialAuthProvider.objects.get(key='github')
+        self.assertEqual(github.client_id, 'new-client-id')
+        self.assertNotEqual(github.client_secret, 'old-secret')
+        self.assertEqual(SocialAuthProviderService.get_client_secret('github'), 'old-secret')
+
+    def test_public_social_providers_only_returns_enabled_configured_providers(self):
+        """로그인 화면에는 사용 가능하고 Client ID가 있는 제공자만 내려준다."""
+        SocialAuthProvider.objects.update_or_create(
+            key='google',
+            defaults={
+                'is_enabled': True,
+                'client_id': 'google-client-id',
+                'client_secret': 'google-secret',
+            }
+        )
+        SocialAuthProvider.objects.update_or_create(
+            key='github',
+            defaults={
+                'is_enabled': False,
+                'client_id': 'github-client-id',
+                'client_secret': 'github-secret',
+            }
+        )
+
+        response = self.client.get('/v1/social-providers')
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'DONE')
+        self.assertEqual(len(content['body']), 1)
+        self.assertEqual(content['body'][0]['key'], 'google')
+        self.assertEqual(content['body'][0]['clientId'], 'google-client-id')
+        self.assertNotIn('clientSecret', content['body'][0])
 
     def test_update_invalid_json_keeps_existing_fields(self):
         setting = SiteSetting.get_instance()

--- a/backend/src/board/tests/templates/test_oauth_callback.py
+++ b/backend/src/board/tests/templates/test_oauth_callback.py
@@ -11,7 +11,7 @@ from django.test import TestCase, Client, override_settings
 from django.contrib.auth.models import User
 from django.urls import reverse
 
-from board.models import Profile, Config, TwoFactorAuth, UserLinkMeta
+from board.models import Profile, Config, TwoFactorAuth, UserLinkMeta, SocialAuth, SocialAuthProvider
 from modules import oauth
 
 
@@ -27,6 +27,16 @@ class OAuthCallbackTestCase(TestCase):
         )
         Profile.objects.create(user=admin, role=Profile.Role.EDITOR)
         Config.objects.create(user=admin)
+
+        for key in ['google', 'github']:
+            SocialAuthProvider.objects.update_or_create(
+                key=key,
+                defaults={
+                    'is_enabled': True,
+                    'client_id': f'{key}-client-id',
+                    'client_secret': f'{key}-secret',
+                }
+            )
 
     def setUp(self):
         """테스트 데이터 설정"""
@@ -50,7 +60,8 @@ class OAuthCallbackTestCase(TestCase):
         self.assertTrue(User.objects.filter(username='githubuser').exists())
         user = User.objects.get(username='githubuser')
         self.assertEqual(user.first_name, 'GitHub User')
-        self.assertEqual(user.last_name, 'github:GITHUB_NODE_ID_123')
+        self.assertEqual(user.last_name, '')
+        self.assertTrue(SocialAuth.objects.filter(user=user, provider__key='github', uid='GITHUB_NODE_ID_123').exists())
 
         # Verify profile and config were created
         self.assertTrue(hasattr(user, 'profile'))
@@ -78,11 +89,16 @@ class OAuthCallbackTestCase(TestCase):
             username='existinguser',
             email='existing@example.com',
             password='testpass123',
-            first_name='Existing User',
-            last_name='github:GITHUB_NODE_ID_456'
+            first_name='Existing User'
         )
         Profile.objects.create(user=user)
         Config.objects.create(user=user)
+        SocialAuth.objects.create(
+            user=user,
+            provider=SocialAuthProvider.objects.get(key='github'),
+            uid='GITHUB_NODE_ID_456',
+            extra_data='{}',
+        )
 
         response = self.client.get('/login/callback/github?code=test_code')
 
@@ -93,6 +109,24 @@ class OAuthCallbackTestCase(TestCase):
         # Verify user is logged in
         user_from_session = self.client.session.get('_auth_user_id')
         self.assertEqual(int(user_from_session), user.id)
+
+
+    def test_disabled_google_provider_blocks_direct_callback(self):
+        """관리자가 제공자를 끄면 콜백 URL 직접 호출도 로그인되지 않는다."""
+        SocialAuthProvider.objects.update_or_create(
+            key='google',
+            defaults={
+                'is_enabled': False,
+                'client_id': '',
+                'client_secret': '',
+            }
+        )
+
+        response = self.client.get('/login/callback/google?code=test_code')
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, reverse('login'))
+        self.assertFalse(User.objects.filter(username='googleuser').exists())
 
     @patch('modules.oauth.auth_google', return_value=oauth.State(success=True, user={
         'id': 'GOOGLE_ID_789',
@@ -113,7 +147,8 @@ class OAuthCallbackTestCase(TestCase):
         user = User.objects.get(username='googleuser')
         self.assertEqual(user.first_name, 'Google User')
         self.assertEqual(user.email, 'googleuser@gmail.com')
-        self.assertEqual(user.last_name, 'google:GOOGLE_ID_789')
+        self.assertEqual(user.last_name, '')
+        self.assertTrue(SocialAuth.objects.filter(user=user, provider__key='google', uid='GOOGLE_ID_789').exists())
 
         # Verify user is logged in
         user_from_session = self.client.session.get('_auth_user_id')
@@ -133,11 +168,16 @@ class OAuthCallbackTestCase(TestCase):
             username='user2fa',
             email='user2fa@example.com',
             password='testpass123',
-            first_name='User with 2FA',
-            last_name='github:GITHUB_NODE_ID_2FA'
+            first_name='User with 2FA'
         )
         Profile.objects.create(user=user)
         Config.objects.create(user=user)
+        SocialAuth.objects.create(
+            user=user,
+            provider=SocialAuthProvider.objects.get(key='github'),
+            uid='GITHUB_NODE_ID_2FA',
+            extra_data='{}',
+        )
 
         # Enable 2FA
         totp_secret = pyotp.random_base32()
@@ -190,11 +230,16 @@ class OAuthCallbackTestCase(TestCase):
             username='user2fanext',
             email='user2fanext@example.com',
             password='testpass123',
-            first_name='User with 2FA and Next',
-            last_name='github:GITHUB_NODE_ID_2FA_NEXT'
+            first_name='User with 2FA and Next'
         )
         Profile.objects.create(user=user)
         Config.objects.create(user=user)
+        SocialAuth.objects.create(
+            user=user,
+            provider=SocialAuthProvider.objects.get(key='github'),
+            uid='GITHUB_NODE_ID_2FA_NEXT',
+            extra_data='{}',
+        )
 
         # Enable 2FA
         totp_secret = pyotp.random_base32()

--- a/backend/src/board/views/api/v1/auth.py
+++ b/backend/src/board/views/api/v1/auth.py
@@ -1,6 +1,7 @@
 import datetime
 import traceback
 import io
+import json
 import pyotp
 import qrcode
 import base64
@@ -15,7 +16,7 @@ from django.utils import timezone
 
 from board.models import (
     TwoFactorAuth, Config, Profile, Post,
-    UserLinkMeta, UsernameChangeLog, TelegramSync, SocialAuthProvider, SiteSetting)
+    SocialAuth, UserLinkMeta, UsernameChangeLog, TelegramSync)
 from board.modules.notify import create_notify
 from board.modules.response import StatusDone, StatusError, ErrorCode
 from board.services.auth_login_service import AuthLoginService
@@ -25,6 +26,7 @@ from board.services.auth_service import AuthService, OAuthService, AuthValidatio
 from board.services.initial_setup_service import InitialSetupService
 from board.services.api_request_body_service import ApiRequestBodyService
 from modules import oauth
+from board.services.social_auth_provider_service import SocialAuthProviderService
 from modules.challenge import auth_hcaptcha
 from modules.sub_task import SubTaskProcessor
 from modules.telegram import TelegramBot
@@ -165,6 +167,12 @@ def sign_social(request, social):
                 '첫 관리자 계정을 먼저 만들어주세요.'
             )
 
+        if social not in SocialAuthProviderService.supported_keys():
+            raise Http404
+
+        if not SocialAuthProviderService.is_enabled(social):
+            return StatusError(ErrorCode.REJECT, '소셜 로그인이 설정되지 않았습니다.')
+
         if social == 'github':
             if request.POST.get('code'):
                 state = oauth.auth_github(request.POST.get('code'))
@@ -175,18 +183,22 @@ def sign_social(request, social):
                 node_id = state.user.get('node_id')
                 user_id = state.user.get('login')
                 name = state.user.get('name')
-                token = f'{social}:{node_id}'
-
-                users = User.objects.filter(last_name=token)
-                if users.exists():
-                    return AuthLoginService.common_auth(request, users.first(), is_oauth=True)
+                provider = SocialAuthProviderService.get_provider(social)
+                social_auth = SocialAuth.objects.filter(provider=provider, uid=node_id).select_related('user').first()
+                if social_auth:
+                    return AuthLoginService.common_auth(request, social_auth.user, is_oauth=True)
 
                 user, profile, config = AuthService.create_user(
                     username=user_id,
                     name=name,
                     email='',
                     avatar_url=avatar_url,
-                    token=token,
+                )
+                SocialAuth.objects.create(
+                    user=user,
+                    provider=provider,
+                    uid=node_id,
+                    extra_data=json.dumps(state.user, ensure_ascii=False),
                 )
 
                 UserLinkMeta.objects.create(
@@ -209,18 +221,22 @@ def sign_social(request, social):
                 user_id = state.user.get('email').split('@')[0]
                 email = state.user.get('email')
                 name = state.user.get('name')
-                token = f'{social}:{node_id}'
-
-                users = User.objects.filter(last_name=token)
-                if users.exists():
-                    return AuthLoginService.common_auth(request, users.first(), is_oauth=True)
+                provider = SocialAuthProviderService.get_provider(social)
+                social_auth = SocialAuth.objects.filter(provider=provider, uid=node_id).select_related('user').first()
+                if social_auth:
+                    return AuthLoginService.common_auth(request, social_auth.user, is_oauth=True)
 
                 user, profile, config = AuthService.create_user(
                     username=user_id,
                     name=name,
                     email=email,
                     avatar_url=avatar_url,
-                    token=token,
+                )
+                SocialAuth.objects.create(
+                    user=user,
+                    provider=provider,
+                    uid=node_id,
+                    extra_data=json.dumps(state.user, ensure_ascii=False),
                 )
 
                 auth.login(request, user)
@@ -344,6 +360,5 @@ def social_providers(request):
     Get available social authentication providers
     """
     if request.method == 'GET':
-        providers = SocialAuthProvider.objects.all().values('key', 'name', 'icon', 'color')
-        return StatusDone(list(providers))
+        return StatusDone(SocialAuthProviderService.serialize_public_providers())
     raise Http404

--- a/backend/src/board/views/api/v1/site_setting.py
+++ b/backend/src/board/views/api/v1/site_setting.py
@@ -5,6 +5,7 @@ from board.services.api_permission_service import ApiPermissionService
 from board.services.api_request_body_service import ApiRequestBodyService
 from board.services.agent_content_service import AgentContentService
 from board.services.brand_asset_service import BrandAssetError, BrandAssetService
+from board.services.social_auth_provider_service import SocialAuthProviderService
 
 
 def serialize_site_setting(request, setting):
@@ -19,6 +20,7 @@ def serialize_site_setting(request, setting):
         'robots_txt_default': AgentContentService.build_default_robots_txt(request, setting),
         'aeo_enabled': setting.aeo_enabled,
         'updated_date': setting.updated_date.isoformat(),
+        'social_auth_providers': SocialAuthProviderService.serialize_admin_providers(),
         **BrandAssetService.serialize_setting(setting),
     }
 
@@ -73,6 +75,9 @@ def site_settings(request):
 
         if 'aeo_enabled' in put_data:
             setting.aeo_enabled = put_data['aeo_enabled'] is True
+
+        if 'social_auth_providers' in put_data:
+            SocialAuthProviderService.update_admin_providers(put_data['social_auth_providers'])
 
         setting.save()
 

--- a/backend/src/board/views/oauth_callback.py
+++ b/backend/src/board/views/oauth_callback.py
@@ -1,3 +1,5 @@
+import json
+
 from django.shortcuts import render, redirect
 from django.http import Http404
 from django.contrib import messages, auth
@@ -6,7 +8,8 @@ from django.conf import settings
 from modules import oauth
 from board.services.auth_service import AuthService, OAuthService
 from board.services.initial_setup_service import InitialSetupService
-from board.models import User, UserLinkMeta
+from board.services.social_auth_provider_service import SocialAuthProviderService
+from board.models import SocialAuth, UserLinkMeta
 
 
 def handle_oauth_auth(request, user):
@@ -38,6 +41,10 @@ def oauth_callback(request, provider):
 
     if InitialSetupService.should_prompt_for_initial_setup():
         return redirect('/setup')
+
+    if not SocialAuthProviderService.is_enabled(provider):
+        messages.error(request, '소셜 로그인이 설정되지 않았습니다. 관리자에게 문의해주세요.')
+        return redirect('login')
     
     code = request.GET.get('code')
     if not code:
@@ -55,18 +62,22 @@ def oauth_callback(request, provider):
             node_id = state.user.get('node_id')
             user_id = state.user.get('login')
             name = state.user.get('name')
-            token = f'{provider}:{node_id}'
-
-            users = User.objects.filter(last_name=token)
-            if users.exists():
-                return handle_oauth_auth(request, users.first())
+            social_provider = SocialAuthProviderService.get_provider(provider)
+            social_auth = SocialAuth.objects.filter(provider=social_provider, uid=node_id).select_related('user').first()
+            if social_auth:
+                return handle_oauth_auth(request, social_auth.user)
 
             user, _, _ = AuthService.create_user(
                 username=user_id,
                 name=name,
                 email='',
                 avatar_url=avatar_url,
-                token=token,
+            )
+            SocialAuth.objects.create(
+                user=user,
+                provider=social_provider,
+                uid=node_id,
+                extra_data=json.dumps(state.user, ensure_ascii=False),
             )
 
             UserLinkMeta.objects.create(
@@ -88,18 +99,22 @@ def oauth_callback(request, provider):
             user_id = state.user.get('email').split('@')[0]
             email = state.user.get('email')
             name = state.user.get('name')
-            token = f'{provider}:{node_id}'
-
-            users = User.objects.filter(last_name=token)
-            if users.exists():
-                return handle_oauth_auth(request, users.first())
+            social_provider = SocialAuthProviderService.get_provider(provider)
+            social_auth = SocialAuth.objects.filter(provider=social_provider, uid=node_id).select_related('user').first()
+            if social_auth:
+                return handle_oauth_auth(request, social_auth.user)
 
             user, _, _ = AuthService.create_user(
                 username=user_id,
                 name=name,
                 email=email,
                 avatar_url=avatar_url,
-                token=token,
+            )
+            SocialAuth.objects.create(
+                user=user,
+                provider=social_provider,
+                uid=node_id,
+                extra_data=json.dumps(state.user, ensure_ascii=False),
             )
 
             return handle_oauth_auth(request, user)

--- a/backend/src/modules/oauth.py
+++ b/backend/src/modules/oauth.py
@@ -1,24 +1,26 @@
 import requests
 
-from django.conf import settings
-
 from board.services.site_url_service import SiteUrlService
+from board.services.social_auth_provider_service import SocialAuthProviderService
 
 
 class State:
-    def __init__(self, success, user):
+    def __init__(self, success, user=None):
         self.success = success
-        self.user = user
+        self.user = user or {}
 
 
 def auth_google(code) -> State:
     data = {
         'code': code,
-        'client_id': settings.GOOGLE_OAUTH_CLIENT_ID,
-        'client_secret': settings.GOOGLE_OAUTH_CLIENT_SECRET,
+        'client_id': SocialAuthProviderService.get_client_id('google'),
+        'client_secret': SocialAuthProviderService.get_client_secret('google'),
         'redirect_uri': SiteUrlService.configured_absolute_url('/login/callback/google'),
         'grant_type': 'authorization_code',
     }
+    if not data['client_id'] or not data['client_secret']:
+        return State(success=False, user={})
+
     response = requests.post(
         'https://accounts.google.com/o/oauth2/token',
         data=data
@@ -39,9 +41,12 @@ def auth_google(code) -> State:
 def auth_github(code) -> State:
     data = {
         'code': code,
-        'client_id': settings.GITHUB_OAUTH_CLIENT_ID,
-        'client_secret': settings.GITHUB_OAUTH_CLIENT_SECRET
+        'client_id': SocialAuthProviderService.get_client_id('github'),
+        'client_secret': SocialAuthProviderService.get_client_secret('github')
     }
+    if not data['client_id'] or not data['client_secret']:
+        return State(success=False, user={})
+
     headers = {
         'Accept': 'application/json'
     }

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -119,6 +119,8 @@ Initial setup URL: https://blog.example.com/setup?token=...
 
 첫 관리자 계정을 만들면 `/admin-settings/site-settings`로 이동합니다. 이 계정은 Django 관리자 권한과 BLEX 작가 권한을 함께 받습니다.
 
+소셜 로그인을 사용할 경우 Google/GitHub 개발자 콘솔에서 OAuth 앱을 만든 뒤 BLEX 어드민의 사이트 설정에 Client ID와 Client Secret을 저장합니다. 자세한 절차는 [`SOCIAL_LOGIN.md`](./SOCIAL_LOGIN.md)를 참고하세요.
+
 ## 5. 첫 글 발행
 
 `/write`에서 제목과 본문을 입력하고 발행합니다. 공개 글은 공개 URL, Markdown URL, RSS, sitemap에 노출됩니다.

--- a/docs/SOCIAL_LOGIN.md
+++ b/docs/SOCIAL_LOGIN.md
@@ -1,0 +1,59 @@
+# 소셜 로그인 설정
+
+BLEX의 소셜 로그인은 설치형 운영을 기준으로 **어드민 설정(DB)** 만 사용합니다.
+`GOOGLE_OAUTH_CLIENT_ID`, `GITHUB_OAUTH_CLIENT_SECRET` 같은 환경 변수는 더 이상 소셜 로그인 설정으로 읽지 않습니다.
+
+현재 지원하는 제공자는 다음 두 가지입니다.
+
+- Google
+- GitHub
+
+## 공통 절차
+
+1. 각 제공자 개발자 콘솔에서 OAuth 앱을 만듭니다.
+2. Redirect URI 또는 callback URL에 아래 주소를 등록합니다.
+   - Google: `https://YOUR_DOMAIN/login/callback/google`
+   - GitHub: `https://YOUR_DOMAIN/login/callback/github`
+3. BLEX 어드민의 `/admin-settings/site-settings`로 이동합니다.
+4. **소셜 로그인** 섹션에서 사용할 제공자를 켭니다.
+5. 발급받은 **Client ID** 와 **Client Secret** 을 입력하고 저장합니다.
+6. 로그아웃 상태에서 로그인/회원가입 화면에 소셜 로그인 버튼이 보이는지 확인합니다.
+
+> 로컬 개발 환경에서는 `https://YOUR_DOMAIN` 대신 `http://localhost:8000`처럼 실제 접속 origin을 사용합니다.
+
+## Google
+
+Google Cloud Console에서 OAuth 클라이언트를 만들 때 웹 애플리케이션 유형을 사용합니다.
+
+- 승인된 리디렉션 URI:
+  - 운영: `https://YOUR_DOMAIN/login/callback/google`
+  - 로컬: `http://localhost:8000/login/callback/google`
+
+필요한 사용자 정보는 기본 scope(`openid email profile`)로 요청됩니다.
+
+## GitHub
+
+GitHub Developer settings에서 OAuth App을 만듭니다.
+
+- Authorization callback URL:
+  - 운영: `https://YOUR_DOMAIN/login/callback/github`
+  - 로컬: `http://localhost:8000/login/callback/github`
+
+필요한 사용자 정보는 기본 scope(`user:email`)로 요청됩니다.
+
+## 동작 기준
+
+- 제공자가 꺼져 있으면 로그인/회원가입 화면에 버튼이 나오지 않습니다.
+- 제공자가 켜져 있어도 Client ID가 비어 있으면 버튼이 나오지 않습니다.
+- 직접 callback URL을 호출해도 제공자가 꺼져 있으면 로그인이 차단됩니다.
+- Client Secret 입력칸을 비워 저장하면 기존 Secret이 유지됩니다.
+- 저장된 Secret을 삭제하려면 **저장된 Client Secret 삭제** 를 체크하고 저장합니다.
+- Client Secret은 `CIPHER_KEY`로 암호화되어 DB에 저장됩니다.
+
+## 문제 해결
+
+- `redirect_uri_mismatch`가 나오면 제공자 콘솔에 등록한 callback URL과 실제 접속 URL이 같은지 확인합니다.
+- 버튼이 보이지 않으면 BLEX 어드민에서 제공자가 켜져 있고 Client ID가 저장되어 있는지 확인합니다.
+- 인증 후 실패하면 Client Secret이 저장되어 있는지 확인합니다.
+- 운영 환경에서는 `SITE_URL`, `ALLOWED_HOSTS`, `CSRF_TRUSTED_ORIGINS`도 실제 공개 도메인 기준으로 맞춰야 합니다.
+- `CIPHER_KEY`를 잃어버리거나 변경하면 저장된 Client Secret을 복호화할 수 없습니다. 운영 백업 대상에 반드시 포함하세요.


### PR DESCRIPTION
## 🎯 Goal
- Move social login configuration from environment-only wiring into admin-managed site settings for self-hosted installs.
- Remove legacy provider metadata and last-name based OAuth account matching so social login state is explicit and safer.

## 🔧 Core Changes
- Adds admin/site settings management for supported Google and GitHub OAuth providers.
- Hides social login UI when no usable provider is configured, and blocks disabled providers at API/callback boundaries.
- Migrates legacy `last_name` OAuth identifiers into `SocialAuth(provider, uid)` records and clears migrated values.
- Encrypts OAuth client secrets with the existing `CIPHER_KEY`/Fernet flow.
- Documents social login setup and self-hosting secret handling.

## 🤔 Key Decisions
- Backward compatibility for environment-variable OAuth configuration was intentionally dropped; admins should copy credentials into site settings.
- Supported providers are constrained by constants so arbitrary provider rows cannot be created through admin paths.
- OAuth client secrets are encrypted at rest, while broader auth-secret hardening is deferred to follow-up work.
- The migration remains in `0050` because this migration is newly introduced in this PR.

## 🧪 Verification Guide
### How to verify
1. Configure Google or GitHub OAuth credentials in admin site settings and enable the provider.
2. Confirm login/signup pages show social login only when at least one enabled provider has a client ID.
3. Complete an OAuth login and confirm a `SocialAuth` record is used instead of storing provider data in `auth.User.last_name`.

### Expected result
- Enabled and configured providers work for OAuth login/signup.
- Disabled or unconfigured providers are hidden and rejected by direct API/callback attempts.
- Legacy social account identifiers migrate into `SocialAuth` without preserving provider data in `last_name`.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)
