### PR TITLE
♻️ Refine empty state consistency

### DIFF
--- a/backend/islands/apps/remotes/src/components/remotes/Comments/components/EmptyState.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/Comments/components/EmptyState.tsx
@@ -1,8 +1,8 @@
 export const EmptyState = () => {
     return (
-        <div className="py-12 text-center">
+        <div className="py-8 text-center">
             <svg
-                className="w-10 h-10 text-content-hint mx-auto mb-3"
+                className="w-8 h-8 text-content-hint mx-auto mb-2"
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"

--- a/backend/islands/apps/remotes/src/components/remotes/SearchPage/SearchPage.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SearchPage/SearchPage.tsx
@@ -455,11 +455,11 @@ const SearchPage = ({ username }: SearchPageProps) => {
                             ))}
                         </div>
                     ) : (
-                        <div className="bg-surface border border-line-light rounded-2xl p-12 text-center">
-                            <div className="w-16 h-16 bg-surface-subtle rounded-2xl flex items-center justify-center mx-auto mb-4">
-                                <i className="fas fa-search text-2xl text-content-hint" />
+                        <div className="bg-surface border border-line-light rounded-2xl p-8 text-center">
+                            <div className="w-12 h-12 bg-surface-subtle rounded-xl flex items-center justify-center mx-auto mb-3">
+                                <i className="fas fa-search text-lg text-content-hint" />
                             </div>
-                            <h3 className="text-lg font-semibold text-content mb-1">검색 결과가 없습니다</h3>
+                            <h3 className="text-base font-semibold text-content mb-1">검색 결과가 없습니다</h3>
                             <p className="text-sm text-content-secondary">다른 검색어를 시도해보세요.</p>
                         </div>
                     )}

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/SettingsEmptyState.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/SettingsEmptyState.tsx
@@ -15,18 +15,18 @@ const SettingsEmptyState = ({
     action,
     className = ''
 }: SettingsEmptyStateProps) => {
-    const containerClasses = ['py-16 text-center border border-dashed border-line rounded-2xl', className]
+    const containerClasses = ['py-10 text-center border border-dashed border-line rounded-2xl', className]
         .filter(Boolean)
         .join(' ');
 
     return (
         <div className={containerClasses}>
-            <div className="inline-flex items-center justify-center w-16 h-16 rounded-2xl bg-surface-subtle mb-4">
-                <i className={`${iconClassName} text-2xl text-content-hint`} />
+            <div className="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-surface-subtle mb-3">
+                <i className={`${iconClassName} text-lg text-content-hint`} />
             </div>
-            <h3 className="text-lg font-semibold text-content mb-1">{title}</h3>
+            <h3 className="text-base font-semibold text-content mb-1">{title}</h3>
             {description && (
-                <p className={`text-content-secondary text-sm ${action ? 'mb-6' : ''}`}>{description}</p>
+                <p className={`text-content-secondary text-sm ${action ? 'mb-5' : ''}`}>{description}</p>
             )}
             {action}
         </div>

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PinnedPostsSetting/components/AddPinnedPostModal.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PinnedPostsSetting/components/AddPinnedPostModal.tsx
@@ -116,12 +116,12 @@ export const AddPinnedPostModal = ({
                         ))}
                     </div>
                 ) : pinnablePosts.length === 0 ? (
-                    <div className="flex h-full flex-col items-center justify-center py-20 text-center">
-                        <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-surface-subtle">
-                            <i className="fas fa-search text-2xl text-content-hint" />
+                    <div className="flex h-full flex-col items-center justify-center py-12 text-center">
+                        <div className="mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-surface-subtle">
+                            <i className="fas fa-search text-lg text-content-hint" />
                         </div>
-                        <p className="mb-1 text-lg font-medium text-content">검색 결과가 없습니다</p>
-                        <p className="text-content-secondary">다른 검색어로 다시 시도해보세요.</p>
+                        <p className="mb-1 text-base font-medium text-content">검색 결과가 없습니다</p>
+                        <p className="text-sm text-content-secondary">다른 검색어로 다시 시도해보세요.</p>
                     </div>
                 ) : (
                     <div

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/PostListContent.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/PostListContent.tsx
@@ -78,7 +78,7 @@ export const PostListContent = ({
                     ))}
                 </div>
             ) : (
-                <div className="py-12 text-center text-content-secondary bg-surface-subtle rounded-lg border border-line-light border-dashed">
+                <div className="py-8 text-center text-sm text-content-secondary bg-surface-subtle rounded-lg border border-line-light border-dashed">
                     {emptyMessage}
                 </div>
             )}

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/UserManagementSetting/index.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/UserManagementSetting/index.tsx
@@ -473,11 +473,11 @@ const UserManagementSetting = () => {
                         ))}
 
                         {isUsersError ? (
-                            <div className="px-4 py-12 text-center text-sm text-danger">
+                            <div className="px-4 py-8 text-center text-sm text-danger">
                                 사용자 목록을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.
                             </div>
                         ) : users.length === 0 && (
-                            <div className="px-4 py-12 text-center text-sm text-content-secondary">
+                            <div className="px-4 py-8 text-center text-sm text-content-secondary">
                                 검색 결과가 없습니다.
                             </div>
                         )}

