### PR TITLE
♻️ Improve webhook guidance and cover spacing

### DIFF
--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/WebhookChannelManager.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/WebhookChannelManager.tsx
@@ -21,6 +21,15 @@ type CreateResponse = Response<{ success: boolean; channelId: number }>;
 type DeleteResponse = Response<{ success: boolean }>;
 type TestResponse = Response<{ success: boolean }>;
 
+interface WebhookProviderInfo {
+    title: string;
+    badge: string;
+    description: string;
+    payload: string;
+    iconClassName: string;
+    statusClassName: string;
+}
+
 interface WebhookChannelManagerProps {
     queryKey: string[];
     title: string;
@@ -43,10 +52,70 @@ interface WebhookChannelManagerProps {
 
 const webhookSchema = z.object({
     webhookUrl: z.string().trim().min(1, '웹훅 URL을 입력해주세요.').url('올바른 URL 형식으로 입력해주세요.'),
-    webhookName: z.string().trim().max(100, '채널 이름은 100자 이내여야 합니다.')
+    webhookName: z.string().trim().max(100, '표시 이름은 100자 이내여야 합니다.')
 });
 
 type WebhookFormInputs = z.infer<typeof webhookSchema>;
+
+const WEBHOOK_MESSAGE_PREVIEW =
+    '[baealex] 새 포스트가 발행되었어요: [BLEX 업데이트](https://blex.me/@baealex/blex-update)';
+
+const getWebhookProviderInfo = (webhookUrl: string): WebhookProviderInfo => {
+    const normalizedUrl = webhookUrl.trim().toLowerCase();
+
+    if (!normalizedUrl) {
+        return {
+            title: '지원 방식 확인',
+            badge: 'URL 입력 전',
+            description: 'Discord, Slack은 공식 웹훅 형식으로 전송하고 그 외 주소는 일반 JSON으로 전송합니다.',
+            payload: 'URL을 입력하면 전송 형식이 표시됩니다.',
+            iconClassName: 'fa-circle-info',
+            statusClassName: 'text-content-secondary'
+        };
+    }
+
+    if (
+        normalizedUrl.includes('discord.com/api/webhooks') ||
+        normalizedUrl.includes('discordapp.com/api/webhooks')
+    ) {
+        return {
+            title: 'Discord Webhook',
+            badge: '공식 지원',
+            description: 'Discord 채널 웹훅 URL로 인식했습니다.',
+            payload: JSON.stringify({ content: WEBHOOK_MESSAGE_PREVIEW }, null, 2),
+            iconClassName: 'fa-circle-check',
+            statusClassName: 'text-success'
+        };
+    }
+
+    if (normalizedUrl.includes('hooks.slack.com/services')) {
+        return {
+            title: 'Slack Incoming Webhook',
+            badge: '공식 지원',
+            description: 'Slack Incoming Webhook URL로 인식했습니다.',
+            payload: JSON.stringify({
+                text: WEBHOOK_MESSAGE_PREVIEW,
+                unfurl_links: true
+            }, null, 2),
+            iconClassName: 'fa-circle-check',
+            statusClassName: 'text-success'
+        };
+    }
+
+    return {
+        title: '일반 웹훅 URL',
+        badge: '일반 JSON',
+        description: '등록한 주소로 JSON을 POST합니다. 받는 쪽에서 아래 필드를 처리해야 합니다.',
+        payload: JSON.stringify({
+            content: WEBHOOK_MESSAGE_PREVIEW,
+            text: WEBHOOK_MESSAGE_PREVIEW,
+            message: WEBHOOK_MESSAGE_PREVIEW,
+            url: 'https://blex.me/@baealex/blex-update'
+        }, null, 2),
+        iconClassName: 'fa-code',
+        statusClassName: 'text-content-secondary'
+    };
+};
 
 const WebhookChannelManager = ({
     queryKey,
@@ -55,7 +124,7 @@ const WebhookChannelManager = ({
     formTitle,
     emptyTitle,
     emptyDescription,
-    addButtonLabel = '채널 추가',
+    addButtonLabel = '전송 대상 추가',
     fetchChannels,
     createChannel,
     deleteChannel,
@@ -76,6 +145,7 @@ const WebhookChannelManager = ({
         handleSubmit,
         trigger,
         getValues,
+        watch,
         reset,
         formState: { errors }
     } = useForm<WebhookFormInputs>({
@@ -96,6 +166,7 @@ const WebhookChannelManager = ({
             throw new Error('웹훅 채널 목록을 불러오는데 실패했습니다.');
         }
     });
+    const webhookProvider = getWebhookProviderInfo(watch('webhookUrl'));
 
     const handleTest = async () => {
         const isValid = await trigger('webhookUrl');
@@ -227,19 +298,49 @@ const WebhookChannelManager = ({
                             <Input
                                 id="webhookUrl"
                                 type="url"
-                                placeholder="https://discord.com/api/webhooks/..."
+                                placeholder="https://example.com/webhook"
                                 error={errors.webhookUrl?.message}
                                 {...register('webhookUrl')}
                             />
+                            <div className="mt-3 border-l border-line pl-3">
+                                <div className="flex items-start gap-3">
+                                    <i
+                                        className={`fas ${webhookProvider.iconClassName} mt-0.5 ${webhookProvider.statusClassName}`}
+                                    />
+                                    <div className="min-w-0 flex-1">
+                                        <div className="flex flex-wrap items-center gap-2">
+                                            <p className="text-sm font-semibold text-content">{webhookProvider.title}</p>
+                                            <span className={`text-xs font-semibold ${webhookProvider.statusClassName}`}>
+                                                {webhookProvider.badge}
+                                            </span>
+                                        </div>
+                                        <p className="mt-1 text-xs leading-relaxed text-content-secondary">
+                                            {webhookProvider.description}
+                                        </p>
+                                        <div className="mt-3 space-y-2">
+                                            <div>
+                                                <p className="text-[11px] font-semibold text-content-secondary">전송 문구</p>
+                                                <p className="mt-1 rounded-md bg-surface px-3 py-2 text-xs leading-relaxed text-content">
+                                                    {WEBHOOK_MESSAGE_PREVIEW}
+                                                </p>
+                                            </div>
+                                            <div>
+                                                <p className="text-[11px] font-semibold text-content-secondary">JSON 형식</p>
+                                                <pre className="mt-1 overflow-x-auto rounded-md bg-surface px-3 py-2 text-xs leading-relaxed text-content-secondary"><code>{webhookProvider.payload}</code></pre>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                         <div>
                             <label htmlFor="webhookName" className="block text-sm font-medium text-content mb-1">
-                                채널 이름 (선택)
+                                표시 이름 (선택)
                             </label>
                             <Input
                                 id="webhookName"
                                 type="text"
-                                placeholder="예: 운영 디스코드"
+                                placeholder="예: 새 포스트 알림"
                                 {...register('webhookName')}
                             />
                         </div>

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/GlobalWebhookSetting/GlobalWebhookSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/GlobalWebhookSetting/GlobalWebhookSetting.tsx
@@ -11,20 +11,20 @@ const GlobalWebhookSetting = () => {
         <WebhookChannelManager
             queryKey={['global-webhook-channels']}
             title="전역 웹훅 연동"
-            description="모든 작성자가 발행한 포스트를 등록된 채널로 자동 전송합니다."
-            formTitle="새 전역 채널 추가"
-            emptyTitle="등록된 전역 채널이 없습니다"
-            emptyDescription="운영 채널을 추가해서 전체 발행 알림을 받아보세요."
+            description="모든 작성자가 발행한 포스트를 Discord, Slack 또는 일반 웹훅 URL로 전송합니다."
+            formTitle="새 전역 웹훅 추가"
+            emptyTitle="등록된 전역 웹훅이 없습니다"
+            emptyDescription="전송 대상을 추가해서 전체 발행 알림을 받아보세요."
             fetchChannels={getGlobalWebhookChannels}
             createChannel={addGlobalWebhookChannel}
             deleteChannel={deleteGlobalWebhookChannel}
             testChannel={testWebhook}
-            confirmDeleteTitle="전역 채널 삭제"
-            confirmDeleteMessage="정말 이 전역 채널을 삭제할까요?"
-            addSuccessMessage="전역 채널이 추가되었습니다."
-            addFailMessage="전역 채널 추가 중 오류가 발생했습니다."
-            deleteSuccessMessage="전역 채널이 삭제되었습니다."
-            deleteFailMessage="전역 채널 삭제에 실패했습니다."
+            confirmDeleteTitle="전역 웹훅 삭제"
+            confirmDeleteMessage="정말 이 전역 웹훅을 삭제할까요?"
+            addSuccessMessage="전역 웹훅이 추가되었습니다."
+            addFailMessage="전역 웹훅 추가 중 오류가 발생했습니다."
+            deleteSuccessMessage="전역 웹훅이 삭제되었습니다."
+            deleteFailMessage="전역 웹훅 삭제에 실패했습니다."
         />
     );
 };

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/WebhookSetting/WebhookSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/WebhookSetting/WebhookSetting.tsx
@@ -11,20 +11,20 @@ const WebhookSetting = () => {
         <WebhookChannelManager
             queryKey={['webhook-channels']}
             title="웹훅 연동"
-            description="내가 발행한 새 포스트를 등록된 채널로 자동 전송합니다."
-            formTitle="새 웹훅 채널 추가"
-            emptyTitle="등록된 웹훅 채널이 없습니다"
-            emptyDescription="새 채널을 추가해서 내 포스트 발행 알림을 받아보세요."
+            description="내가 발행한 새 포스트를 Discord, Slack 또는 일반 웹훅 URL로 전송합니다."
+            formTitle="새 웹훅 추가"
+            emptyTitle="등록된 웹훅이 없습니다"
+            emptyDescription="전송 대상을 추가해서 내 포스트 발행 알림을 받아보세요."
             fetchChannels={getWebhookChannels}
             createChannel={addWebhookChannel}
             deleteChannel={deleteWebhookChannel}
             testChannel={testWebhook}
-            confirmDeleteTitle="웹훅 채널 삭제"
-            confirmDeleteMessage="정말 이 웹훅 채널을 삭제할까요?"
-            addSuccessMessage="웹훅 채널이 추가되었습니다."
-            addFailMessage="웹훅 채널 추가 중 오류가 발생했습니다."
-            deleteSuccessMessage="웹훅 채널이 삭제되었습니다."
-            deleteFailMessage="웹훅 채널 삭제에 실패했습니다."
+            confirmDeleteTitle="웹훅 삭제"
+            confirmDeleteMessage="정말 이 웹훅을 삭제할까요?"
+            addSuccessMessage="웹훅이 추가되었습니다."
+            addFailMessage="웹훅 추가 중 오류가 발생했습니다."
+            deleteSuccessMessage="웹훅이 삭제되었습니다."
+            deleteFailMessage="웹훅 삭제에 실패했습니다."
         />
     );
 };

--- a/backend/src/board/services/webhook_service.py
+++ b/backend/src/board/services/webhook_service.py
@@ -146,7 +146,7 @@ class WebhookService:
 
         post_url = SiteUrlService.configured_absolute_url(post.get_absolute_url())
         author_name = post.author.first_name or post.author.username
-        content = f'[{author_name}] 새 글이 발행되었어요: [{post.title}]({post_url})'
+        content = f'[{author_name}] 새 포스트가 발행되었어요: [{post.title}]({post_url})'
         delay_seconds = max(0.0, WebhookService.DEFAULT_NOTIFICATION_DELAY_SECONDS)
 
         def send_all_webhooks():

--- a/backend/src/board/templates/board/posts/covers/split.html
+++ b/backend/src/board/templates/board/posts/covers/split.html
@@ -1,5 +1,5 @@
 <section class="post-cover-split px-4 md:px-6">
-    <div class="post-detail-frame grid gap-8 py-10 sm:py-14 lg:grid-cols-2 lg:items-center">
+    <div class="post-detail-frame grid gap-8 pt-10 sm:pt-14 lg:grid-cols-2 lg:items-center lg:py-14">
         <div class="{% if post.config.cover_image_position == 'left' %}lg:order-2{% endif %}">
             {% include 'board/posts/covers/_series_badge.html' with cover_inverted=False %}
 

--- a/backend/src/board/tests/api/test_webhook.py
+++ b/backend/src/board/tests/api/test_webhook.py
@@ -490,6 +490,10 @@ class WebhookNotificationTestCase(TestCase):
                 call_args.kwargs['post_url'],
                 'https://blex.example/@author/test-post',
             )
+            self.assertEqual(
+                call_args.kwargs['content'],
+                '[author] 새 포스트가 발행되었어요: [Test Post](https://blex.example/@author/test-post)',
+            )
 
     @patch.object(WebhookService, 'DEFAULT_NOTIFICATION_DELAY_SECONDS', 1.25)
     @patch('board.services.webhook_service.WebhookService.send_webhook_with_tracking')


### PR DESCRIPTION
## 🎯 Goal
- Make webhook setup clearer by showing whether a URL is officially supported for Discord or Slack, and what payload BLEX sends.
- Reduce confusing copy that made every webhook target sound Discord-specific.
- Align split post cover spacing on mobile with the default cover layout.

## 🔧 Core Changes
- Detect Discord, Slack, and generic webhook URLs in the webhook settings form and show the expected message and JSON payload.
- Rename webhook UI copy from channel-focused wording to webhook/target-focused wording.
- Update the published-post webhook message to consistently use 포스트 instead of 글.
- Remove extra mobile bottom padding from split post covers while preserving desktop split spacing.

## 🤔 Key Decisions
- Kept the webhook helper inline and neutral so it explains behavior without becoming a separate visual card.
- Kept generic webhook support as plain JSON instead of pretending every URL is officially compatible.
- Did not add visual size tests or design lint; this is a small UI/copy adjustment.
- Documentation changes were not needed because the behavior is explained in the settings UI.

## 🧪 Verification Guide
### How to verify
1. Open webhook settings and enter a Discord webhook URL, a Slack incoming webhook URL, and a generic URL.
2. Confirm the helper switches between official Discord, official Slack, and generic JSON guidance.
3. Open a split-cover post on mobile width and confirm the bottom spacing no longer grows beyond the normal post body spacing.

### Expected result
- Webhook setup shows the actual outgoing message and payload shape before saving.
- Discord and Slack URLs are clearly marked as officially supported; generic URLs show the generic JSON contract.
- Split cover mobile spacing matches the rest of the post layout more closely.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)

Verification run:
- `npm run islands:type-check`
- `npm run islands:lint` (passed with existing warnings)
- `node ./scripts/manage.mjs test board.tests.api.test_webhook.WebhookNotificationTestCase board.tests.templates.test_post_detail.PostDetailViewTestCase.test_post_detail_uses_split_cover_outside_content_grid`
- `git diff --check`