### PR TITLE
🐛 Harden two-factor auth secret storage

### DIFF
--- a/backend/src/board/migrations/0053_encrypt_two_factor_auth_secrets.py
+++ b/backend/src/board/migrations/0053_encrypt_two_factor_auth_secrets.py
@@ -1,0 +1,81 @@
+import hashlib
+import re
+
+from django.db import migrations, models
+
+from modules.cipher import decrypt_value, encrypt_value
+
+
+SHA256_HEX_PATTERN = re.compile(r'^[0-9a-f]{64}$')
+
+
+def is_encrypted(value):
+    if not value:
+        return False
+    try:
+        decrypt_value(value)
+        return True
+    except Exception:
+        return False
+
+
+def encrypt_totp_secret(value):
+    value = (value or '').strip()
+    if not value or is_encrypted(value):
+        return value
+    return encrypt_value(value).decode()
+
+
+def is_recovery_key_hash(value):
+    return bool(SHA256_HEX_PATTERN.fullmatch((value or '').strip()))
+
+
+def hash_recovery_key(value):
+    return hashlib.sha256((value or '').strip().encode('utf-8')).hexdigest()
+
+
+def protect_recovery_key(value):
+    value = (value or '').strip()
+    if not value or is_recovery_key_hash(value):
+        return value
+    return hash_recovery_key(value)
+
+
+def protect_existing_two_factor_auth_secrets(apps, schema_editor):
+    TwoFactorAuth = apps.get_model('board', 'TwoFactorAuth')
+    for two_factor_auth in TwoFactorAuth.objects.all().iterator():
+        update_fields = []
+
+        totp_secret = encrypt_totp_secret(two_factor_auth.totp_secret)
+        if totp_secret != two_factor_auth.totp_secret:
+            two_factor_auth.totp_secret = totp_secret
+            update_fields.append('totp_secret')
+
+        recovery_key = protect_recovery_key(two_factor_auth.recovery_key)
+        if recovery_key != two_factor_auth.recovery_key:
+            two_factor_auth.recovery_key = recovery_key
+            update_fields.append('recovery_key')
+
+        if update_fields:
+            two_factor_auth.save(update_fields=update_fields)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('board', '0052_integrationsetting'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='twofactorauth',
+            name='recovery_key',
+            field=models.CharField(blank=True, max_length=64),
+        ),
+        migrations.AlterField(
+            model_name='twofactorauth',
+            name='totp_secret',
+            field=models.TextField(blank=True),
+        ),
+        migrations.RunPython(protect_existing_two_factor_auth_secrets),
+    ]

--- a/backend/src/board/models.py
+++ b/backend/src/board/models.py
@@ -27,6 +27,7 @@ from board.services.user_config_meta_service import UserConfigMetaService
 from board.services.series_save_service import SeriesSaveService
 from board.services.telegram_sync_encryption_service import TelegramSyncEncryptionService
 from board.services.integration_setting_service import IntegrationSettingService