--- a/backend/src/board/templates/board/author/author_posts.html
+++ b/backend/src/board/templates/board/author/author_posts.html
@@ -35,11 +35,11 @@
         <div class="md:col-span-3">
             {% if not posts %}
                 {% if request.GET.q or request.GET.tag %}
-                    {% with empty_title='조건에 맞는 포스트가 없습니다' empty_message='검색어나 태그를 다시 확인해주세요.' %}
+                    {% with empty_icon_class='far fa-file-alt' empty_title='조건에 맞는 포스트가 없습니다' empty_message='검색어나 태그를 다시 확인해주세요.' %}
                         {% include 'board/author/components/empty_state.html' %}
                     {% endwith %}
                 {% else %}
-                    {% with empty_title='아직 공개된 포스트가 없습니다' empty_message='새 글이 발행되면 이곳에 표시됩니다.' %}
+                    {% with empty_icon_class='far fa-file-alt' empty_title='아직 공개된 포스트가 없습니다' empty_message='새 포스트가 발행되면 이곳에 표시됩니다.' %}
                         {% include 'board/author/components/empty_state.html' %}
                     {% endwith %}
                 {% endif %}

--- a/backend/src/board/templates/board/author/author_series.html
+++ b/backend/src/board/templates/board/author/author_series.html
@@ -35,11 +35,11 @@
         <div class="md:col-span-3">        
             {% if not series_list %}
                 {% if request.GET.q %}
-                    {% with empty_title='조건에 맞는 시리즈가 없습니다' empty_message='검색어를 다시 확인해주세요.' %}
+                    {% with empty_icon_class='fas fa-layer-group' empty_title='조건에 맞는 시리즈가 없습니다' empty_message='검색어를 다시 확인해주세요.' %}
                         {% include 'board/author/components/empty_state.html' %}
                     {% endwith %}
                 {% else %}
-                    {% with empty_title='아직 공개된 시리즈가 없습니다' empty_message='시리즈가 공개되면 이곳에 표시됩니다.' %}
+                    {% with empty_icon_class='fas fa-layer-group' empty_title='아직 공개된 시리즈가 없습니다' empty_message='시리즈가 공개되면 이곳에 표시됩니다.' %}
                         {% include 'board/author/components/empty_state.html' %}
                     {% endwith %}
                 {% endif %}

--- a/backend/src/board/templates/board/author/components/activity_section.html
+++ b/backend/src/board/templates/board/author/components/activity_section.html
@@ -57,10 +57,7 @@
                 </div>
             </div>
         {% else %}
-            <div class="py-12 text-center">
-                <i class="fas fa-wind text-content-hint text-2xl mb-3"></i>
-                <p class="text-sm text-content-hint">표시할 활동이 없습니다</p>
-            </div>
+            {% include 'board/author/components/section_empty_state.html' with section_empty_embedded=True section_empty_title='표시할 활동이 없습니다' only %}
         {% endif %}
     </div>
 </section>

--- a/backend/src/board/templates/board/author/components/empty_state.html
+++ b/backend/src/board/templates/board/author/components/empty_state.html
@@ -1,4 +1,1 @@
-<div class="text-center py-16">
-    <h2 class="text-2xl font-bold mb-2 text-content">{{ empty_title }}</h2>
-    <p class="text-base text-content-secondary">{{ empty_message }}</p>
-</div>
+{% include 'components/empty_state.html' with empty_icon_class=empty_icon_class empty_title=empty_title empty_message=empty_message empty_action_url=empty_action_url empty_action_label=empty_action_label empty_action_icon=empty_action_icon empty_framed=empty_framed only %}

