### PR TITLE
♻️ Extract social signup provider service

### DIFF
--- a/backend/src/board/services/social_signup_service.py
+++ b/backend/src/board/services/social_signup_service.py
@@ -1,0 +1,183 @@
+"""Typed orchestration for the social-signup API."""
+
+from __future__ import annotations
+
+import json
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import ClassVar, Mapping, Protocol, cast
+
+from django.contrib.auth.models import User
+from django.db import transaction
+
+from board.models import SocialAuth, SocialAuthProvider, UserLinkMeta
+from board.services.auth_service import AuthService
+from board.services.initial_setup_service import InitialSetupService
+from board.services.social_auth_provider_service import SocialAuthProviderService
+from modules import oauth
+
+
+class SocialSignupErrorKind(Enum):
+    INITIAL_SETUP_REQUIRED = 'initial_setup_required'
+    UNSUPPORTED_PROVIDER = 'unsupported_provider'
+    PROVIDER_DISABLED = 'provider_disabled'
+    MISSING_CODE = 'missing_code'
+    EXTERNAL_AUTH_FAILED = 'external_auth_failed'
+
+
+class SocialSignupError(Exception):
+    """Raised when social signup cannot continue before persistence."""
+
+    def __init__(self, kind: SocialSignupErrorKind):
+        super().__init__(kind.value)
+        self.kind = kind
+
+
+@dataclass(frozen=True)
+class SocialSignupIdentity:
+    provider_key: str
+    uid: str
+    username: str
+    name: str
+    email: str
+    avatar_url: str | None
+    extra_data: Mapping[str, object]
+    link_name: str | None = None
+    link_value: str | None = None
+
+
+@dataclass(frozen=True)
+class SocialSignupResult:
+    user: User
+    is_first_login: bool
+
+
+class SocialSignupProviderAdapter(Protocol):
+    provider_key: ClassVar[str]
+
+    @staticmethod
+    def authenticate(code: str) -> oauth.State:
+        ...
+
+    @staticmethod
+    def map_identity(user_data: Mapping[str, object]) -> SocialSignupIdentity:
+        ...
+
+
+class GitHubSocialSignupAdapter:
+    provider_key = 'github'
+
+    @staticmethod
+    def authenticate(code: str) -> oauth.State:
+        return oauth.auth_github(code)
+
+    @staticmethod
+    def map_identity(user_data: Mapping[str, object]) -> SocialSignupIdentity:
+        username = cast(str, user_data.get('login'))
+        return SocialSignupIdentity(
+            provider_key=GitHubSocialSignupAdapter.provider_key,
+            uid=cast(str, user_data.get('node_id')),
+            username=username,
+            name=cast(str, user_data.get('name')),
+            email='',
+            avatar_url=cast(str | None, user_data.get('avatar_url')),
+            extra_data=user_data,
+            link_name='github',
+            link_value=f'https://github.com/{username}',
+        )
+
+
+class GoogleSocialSignupAdapter:
+    provider_key = 'google'
+
+    @staticmethod
+    def authenticate(code: str) -> oauth.State:
+        return oauth.auth_google(code)
+
+    @staticmethod
+    def map_identity(user_data: Mapping[str, object]) -> SocialSignupIdentity:
+        email = cast(str, user_data.get('email'))
+        return SocialSignupIdentity(
+            provider_key=GoogleSocialSignupAdapter.provider_key,
+            uid=cast(str, user_data.get('id')),
+            username=email.split('@')[0],
+            name=cast(str, user_data.get('name')),
+            email=email,
+            avatar_url=cast(str | None, user_data.get('picture')),
+            extra_data=user_data,
+        )
+
+
+class SocialSignupService:
+    """Authenticate a provider identity and persist a social account atomically."""
+
+    ADAPTERS: ClassVar[dict[str, type[SocialSignupProviderAdapter]]] = {
+        GitHubSocialSignupAdapter.provider_key: GitHubSocialSignupAdapter,
+        GoogleSocialSignupAdapter.provider_key: GoogleSocialSignupAdapter,
+    }
+
+    @classmethod
+    def sign_up(cls, provider_key: str, code: str | None) -> SocialSignupResult:
+        if InitialSetupService.should_prompt_for_initial_setup():
+            raise SocialSignupError(SocialSignupErrorKind.INITIAL_SETUP_REQUIRED)
+
+        adapter = cls.ADAPTERS.get(provider_key)
+        if adapter is None or provider_key not in SocialAuthProviderService.supported_keys():
+            raise SocialSignupError(SocialSignupErrorKind.UNSUPPORTED_PROVIDER)
+
+        if not SocialAuthProviderService.is_enabled(provider_key):
+            raise SocialSignupError(SocialSignupErrorKind.PROVIDER_DISABLED)
+
+        if not code:
+            raise SocialSignupError(SocialSignupErrorKind.MISSING_CODE)
+
+        state = adapter.authenticate(code)
+        if not state.success:
+            raise SocialSignupError(SocialSignupErrorKind.EXTERNAL_AUTH_FAILED)
+
+        identity = adapter.map_identity(cast(Mapping[str, object], state.user))
+        provider = cast(
+            SocialAuthProvider,
+            SocialAuthProviderService.get_provider(provider_key),
+        )
+        social_auth = SocialAuth.objects.filter(
+            provider=provider,
+            uid=identity.uid,
+        ).select_related('user').first()
+        if social_auth:
+            return SocialSignupResult(
+                user=social_auth.user,
+                is_first_login=False,
+            )
+
+        user = cls._create_social_user(provider, identity)
+        return SocialSignupResult(user=user, is_first_login=True)
+
+    @staticmethod
+    @transaction.atomic
+    def _create_social_user(
+        provider: SocialAuthProvider,
+        identity: SocialSignupIdentity,
+    ) -> User:
+        user, _profile, _config = AuthService.create_user(
+            username=identity.username,
+            name=identity.name,
+            email=identity.email,
+            avatar_url=identity.avatar_url,
+        )
+        SocialAuth.objects.create(
+            user=user,
+            provider=provider,
+            uid=identity.uid,
+            extra_data=json.dumps(identity.extra_data, ensure_ascii=False),
+        )
+
+        if identity.link_name and identity.link_value:
+            UserLinkMeta.objects.create(
+                user=user,
+                name=identity.link_name,
+                value=identity.link_value,
+            )
+
+        return user

