### PR TITLE
🐛 Enforce atomic post like toggles

### DIFF
--- a/backend/src/board/migrations/0054_postlikes_unique_constraint.py
+++ b/backend/src/board/migrations/0054_postlikes_unique_constraint.py
@@ -1,0 +1,55 @@
+import logging
+
+from django.db import migrations, models
+from django.db.models import Count
+
+
+logger = logging.getLogger(__name__)
+
+
+def merge_duplicate_post_likes(apps, schema_editor):
+    PostLikes = apps.get_model('board', 'PostLikes')
+    duplicate_groups = list(
+        PostLikes.objects.values('post_id', 'user_id')
+        .annotate(row_count=Count('id'))
+        .filter(row_count__gt=1)
+        .order_by('post_id', 'user_id')
+    )
+    duplicate_group_count = len(duplicate_groups)
+
+    removed_count = 0
+    for duplicate in duplicate_groups:
+        group = PostLikes.objects.filter(
+            post_id=duplicate['post_id'],
+            user_id=duplicate['user_id'],
+        ).order_by('created_date', 'pk')
+        keep_id = group.values_list('pk', flat=True).first()
+        deleted_count, _ = group.exclude(pk=keep_id).delete()
+        removed_count += deleted_count
+
+    logger.info(
+        'PostLikes duplicate cleanup removed %s row(s) across %s group(s).',
+        removed_count,
+        duplicate_group_count,
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('board', '0053_encrypt_two_factor_auth_secrets'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            merge_duplicate_post_likes,
+            reverse_code=migrations.RunPython.noop,
+        ),
+        migrations.AddConstraint(
+            model_name='postlikes',
+            constraint=models.UniqueConstraint(
+                fields=('post', 'user'),
+                name='board_postlike_post_user_uniq',
+            ),
+        ),
+    ]

--- a/backend/src/board/models.py
+++ b/backend/src/board/models.py
@@ -421,6 +421,12 @@ class PinnedPost(models.Model):
 class PostLikes(models.Model):
     class Meta:
         db_table = 'board_post_likes'
