### PR TITLE
♻️ Extract settings post management service

### DIFF
--- a/backend/src/board/services/setting_post_management_service.py
+++ b/backend/src/board/services/setting_post_management_service.py
@@ -1,0 +1,271 @@
+"""Read services for the post-management sections of user settings."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar, Iterable, TypedDict
+
+from django.contrib.auth.models import User
+from django.db.models import Count, QuerySet
+from django.http import Http404
+
+from board.models import Post, Series
+from board.modules.paginator import Paginator
+from board.modules.time import convert_to_localtime
+from board.services.post_status_service import PostStatusService
+
+
+class PostManagementQueryError(ValueError):
+    """Raised when a post-management query cannot be served."""
+
+
+@dataclass(frozen=True)
+class PostManagementQuery:
+    tag: str = ''
+    series: str = ''
+    search: str = ''
+    visibility: str = ''
+    order: str = ''
+    page: int = 1
+
+
+class PostManagementPostData(TypedDict):
+    url: str
+    title: str
+    image: str | None
+    created_date: str
+    updated_date: str
+    is_hide: bool
+    count_likes: int
+    count_comments: int
+    read_time: int
+    tag: str
+    series: str
+
+
+class PostManagementData(TypedDict):
+    username: str
+    posts: list[PostManagementPostData]
+    last_page: int
+    total_count: int
+
+
+class PostManagementTagData(TypedDict):
+    name: str | None
+    count: int
+
+
+class PostManagementTagsData(TypedDict):
+    username: str
+    tags: list[PostManagementTagData]
+
+
+class PostManagementSeriesData(TypedDict):
+    id: int
+    url: str
+    title: str
+    total_posts: int
+
+
+class PostManagementSeriesListData(TypedDict):
+    username: str
+    series: list[PostManagementSeriesData]
+
+
+class SettingPostManagementService:
+    """Build and serialize existing settings post-management responses."""
+
+    POST_MANAGEMENT_ORDERS: ClassVar[set[str]] = {
+        'title',
+        'read_time',
+        'published_date',
+        'updated_date',
+        'count_likes',
+        'count_comments',
+    }
+
+    @staticmethod
+    def get_post_management_queryset(
+        user: User,
+        *,
+        scheduled: bool = False,
+    ) -> QuerySet[Post]:
+        posts = Post.objects.select_related(
+            'config',
+            'series',
+        ).prefetch_related(
+            'tags',
+        ).annotate(
+            count_likes=Count('likes', distinct=True),
+            count_comments=Count('comments', distinct=True),
+        ).filter(
+            author=user,
+        ).order_by('-published_date')
+        if scheduled:
+            return PostStatusService.filter_scheduled(posts)
+        return PostStatusService.filter_published(posts)
+
+    @staticmethod
+    def apply_post_management_filters(
+        posts: QuerySet[Post],
+        query: PostManagementQuery,
+    ) -> QuerySet[Post]:
+        if query.tag:
+            posts = posts.filter(tags__value=query.tag)
+
+        if query.series:
+            posts = posts.filter(series__url=query.series)
+
+        if query.search:
+            posts = posts.filter(title__icontains=query.search)
+
+        if query.visibility == 'public':
+            posts = posts.filter(config__hide=False)
+        elif query.visibility == 'hidden':
+            posts = posts.filter(config__hide=True)
+
+        return posts
+
+    @staticmethod
+    def apply_post_management_order(
+        posts: QuerySet[Post],
+        query: PostManagementQuery,
+    ) -> QuerySet[Post]:
+        if not query.order:
+            return posts
+
+        normalized_order = query.order[1:] if query.order.startswith('-') else query.order
+        if normalized_order not in SettingPostManagementService.POST_MANAGEMENT_ORDERS:
+            raise PostManagementQueryError('Unsupported post-management order.')
+
+        return posts.order_by(query.order)
+
+    @staticmethod
+    def paginate_post_management_posts(
+        posts: QuerySet[Post],
+        page: int,
+        total_count: int,
+    ) -> tuple[Iterable[Post], int]:
+        if page < 1:
+            raise PostManagementQueryError('Invalid post-management page.')
+
+        if total_count == 0:
+            if page > 1:
+                raise PostManagementQueryError('Invalid post-management page.')
+            return [], 1
+
+        try:
+            page_posts = Paginator(
+                objects=posts,
+                offset=10,
+                page=page,
+            )
+        except Http404 as error:
+            raise PostManagementQueryError('Invalid post-management page.') from error
+
+        return page_posts, page_posts.paginator.num_pages
+
+    @staticmethod
+    def serialize_post_management_post(
+        post: Post,
+        *,
+        date_format: str,
+    ) -> PostManagementPostData:
+        count_likes = getattr(post, 'count_likes', None)
+        if count_likes is None:
+            count_likes = post.likes.count()
+
+        count_comments = getattr(post, 'count_comments', None)
+        if count_comments is None:
+            count_comments = post.comments.count()
+
+        return {
+            'url': post.url,
+            'title': post.title,
+            'image': str(post.image) if post.image else None,
+            'created_date': convert_to_localtime(post.published_date).strftime(date_format),
+            'updated_date': convert_to_localtime(post.updated_date).strftime('%Y-%m-%d'),
+            'is_hide': post.config.hide,
+            'count_likes': count_likes,
+            'count_comments': count_comments,
+            'read_time': post.read_time,
+            'tag': ','.join(post.tagging()),
+            'series': post.series.url if post.series else '',
+        }
+
+    @staticmethod
+    def get_post_management_data(
+        user: User,
+        query: PostManagementQuery,
+        *,
+        username: str,
+        scheduled: bool = False,
+    ) -> PostManagementData:
+        posts = SettingPostManagementService.get_post_management_queryset(
+            user,
+            scheduled=scheduled,
+        )
+        posts = SettingPostManagementService.apply_post_management_filters(posts, query)
+        posts = SettingPostManagementService.apply_post_management_order(posts, query)
+        total_count = posts.count()
+        page_posts, last_page = SettingPostManagementService.paginate_post_management_posts(
+            posts,
+            query.page,
+            total_count,
+        )
+        date_format = '%Y-%m-%d %H:%M' if scheduled else '%Y-%m-%d'
+
+        return {
+            'username': username,
+            'posts': [
+                SettingPostManagementService.serialize_post_management_post(
+                    post,
+                    date_format=date_format,
+                )
+                for post in page_posts
+            ],
+            'last_page': last_page,
+            'total_count': total_count,
+        }
+
+    @staticmethod
+    def get_tag_management_data(user: User) -> PostManagementTagsData:
+        tags = Post.objects.filter(
+            author=user,
+        ).values(
+            'tags__value',
+        ).annotate(
+            count=Count('tags__value'),
+        ).order_by('-count')
+
+        return {
+            'username': user.username,
+            'tags': [
+                {
+                    'name': tag['tags__value'],
+                    'count': tag['count'],
+                }
+                for tag in tags
+            ],
+        }
+
+    @staticmethod
+    def get_series_management_data(user: User) -> PostManagementSeriesListData:
+        series_items = Series.objects.filter(
+            owner=user,
+        ).annotate(
+            total_posts=Count('posts'),
+        ).order_by('order', '-id')
+
+        return {
+            'username': user.username,
+            'series': [
+                {
+                    'id': series_item.id,
+                    'url': series_item.url,
+                    'title': series_item.name,
+                    'total_posts': series_item.total_posts,
+                }
+                for series_item in series_items
+            ],
+        }

--- a/backend/src/board/tests/api/test_setting.py
+++ b/backend/src/board/tests/api/test_setting.py
@@ -1,14 +1,17 @@
 import json
+from datetime import datetime
 
 from django.core.cache import cache
+from django.db import connection
 from django.test import TestCase
 from django.test.client import Client
+from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 
 from board.constants.config_meta import CONFIG_TYPE
 from board.models import (
     Comment, Config, Notify, Post, PostConfig, PostContent,
-    PinnedPost, PostLikes, Profile, User, UserLinkMeta
+    PinnedPost, PostLikes, Profile, Series, Tag, User, UserLinkMeta
 )
 
 
@@ -42,6 +45,33 @@ class SettingTestCase(TestCase):
     def setUp(self):
         self.client = Client(HTTP_USER_AGENT='Mozilla/5.0')
         cache.clear()
+
+    @staticmethod
+    def create_management_post(
+        user,
+        *,
+        title,
+        url,
+        published_date,
+        hide=False,
+        series=None,
+        tags=(),
+        read_time=0,
+        updated_date=None,
+    ):
+        post = Post.objects.create(
+            author=user,
+            title=title,
+            url=url,
+            published_date=published_date,
+            updated_date=updated_date or timezone.now(),
+            series=series,
+            read_time=read_time,
+        )
+        PostContent.objects.create(post=post, content_html=f'<p>{title}</p>')
+        PostConfig.objects.create(post=post, hide=hide)
+        post.tags.add(*tags)
+        return post
 
     def test_get_setting_notify_not_login(self):
         """비로그인 상태에서 알림 설정 조회 시 에러 테스트"""
@@ -381,6 +411,234 @@ class SettingTestCase(TestCase):
         self.assertEqual(content['status'], 'DONE')
         self.assertEqual(content['body']['totalCount'], 1)
         self.assertEqual(content['body']['posts'][0]['url'], 'public-post')
+
+    def test_get_setting_posts_preserves_combined_filters_and_response_body(self):
+        """포스트 관리 서비스 분리 후에도 필터 조합과 응답 본문을 그대로 유지한다."""
+        user = User.objects.get(username='test')
+        python = Tag.objects.create(value='python')
+        django = Tag.objects.create(value='django')
+        series = Series.objects.create(owner=user, name='Service Series', url='service-series')
+        other_series = Series.objects.create(owner=user, name='Other Series', url='other-series')
+        fixed_date = timezone.make_aware(datetime(2025, 1, 2, 3, 4))
+        expected = self.create_management_post(
+            user,
+            title='Needle Hidden Post',
+            url='needle-hidden-post',
+            published_date=fixed_date,
+            updated_date=fixed_date,
+            hide=True,
+            series=series,
+            tags=(python,),
+            read_time=1,
+        )
+        self.create_management_post(
+            user,
+            title='Needle Public Post',
+            url='needle-public-post',
+            published_date=fixed_date,
+            series=series,
+            tags=(python,),
+        )
+        self.create_management_post(
+            user,
+            title='Needle Other Tag',
+            url='needle-other-tag',
+            published_date=fixed_date,
+            hide=True,
+            series=series,
+            tags=(django,),
+        )
+        self.create_management_post(
+            user,
+            title='Needle Other Series',
+            url='needle-other-series',
+            published_date=fixed_date,
+            hide=True,
+            series=other_series,
+            tags=(python,),
+        )
+        self.create_management_post(
+            user,
+            title='Haystack Hidden Post',
+            url='haystack-hidden-post',
+            published_date=fixed_date,
+            hide=True,
+            series=series,
+            tags=(python,),
+        )
+        self.client.login(username='test', password='test')
+
+        response = self.client.get('/v1/setting/posts', {
+            'tag': 'python',
+            'series': 'service-series',
+            'search': 'Needle',
+            'visibility': 'hidden',
+            'order': 'title',
+            'page': '1',
+        })
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {
+            'status': 'DONE',
+            'body': {
+                'username': 'test',
+                'posts': [{
+                    'url': expected.url,
+                    'title': expected.title,
+                    'image': None,
+                    'createdDate': '2025-01-02',
+                    'updatedDate': '2025-01-02',
+                    'isHide': True,
+                    'countLikes': 0,
+                    'countComments': 0,
+                    'readTime': 1,
+                    'tag': 'python',
+                    'series': 'service-series',
+                }],
+                'lastPage': 1,
+                'totalCount': 1,
+            },
+        })
+
+    def test_get_setting_post_management_rejects_legacy_invalid_queries(self):
+        """포스트 관리의 잘못된 page와 order는 기존처럼 404를 반환한다."""
+        self.client.login(username='test', password='test')
+
+        for parameter in ('posts', 'reserved-posts'):
+            for query in (
+                {'page': 'invalid'},
+                {'page': '0'},
+                {'page': '2'},
+                {'order': 'unknown'},
+            ):
+                with self.subTest(parameter=parameter, query=query):
+                    response = self.client.get(f'/v1/setting/{parameter}', query)
+                    self.assertEqual(response.status_code, 404)
+
+    def test_get_setting_posts_preserves_allowed_orders(self):
+        """기존 포스트 관리 정렬 필드와 내림차순 표기를 모두 허용한다."""
+        user = User.objects.get(username='test')
+        self.create_management_post(
+            user,
+            title='Allowed Order Post',
+            url='allowed-order-post',
+            published_date=timezone.now(),
+        )
+        self.client.login(username='test', password='test')
+
+        for field in (
+            'title',
+            'read_time',
+            'published_date',
+            'updated_date',
+            'count_likes',
+            'count_comments',
+        ):
+            for order in (field, f'-{field}'):
+                with self.subTest(order=order):
+                    response = self.client.get('/v1/setting/posts', {'order': order})
+                    self.assertEqual(response.status_code, 200)
+                    self.assertEqual(response.json()['status'], 'DONE')
+
+    def test_get_setting_tag_preserves_aggregate_response(self):
+        """태그 관리 조회의 이름, count, 정렬과 응답 필드를 유지한다."""
+        user = User.objects.get(username='test')
+        python = Tag.objects.create(value='python')
+        django = Tag.objects.create(value='django')
+        first = Post.objects.create(author=user, title='Python One', url='python-one')
+        second = Post.objects.create(author=user, title='Python Two', url='python-two')
+        third = Post.objects.create(author=user, title='Django One', url='django-one')
+        first.tags.add(python)
+        second.tags.add(python)
+        third.tags.add(django)
+        self.client.login(username='test', password='test')
+
+        response = self.client.get('/v1/setting/tag')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {
+            'status': 'DONE',
+            'body': {
+                'username': 'test',
+                'tags': [
+                    {'name': 'python', 'count': 2},
+                    {'name': 'django', 'count': 1},
+                ],
+            },
+        })
+
+    def test_get_setting_series_preserves_aggregate_response(self):
+        """시리즈 관리 조회의 순서, 게시글 수와 응답 필드를 유지한다."""
+        user = User.objects.get(username='test')
+        later = Series.objects.create(
+            owner=user,
+            name='Later Series',
+            url='later-series',
+            order=1,
+        )
+        first = Series.objects.create(
+            owner=user,
+            name='First Series',
+            url='first-series',
+            order=0,
+        )
+        Post.objects.create(author=user, title='First One', url='first-one', series=first)
+        Post.objects.create(author=user, title='First Two', url='first-two', series=first)
+        Post.objects.create(author=user, title='Later One', url='later-one', series=later)
+        self.client.login(username='test', password='test')
+
+        response = self.client.get('/v1/setting/series')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {
+            'status': 'DONE',
+            'body': {
+                'username': 'test',
+                'series': [
+                    {
+                        'id': first.id,
+                        'url': 'first-series',
+                        'title': 'First Series',
+                        'totalPosts': 2,
+                    },
+                    {
+                        'id': later.id,
+                        'url': 'later-series',
+                        'title': 'Later Series',
+                        'totalPosts': 1,
+                    },
+                ],
+            },
+        })
+
+    def test_get_setting_post_management_query_budget(self):
+        """서비스 분리 후 posts/tag/series 관리 조회의 쿼리 수가 증가하지 않는다."""
+        user = User.objects.get(username='test')
+        tag = Tag.objects.create(value='query-budget')
+        series = Series.objects.create(owner=user, name='Query Budget', url='query-budget')
+        self.create_management_post(
+            user,
+            title='Query Budget Post',
+            url='query-budget-post',
+            published_date=timezone.now(),
+            series=series,
+            tags=(tag,),
+        )
+        self.client.login(username='test', password='test')
+
+        with CaptureQueriesContext(connection) as post_queries:
+            posts_response = self.client.get('/v1/setting/posts')
+        with CaptureQueriesContext(connection) as tag_queries:
+            tag_response = self.client.get('/v1/setting/tag')
+        with CaptureQueriesContext(connection) as series_queries:
+            series_response = self.client.get('/v1/setting/series')
+
+        self.assertEqual(posts_response.status_code, 200)
+        self.assertEqual(tag_response.status_code, 200)
+        self.assertEqual(series_response.status_code, 200)
+        self.assertLessEqual(len(post_queries), 9)
+        self.assertLessEqual(len(tag_queries), 6)
+        self.assertLessEqual(len(series_queries), 6)
 
     def test_get_setting_reserved_posts_orders_by_count_fields(self):
         """예약 포스트 설정 목록은 좋아요/댓글 수 정렬을 지원한다."""

--- a/backend/src/board/tests/test_backend_compatibility_contract.py
+++ b/backend/src/board/tests/test_backend_compatibility_contract.py
@@ -475,6 +475,33 @@ class PythonImportCompatibilityContractTests(SimpleTestCase):
                 implementation = getattr(import_module(module_path), export_name)
                 self.assertIs(getattr(api_v1, export_name), implementation)
 
+    def test_setting_post_management_facade_signatures_are_stable(self):
+        setting_module = import_module('board.views.api.v1.setting')
+
+        setting_parameters = tuple(inspect.signature(setting_module.setting).parameters.values())
+        self.assertEqual(
+            tuple(parameter.name for parameter in setting_parameters),
+            ('request', 'parameter'),
+        )
+        self.assertTrue(all(
+            parameter.kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+            for parameter in setting_parameters
+        ))
+
+        response_parameters = tuple(
+            inspect.signature(setting_module.get_post_management_response).parameters.values()
+        )
+        self.assertEqual(
+            tuple(parameter.name for parameter in response_parameters),
+            ('request', 'user', 'scheduled'),
+        )
+        self.assertTrue(all(
+            parameter.kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+            for parameter in response_parameters[:2]
+        ))
+        self.assertIs(response_parameters[2].kind, inspect.Parameter.KEYWORD_ONLY)
+        self.assertIs(response_parameters[2].default, False)
+
     def test_post_service_facade_parameter_names_order_and_defaults_are_stable(self):
         for method_name, expected_parameters in EXPECTED_POST_SERVICE_SIGNATURES.items():
             with self.subTest(method_name=method_name):

--- a/backend/src/board/views/api/v1/setting.py
+++ b/backend/src/board/views/api/v1/setting.py
@@ -1,13 +1,11 @@
 import json
 
 from django.contrib import auth
-from django.db.models import Count
-from django.http import Http404
+from django.http import Http404, HttpRequest
 from django.shortcuts import get_object_or_404
 from board.models import (
-    User, Series, Post, LoginSetting,
+    User, LoginSetting,
     Profile, Notify)
-from board.modules.paginator import Paginator
 from board.modules.response import StatusDone, StatusError, ErrorCode
 from board.modules.time import convert_to_localtime
 from board.services.auth_service import AuthService, AuthValidationError
@@ -15,7 +13,11 @@ from board.services.api_permission_service import ApiPermissionService
 from board.services.api_request_body_service import ApiRequestBodyService
 from board.services.integration_setting_service import IntegrationSettingService
 from board.services.pinned_post_service import PinnedPostService, PinnedPostError
-from board.services.post_status_service import PostStatusService
+from board.services.setting_post_management_service import (
+    PostManagementQuery,
+    PostManagementQueryError,
+    SettingPostManagementService,
+)
 from board.services.user_heatmap_service import UserHeatmapService
 from board.services.user_notification_service import UserNotificationService
 from board.services.user_social_link_service import UserSocialLinkService
@@ -32,129 +34,89 @@ EDITOR_SETTING_PARAMETERS = {
 }
 
 
-POST_MANAGEMENT_ORDERS = {
-    'title',
-    'read_time',
-    'published_date',
-    'updated_date',
-    'count_likes',
-    'count_comments',
-}
+POST_MANAGEMENT_ORDERS = SettingPostManagementService.POST_MANAGEMENT_ORDERS
 
 
 def get_post_management_queryset(user, *, scheduled=False):
-    posts = Post.objects.select_related(
-        'config', 'series',
-    ).prefetch_related(
-        'tags'
-    ).annotate(
-        count_likes=Count('likes', distinct=True),
-        count_comments=Count('comments', distinct=True),
-    ).filter(
-        author=user,
-    ).order_by('-published_date')
-    if scheduled:
-        return PostStatusService.filter_scheduled(posts)
-    return PostStatusService.filter_published(posts)
+    return SettingPostManagementService.get_post_management_queryset(
+        user,
+        scheduled=scheduled,
+    )
+
+
+def _parse_post_management_query(request: HttpRequest) -> PostManagementQuery:
+    try:
+        page = int(request.GET.get('page', 1))
+    except (TypeError, ValueError):
+        raise Http404 from None
+
+    if page < 1:
+        raise Http404
+
+    return PostManagementQuery(
+        tag=request.GET.get('tag', ''),
+        series=request.GET.get('series', ''),
+        search=request.GET.get('search', ''),
+        visibility=request.GET.get('visibility', ''),
+        order=request.GET.get('order', ''),
+        page=page,
+    )
 
 
 def apply_post_management_filters(posts, request):
-    tag = request.GET.get('tag', '')
-    if tag:
-        posts = posts.filter(tags__value=tag)
-
-    series = request.GET.get('series', '')
-    if series:
-        posts = posts.filter(series__url=series)
-
-    search = request.GET.get('search', '')
-    if search:
-        posts = posts.filter(title__icontains=search)
-
-    visibility = request.GET.get('visibility', '')
-    if visibility == 'public':
-        posts = posts.filter(config__hide=False)
-    elif visibility == 'hidden':
-        posts = posts.filter(config__hide=True)
-
-    return posts
+    query = PostManagementQuery(
+        tag=request.GET.get('tag', ''),
+        series=request.GET.get('series', ''),
+        search=request.GET.get('search', ''),
+        visibility=request.GET.get('visibility', ''),
+    )
+    return SettingPostManagementService.apply_post_management_filters(posts, query)
 
 
 def apply_post_management_order(posts, request):
-    order = request.GET.get('order', '')
-    if not order:
-        return posts
-
-    normalized_order = order[1:] if order.startswith('-') else order
-    if normalized_order not in POST_MANAGEMENT_ORDERS:
-        raise Http404
-
-    return posts.order_by(order)
+    query = PostManagementQuery(order=request.GET.get('order', ''))
+    try:
+        return SettingPostManagementService.apply_post_management_order(posts, query)
+    except PostManagementQueryError:
+        raise Http404 from None
 
 
 def paginate_post_management_posts(posts, request, total_count):
     try:
         page = int(request.GET.get('page', 1))
     except (TypeError, ValueError):
-        raise Http404
+        raise Http404 from None
 
-    if page < 1:
-        raise Http404
-
-    if total_count == 0:
-        if page > 1:
-            raise Http404
-        return [], 1
-
-    page_posts = Paginator(
-        objects=posts,
-        offset=10,
-        page=page
-    )
-    return page_posts, page_posts.paginator.num_pages
+    try:
+        return SettingPostManagementService.paginate_post_management_posts(
+            posts,
+            page,
+            total_count,
+        )
+    except PostManagementQueryError:
+        raise Http404 from None
 
 
 def serialize_post_management_post(post, *, date_format):
-    count_likes = getattr(post, 'count_likes', None)
-    if count_likes is None:
-        count_likes = post.likes.count()
-
-    count_comments = getattr(post, 'count_comments', None)
-    if count_comments is None:
-        count_comments = post.comments.count()
-
-    return {
-        'url': post.url,
-        'title': post.title,
-        'image': str(post.image) if post.image else None,
-        'created_date': convert_to_localtime(post.published_date).strftime(date_format),
-        'updated_date': convert_to_localtime(post.updated_date).strftime('%Y-%m-%d'),
-        'is_hide': post.config.hide,
-        'count_likes': count_likes,
-        'count_comments': count_comments,
-        'read_time': post.read_time,
-        'tag': ','.join(post.tagging()),
-        'series': post.series.url if post.series else '',
-    }
+    return SettingPostManagementService.serialize_post_management_post(
+        post,
+        date_format=date_format,
+    )
 
 
 def get_post_management_response(request, user, *, scheduled=False):
-    posts = get_post_management_queryset(user, scheduled=scheduled)
-    posts = apply_post_management_filters(posts, request)
-    posts = apply_post_management_order(posts, request)
-    total_count = posts.count()
-    page_posts, last_page = paginate_post_management_posts(posts, request, total_count)
-    date_format = '%Y-%m-%d %H:%M' if scheduled else '%Y-%m-%d'
+    query = _parse_post_management_query(request)
+    try:
+        data = SettingPostManagementService.get_post_management_data(
+            user,
+            query,
+            username=request.user.username,
+            scheduled=scheduled,
+        )
+    except PostManagementQueryError:
+        raise Http404 from None
 
-    return StatusDone({
-        'username': request.user.username,
-        'posts': [
-            serialize_post_management_post(post, date_format=date_format)
-            for post in page_posts
-        ],
-        'last_page': last_page,
-        'total_count': total_count,
-    })
+    return StatusDone(data)
 
 
 def setting(request, parameter):
@@ -226,37 +188,14 @@ def setting(request, parameter):
             return get_post_management_response(request, user, scheduled=True)
 
         if parameter == 'tag':
-            tags = Post.objects.filter(
-                author=user
-            ).values(
-                'tags__value'
-            ).annotate(
-                count=Count('tags__value')
-            ).order_by('-count')
-
-            return StatusDone({
-                'username': user.username,
-                'tags': list(map(lambda tag: {
-                    'name': tag['tags__value'],
-                    'count': tag['count']
-                }, tags))
-            })
+            return StatusDone(
+                SettingPostManagementService.get_tag_management_data(user)
+            )
 
         if parameter == 'series':
-            series_items = Series.objects.filter(
-                owner=user
-            ).annotate(
-                total_posts=Count('posts')
-            ).order_by('order', '-id')
-            return StatusDone({
-                'username': user.username,
-                'series': list(map(lambda series_item: {
-                    'id': series_item.id,
-                    'url': series_item.url,
-                    'title': series_item.name,
-                    'total_posts': series_item.total_posts
-                }, series_items))
-            })
+            return StatusDone(
+                SettingPostManagementService.get_series_management_data(user)
+            )
 
         if parameter == 'integration-telegram':
             return StatusDone(IntegrationSettingService.serialize_user_telegram_status(request.user))


### PR DESCRIPTION
## 🎯 Goal
- Move settings post-management reads out of the monolithic setting view without changing any endpoint behavior.
- Give posts, reserved posts, tag, and series management a typed service boundary.

## 🔧 Core Changes
- Add an immutable typed query object, typed response contracts, and SettingPostManagementService for querysets, filters, allowed ordering, pagination, serialization, and tag and series aggregation.
- Keep HTTP query parsing, legacy 404 conversion, and StatusDone wrapping in the view.
- Preserve all existing view helpers and get_post_management_response as service-backed compatibility facades.
- Add exact response, combined filter, invalid query, ordering, empty result, aggregation, permission, signature, and query-budget coverage.

## 🤔 Key Decisions
- Move the existing ORM and serialization algorithm as-is instead of changing pagination or response semantics during extraction.
- Pass the request username into the service result so even direct legacy facade calls retain their prior username source.
- Translate typed service query errors back to an empty Http404 at the view boundary.

## 🧪 Verification Guide
### How to verify
1. Run node ./scripts/manage.mjs test board.tests.api.test_setting board.tests.api.test_editor_demotion_permissions board.tests.test_backend_compatibility_contract -v 2.
2. Run npm run server:test.
3. Run npm run server:check-migrations.

### Expected result
- GET setting posts, reserved-posts, tag, and series keep their paths, query parameters, 404 behavior, camelCase JSON, fields, dates, filters, ordering, and visibility.
- Query counts remain at or below posts 9, tag 6, and series 6 through the real API path.
- All 1,061 backend tests pass and Django reports No changes detected.

## ✅ Checklist
- [x] Lint completed via git diff --check; no backend lint command is defined
- [x] Type-check completed through typed query and response service boundaries; no standalone backend type-check command is defined
- [x] Tests completed
- [x] Documentation updated as not needed; compatibility and service boundaries are recorded in tests and the task log