--- a/backend/src/board/tests/api/test_auth.py
+++ b/backend/src/board/tests/api/test_auth.py
@@ -3,10 +3,20 @@ import json
 from unittest.mock import patch, MagicMock
 from datetime import timedelta
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.utils import timezone
 
-from board.models import User, UsernameChangeLog, Profile, Config, SocialAuth, SocialAuthProvider, LoginSetting
+from board.models import (
+    Config,
+    LoginSetting,
+    Profile,
+    SocialAuth,
+    SocialAuthProvider,
+    TwoFactorAuth,
+    User,
+    UserLinkMeta,
+    UsernameChangeLog,
+)
 from board.services.hcaptcha_service import HCaptchaService
 from modules import oauth
 
@@ -237,27 +247,97 @@ class AuthTestCase(TestCase):
 
         self.assertEqual(response.status_code, 200)
         content = json.loads(response.content)
-        self.assertEqual(content['status'], 'ERROR')
-        self.assertEqual(content['errorCode'], 'error:RJ')
+        self.assertEqual(content, {
+            'status': 'ERROR',
+            'errorCode': 'error:RJ',
+            'errorMessage': '소셜 로그인이 설정되지 않았습니다.',
+        })
+
+    def test_social_signup_keeps_missing_code_and_unsupported_provider_as_404(self):
+        """지원하지 않는 provider와 code 누락은 기존처럼 404다."""
+        missing_code_response = self.client.post('/v1/sign/github')
+        unsupported_response = self.client.post('/v1/sign/facebook', {
+            'code': 'SECRET_TOKEN_VALUE',
+        })
+
+        self.assertEqual(missing_code_response.status_code, 404)
+        self.assertEqual(unsupported_response.status_code, 404)
+
+    @patch('modules.oauth.auth_github', return_value=oauth.State(success=False, user={}))
+    def test_social_signup_keeps_external_auth_failure_response(self, mock_service):
+        """외부 인증 실패의 상태·오류 코드·빈 메시지를 보존한다."""
+        response = self.client.post('/v1/sign/github', {
+            'code': 'INVALID_TOKEN_VALUE',
+        })
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.content), {
+            'status': 'ERROR',
+            'errorCode': 'error:RJ',
+            'errorMessage': '',
+        })
+        mock_service.assert_called_once_with('INVALID_TOKEN_VALUE')
+
+    @patch('modules.oauth.requests.post')
+    def test_social_signup_rejects_enabled_but_unconfigured_provider(self, mock_post):
+        """enabled 상태여도 credential이 없으면 기존 OAuth 실패 응답을 반환한다."""
+        SocialAuthProvider.objects.filter(key='google').update(
+            client_id='',
+            client_secret='',
+        )
+
+        response = self.client.post('/v1/sign/google', {
+            'code': 'SECRET_TOKEN_VALUE',
+        })
+
+        self.assertEqual(json.loads(response.content), {
+            'status': 'ERROR',
+            'errorCode': 'error:RJ',
+            'errorMessage': '',
+        })
+        mock_post.assert_not_called()
 
     @patch('modules.oauth.auth_github', return_value=oauth.State(success=True, user={
         'node_id': 'SECRET_TOKEN_VALUE',
         'login': 'test3',
         'name': 'Test User 3',
+        'avatar_url': 'https://avatars.example.com/test3',
     }))
     def test_create_account_from_github(self, mock_servuce):
         """GitHub OAuth로 계정 생성 테스트"""