--- a/backend/src/board/templates/board/author/components/featured_posts_section.html
+++ b/backend/src/board/templates/board/author/components/featured_posts_section.html
@@ -53,13 +53,7 @@
         {% endfor %}
     </div>
     {% elif request.user == author %}
-    <div class="rounded-2xl border border-dashed border-line bg-surface px-6 py-8 text-center">
-        <p class="text-sm font-semibold text-content">아직 공개된 포스트가 없습니다.</p>
-        <p class="mt-1 text-sm text-content-secondary">첫 포스트를 발행하면 이 영역에 표시됩니다.</p>
-        <a href="/write" class="mt-4 inline-flex items-center justify-center rounded-lg bg-action px-4 py-2 text-sm font-semibold text-content-inverted transition-colors hover:bg-action-hover">
-            포스트 작성하기
-        </a>
-    </div>
+    {% include 'board/author/components/section_empty_state.html' with section_empty_title='아직 공개된 포스트가 없습니다.' section_empty_action_url='/write' section_empty_action_label='포스트 작성하기' section_empty_action_icon='fas fa-edit' only %}
     {% endif %}
 </section>
 {% endif %}

--- a/backend/src/board/templates/board/author/components/readme_section.html
+++ b/backend/src/board/templates/board/author/components/readme_section.html
@@ -76,14 +76,8 @@
             <div class="prose blog-post-content" x-show="!editing && hasRenderedContent" x-html="renderedContent">
                 {% if about_html %}{{ about_html|safe }}{% endif %}
             </div>
-            <div class="rounded-2xl border border-dashed border-line bg-surface px-5 py-4" x-show="!editing && !hasRenderedContent" x-cloak>
-                <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                    <p class="text-sm text-content-secondary">소개글을 작성하면 프로필에 표시됩니다.</p>
-                    <button type="button" @click="startEditing()" class="inline-flex items-center justify-center rounded-lg bg-surface-subtle px-4 py-2 text-sm font-semibold text-content-secondary transition-colors hover:bg-surface-subtle/80 hover:text-content">
-                        <i class="fas fa-edit mr-2"></i>
-                        소개글 작성
-                    </button>
-                </div>
+            <div x-show="!editing && !hasRenderedContent" x-cloak>
+                {% include 'board/author/components/section_empty_state.html' with section_empty_title='아직 소개가 없습니다' section_empty_action_label='소개글 작성' section_empty_action_icon='fas fa-edit' section_empty_action_click='startEditing()' only %}
             </div>
         {% elif about_html %}
             <div class="prose blog-post-content">

--- a/backend/src/board/templates/board/author/components/section_empty_state.html
+++ b/backend/src/board/templates/board/author/components/section_empty_state.html
@@ -1,0 +1,25 @@
+<div class="{% if section_empty_embedded %}py-8 text-center{% else %}rounded-2xl border border-dashed border-line bg-surface px-5 py-6{% endif %}">
+    <div class="{% if section_empty_embedded %}mx-auto max-w-sm{% else %}flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between{% endif %}">
+        <div class="min-w-0">
+            <p class="text-sm font-semibold text-content">{{ section_empty_title }}</p>
+        </div>
+
+        {% if section_empty_action_label %}
+            {% if section_empty_action_url %}
+            <a href="{{ section_empty_action_url }}" class="{% if section_empty_embedded %}mt-4 {% endif %}inline-flex items-center justify-center rounded-lg bg-action px-4 py-2 text-sm font-semibold text-content-inverted transition-colors hover:bg-action-hover active:scale-[0.98]">
+                {% if section_empty_action_icon %}
+                <i class="{{ section_empty_action_icon }} mr-2" aria-hidden="true"></i>
+                {% endif %}
+                {{ section_empty_action_label }}
+            </a>
+            {% else %}
+            <button type="button" @click="{{ section_empty_action_click }}" class="{% if section_empty_embedded %}mt-4 {% endif %}inline-flex items-center justify-center rounded-lg bg-surface-subtle px-4 py-2 text-sm font-semibold text-content-secondary transition-colors hover:bg-surface-subtle/80 hover:text-content active:scale-[0.98]">
+                {% if section_empty_action_icon %}
+                <i class="{{ section_empty_action_icon }} mr-2" aria-hidden="true"></i>
+                {% endif %}
+                {{ section_empty_action_label }}
+            </button>
+            {% endif %}
+        {% endif %}
+    </div>
+</div>