+from board.services.two_factor_auth_secret_service import TwoFactorAuthSecretService
 from board.constants.social_auth import (
     SUPPORTED_SOCIAL_AUTH_PROVIDERS,
     SUPPORTED_SOCIAL_AUTH_PROVIDER_CHOICES,
@@ -602,8 +603,8 @@ class TelegramSync(models.Model):
 
 class TwoFactorAuth(models.Model):
     user = models.OneToOneField('auth.User', on_delete=models.CASCADE)
-    recovery_key = models.CharField(max_length=45, blank=True)
-    totp_secret = models.CharField(max_length=32, blank=True)  # TOTP secret key
+    recovery_key = models.CharField(max_length=64, blank=True)
+    totp_secret = models.TextField(blank=True)
     created_date = models.DateTimeField(default=timezone.now)
 
     def has_been_a_day(self):
@@ -612,22 +613,37 @@ class TwoFactorAuth(models.Model):
             return True
         return False
 
+    def get_totp_secret(self):
+        return TwoFactorAuthSecretService.decrypt_totp_secret(self.totp_secret)
+
+    def verify_recovery_key(self, token):
+        return TwoFactorAuthSecretService.verify_recovery_key(self.recovery_key, token)
+
     def verify_totp(self, token):
         """Verify TOTP token"""
-        if not self.totp_secret:
+        totp_secret = self.get_totp_secret()
+        if not totp_secret:
             return False
-        totp = pyotp.TOTP(self.totp_secret)
-        return totp.verify(token, valid_window=1)  # Allow 30s window on each side
+        try:
+            totp = pyotp.TOTP(totp_secret)
+            return totp.verify(token, valid_window=1)  # Allow 30s window on each side
+        except Exception:
+            return False
 
     def get_provisioning_uri(self):
         """Get provisioning URI for QR code"""
-        if not self.totp_secret:
+        totp_secret = self.get_totp_secret()
+        if not totp_secret:
             return None
-        totp = pyotp.TOTP(self.totp_secret)
+        totp = pyotp.TOTP(totp_secret)
         return totp.provisioning_uri(
             name=self.user.email,
             issuer_name='BLEX'
         )
+
+    def save(self, *args, **kwargs):
+        TwoFactorAuthSecretService.prepare_for_save(self)
+        super().save(*args, **kwargs)
 
     def __str__(self):
         return self.user.username

--- a/backend/src/board/services/auth_service.py
+++ b/backend/src/board/services/auth_service.py
@@ -7,6 +7,7 @@ Extracted from views to improve testability and reusability.
 
 import re
 import io
+import secrets
 import pyotp
 import qrcode
 import base64
@@ -97,6 +98,7 @@ class AuthService:
     """Service class for handling authentication-related business logic"""
     USERNAME_PATTERN = re.compile(r'[a-z0-9]{4,15}')
     EMAIL_PATTERN = re.compile(r'[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,64}')
+    RECOVERY_KEY_ALPHABET = '0123456789abcdefghijklnmopqrstuvwxyzABCDEFGHIJKLNMOPQRSTUVWXYZ'
 
     @staticmethod
     def validate_username(username: str) -> None:
@@ -293,6 +295,13 @@ class AuthService:
         return pyotp.random_base32()
 
     @staticmethod
+    def create_recovery_key() -> str:
+        return ''.join(
+            secrets.choice(AuthService.RECOVERY_KEY_ALPHABET)
+            for _ in range(45)
+        )
+
+    @staticmethod
     def verify_totp_token(user: User, token: str) -> bool:
         """
         Verify TOTP token or recovery key.
@@ -309,7 +318,7 @@ class AuthService:
 
             # Check if it's a recovery key (longer than 6 chars)
             if len(token) > 6:
-                return two_factor_auth.recovery_key == token
+                return two_factor_auth.verify_recovery_key(token)
 
             # Otherwise verify TOTP
             return two_factor_auth.verify_totp(token)

--- a/backend/src/board/services/two_factor_auth_secret_service.py
+++ b/backend/src/board/services/two_factor_auth_secret_service.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import re
+from typing import TYPE_CHECKING
+
+from cryptography.fernet import InvalidToken
+
+from modules.cipher import decrypt_value, encrypt_value
+
+if TYPE_CHECKING:
+    from board.models import TwoFactorAuth
+
+
+class TwoFactorAuthSecretService:
+    """Protect TOTP secrets and recovery keys stored for 2FA."""
+
+    SHA256_HEX_PATTERN = re.compile(r'^[0-9a-f]{64}$')
+    TOTP_SECRET_PATTERN = re.compile(r'^[A-Z2-7=]{16,64}$')
+
+    @staticmethod
+    def is_encrypted(value: str) -> bool:
+        if not value:
+            return False
+        try:
+            decrypt_value(value)
+            return True
+        except Exception:
+            return False
+
+    @classmethod
+    def encrypt_totp_secret(cls, value: str) -> str:
+        value = (value or '').strip()
+        if not value:
+            return ''
+        if cls.is_encrypted(value):
+            return value
+        return encrypt_value(value).decode()
+
+    @classmethod
+    def decrypt_totp_secret(cls, value: str) -> str:
+        value = (value or '').strip()
+        if not value:
+            return ''
+        try:
+            return decrypt_value(value)
+        except (InvalidToken, Exception):
+            if cls.is_plain_totp_secret(value):
+                return value
+            return ''
+
+    @classmethod
+    def is_plain_totp_secret(cls, value: str) -> bool:
+        return bool(cls.TOTP_SECRET_PATTERN.fullmatch((value or '').strip().upper()))
+
+    @classmethod
+    def is_recovery_key_hash(cls, value: str) -> bool:
+        return bool(cls.SHA256_HEX_PATTERN.fullmatch((value or '').strip()))
+
+    @staticmethod
+    def hash_recovery_key(value: str) -> str:
+        return hashlib.sha256((value or '').strip().encode('utf-8')).hexdigest()
+
+    @classmethod
+    def protect_recovery_key(cls, value: str) -> str:
+        value = (value or '').strip()
+        if not value:
+            return ''
+        if cls.is_recovery_key_hash(value):
+            return value
+        return cls.hash_recovery_key(value)
+
+    @classmethod
+    def verify_recovery_key(cls, stored_value: str, token: str) -> bool:
+        stored_value = (stored_value or '').strip()
+        token = (token or '').strip()
+        if not stored_value or not token:
+            return False
+
+        if cls.is_recovery_key_hash(stored_value):
+            return hmac.compare_digest(stored_value, cls.hash_recovery_key(token))
+
+        return hmac.compare_digest(stored_value, token)
+
+    @classmethod
+    def prepare_for_save(cls, two_factor_auth: 'TwoFactorAuth') -> None:
+        if two_factor_auth.totp_secret:
+            two_factor_auth.totp_secret = cls.encrypt_totp_secret(two_factor_auth.totp_secret)
+        if two_factor_auth.recovery_key:
+            two_factor_auth.recovery_key = cls.protect_recovery_key(two_factor_auth.recovery_key)

--- a/backend/src/board/tests/api/test_two_factor_auth.py
+++ b/backend/src/board/tests/api/test_two_factor_auth.py
@@ -9,6 +9,7 @@ from django.test import TestCase, override_settings
 from django.utils import timezone
 
 from board.models import User, Profile, Config, TwoFactorAuth
+from board.services.two_factor_auth_secret_service import TwoFactorAuthSecretService
 
 
 class TwoFactorAuthTestCase(TestCase):
@@ -46,6 +47,7 @@ class TwoFactorAuthTestCase(TestCase):
         self.assertIn('recoveryKey', content['body'])
         self.assertTrue(content['body']['qrCode'].startswith('data:image/png;base64,'))
         self.assertEqual(len(content['body']['recoveryKey']), 45)
+        recovery_key = content['body']['recoveryKey']
 
         # At this point, 2FA should NOT be saved to database yet
         user = User.objects.get(username='test2fa')
@@ -70,9 +72,14 @@ class TwoFactorAuthTestCase(TestCase):
         # NOW the TwoFactorAuth record should be created
         user = User.objects.get(username='test2fa')
         self.assertTrue(hasattr(user, 'twofactorauth'))
-        self.assertEqual(len(user.twofactorauth.recovery_key), 45)
-        self.assertIsNotNone(user.twofactorauth.totp_secret)
-        self.assertGreater(len(user.twofactorauth.totp_secret), 0)
+        self.assertEqual(len(user.twofactorauth.recovery_key), 64)
+        self.assertNotEqual(user.twofactorauth.recovery_key, recovery_key)
+        self.assertTrue(user.twofactorauth.verify_recovery_key(recovery_key))
+        self.assertNotEqual(user.twofactorauth.totp_secret, totp_secret)
+        self.assertEqual(
+            TwoFactorAuthSecretService.decrypt_totp_secret(user.twofactorauth.totp_secret),
+            totp_secret,
+        )
 
     def test_enable_2fa_invalid_verification_code(self):
         """잘못된 TOTP 코드로 2FA 설정 완료 시도 테스트"""
@@ -145,6 +152,25 @@ class TwoFactorAuthTestCase(TestCase):
         content = json.loads(response.content)
         self.assertEqual(content['status'], 'ERROR')
         self.assertEqual(content['errorCode'], 'error:AC')
+
+    def test_get_2fa_security_does_not_return_stored_recovery_key(self):
+        """2FA 조회 시 저장된 복구 키 원문이나 해시를 반환하지 않는다."""
+        user = User.objects.get(username='test2fa')
+        TwoFactorAuth.objects.create(
+            user=user,
+            recovery_key='x' * 45,
+            totp_secret=pyotp.random_base32()
+        )
+
+        self.client.login(username='test2fa', password='test2fa')
+
+        response = self.client.get('/v1/auth/security')
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'DONE')
+        self.assertIn('qrCode', content['body'])
+        self.assertNotIn('recoveryKey', content['body'])
+        self.assertTrue(content['body']['hasRecoveryKey'])
 
     @override_settings(DEBUG=False)
     def test_login_with_2fa_enabled(self):
@@ -250,6 +276,70 @@ class TwoFactorAuthTestCase(TestCase):
         content = json.loads(response.content)
         self.assertEqual(content['status'], 'ERROR')
         self.assertEqual(content['errorCode'], 'error:AU')
+
+    @override_settings(DEBUG=False)
+    def test_login_with_recovery_key(self):
+        """2FA가 활성화된 사용자가 복구 키로 로그인 성공 테스트"""
+        user = User.objects.get(username='test2fa')
+        recovery_key = 'r' * 45
+        TwoFactorAuth.objects.create(
+            user=user,
+            recovery_key=recovery_key,
+            totp_secret=pyotp.random_base32()
+        )
+
+        response = self.client.post('/v1/login', {
+            'username': 'test2fa',
+            'password': 'test2fa',
+            'code': recovery_key,
+        })
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'DONE')
+        self.assertEqual(content['body']['username'], 'test2fa')
+
+        two_factor_auth = TwoFactorAuth.objects.get(user=user)
+        self.assertEqual(len(two_factor_auth.recovery_key), 64)
+        self.assertNotEqual(two_factor_auth.recovery_key, recovery_key)
+
+    @override_settings(DEBUG=False)
+    def test_login_with_legacy_plaintext_two_factor_values(self):
+        """기존 평문 2FA secret과 복구 키도 계속 검증된다."""
+        user = User.objects.get(username='test2fa')
+        totp_secret = pyotp.random_base32()
+        recovery_key = 'legacy-recovery-key-value-over-six-chars'
+        two_factor_auth = TwoFactorAuth.objects.create(
+            user=user,
+            recovery_key='temporary-recovery-key',
+            totp_secret=pyotp.random_base32()
+        )
+        TwoFactorAuth.objects.filter(id=two_factor_auth.id).update(
+            recovery_key=recovery_key,
+            totp_secret=totp_secret,
+        )
+
+        response = self.client.post('/v1/login', {
+            'username': 'test2fa',
+            'password': 'test2fa',
+            'code': pyotp.TOTP(totp_secret).now(),
+        })
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'DONE')
+
+        self.client.logout()
+
+        response = self.client.post('/v1/login', {
+            'username': 'test2fa',
+            'password': 'test2fa',
+            'code': recovery_key,
+        })
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'DONE')
 
     @override_settings(DEBUG=False)
     def test_login_with_valid_2fa_code(self):

--- a/backend/src/board/views/api/v1/auth.py
+++ b/backend/src/board/views/api/v1/auth.py
@@ -30,7 +30,6 @@ from board.services.social_auth_provider_service import SocialAuthProviderServic
 from modules.challenge import auth_hcaptcha
 from modules.sub_task import SubTaskProcessor
 from modules.telegram import TelegramBot
-from modules.randomness import randnum, randstr
 
 
 def login(request):
@@ -255,7 +254,7 @@ def security(request):
             if qr_code:
                 return StatusDone({
                     'qr_code': qr_code,
-                    'recovery_key': two_factor_auth.recovery_key
+                    'has_recovery_key': bool(two_factor_auth.recovery_key),
                 })
         return StatusError(ErrorCode.NOT_FOUND)
 
@@ -265,7 +264,7 @@ def security(request):
                 return StatusError(ErrorCode.ALREADY_CONNECTED)
 
             totp_secret = AuthService.create_totp_secret()
-            recovery_key = randstr(45)
+            recovery_key = AuthService.create_recovery_key()
 
             request.session['totp_setup'] = {
                 'secret': totp_secret,

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -39,6 +39,8 @@ python -c "import secrets; print(secrets.token_urlsafe(24))"
 
 첫 번째 값은 `SECRET_KEY`, 두 번째 값은 32글자라 `CIPHER_KEY`에 사용할 수 있습니다. `INITIAL_SETUP_TOKEN`은 직접 고정해도 되고, Docker 로그에 출력되는 자동 생성 값을 사용해도 됩니다.
 
+`CIPHER_KEY`는 DB에 저장되는 OAuth Client Secret, 2FA TOTP secret, 텔레그램/hCaptcha secret 복호화에 필요합니다. 운영을 시작한 뒤 이 값을 잃어버리거나 바꾸면 기존 암호화 값은 복호화할 수 없으므로 백업 대상에 포함하세요.
+
 `ADMIN_PATH`는 비워 두면 Docker 실행 시 자동 생성되고 backend 로그에 출력됩니다. 재시작 후에도 같은 관리자 경로를 유지하고 싶을 때만 직접 설정하세요.
 운영에서는 북마크, 모니터링, 여러 worker 구성을 고려해 고정된 `ADMIN_PATH`를 쓰는 편이 안전합니다.
 


### PR DESCRIPTION
## 🎯 Goal
- Protect 2FA TOTP secrets and recovery keys stored in the database.
- Preserve existing users' authenticator app and recovery-key login after migration.

## 🔧 Core Changes
- Encrypt `TwoFactorAuth.totp_secret` at rest and decrypt only for TOTP verification / QR regeneration.
- Hash `TwoFactorAuth.recovery_key` and stop returning stored recovery keys after setup.
- Add an irreversible, idempotent data migration for existing 2FA rows.
- Generate new recovery keys with `secrets` and document `CIPHER_KEY` backup requirements.

## 🤔 Key Decisions
- TOTP secrets are encrypted, not hashed, because verification and QR regeneration need the original secret.
- Recovery keys are hashed because the server only needs verification.
- The migration is irreversible because recovery key hashes cannot be converted back to plaintext and rollback would otherwise shrink protected values.

## 🧪 Verification Guide
### How to verify
1. Run `npm run server:check-migrations`.
2. Run `npm run server:test -- board.tests.api.test_two_factor_auth board.tests.templates.test_oauth_callback`.
3. Run `npm run server:test`.

### Expected result
- Migration check reports no changes.
- Existing TOTP and recovery-key login paths keep working.
- Stored recovery keys are not returned by the security API after setup.

## ✅ Checklist
- [x] Lint not required (backend-only change)
- [x] Type-check not required (backend-only change)
- [x] Tests completed
- [x] Documentation updated (if needed)
