### PR TITLE
♻️ Extract settings account profile service

### DIFF
--- a/backend/src/board/services/setting_account_profile_service.py
+++ b/backend/src/board/services/setting_account_profile_service.py
@@ -1,0 +1,147 @@
+"""Mutation services for account and profile sections of user settings."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from django.contrib.auth.models import User
+from django.core.files.uploadedfile import UploadedFile
+
+from board.models import Profile
+from board.modules.response import ErrorCode
+from board.services.auth_service import AuthService, AuthValidationError
+from board.services.user_social_link_service import UserSocialLinkService
+
+
+class SettingAccountProfileError(Exception):
+    """Raised when an account or profile mutation is rejected."""
+
+    def __init__(self, code: ErrorCode, message: str):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+@dataclass(frozen=True)
+class AccountUpdateResult:
+    should_save: bool
+    should_refresh_session: bool
+
+
+class SettingAccountProfileService:
+    """Apply existing account and profile mutation rules without HTTP objects."""
+
+    @staticmethod
+    def prepare_account_update(
+        user: User,
+        *,
+        username: str,
+        name: str,
+        password: str,
+    ) -> AccountUpdateResult:
+        should_save = False
+
+        if username and user.username != username:
+            try:
+                AuthService.validate_username_change_restriction(user)
+                AuthService.change_username(user, username, create_log=True)
+            except AuthValidationError as error:
+                raise SettingAccountProfileError(error.code, error.message) from error
+
+        if name and user.first_name != name:
+            user.first_name = name
+            should_save = True
+
+        if password:
+            SettingAccountProfileService.validate_password(password)
+            user.set_password(password)
+            should_save = True
+
+        return AccountUpdateResult(
+            should_save=should_save,
+            should_refresh_session=bool(password),
+        )
+
+    @staticmethod
+    def validate_password(password: str) -> None:
+        if len(password) < 8:
+            raise SettingAccountProfileError(
+                ErrorCode.VALIDATE,
+                '비밀번호는 8자 이상이어야 합니다.',
+            )
+
+        if not any(character.isdigit() for character in password):
+            raise SettingAccountProfileError(
+                ErrorCode.VALIDATE,
+                '비밀번호는 숫자를 포함해야 합니다.',
+            )
+
+        if not any(character.islower() for character in password):
+            raise SettingAccountProfileError(
+                ErrorCode.VALIDATE,
+                '비밀번호는 소문자를 포함해야 합니다.',
+            )
+
+        if not any(character.isupper() for character in password):
+            raise SettingAccountProfileError(
+                ErrorCode.VALIDATE,
+                '비밀번호는 대문자를 포함해야 합니다.',
+            )
+
+        if not any(
+            not character.isupper()
+            and not character.islower()
+            and not character.isdigit()
+            for character in password
+        ):
+            raise SettingAccountProfileError(
+                ErrorCode.VALIDATE,
+                '비밀번호는 특수문자를 포함해야 합니다.',
+            )
+
+    @staticmethod
+    def persist_account_update(user: User, result: AccountUpdateResult) -> None:
+        if result.should_save:
+            user.save()
+
+    @staticmethod
+    def update_profile(
+        user: User,
+        *,
+        bio: str,
+        homepage: str,
+    ) -> None:
+        profile = Profile.objects.get(user=user)
+        profile.bio = bio
+        profile.homepage = homepage
+        profile.save()
+
+    @staticmethod
+    def save_avatar(user: User, avatar: UploadedFile) -> str:
+        profile = Profile.objects.get(user=user)
+        profile.avatar = avatar
+        profile.save()
+        return profile.get_thumbnail()
+
+    @staticmethod
+    def save_cover(user: User, cover: UploadedFile) -> str | None:
+        profile = Profile.objects.get(user=user)
+        profile.cover = cover
+        profile.save()
+        return profile.cover.url if profile.cover else None
+
+    @staticmethod
+    def delete_cover(user: User) -> None:
+        profile = Profile.objects.get(user=user)
+        if profile.cover:
+            profile.cover.delete(save=False)
+            profile.cover = None
+            profile.save(update_fields=['cover'])
+
+    @staticmethod
+    def update_social_links(
+        user: User,
+        data: Mapping[str, Any],
+    ) -> list[dict[str, Any]]:
+        return UserSocialLinkService.update_user_social_links(user, data)

--- a/backend/src/board/tests/api/test_setting.py
+++ b/backend/src/board/tests/api/test_setting.py
@@ -1,7 +1,9 @@
 import json
 from datetime import datetime
+from unittest.mock import patch
 
 from django.core.cache import cache
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.db import connection
 from django.test import TestCase
 from django.test.client import Client
@@ -11,7 +13,8 @@ from django.utils import timezone
 from board.constants.config_meta import CONFIG_TYPE
 from board.models import (
     Comment, Config, Notify, Post, PostConfig, PostContent,
-    PinnedPost, PostLikes, Profile, Series, Tag, User, UserLinkMeta
+    PinnedPost, PostLikes, Profile, Series, Tag, User, UserLinkMeta,
+    UsernameChangeLog,
 )
 
 
@@ -777,6 +780,12 @@ class SettingTestCase(TestCase):
 
         user = User.objects.get(id=User.objects.get(username='newtest').id)
         self.assertEqual(user.username, 'newtest')
+        self.assertTrue(
+            UsernameChangeLog.objects.filter(
+                user=user,
+                username='test',
+            ).exists()
+        )
 
     def test_update_username_duplicate(self):
         """중복된 사용자 필명 변경 테스트"""
@@ -798,6 +807,99 @@ class SettingTestCase(TestCase):
         content = json.loads(response.content)
         self.assertEqual(content['status'], 'ERROR')
         self.assertEqual(content['errorMessage'], '이미 사용중인 아이디입니다.')
+
+    def test_update_username_preserves_six_month_restriction(self):
+        """게시글 작성자의 6개월 username 변경 제한과 오류 계약을 유지한다."""
+        user = User.objects.get(username='test')
+        Post.objects.create(author=user, title='Restriction Post', url='restriction-post')
+        UsernameChangeLog.objects.create(user=user, username='previous-test')
+        self.client.login(username='test', password='test')
+
+        response = self.client.put(
+            '/v1/setting/account',
+            'username=restricted',
+            content_type='application/x-www-form-urlencoded',
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {
+            'status': 'ERROR',
+            'errorCode': 'error:VA',
+            'errorMessage': (
+                '작성한 포스트가 존재하는 경우 6개월에 한번만 변경할 수 있습니다.'
+            ),
+        })
+        user.refresh_from_db()
+        self.assertEqual(user.username, 'test')
+
+    def test_update_account_preserves_password_validation_priority(self):
+        """비밀번호 검증 순서와 한국어 오류 메시지를 그대로 유지한다."""
+        self.client.login(username='test', password='test')
+        cases = (
+            ('Aa1!aaa', '비밀번호는 8자 이상이어야 합니다.'),
+            ('Abcdefg!', '비밀번호는 숫자를 포함해야 합니다.'),
+            ('ABCDEFG1!', '비밀번호는 소문자를 포함해야 합니다.'),
+            ('abcdefg1!', '비밀번호는 대문자를 포함해야 합니다.'),
+            ('Abcdefg1', '비밀번호는 특수문자를 포함해야 합니다.'),
+        )
+
+        for password, message in cases:
+            with self.subTest(password=password):
+                response = self.client.put(
+                    '/v1/setting/account',
+                    json.dumps({'password': password}),
+                    content_type='application/json',
+                )
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.json(), {
+                    'status': 'ERROR',
+                    'errorCode': 'error:VA',
+                    'errorMessage': message,
+                })
+
+    def test_update_password_keeps_authenticated_session(self):
+        """비밀번호 변경 성공 후 새 hash를 저장하고 현재 세션 로그인을 유지한다."""
+        self.client.login(username='test', password='test')
+
+        response = self.client.put(
+            '/v1/setting/account',
+            json.dumps({'password': 'Strong123!'}),
+            content_type='application/json',
+        )
+        authenticated_response = self.client.get('/v1/setting/account')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {'status': 'DONE', 'body': {}})
+        self.assertEqual(authenticated_response.status_code, 200)
+        self.assertEqual(authenticated_response.json()['status'], 'DONE')
+        user = User.objects.get(username='test')
+        self.assertTrue(user.check_password('Strong123!'))
+
+    def test_update_account_preserves_existing_partial_save_characteristic(self):
+        """username 선행 저장 뒤 비밀번호 오류 시 기존 부분 저장 특성을 바꾸지 않는다."""
+        self.client.login(username='test', password='test')
+
+        response = self.client.put(
+            '/v1/setting/account',
+            json.dumps({
+                'username': 'partialsave',
+                'name': 'Unsaved Name',
+                'password': 'short',
+            }),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {
+            'status': 'ERROR',
+            'errorCode': 'error:VA',
+            'errorMessage': '비밀번호는 8자 이상이어야 합니다.',
+        })
+        user = User.objects.get(username='partialsave')
+        self.assertEqual(user.first_name, 'Test User')
+        self.assertTrue(
+            UsernameChangeLog.objects.filter(user=user, username='test').exists()
+        )
 
     def test_upload_avatar(self):
         """프로필 이미지 업로드 테스트"""
@@ -821,6 +923,25 @@ class SettingTestCase(TestCase):
         content = json.loads(response.content)
         self.assertEqual(content['status'], 'DONE')
         self.assertIn('url', content['body'])
+
+    def test_upload_avatar_save_failure_keeps_existing_database_value(self):
+        """avatar 저장 실패는 기존 DB 경로를 바꾸거나 성공 응답으로 숨기지 않는다."""
+        user = User.objects.get(username='test')
+        profile = Profile.objects.get(user=user)
+        Profile.objects.filter(pk=profile.pk).update(avatar='images/avatar/test/old.png')
+        self.client.login(username='test', password='test')
+        uploaded = SimpleUploadedFile('new.png', b'new-avatar', content_type='image/png')
+
+        with self.settings(DEBUG_PROPAGATE_EXCEPTIONS=True), patch.object(
+            Profile,
+            'save',
+            side_effect=OSError('avatar save failed'),
+        ):
+            with self.assertRaisesMessage(OSError, 'avatar save failed'):
+                self.client.post('/v1/setting/avatar', {'avatar': uploaded})
+
+        profile.refresh_from_db()
+        self.assertEqual(profile.avatar.name, 'images/avatar/test/old.png')
 
     def test_upload_cover(self):
         """커버 이미지 업로드 테스트"""
@@ -864,6 +985,25 @@ class SettingTestCase(TestCase):
         profile.refresh_from_db()
         self.assertFalse(profile.cover)
 
+    def test_delete_cover_storage_failure_keeps_existing_database_value(self):
+        """cover storage 삭제 실패 시 DB 경로 저장을 진행하지 않는다."""
+        user = User.objects.get(username='test')
+        profile = Profile.objects.get(user=user)
+        Profile.objects.filter(pk=profile.pk).update(cover='images/avatar/test/cover.png')
+        storage = Profile._meta.get_field('cover').storage
+        self.client.login(username='test', password='test')
+
+        with self.settings(DEBUG_PROPAGATE_EXCEPTIONS=True), patch.object(
+            storage,
+            'delete',
+            side_effect=OSError('cover delete failed'),
+        ):
+            with self.assertRaisesMessage(OSError, 'cover delete failed'):
+                self.client.delete('/v1/setting/cover')
+
+        profile.refresh_from_db()
+        self.assertEqual(profile.cover.name, 'images/avatar/test/cover.png')
+
     def test_get_setting_profile(self):
         """프로필 설정 조회 테스트"""
         self.client.login(username='test', password='test')
@@ -893,6 +1033,27 @@ class SettingTestCase(TestCase):
         profile = Profile.objects.get(user=User.objects.get(username='test'))
         self.assertEqual(profile.bio, 'Test bio')
         self.assertEqual(profile.homepage, 'https://example.com')
+
+    def test_update_profile_preserves_json_fallback_and_missing_field_reset(self):
+        """JSON profile 변경과 누락 필드를 빈 문자열로 초기화하는 기존 동작을 유지한다."""
+        user = User.objects.get(username='test')
+        Profile.objects.filter(user=user).update(
+            bio='Old bio',
+            homepage='https://old.example.com',
+        )
+        self.client.login(username='test', password='test')
+
+        response = self.client.put(
+            '/v1/setting/profile',
+            json.dumps({'bio': 'JSON bio'}),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {'status': 'DONE', 'body': {}})
+        profile = Profile.objects.get(user=user)
+        self.assertEqual(profile.bio, 'JSON bio')
+        self.assertEqual(profile.homepage, '')
 
     def test_update_social_links(self):
         """소셜 링크 생성/수정/삭제 테스트"""

--- a/backend/src/board/views/api/v1/setting.py
+++ b/backend/src/board/views/api/v1/setting.py
@@ -5,14 +5,17 @@ from django.http import Http404, HttpRequest
 from django.shortcuts import get_object_or_404
 from board.models import (
     User, LoginSetting,
-    Profile, Notify)
+    Notify)
 from board.modules.response import StatusDone, StatusError, ErrorCode
 from board.modules.time import convert_to_localtime
-from board.services.auth_service import AuthService, AuthValidationError
 from board.services.api_permission_service import ApiPermissionService
 from board.services.api_request_body_service import ApiRequestBodyService
 from board.services.integration_setting_service import IntegrationSettingService
 from board.services.pinned_post_service import PinnedPostService, PinnedPostError
+from board.services.setting_account_profile_service import (
+    SettingAccountProfileError,
+    SettingAccountProfileService,
+)
 from board.services.setting_post_management_service import (
     PostManagementQuery,
     PostManagementQueryError,
@@ -20,7 +23,6 @@ from board.services.setting_post_management_service import (
 )
 from board.services.user_heatmap_service import UserHeatmapService
 from board.services.user_notification_service import UserNotificationService
-from board.services.user_social_link_service import UserSocialLinkService
 
 
 EDITOR_SETTING_PARAMETERS = {
@@ -222,19 +224,19 @@ def setting(request, parameter):
 
     if request.method == 'POST':
         if parameter == 'avatar':
-            profile = Profile.objects.get(user=user)
-            profile.avatar = request.FILES['avatar']
-            profile.save()
             return StatusDone({
-                'url': profile.get_thumbnail(),
+                'url': SettingAccountProfileService.save_avatar(
+                    user,
+                    request.FILES['avatar'],
+                ),
             })
 
         if parameter == 'cover':
-            profile = Profile.objects.get(user=user)
-            profile.cover = request.FILES['cover']
-            profile.save()
             return StatusDone({
-                'url': profile.cover.url if profile.cover else None,
+                'url': SettingAccountProfileService.save_cover(
+                    user,
+                    request.FILES['cover'],
+                ),
             })
 
         if parameter == 'pinned-posts':
@@ -250,11 +252,7 @@ def setting(request, parameter):
 
     if request.method == 'DELETE':
         if parameter == 'cover':
-            profile = Profile.objects.get(user=user)
-            if profile.cover:
-                profile.cover.delete(save=False)
-                profile.cover = None
-                profile.save(update_fields=['cover'])
+            SettingAccountProfileService.delete_cover(user)
 
             return StatusDone({
                 'url': None,
@@ -288,64 +286,39 @@ def setting(request, parameter):
             return StatusDone()
 
         if parameter == 'account':
-            should_update = False
-
             username = put.get('username', '')
             name = put.get('name', '')
             password = put.get('password', '')
 
-            if username and user.username != username:
-                try:
-                    AuthService.validate_username_change_restriction(user)
-                    AuthService.change_username(user, username, create_log=True)
-                    should_update = False
-                except AuthValidationError as e:
-                    return StatusError(e.code, e.message)
+            try:
+                result = SettingAccountProfileService.prepare_account_update(
+                    user,
+                    username=username,
+                    name=name,
+                    password=password,
+                )
+            except SettingAccountProfileError as error:
+                return StatusError(error.code, error.message)
 
-            if name and user.first_name != name:
-                user.first_name = name
-                should_update = True
-
-            if password:
-                if len(password) < 8:
-                    return StatusError(ErrorCode.VALIDATE, '비밀번호는 8자 이상이어야 합니다.')
-
-                if not any(x.isdigit() for x in password):
-                    return StatusError(ErrorCode.VALIDATE, '비밀번호는 숫자를 포함해야 합니다.')
-
-                if not any(x.islower() for x in password):
-                    return StatusError(ErrorCode.VALIDATE, '비밀번호는 소문자를 포함해야 합니다.')
-
-                if not any(x.isupper() for x in password):
-                    return StatusError(ErrorCode.VALIDATE, '비밀번호는 대문자를 포함해야 합니다.')
-
-                if not any(not x.isupper() and not x.islower() and not x.isdigit() for x in password):
-                    return StatusError(ErrorCode.VALIDATE, '비밀번호는 특수문자를 포함해야 합니다.')
-
-                user.set_password(password)
+            if result.should_refresh_session:
                 auth.login(request, user)
-                should_update = True
 
-            if should_update:
-                user.save()
+            SettingAccountProfileService.persist_account_update(user, result)
 
             return StatusDone()
 
         if parameter == 'profile':
-            profile = Profile.objects.get(user=user)
-
-            attrs = [
-                'bio',
-                'homepage',
-            ]
-            for attr in attrs:
-                setattr(profile, attr, put.get(attr, ''))
-
-            profile.save()
+            SettingAccountProfileService.update_profile(
+                user,
+                bio=put.get('bio', ''),
+                homepage=put.get('homepage', ''),
+            )
             return StatusDone()
     
         if parameter == 'social':
-            return StatusDone(UserSocialLinkService.update_user_social_links(user, put))
+            return StatusDone(
+                SettingAccountProfileService.update_social_links(user, put)
+            )
 
         if parameter == 'pinned-posts/order':
             post_urls_data = put.get('post_urls', '[]')


### PR DESCRIPTION
## Goal

- Move settings account and profile mutations out of the HTTP view into a typed service without changing public behavior.
- Preserve session renewal, username-change restrictions, validation messages, and file side-effect ordering.

## Core Changes

- Add SettingAccountProfileService with typed results and domain errors.
- Keep account updates as prepare → session login → persist so the existing ordering remains intact.
- Delegate profile, avatar, cover image, and social-link mutations from the view to the service.
- Add regression coverage for username logs/restrictions, password-validation priority, partial saves, JSON/form input, and storage/model failures.

## Key Decisions

- Preserve the existing username-first partial-save behavior when a later password validation fails.
- Keep request/session handling in the view and call auth.login before the final user save.
- Preserve Profile.save hooks and the current cover-image delete/save sequence.

## Verification Guide

- Related backend suites: 77 tests passed.
- Full backend suite: 1,068 tests passed.
- Migration drift check: no changes detected.
- git diff --check: passed.

## Checklist

- [x] Backward-compatible behavior is covered by regression tests.
- [x] No schema or migration changes.
- [x] Full backend test suite passes locally.
- [x] Migration drift check passes locally.