### PR TITLE
♻️ Standardize post terminology

### DIFF
--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/components/DraftsPanel.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/components/DraftsPanel.tsx
@@ -88,7 +88,7 @@ const DraftsPanel = ({
 
                     {/* Header */}
                     <div className="flex items-center justify-between p-5 border-b border-line">
-                        <Dialog.Title className="text-lg font-semibold text-content">임시 저장 글</Dialog.Title>
+                        <Dialog.Title className="text-lg font-semibold text-content">임시 포스트</Dialog.Title>
                         <Dialog.Close asChild>
                             <IconButton aria-label="닫기">
                                 <X className="w-5 h-5" />
@@ -116,7 +116,7 @@ const DraftsPanel = ({
                         ) : drafts.length === 0 ? (
                             <div className="flex flex-col items-center justify-center flex-1 min-h-[200px] text-content-secondary">
                                 <FileText className="w-12 h-12 mb-3 text-content-hint" />
-                                <p className="text-sm">임시 저장된 글이 없습니다</p>
+                                <p className="text-sm">임시 저장된 포스트가 없습니다</p>
                             </div>
                         ) : (
                             <div className="divide-y divide-line-light">
@@ -153,7 +153,7 @@ const DraftsPanel = ({
                     {/* Footer */}
                     <div className="p-4 border-t border-line bg-surface-subtle">
                         <p className="text-xs text-content-secondary text-center">
-                            총 {drafts.length}개의 임시 저장 글
+                            총 {drafts.length}개의 임시 포스트
                         </p>
                     </div>
                 </Dialog.Content>

--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/components/PostActions.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/components/PostActions.tsx
@@ -63,8 +63,8 @@ const PostActions = ({
                 <IconButton
                     onClick={onOpenDrafts}
                     rounded="full"
-                    aria-label="임시 저장 글"
-                    title="임시 저장 글">
+                    aria-label="임시 포스트"
+                    title="임시 포스트">
                     <FileText className="w-5 h-5" />
                 </IconButton>
             )}

--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/components/PostCoverEditor.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/components/PostCoverEditor.tsx
@@ -102,7 +102,7 @@ const CoverImageSlot = ({
                     <span className="min-w-0">
                         <span className="block text-sm font-medium text-content">대표 이미지</span>
                         <span className="block truncate text-xs text-content-secondary">
-                            {imagePreview ? '글 상단에는 표시하지 않고 공유와 목록에 사용합니다' : '공유와 목록에 사용할 이미지를 추가하세요'}
+                            {imagePreview ? '포스트 상단에는 표시하지 않고 공유와 목록에 사용합니다' : '공유와 목록에 사용할 이미지를 추가하세요'}
                         </span>
                     </span>
                 </button>

--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/utils/coverSettings.ts
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/utils/coverSettings.ts
@@ -23,7 +23,7 @@ export const COVER_LAYOUT_OPTIONS: Array<{
     {
         value: 'none',
         label: '커버 숨김',
-        description: '대표 이미지는 공유와 목록에만 사용하고 글 상단에는 보이지 않습니다.'
+        description: '대표 이미지는 공유와 목록에만 사용하고 포스트 상단에는 보이지 않습니다.'
     }
 ];
 

--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/utils/publishChecklist.ts
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/utils/publishChecklist.ts
@@ -60,7 +60,7 @@ export const getPublishChecklist = (input: PublishChecklistInput): PublishCheckl
         {
             id: 'title',
             label: '제목',
-            description: '독자가 글을 구분할 수 있는 제목이 필요합니다.',
+            description: '독자가 포스트를 구분할 수 있는 제목이 필요합니다.',
             severity: 'required',
             status: hasText(input.title) ? 'pass' : 'missing'
         },
@@ -74,21 +74,21 @@ export const getPublishChecklist = (input: PublishChecklistInput): PublishCheckl
         {
             id: 'description',
             label: '설명',
-            description: '검색 결과와 공유 화면에서 글을 설명합니다. 비워도 발행은 가능합니다.',
+            description: '검색 결과와 공유 화면에서 포스트를 설명합니다. 비워도 발행은 가능합니다.',
             severity: 'recommended',
             status: hasText(input.description) ? 'pass' : 'missing'
         },
         {
             id: 'tags',
             label: '태그',
-            description: '관련 글을 묶고 독자가 비슷한 글을 찾기 쉽게 만듭니다.',
+            description: '관련 포스트를 묶고 독자가 비슷한 포스트를 찾기 쉽게 만듭니다.',
             severity: 'recommended',
             status: input.tags.length > 0 ? 'pass' : 'missing'
         },
         {
             id: 'coverImage',
             label: '커버 이미지',
-            description: '목록과 공유 카드에서 글의 첫인상을 만듭니다. 본문 이미지를 대신 쓰지는 않습니다.',
+            description: '목록과 공유 카드에서 포스트의 첫인상을 만듭니다. 본문 이미지를 대신 쓰지는 않습니다.',
             severity: 'recommended',
             status: input.hasCoverImage ? 'pass' : 'missing'
         }

--- a/backend/islands/apps/remotes/src/components/remotes/RelatedPosts/RelatedPosts.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/RelatedPosts/RelatedPosts.tsx
@@ -147,10 +147,10 @@ const RelatedPosts = ({ postUrl, username }: RelatedPostsProps) => {
                     <i className="fas fa-compass text-2xl text-content-hint" />
                 </div>
                 <h3 className="text-lg font-semibold text-content mb-2">
-                    {username}의 다른 글 둘러보기
+                    {username}의 다른 포스트 둘러보기
                 </h3>
                 <p className="text-content-secondary text-sm mb-6">
-                    프로필에서 더 많은 글을 확인할 수 있습니다.
+                    프로필에서 더 많은 포스트를 확인할 수 있습니다.
                 </p>
                 <a
                     href={`/@${username}`}

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/FormsSetting/FormsSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/FormsSetting/FormsSetting.tsx
@@ -152,7 +152,7 @@ const FormsManagement = () => {
         <div>
             <SettingsHeader
                 title={`서식 (${forms.length})`}
-                description="자주 사용하는 서식을 미리 만들어두면, 글을 더 빠르게 작성할 수 있어요."
+                description="자주 사용하는 서식을 미리 만들어두면, 포스트를 더 빠르게 작성할 수 있어요."
                 actionPosition="right"
                 action={
                     <Button

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/GlobalWebhookSetting/GlobalWebhookSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/GlobalWebhookSetting/GlobalWebhookSetting.tsx
@@ -11,7 +11,7 @@ const GlobalWebhookSetting = () => {
         <WebhookChannelManager
             queryKey={['global-webhook-channels']}
             title="전역 웹훅 연동"
-            description="모든 작성자가 발행한 글을 등록된 채널로 자동 전송합니다."
+            description="모든 작성자가 발행한 포스트를 등록된 채널로 자동 전송합니다."
             formTitle="새 전역 채널 추가"
             emptyTitle="등록된 전역 채널이 없습니다"
             emptyDescription="운영 채널을 추가해서 전체 발행 알림을 받아보세요."

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/PostCard.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/PostCard.tsx
@@ -228,7 +228,7 @@ const PostCard = ({
                             size="sm"
                             disabled
                             className="w-full justify-start text-content-secondary border-dashed">
-                            긴 글 주의: 읽는데 {post.readTime}분이 걸립니다.
+                            긴 포스트 주의: 읽는데 {post.readTime}분이 걸립니다.
                         </Button>
                     )}
                 </div>

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SeriesSetting/components/PostSelector.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SeriesSetting/components/PostSelector.tsx
@@ -46,7 +46,7 @@ const PostSelector = ({ posts, selectedPostIds, onChange }: PostSelectorProps) =
     return (
         <section className="space-y-4">
             <div className="flex items-end justify-between gap-4">
-                <h2 className="text-base font-semibold text-content">포함할 글 선택</h2>
+                <h2 className="text-base font-semibold text-content">포함할 포스트 선택</h2>
                 <div className="rounded-full bg-surface-subtle px-3 py-1 text-xs font-medium text-content-secondary">
                     {selectedPostIds.length}개 선택
                 </div>

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SeriesSetting/components/SeriesEditor.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SeriesSetting/components/SeriesEditor.tsx
@@ -231,7 +231,7 @@ const SeriesEditor = ({ seriesId }: SeriesEditorProps) => {
     const handleDelete = async () => {
         const confirmed = await confirm({
             title: '시리즈 삭제',
-            message: `"${titleValue}" 시리즈를 삭제하면 연결된 글은 유지되고 시리즈 연결만 해제됩니다.\n\n이 작업은 되돌릴 수 없습니다. 계속할까요?`,
+            message: `"${titleValue}" 시리즈를 삭제하면 연결된 포스트는 유지되고 시리즈 연결만 해제됩니다.\n\n이 작업은 되돌릴 수 없습니다. 계속할까요?`,
             confirmText: '삭제',
             variant: 'danger'
         });

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/UserManagementSetting/index.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/UserManagementSetting/index.tsx
@@ -61,11 +61,11 @@ const orderingItems: { value: ManagedUserOrdering; label: string }[] = [
     },
     {
         value: '-post_count',
-        label: '글 많은 순'
+        label: '포스트 많은 순'
     },
     {
         value: 'post_count',
-        label: '글 적은 순'
+        label: '포스트 적은 순'
     },
     {
         value: '-date_joined',
@@ -387,7 +387,7 @@ const UserManagementSetting = () => {
 
             <Card
                 title="사용자 목록"
-                subtitle="사용자명, 이름, 이메일로 검색하고 권한과 글 수 기준으로 좁혀볼 수 있습니다."
+                subtitle="사용자명, 이름, 이메일로 검색하고 권한과 포스트 수 기준으로 좁혀볼 수 있습니다."
                 icon={<i className="fas fa-users" />}>
                 <div className="mb-6 grid gap-3 lg:grid-cols-[minmax(0,1fr)_180px_180px_auto]">
                     <Input
@@ -426,7 +426,7 @@ const UserManagementSetting = () => {
                     <div className="hidden grid-cols-[minmax(0,1.5fr)_110px_90px_100px_130px] gap-4 bg-surface-subtle px-4 py-3 text-xs font-semibold text-content-secondary md:grid">
                         <span>사용자</span>
                         <span>권한</span>
-                        <span>글</span>
+                        <span>포스트</span>
                         <span>상태</span>
                         <span>가입일</span>
                     </div>
@@ -458,7 +458,7 @@ const UserManagementSetting = () => {
                                 </div>
 
                                 <div className="flex items-center justify-between gap-3 text-sm text-content-secondary md:block md:text-content">
-                                    <span className="text-xs font-medium md:hidden">글</span>
+                                    <span className="text-xs font-medium md:hidden">포스트</span>
                                     <span>{user.postCount}</span>
                                 </div>
                                 <div className="flex items-center justify-between gap-3 md:block">

--- a/backend/src/board/templates/board/posts/interested_posts.html
+++ b/backend/src/board/templates/board/posts/interested_posts.html
@@ -16,7 +16,7 @@
     </div>
 
     <div class="mb-8">
-        <p class="text-sm font-semibold text-action mb-2">내가 다시 보고 싶은 글</p>
+        <p class="text-sm font-semibold text-action mb-2">내가 다시 보고 싶은 포스트</p>
         <h1 class="text-3xl md:text-4xl font-bold text-content tracking-tight">관심 포스트</h1>
         <p class="mt-3 text-content-secondary leading-relaxed max-w-2xl">
             추천으로 관심 표시한 포스트를 최신 관심순으로 모아볼 수 있어요.

--- a/backend/src/board/templates/board/posts/post_detail.html
+++ b/backend/src/board/templates/board/posts/post_detail.html
@@ -88,17 +88,17 @@
                         class="mb-8 rounded-lg border border-line bg-surface-subtle px-4 py-4 sm:px-5 sm:py-5">
                         <div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
                             <div class="min-w-0">
-                                <p class="text-xs font-semibold uppercase text-content-hint">글 상태</p>
+                                <p class="text-xs font-semibold uppercase text-content-hint">포스트 상태</p>
                                 <h2 class="mt-1 text-lg font-semibold text-content">
                                     {% if post_visibility_status == 'hidden' %}
-                                    비공개 글입니다
+                                    비공개 포스트입니다
                                     {% else %}
-                                    예약 발행 글입니다
+                                    예약 발행 포스트입니다
                                     {% endif %}
                                 </h2>
                                 <p class="mt-1 text-sm leading-relaxed text-content-secondary">
                                     {% if post_visibility_status == 'hidden' %}
-                                    이 글은 작성자만 볼 수 있습니다. 공개하려면 글 설정에서 비공개를 해제하세요.
+                                    이 포스트는 작성자만 볼 수 있습니다. 공개하려면 포스트 설정에서 비공개를 해제하세요.
                                     {% else %}
                                     예약 시각 전에는 작성자만 볼 수 있습니다. 예약 시각이 되면 공개 URL, RSS, Sitemap, Markdown URL에 반영됩니다.
                                     {% endif %}
@@ -157,7 +157,7 @@
 
                     <section class="mt-16 mb-16 bg-surface rounded-2xl p-6 sm:p-8 ring-1 ring-line/60" aria-labelledby="post-info-heading">
                         <div class="mb-6 flex items-start justify-between gap-4 border-b border-line-light pb-4">
-                            <h2 id="post-info-heading" class="text-lg font-bold leading-snug text-content">글 정보</h2>
+                            <h2 id="post-info-heading" class="text-lg font-bold leading-snug text-content">포스트 정보</h2>
                         </div>
                         <dl class="grid gap-4 text-sm">
                             <div class="sm:flex sm:items-start sm:gap-6">
@@ -360,7 +360,7 @@
                                     </span>
                                     <span class="flex flex-col">
                                         <span class="font-semibold">X에 공유</span>
-                                        <span class="text-xs text-content-hint">새 창에서 공유 글 작성</span>
+                                        <span class="text-xs text-content-hint">새 창에서 공유 포스트 작성</span>
                                     </span>
                                 </button>
                                 <button @click="shareToLinkedIn(); closeLinkCopyMenu()"

--- a/backend/src/board/tests/templates/test_post_detail.py
+++ b/backend/src/board/tests/templates/test_post_detail.py
@@ -278,14 +278,14 @@ class PostDetailViewTestCase(TestCase):
         self.assertContains(response, '수정일')
 
     def test_post_detail_shows_post_info_section(self):
-        """포스트 상세 하단에 사람이 확인할 수 있는 글 정보를 보여준다."""
+        """포스트 상세 하단에 사람이 확인할 수 있는 포스트 정보를 보여준다."""
         response = self.client.get(reverse('post_detail', kwargs={
             'username': 'testauthor',
             'post_url': 'test-post'
         }))
 
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, '글 정보')
+        self.assertContains(response, '포스트 정보')
         self.assertContains(response, '작성자')
         self.assertContains(response, '최초 발행')
         self.assertContains(response, '/@testauthor')


### PR DESCRIPTION
## 🎯 Goal
- Reduce visible Korean copy inconsistency by using `포스트` consistently for product post entities.
- Avoid mixing `글` and `포스트` across editor, settings, related posts, and post detail surfaces.

## 🔧 Core Changes
- Updated post-related UI copy from `글` to `포스트` in editor controls, publish checklist, related posts, settings pages, interested posts, and post detail.
- Updated the post detail template test expectation to match the new visible copy.

## 🤔 Key Decisions
- Kept this PR copy-only, except for the matching template test expectation.
- Did not change layout, spacing, tokens, global CSS, or design system docs.
- Did not add design lint, visual size tests, or e2e coverage.

## 🧪 Verification Guide
### How to verify
1. Open post editor draft/cover/publish checklist surfaces.
2. Open settings pages that mention post counts, series posts, forms, and webhooks.
3. Open interested posts and post detail status/info/share copy.

### Expected result
- User-facing copy refers to posts as `포스트` consistently in the changed surfaces.

## ✅ Checklist
- [ ] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)

Note: lint was not run for this copy-only scoped PR. Verification used targeted Django template tests and island type-check.