+        constraints = [
+            models.UniqueConstraint(
+                fields=['post', 'user'],
+                name='board_postlike_post_user_uniq',
+            ),
+        ]
         indexes = [
             models.Index(fields=['post', 'user']),
             models.Index(fields=['user', 'created_date']),

--- a/backend/src/board/services/__init__.py
+++ b/backend/src/board/services/__init__.py
@@ -9,6 +9,7 @@ from importlib import import_module
 
 _SERVICE_MODULES = {
     'PostService': 'post_service',
+    'PostLikeService': 'post_like_service',
     'PostThumbnailService': 'post_thumbnail_service',
     'ProfileImageService': 'profile_image_service',
     'NotificationDeliveryService': 'notification_delivery_service',

--- a/backend/src/board/services/post_like_service.py
+++ b/backend/src/board/services/post_like_service.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from django.contrib.auth.models import User
+from django.db import IntegrityError, transaction
+
+from board.models import Post, PostLikes
+
+
+@dataclass(frozen=True)
+class PostLikeToggleResult:
+    count_likes: int
+    has_liked: bool
+    created: bool
+
+
+class PostLikeService:
+    """Manage the transactional boundary for template post-like toggles."""
+
+    @staticmethod
+    def _create_like(post: Post, user: User) -> bool:
+        try:
+            with transaction.atomic():
+                PostLikes.objects.create(post=post, user=user)
+            return True
+        except IntegrityError:
+            if PostLikes.objects.filter(post=post, user=user).exists():
+                return False
+            raise
+
+    @staticmethod
+    def toggle(post: Post, user: User) -> PostLikeToggleResult:
+        with transaction.atomic():
+            locked_post = Post.objects.select_for_update().get(pk=post.pk)
+            existing_like = PostLikes.objects.filter(
+                post=locked_post,
+                user=user,
+            ).first()
+
+            if existing_like is not None:
+                existing_like.delete()
+                has_liked = False
+                created = False
+            else:
+                created = PostLikeService._create_like(locked_post, user)
+                has_liked = True
+
+            count_likes = PostLikes.objects.filter(post=locked_post).count()
+
+        return PostLikeToggleResult(
+            count_likes=count_likes,
+            has_liked=has_liked,
+            created=created,
+        )

--- a/backend/src/board/tests/api/test_setting.py
+++ b/backend/src/board/tests/api/test_setting.py
@@ -272,7 +272,14 @@ class SettingTestCase(TestCase):
         content = json.loads(response.content)
         self.assertEqual(sum(content['body'].values()), 3)
 
-        PostLikes.objects.create(post=post, user=user)
+        other_author = User.objects.create_user(username='heatmap-other-author')
+        other_post = Post.objects.create(
+            url='heatmap-other-post',
+            title='Heatmap Other Post',
+            author=other_author,
+            published_date=timezone.now(),
+        )
+        PostLikes.objects.create(post=other_post, user=user)
         cached_response = self.client.get('/v1/setting/heatmap')
         cached_content = json.loads(cached_response.content)
 

--- a/backend/src/board/tests/services/test_post_like_service.py
+++ b/backend/src/board/tests/services/test_post_like_service.py
@@ -1,0 +1,68 @@
+from unittest.mock import patch
+
+from django.contrib.auth.models import User
+from django.db import IntegrityError, transaction
+from django.test import TestCase
+from django.utils import timezone
+
+from board.models import Post, PostLikes
+from board.services.post_like_service import PostLikeService, PostLikeToggleResult
+
+
+class PostLikeServiceTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.author = User.objects.create_user(username='like-author')
+        cls.reader = User.objects.create_user(username='like-reader')
+        cls.post = Post.objects.create(
+            author=cls.author,
+            title='Atomic Like',
+            url='atomic-like',
+            published_date=timezone.now(),
+        )
+
+    def test_toggle_creates_then_removes_one_like(self):
+        liked = PostLikeService.toggle(self.post, self.reader)
+
+        self.assertEqual(liked, PostLikeToggleResult(
+            count_likes=1,
+            has_liked=True,
+            created=True,
+        ))
+        self.assertEqual(
+            PostLikes.objects.filter(post=self.post, user=self.reader).count(),
+            1,
+        )
+
+        unliked = PostLikeService.toggle(self.post, self.reader)
+
+        self.assertEqual(unliked, PostLikeToggleResult(
+            count_likes=0,
+            has_liked=False,
+            created=False,
+        ))
+        self.assertFalse(PostLikes.objects.filter(post=self.post, user=self.reader).exists())
+
+    def test_create_like_treats_unique_collision_as_already_liked(self):
+        PostLikes.objects.create(post=self.post, user=self.reader)
+
+        with patch.object(PostLikes.objects, 'create', side_effect=IntegrityError):
+            created = PostLikeService._create_like(self.post, self.reader)
+
+        self.assertFalse(created)
+        self.assertEqual(
+            PostLikes.objects.filter(post=self.post, user=self.reader).count(),
+            1,
+        )
+
+    def test_create_like_reraises_unrelated_integrity_error(self):
+        with patch.object(PostLikes.objects, 'create', side_effect=IntegrityError):
+            with self.assertRaises(IntegrityError):
+                PostLikeService._create_like(self.post, self.reader)
+
+    def test_database_rejects_duplicate_post_and_user(self):
+        PostLikes.objects.create(post=self.post, user=self.reader)
+
+        with self.assertRaises(IntegrityError):
+            with transaction.atomic():
+                PostLikes.objects.create(post=self.post, user=self.reader)

--- a/backend/src/board/tests/templates/test_post_actions.py
+++ b/backend/src/board/tests/templates/test_post_actions.py
@@ -1,0 +1,79 @@
+import json
+from unittest.mock import patch
+
+from django.test import TestCase
+from django.utils import timezone
+
+from board.constants.config_meta import CONFIG_TYPE
+from board.models import Config, Post, PostConfig, PostContent, Profile, User
+
+
+class PostLikeActionTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.author = User.objects.create_user(username='action-author')
+        Profile.objects.create(user=cls.author, role=Profile.Role.EDITOR)
+        cls.author_config = Config.objects.create(user=cls.author)
+        cls.reader = User.objects.create_user(username='action-reader')
+        Profile.objects.create(user=cls.reader, role=Profile.Role.READER)
+        Config.objects.create(user=cls.reader)
+        cls.post = Post.objects.create(
+            author=cls.author,
+            title='Like Action',
+            url='like-action',
+            published_date=timezone.now(),
+        )
+        PostContent.objects.create(post=cls.post, content_html='<p>like</p>')
+        PostConfig.objects.create(post=cls.post)
+
+    def setUp(self):
+        self.client.force_login(self.reader)
+
+    @patch('board.views.post_actions.create_notify')
+    def test_like_notifies_author_when_notification_setting_is_enabled(self, mock_notify):
+        self.author_config.create_or_update_meta(CONFIG_TYPE.NOTIFY_POSTS_LIKE, 'true')
+
+        response = self.client.post('/like/like-action')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.content), {
+            'status': 'done',
+            'count_likes': 1,
+            'has_liked': True,
+        })
+        mock_notify.assert_called_once_with(
+            user=self.author,
+            url=self.post.get_absolute_url(),
+            content="'Like Action' 글을 @action-reader님께서 추천하였습니다.",
+        )
+
+    @patch('board.views.post_actions.create_notify')
+    def test_like_does_not_notify_when_notification_setting_is_disabled(self, mock_notify):
+        self.author_config.create_or_update_meta(CONFIG_TYPE.NOTIFY_POSTS_LIKE, 'false')
+
+        self.client.post('/like/like-action')
+
+        mock_notify.assert_not_called()
+
+    @patch('board.views.post_actions.create_notify')
+    def test_unlike_does_not_send_a_second_notification(self, mock_notify):
+        self.author_config.create_or_update_meta(CONFIG_TYPE.NOTIFY_POSTS_LIKE, 'true')
+
+        self.client.post('/like/like-action')
+        response = self.client.post('/like/like-action')
+
+        self.assertEqual(json.loads(response.content), {
+            'status': 'done',
+            'count_likes': 0,
+            'has_liked': False,
+        })
+        self.assertEqual(mock_notify.call_count, 1)
+
+    @patch('board.views.post_actions.create_notify')
+    def test_author_liking_own_post_does_not_notify(self, mock_notify):
+        self.author_config.create_or_update_meta(CONFIG_TYPE.NOTIFY_POSTS_LIKE, 'true')
+        self.client.force_login(self.author)
+
+        self.client.post('/like/like-action')
+
+        mock_notify.assert_not_called()