--- a/backend/src/board/templates/board/posts/interested_posts.html
+++ b/backend/src/board/templates/board/posts/interested_posts.html
@@ -34,19 +34,7 @@
         {% include 'components/pagination.html' with style='numbered' page=page_number last=page_count %}
     </div>
 {% else %}
-    <div class="flex flex-col items-center justify-center min-h-[52vh] text-center py-12">
-        <div class="w-24 h-24 bg-surface-subtle rounded-3xl flex items-center justify-center mb-6 shadow-inner">
-            <i class="far fa-heart text-3xl text-content-hint"></i>
-        </div>
-        <h2 class="text-2xl md:text-3xl font-bold text-content mb-3 tracking-tight">아직 관심 포스트가 없어요</h2>
-        <p class="text-base md:text-lg text-content-secondary mb-8 max-w-md leading-relaxed">
-            나중에 다시 보고 싶은 글에서 추천 버튼을 눌러두면 여기에 모입니다.
-        </p>
-        <a href="/" class="bg-action hover:bg-action-hover text-content-inverted px-8 py-3.5 rounded-full font-medium transition-all duration-300 inline-flex items-center gap-2 shadow-floating hover:shadow-floating hover:-translate-y-0.5">
-            <i class="fas fa-compass text-sm"></i>
-            <span>포스트 둘러보기</span>
-        </a>
-    </div>
+    {% include 'components/empty_state.html' with empty_icon_class='far fa-heart' empty_title='아직 관심 포스트가 없어요' empty_message='추천 버튼을 눌러둔 포스트가 여기에 모입니다.' empty_action_url='/' empty_action_label='포스트 둘러보기' empty_action_icon='fas fa-compass' only %}
 {% endif %}
 </div>
 {% endblock %}

--- a/backend/src/board/templates/board/posts/post_list.html
+++ b/backend/src/board/templates/board/posts/post_list.html
@@ -40,21 +40,11 @@
         {% include 'components/pagination.html' with style='numbered' page=page_number last=page_count %}
     </div>
 {% else %}
-    <div class="flex flex-col items-center justify-center min-h-[60vh] text-center py-12">
-        <div class="w-24 h-24 bg-surface-subtle rounded-3xl flex items-center justify-center mb-6 shadow-inner">
-            <i class="fas fa-pen-nib text-3xl text-content-hint"></i>
-        </div>
-        <h2 class="text-2xl md:text-3xl font-bold text-content mb-3 tracking-tight">아직 포스트가 없어요</h2>
-        <p class="text-base md:text-lg text-content-secondary mb-8 max-w-md leading-relaxed">
-            첫 번째 작가가 되어 멋진 콘텐츠를 공유해보세요. 당신의 이야기를 기다리고 있습니다.
-        </p>
-        {% if user.is_authenticated and user.profile.is_editor %}
-        <a href="/write" class="bg-action hover:bg-action-hover text-content-inverted px-8 py-3.5 rounded-full font-medium transition-all duration-300 inline-flex items-center gap-2 shadow-floating hover:shadow-floating hover:-translate-y-0.5">
-            <i class="fas fa-edit text-sm"></i>
-            <span>포스트 작성하기</span>
-        </a>
-        {% endif %}
-    </div>
+    {% if user.is_authenticated and user.profile.is_editor %}
+        {% include 'components/empty_state.html' with empty_icon_class='fas fa-pen-nib' empty_title='아직 포스트가 없어요' empty_message='공개된 포스트가 발행되면 이곳에 표시됩니다.' empty_action_url='/write' empty_action_label='포스트 작성하기' empty_action_icon='fas fa-edit' only %}
+    {% else %}
+        {% include 'components/empty_state.html' with empty_icon_class='fas fa-pen-nib' empty_title='아직 포스트가 없어요' empty_message='공개된 포스트가 발행되면 이곳에 표시됩니다.' only %}
+    {% endif %}
 {% endif %}
 </div>
 {% endblock %}

--- a/backend/src/board/templates/board/series/series_detail.html
+++ b/backend/src/board/templates/board/series/series_detail.html
@@ -76,13 +76,7 @@
     </div>
 
     {% elif not posts %}
