### PR TITLE
📦 Trim security dependency overrides

### DIFF
--- a/backend/islands/package.json
+++ b/backend/islands/package.json
@@ -25,13 +25,8 @@
     "packageManager": "pnpm@10.34.4",
     "pnpm": {
         "overrides": {
-            "@babel/core": "7.29.6",
             "dompurify": "3.4.11",
-            "esbuild": "0.28.1",
-            "form-data": "4.0.6",
-            "js-yaml": "4.2.0",
-            "linkify-it": "5.0.1",
-            "markdown-it": "14.2.0"
+            "esbuild": "0.28.1"
         }
     }
 }

--- a/backend/islands/pnpm-lock.yaml
+++ b/backend/islands/pnpm-lock.yaml
@@ -5,13 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@babel/core': 7.29.6
   dompurify: 3.4.11
   esbuild: 0.28.1
-  form-data: 4.0.6
-  js-yaml: 4.2.0
-  linkify-it: 5.0.1
-  markdown-it: 14.2.0
 
 importers:
 
@@ -420,7 +415,7 @@ packages:
     resolution: {integrity: sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': ^7.0.0
 
   '@babel/helper-globals@7.28.0':
     resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
@@ -438,7 +433,7 @@ packages:
     resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': ^7.0.0
 
   '@babel/helper-optimise-call-expression@7.27.1':
     resolution: {integrity: sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==}
@@ -452,7 +447,7 @@ packages:
     resolution: {integrity: sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': ^7.0.0
 
   '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
     resolution: {integrity: sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==}
@@ -497,19 +492,19 @@ packages:
     engines: {node: '>=6.9.0'}
     deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-methods instead.
     peerDependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': ^7.0.0-0
 
   '@babel/plugin-transform-react-jsx-self@7.27.1':
     resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': ^7.0.0-0
 
   '@babel/plugin-transform-react-jsx-source@7.27.1':
     resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': ^7.0.0-0
 
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}


### PR DESCRIPTION
## 🎯 Goal
- Reduce the security dependency override surface introduced while resolving Dependabot alerts.
- Keep only overrides that are actually needed after lockfile resolution.

## 🔧 Core Changes
- Remove unnecessary pnpm overrides for `@babel/core`, `form-data`, `js-yaml`, `linkify-it`, and `markdown-it`.
- Keep `dompurify` override because `monaco-editor@0.55.1` pins `dompurify` to `3.2.7` exactly when the override is removed.
- Keep the existing `esbuild` override.

## 🤔 Key Decisions
- Verified that non-DOMPurify packages stay on patched versions through normal lockfile resolution.
- Avoided updating to unstable Monaco dev releases; stable `monaco-editor@0.55.1` is currently the latest stable and still pins vulnerable DOMPurify.

## 🧪 Verification Guide
### How to verify
1. Run `npx -y pnpm@10.34.4 --dir backend/islands audit --audit-level=low`.
2. Run `npm audit --audit-level=low`.
3. Run `npm run islands:lint`.
4. Run `npm run islands:type-check`.

### Expected result
- Audits report no known vulnerabilities.
- Lint and type-check complete successfully.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)