-        response = self.client.post('/v1/sign/github', {
-            'code': 'SECRET_TOKEN_VALUE',
-        })
+        with patch(
+            'board.services.auth_service.download_image',
+            return_value=None,
+        ) as mock_download_image:
+            response = self.client.post('/v1/sign/github', {
+                'code': 'SECRET_TOKEN_VALUE',
+            })
         self.assertEqual(response.status_code, 200)
         content = json.loads(response.content)
         self.assertEqual(content['status'], 'DONE')
         self.assertEqual(content['body']['username'], 'test3')
         self.assertEqual(content['body']['isFirstLogin'], True)
         user = User.objects.get(username='test3')
+        self.assertEqual(user.first_name, 'Test User 3')
+        self.assertEqual(user.email, '')
         self.assertEqual(user.last_name, '')
-        self.assertTrue(SocialAuth.objects.filter(user=user, provider__key='github', uid='SECRET_TOKEN_VALUE').exists())
+        social_auth = SocialAuth.objects.get(
+            user=user,
+            provider__key='github',
+            uid='SECRET_TOKEN_VALUE',
+        )
+        self.assertEqual(json.loads(social_auth.extra_data), {
+            'node_id': 'SECRET_TOKEN_VALUE',
+            'login': 'test3',
+            'name': 'Test User 3',
+            'avatar_url': 'https://avatars.example.com/test3',
+        })
+        link = UserLinkMeta.objects.get(user=user, name='github')
+        self.assertEqual(link.value, 'https://github.com/test3')
+        mock_download_image.assert_called_once_with(
+            'https://avatars.example.com/test3',
+            stream=True,
+        )
 
         self.client.logout()
 
@@ -274,20 +354,42 @@ class AuthTestCase(TestCase):
         'id': 'SECRET_TOKEN_VALUE',
         'email': 'test3@google.com',
         'name': 'Test User 3',
+        'picture': 'https://images.example.com/test3',
     }))
     def test_create_account_from_google(self, mock_servuce):
         """Google OAuth로 계정 생성 테스트"""
-        response = self.client.post('/v1/sign/google', {
-            'code': 'SECRET_TOKEN_VALUE',
-        })
+        with patch(
+            'board.services.auth_service.download_image',
+            return_value=None,
+        ) as mock_download_image:
+            response = self.client.post('/v1/sign/google', {
+                'code': 'SECRET_TOKEN_VALUE',
+            })
         self.assertEqual(response.status_code, 200)
         content = json.loads(response.content)
         self.assertEqual(content['status'], 'DONE')
         self.assertEqual(content['body']['username'], 'test3')
         self.assertEqual(content['body']['isFirstLogin'], True)
         user = User.objects.get(username='test3')
+        self.assertEqual(user.first_name, 'Test User 3')
+        self.assertEqual(user.email, 'test3@google.com')
         self.assertEqual(user.last_name, '')
-        self.assertTrue(SocialAuth.objects.filter(user=user, provider__key='google', uid='SECRET_TOKEN_VALUE').exists())
+        social_auth = SocialAuth.objects.get(
+            user=user,
+            provider__key='google',
+            uid='SECRET_TOKEN_VALUE',
+        )
+        self.assertEqual(json.loads(social_auth.extra_data), {
+            'id': 'SECRET_TOKEN_VALUE',
+            'email': 'test3@google.com',
+            'name': 'Test User 3',
+            'picture': 'https://images.example.com/test3',
+        })
+        self.assertFalse(UserLinkMeta.objects.filter(user=user).exists())
+        mock_download_image.assert_called_once_with(
+            'https://images.example.com/test3',
+            stream=True,
+        )
 
         self.client.logout()
 