-    <div class="flex flex-col items-center justify-center py-20 text-center bg-surface-subtle rounded-3xl border border-line-light">
-        <div class="w-16 h-16 bg-surface-elevated rounded-2xl flex items-center justify-center mb-4 shadow-sm">
-            <i class="fas fa-layer-group text-2xl text-content-hint"></i>
-        </div>
-        <h2 class="text-xl font-bold text-content mb-2">아직 포스트가 없습니다</h2>
-        <p class="text-content-secondary">이 시리즈에는 아직 포스트가 추가되지 않았습니다.</p>
-    </div>
+    {% include 'components/empty_state.html' with empty_framed=True empty_icon_class='fas fa-layer-group' empty_title='아직 포스트가 없습니다' empty_message='이 시리즈에는 아직 포스트가 추가되지 않았습니다.' only %}
 
     {% else %}
     <!-- 정렬 컨트롤 -->

--- a/backend/src/board/templates/board/tags/tag_detail.html
+++ b/backend/src/board/templates/board/tags/tag_detail.html
@@ -32,21 +32,10 @@
             {% include 'components/pagination.html' with style='numbered' page=page last=last_page %}
         </div>
     {% else %}
-        <!-- Empty State -->
-        <div class="text-center py-24 bg-surface-subtle rounded-3xl border border-line-light">
-            <div class="max-w-md mx-auto px-6">
-                <div class="inline-flex items-center justify-center w-20 h-20 bg-surface-elevated shadow-sm rounded-2xl mb-8">
-                    <i class="fas fa-hashtag text-3xl text-content-hint"></i>
-                </div>
-                <h3 class="text-2xl font-bold text-content mb-3">포스트가 없습니다</h3>
-                <p class="text-content-secondary mb-10 text-lg leading-relaxed">#{{ tag }} 태그로 작성된 포스트가 아직 없습니다.</p>
-                <a href="{% url 'post_write' %}" class="inline-flex items-center gap-2 bg-action text-content-inverted px-8 py-3.5 rounded-full font-medium transition-all duration-150 hover:bg-action-hover active:scale-[0.98]">
-                    <i class="fas fa-pen text-sm"></i>
-                    <span>포스트 작성하기</span>
-                </a>
-            </div>
-        </div>
+        {% url 'post_write' as post_write_url %}
+        {% with empty_message='#'|add:tag|add:' 태그로 작성된 포스트가 아직 없습니다.' %}
+            {% include 'components/empty_state.html' with empty_framed=True empty_icon_class='fas fa-hashtag' empty_title='포스트가 없습니다' empty_message=empty_message empty_action_url=post_write_url empty_action_label='포스트 작성하기' empty_action_icon='fas fa-pen' only %}
+        {% endwith %}
     {% endif %}
 </div>
 {% endblock %}
-

--- a/backend/src/board/templates/board/tags/tag_list.html
+++ b/backend/src/board/templates/board/tags/tag_list.html
@@ -52,21 +52,11 @@
             {% include 'components/pagination.html' with style='numbered' page=page last=last_page %}
         </div>
     {% else %}
-        <div class="text-center py-20 bg-surface-subtle rounded-3xl border border-line-light">
-            <div class="max-w-md mx-auto px-6">
-                <div class="inline-flex items-center justify-center w-16 h-16 bg-surface-elevated shadow-sm rounded-2xl mb-6">
-                    <i class="fas fa-tags text-2xl text-content-hint"></i>
-                </div>
-                <h3 class="text-xl font-bold text-content mb-2">태그가 없습니다</h3>
-                <p class="text-content-secondary">
-                    {% if request.GET.q %}
-                        검색 조건에 맞는 태그가 없습니다.
-                    {% else %}
-                        포스트에 태그를 추가하면 여기에 표시됩니다.
-                    {% endif %}
-                </p>
-            </div>
-        </div>
+        {% if request.GET.q %}
+            {% include 'components/empty_state.html' with empty_framed=True empty_icon_class='fas fa-tags' empty_title='태그가 없습니다' empty_message='검색 조건에 맞는 태그가 없습니다.' only %}
+        {% else %}
+            {% include 'components/empty_state.html' with empty_framed=True empty_icon_class='fas fa-tags' empty_title='태그가 없습니다' empty_message='포스트에 태그를 추가하면 여기에 표시됩니다.' only %}
+        {% endif %}
     {% endif %}
 </div>
 {% endblock %}