--- a/backend/src/board/tests/test_postlikes_migration.py
+++ b/backend/src/board/tests/test_postlikes_migration.py
@@ -1,0 +1,84 @@
+from datetime import timedelta
+
+from django.db import connection
+from django.db.migrations.executor import MigrationExecutor
+from django.test import TransactionTestCase
+from django.utils import timezone
+
+
+class PostLikesUniqueMigrationTestCase(TransactionTestCase):
+    migrate_from = [('board', '0053_encrypt_two_factor_auth_secrets')]
+    migrate_to = [('board', '0054_postlikes_unique_constraint')]
+
+    def migrate_to_old_state(self):
+        executor = MigrationExecutor(connection)
+        executor.migrate(self.migrate_from)
+        return executor.loader.project_state(self.migrate_from).apps
+
+    def migrate_to_new_state(self):
+        executor = MigrationExecutor(connection)
+        executor.migrate(self.migrate_to)
+        return executor.loader.project_state(self.migrate_to).apps
+
+    def test_migration_preserves_database_without_duplicates(self):
+        old_apps = self.migrate_to_old_state()
+        User = old_apps.get_model('auth', 'User')
+        Post = old_apps.get_model('board', 'Post')
+        PostLikes = old_apps.get_model('board', 'PostLikes')
+        author = User.objects.create(username='no-duplicate-author')
+        reader = User.objects.create(username='no-duplicate-reader')
+        post = Post.objects.create(
+            author=author,
+            title='Valid Migration Like',
+            url='valid-migration-like',
+        )
+        valid_like = PostLikes.objects.create(post=post, user=reader)
+
+        new_apps = self.migrate_to_new_state()
+        MigratedPostLikes = new_apps.get_model('board', 'PostLikes')
+
+        self.assertTrue(MigratedPostLikes.objects.filter(pk=valid_like.pk).exists())
+
+    def test_migration_keeps_earliest_duplicate_and_preserves_valid_like(self):
+        old_apps = self.migrate_to_old_state()
+
+        User = old_apps.get_model('auth', 'User')
+        Post = old_apps.get_model('board', 'Post')
+        PostLikes = old_apps.get_model('board', 'PostLikes')
+        author = User.objects.create(username='migration-author')
+        duplicate_user = User.objects.create(username='migration-duplicate')
+        valid_user = User.objects.create(username='migration-valid')
+        post = Post.objects.create(
+            author=author,
+            title='Migration Like',
+            url='migration-like',
+        )
+        earliest = timezone.now() - timedelta(days=2)
+        later = timezone.now() - timedelta(days=1)
+        kept_like = PostLikes.objects.create(
+            post=post,
+            user=duplicate_user,
+            created_date=earliest,
+        )
+        PostLikes.objects.create(
+            post=post,
+            user=duplicate_user,
+            created_date=later,
+        )
+        valid_like = PostLikes.objects.create(
+            post=post,
+            user=valid_user,
+            created_date=later,
+        )
+
+        new_apps = self.migrate_to_new_state()
+        MigratedPostLikes = new_apps.get_model('board', 'PostLikes')
+
+        duplicate_likes = MigratedPostLikes.objects.filter(
+            post_id=post.pk,
+            user_id=duplicate_user.pk,
+        )
+        self.assertEqual(duplicate_likes.count(), 1)
+        self.assertEqual(duplicate_likes.get().pk, kept_like.pk)
+        self.assertEqual(duplicate_likes.get().created_date, earliest)
+        self.assertTrue(MigratedPostLikes.objects.filter(pk=valid_like.pk).exists())