@@ -299,6 +401,87 @@ class AuthTestCase(TestCase):
         self.assertEqual(content['status'], 'DONE')
         self.assertEqual(content['body']['username'], 'test3')
         self.assertEqual(content['body']['isFirstLogin'], False)
+
+    @patch('modules.oauth.auth_github', return_value=oauth.State(success=True, user={
+        'node_id': 'EXISTING_2FA_UID',
+        'login': 'ignored-provider-name',
+        'name': 'Ignored Provider Name',
+    }))
+    def test_existing_social_account_keeps_oauth_2fa_login_response(self, mock_service):
+        """기존 소셜 계정은 신규 생성 없이 기존 OAuth 2FA 응답을 유지한다."""
+        user = User.objects.create_user(username='oauth2fa', email='oauth2fa@test.com')
+        Profile.objects.create(user=user)
+        Config.objects.create(user=user)
+        SocialAuth.objects.create(
+            user=user,
+            provider=SocialAuthProvider.objects.get(key='github'),
+            uid='EXISTING_2FA_UID',
+            extra_data='{}',
+        )
+        TwoFactorAuth.objects.create(
+            user=user,
+            recovery_key='recovery-key',
+            totp_secret='JBSWY3DPEHPK3PXP',
+        )
+
+        response = self.client.post('/v1/sign/github', {
+            'code': 'EXISTING_TOKEN_VALUE',
+        })
+
+        self.assertEqual(json.loads(response.content), {
+            'status': 'DONE',
+            'body': {
+                'username': 'oauth2fa',
+                'security': True,
+                'isOauth': True,
+            },
+        })
+        self.assertNotIn('_auth_user_id', self.client.session)
+        self.assertEqual(User.objects.filter(username='oauth2fa').count(), 1)
+        mock_service.assert_called_once_with('EXISTING_TOKEN_VALUE')
+
+    @override_settings(DEBUG_PROPAGATE_EXCEPTIONS=True)
+    @patch(
+        'board.services.social_signup_service.SocialAuth.objects.create',
+        side_effect=RuntimeError('social auth persistence failed'),
+    )
+    @patch('modules.oauth.auth_google', return_value=oauth.State(success=True, user={
+        'id': 'ROLLBACK_GOOGLE_UID',
+        'email': 'rollback-google@example.com',
+        'name': 'Rollback Google',
+    }))
+    def test_social_auth_failure_rolls_back_new_google_user(self, mock_oauth, mock_create):
+        """SocialAuth 저장 실패 시 User·Profile·Config가 모두 롤백된다."""
+        with self.assertRaisesMessage(RuntimeError, 'social auth persistence failed'):
+            self.client.post('/v1/sign/google', {
+                'code': 'ROLLBACK_TOKEN_VALUE',
+            })
+
+        self.assertFalse(User.objects.filter(username='rollback-google').exists())
+        self.assertFalse(SocialAuth.objects.filter(uid='ROLLBACK_GOOGLE_UID').exists())
+        self.assertFalse(Profile.objects.filter(user__username='rollback-google').exists())
+        self.assertFalse(Config.objects.filter(user__username='rollback-google').exists())
+
+    @override_settings(DEBUG_PROPAGATE_EXCEPTIONS=True)
+    @patch(
+        'board.services.social_signup_service.UserLinkMeta.objects.create',
+        side_effect=RuntimeError('github link persistence failed'),
+    )
+    @patch('modules.oauth.auth_github', return_value=oauth.State(success=True, user={
+        'node_id': 'ROLLBACK_GITHUB_UID',
+        'login': 'rollbackgithub',
+        'name': 'Rollback GitHub',
+    }))
+    def test_github_link_failure_rolls_back_user_and_social_auth(self, mock_oauth, mock_create):
+        """GitHub link 저장 실패도 전체 신규 가입 transaction을 롤백한다."""
+        with self.assertRaisesMessage(RuntimeError, 'github link persistence failed'):
+            self.client.post('/v1/sign/github', {
+                'code': 'ROLLBACK_TOKEN_VALUE',
+            })
+
+        self.assertFalse(User.objects.filter(username='rollbackgithub').exists())
+        self.assertFalse(SocialAuth.objects.filter(uid='ROLLBACK_GITHUB_UID').exists())
+        self.assertFalse(UserLinkMeta.objects.filter(value='https://github.com/rollbackgithub').exists())
 
     def test_change_username(self):
         """유저네임 변경 테스트"""