--- a/backend/src/board/templates/components/empty_state.html
+++ b/backend/src/board/templates/components/empty_state.html
@@ -1,0 +1,26 @@
+<div class="{% if empty_framed %}text-center py-10 bg-surface-subtle rounded-2xl border border-line-light{% else %}text-center py-10{% endif %}">
+    <div class="{% if empty_framed %}max-w-sm mx-auto px-5{% else %}max-w-sm mx-auto{% endif %}">
+        {% if empty_icon_class %}
+        <div class="inline-flex items-center justify-center w-12 h-12 {% if empty_framed %}bg-surface-elevated{% else %}bg-surface-subtle{% endif %} rounded-xl mb-4">
+            <i class="{{ empty_icon_class }} text-lg text-content-hint" aria-hidden="true"></i>
+        </div>
+        {% endif %}
+
+        <h2 class="text-lg font-semibold text-content mb-2">{{ empty_title }}</h2>
+
+        {% if empty_message %}
+        <p class="text-sm text-content-secondary {% if empty_action_url and empty_action_label %}mb-6{% endif %} leading-relaxed">
+            {{ empty_message }}
+        </p>
+        {% endif %}
+
+        {% if empty_action_url and empty_action_label %}
+        <a href="{{ empty_action_url }}" class="inline-flex items-center gap-2 bg-action text-content-inverted px-5 py-2.5 rounded-full text-sm font-medium transition-colors duration-150 hover:bg-action-hover active:scale-[0.98]">
+            {% if empty_action_icon %}
+            <i class="{{ empty_action_icon }} text-sm" aria-hidden="true"></i>
+            {% endif %}
+            <span>{{ empty_action_label }}</span>
+        </a>
+        {% endif %}
+    </div>
+</div>

--- a/backend/src/board/tests/templates/test_author.py
+++ b/backend/src/board/tests/templates/test_author.py
@@ -181,10 +181,9 @@ class AuthorPostsPageTestCase(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, 'About')
-        self.assertNotContains(response, '소개글을 작성하면 프로필에 표시됩니다.')
+        self.assertNotContains(response, '아직 소개가 없습니다')
         self.assertNotContains(response, '소개글 작성')
         self.assertNotContains(response, reverse('user_about_edit', kwargs={'username': self.user.username}))
-        self.assertNotContains(response, '아직 소개글이 없습니다')
 
     def test_author_overview_shows_empty_intro_prompt_to_owner(self):
         """소개글이 없으면 작성자 본인에게 작성 진입점을 보여준다."""
@@ -198,10 +197,9 @@ class AuthorPostsPageTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'About')
         self.assertContains(response, '소개')
-        self.assertContains(response, '소개글을 작성하면 프로필에 표시됩니다.')
+        self.assertContains(response, '아직 소개가 없습니다')
         self.assertContains(response, '소개글 작성')
         self.assertNotContains(response, f'href="{edit_path}"')
-        self.assertNotContains(response, '아직 소개글이 없습니다')
 
     def test_author_overview_renders_intro_content_with_owner_edit_entrypoint(self):
         """작성된 소개글은 방문자에게 보이고, 수정 진입점은 작성자 본인에게만 보인다."""


### PR DESCRIPTION
## 🎯 Goal
- Keep empty states visually consistent without inflating UI scale.
- Remove oversized one-off empty-state blocks and repeated explanatory copy from affected surfaces.

## 🔧 Core Changes
- Added a shared Django empty-state partial for page-level empty states.
- Added a smaller author-profile section empty-state partial for embedded sections.
- Replaced custom empty states on post lists, interested posts, series, tags, and author profile sections.
- Reduced React empty-state spacing/icon/title scale in comments, search, pinned-post modal, post settings, and user management surfaces.

## 🤔 Key Decisions
- Kept this PR limited to empty-state consistency only.
- Did not change design-system docs, global tokens, navigation structure, `main.scss`, or unrelated copy.
- Did not add design lint, size snapshot tests, or e2e coverage.

## 🧪 Verification Guide
### How to verify
1. Open the main post list with no public posts.
2. Open interested posts, tag/series empty views, and author profile empty sections.
3. Open settings/search/comment empty states in the React islands.

### Expected result
- Empty states use a quieter scale, consistent icon/title/message/action structure, and no oversized marketing-style copy.

## ✅ Checklist
- [ ] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)

Note: lint was not run for this scoped PR; verification is limited to targeted Django render tests and island type-check. No design lint or e2e tests were added.