--- a/backend/src/board/views/post_actions.py
+++ b/backend/src/board/views/post_actions.py
@@ -3,8 +3,9 @@ from django.shortcuts import get_object_or_404
 from django.views.decorators.http import require_POST
 
 from board.constants.config_meta import CONFIG_TYPE
-from board.models import Post, PostLikes
+from board.models import Post
 from board.modules.notify import create_notify
+from board.services.post_like_service import PostLikeService
 
 
 @require_POST
@@ -18,24 +19,12 @@ def like_post(request, url):
             'status': 'error',
             'message': 'Authentication required'
         }, status=401)
-    
+
     post = get_object_or_404(Post, url=url)
-    
-    like_exists = PostLikes.objects.filter(
-        post=post,
-        user=request.user
-    ).exists()
-    
-    if like_exists:
-        PostLikes.objects.filter(
-            post=post,
-            user=request.user
-        ).delete()
-    else:
-        PostLikes.objects.create(
-            post=post,
-            user=request.user
-        )
+
+    result = PostLikeService.toggle(post, request.user)
+
+    if result.created:
         if request.user != post.author and post.author.config.get_meta(CONFIG_TYPE.NOTIFY_POSTS_LIKE):
             send_notify_content = (
                 f"'{post.title}' 글을 "
@@ -44,11 +33,9 @@ def like_post(request, url):
                 user=post.author,
                 url=post.get_absolute_url(),
                 content=send_notify_content)
-    
-    count_likes = PostLikes.objects.filter(post=post).count()
-    
+
     return JsonResponse({
         'status': 'done',
-        'count_likes': count_likes,
-        'has_liked': not like_exists
+        'count_likes': result.count_likes,
+        'has_liked': result.has_liked
     })


### PR DESCRIPTION
## 🎯 Goal
- Guarantee that one user can have at most one like row for a post, including under concurrent requests.
- Preserve the existing template like endpoint and notification behavior.

## 🔧 Core Changes
- Add a deterministic data migration that keeps the earliest valid like per post and user, logs the cleanup impact, and adds a database unique constraint.
- Move the like toggle into a typed service with a transaction boundary, post row lock, and explicit unique-collision handling.
- Keep the existing view as the POST endpoint and snake_case JSON response facade.
- Cover duplicate and clean migration states, database rejection, collision handling, toggle results, and author notification conditions.
- Replace one legacy test fixture that inserted an invalid duplicate with a valid like on another post while preserving its cache assertion.

## 🤔 Key Decisions
- Serialize toggles through the post row so two toggle requests have deterministic ordering.
- Use a nested savepoint for IntegrityError recovery so the outer transaction remains usable.
- Treat duplicate rows as invalid copies of the same relationship and preserve the earliest created_date, then lowest primary key, without deleting any distinct user or post relationship.

## 🧪 Verification Guide
### How to verify
1. Run node ./scripts/manage.mjs test board.tests.services.test_post_like_service board.tests.templates.test_post_actions board.tests.test_postlikes_migration -v 2.
2. Run npm run server:test.
3. Run npm run server:check-migrations.

### Expected result
- Like and unlike responses retain status, count_likes, and has_liked semantics.
- Duplicate post and user rows are rejected after migration.
- All 1,038 backend tests pass and Django reports No changes detected.

## ✅ Checklist
- [x] Lint completed via git diff --check; no backend lint command is defined
- [x] Type-check completed through fully annotated service inputs and result; no standalone backend type-check command is defined
- [x] Tests completed
- [x] Documentation updated as not needed; migration behavior and impact are recorded in code and tests