--- a/backend/src/board/tests/test_backend_compatibility_contract.py
+++ b/backend/src/board/tests/test_backend_compatibility_contract.py
@@ -11,6 +11,7 @@ import board.models as board_models
 from board import urls as board_urls
 from board.models import Config, Post, PostConfig, PostContent, PostLikes, Profile, User
 from board.modules.response import ErrorCode, StatusDone, StatusError
+from board.services.auth_service import AuthService
 from board.services.post_service import PostService
 from board.views.api import v1 as api_v1
 
@@ -501,6 +502,27 @@ class PythonImportCompatibilityContractTests(SimpleTestCase):
         ))
         self.assertIs(response_parameters[2].kind, inspect.Parameter.KEYWORD_ONLY)
         self.assertIs(response_parameters[2].default, False)
+
+    def test_auth_service_create_user_signature_is_stable(self):
+        parameters = tuple(inspect.signature(AuthService.create_user).parameters.values())
+        actual = tuple(
+            (
+                parameter.name,
+                REQUIRED if parameter.default is inspect.Parameter.empty else parameter.default,
+            )
+            for parameter in parameters
+        )
+        self.assertEqual(actual, (
+            ('username', REQUIRED),
+            ('name', REQUIRED),
+            ('email', REQUIRED),
+            ('password', None),
+            ('avatar_url', None),
+        ))
+        self.assertTrue(all(
+            parameter.kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+            for parameter in parameters
+        ))
 
     def test_post_service_facade_parameter_names_order_and_defaults_are_stable(self):
         for method_name, expected_parameters in EXPECTED_POST_SERVICE_SIGNATURES.items():

--- a/backend/src/board/views/api/v1/auth.py
+++ b/backend/src/board/views/api/v1/auth.py
@@ -1,7 +1,6 @@
 import datetime
 import traceback
 import io
-import json
 import pyotp
 import qrcode
 import base64
@@ -15,7 +14,7 @@ from django.utils import timezone
 
 from board.models import (
     TwoFactorAuth, Config, Profile, Post,
-    SocialAuth, UserLinkMeta, UsernameChangeLog, TelegramSync)
+    UsernameChangeLog, TelegramSync)
 from board.modules.notify import create_notify
 from board.modules.response import StatusDone, StatusError, ErrorCode
 from board.services.auth_login_service import AuthLoginService
@@ -25,8 +24,12 @@ from board.services.auth_service import AuthService, OAuthService, AuthValidatio
 from board.services.initial_setup_service import InitialSetupService
 from board.services.api_request_body_service import ApiRequestBodyService
 from board.services.hcaptcha_service import HCaptchaService
-from modules import oauth
 from board.services.social_auth_provider_service import SocialAuthProviderService
+from board.services.social_signup_service import (
+    SocialSignupError,
+    SocialSignupErrorKind,
+    SocialSignupService,
+)
 from modules.challenge import auth_hcaptcha
 from modules.sub_task import SubTaskProcessor
 from modules.telegram import TelegramBot
@@ -159,86 +162,33 @@ def sign(request):
 
 def sign_social(request, social):
     if request.method == 'POST':
-        if InitialSetupService.should_prompt_for_initial_setup():
+        try:
+            result = SocialSignupService.sign_up(
+                provider_key=social,
+                code=request.POST.get('code'),
+            )
+        except SocialSignupError as error:
+            if error.kind == SocialSignupErrorKind.INITIAL_SETUP_REQUIRED:
+                return StatusError(
+                    ErrorCode.REJECT,
+                    '첫 관리자 계정을 먼저 만들어주세요.'
+                )
+            if error.kind in {
+                SocialSignupErrorKind.UNSUPPORTED_PROVIDER,
+                SocialSignupErrorKind.MISSING_CODE,
+            }:
+                raise Http404
+            if error.kind == SocialSignupErrorKind.PROVIDER_DISABLED:
+                return StatusError(ErrorCode.REJECT, '소셜 로그인이 설정되지 않았습니다.')
             return StatusError(
                 ErrorCode.REJECT,
-                '첫 관리자 계정을 먼저 만들어주세요.'
             )
 
-        if social not in SocialAuthProviderService.supported_keys():
-            raise Http404
+        if not result.is_first_login:
+            return AuthLoginService.common_auth(request, result.user, is_oauth=True)
 
-        if not SocialAuthProviderService.is_enabled(social):
-            return StatusError(ErrorCode.REJECT, '소셜 로그인이 설정되지 않았습니다.')
-
-        if social == 'github':
-            if request.POST.get('code'):
-                state = oauth.auth_github(request.POST.get('code'))
-                if not state.success:
-                    return StatusError(ErrorCode.REJECT)
-
-                avatar_url = state.user.get('avatar_url')
-                node_id = state.user.get('node_id')
-                user_id = state.user.get('login')
-                name = state.user.get('name')
-                provider = SocialAuthProviderService.get_provider(social)
-                social_auth = SocialAuth.objects.filter(provider=provider, uid=node_id).select_related('user').first()
-                if social_auth:
-                    return AuthLoginService.common_auth(request, social_auth.user, is_oauth=True)
-
-                user, profile, config = AuthService.create_user(
-                    username=user_id,
-                    name=name,
-                    email='',
-                    avatar_url=avatar_url,
-                )
-                SocialAuth.objects.create(
-                    user=user,
-                    provider=provider,
-                    uid=node_id,
-                    extra_data=json.dumps(state.user, ensure_ascii=False),
-                )
-
-                UserLinkMeta.objects.create(
-                    user=user,
-                    name='github',
-                    value=f'https://github.com/{user_id}'
-                )
-
-                auth.login(request, user)
-                return AuthLoginService.login_response(request.user, is_first_login=True)
-
-        if social == 'google':
-            if request.POST.get('code'):
-                state = oauth.auth_google(request.POST.get('code'))
-                if not state.success:
-                    return StatusError(ErrorCode.REJECT)
-
-                avatar_url = state.user.get('picture')
-                node_id = state.user.get('id')
-                user_id = state.user.get('email').split('@')[0]
-                email = state.user.get('email')
-                name = state.user.get('name')
-                provider = SocialAuthProviderService.get_provider(social)
-                social_auth = SocialAuth.objects.filter(provider=provider, uid=node_id).select_related('user').first()
-                if social_auth:
-                    return AuthLoginService.common_auth(request, social_auth.user, is_oauth=True)
-
-                user, profile, config = AuthService.create_user(
-                    username=user_id,
-                    name=name,
-                    email=email,
-                    avatar_url=avatar_url,
-                )
-                SocialAuth.objects.create(
-                    user=user,
-                    provider=provider,
-                    uid=node_id,
-                    extra_data=json.dumps(state.user, ensure_ascii=False),
-                )
-
-                auth.login(request, user)
-                return AuthLoginService.login_response(request.user, is_first_login=True)
+        auth.login(request, result.user)
+        return AuthLoginService.login_response(request.user, is_first_login=True)
 
     raise Http404
 


### PR DESCRIPTION
## Goal

- Move the repeated GitHub and Google social-signup flow into typed orchestration without changing API behavior.
- Make new-account persistence atomic while preserving existing-account OAuth and 2FA login responses.

## Core Changes

- Add typed social-signup identities, results, failures, and provider adapters.
- Keep provider policy and external OAuth calls outside the persistence transaction.
- Persist User, Profile, Config, SocialAuth, and the GitHub link in one transaction.
- Reduce the API view to input forwarding, legacy response conversion, and session/login handling.
- Add regression coverage for mapping, provider policy, exact failures, existing 2FA accounts, and rollback paths.

## Key Decisions

- Preserve the order of initial-setup, provider support/enabled, missing-code, and external-auth checks.
- Preserve GitHub link creation and keep Google without a default link.
- Preserve AuthService.create_user parameter names, order, defaults, and return contract.
- Leave the separate browser OAuth callback implementation untouched and verify its existing suite.

## Verification Guide

- Related auth, callback, setup, and compatibility suites: 56 tests passed.
- Full backend suite: 1,075 tests passed in 137.846s.
- Migration drift check: no changes detected.
- git diff --check: passed.

## Checklist

- [x] Backward-compatible URL, payload, error, login, and mapping behavior is covered.
- [x] New-account intermediate persistence failures roll back all database rows.
- [x] No schema or migration changes.
- [x] Full backend test suite passes locally.
- [x] Migration drift check passes locally.