### PR TITLE
♻️ Extract two-factor setup service

### DIFF
--- a/backend/src/board/services/auth_service.py
+++ b/backend/src/board/services/auth_service.py
@@ -6,11 +6,6 @@ Extracted from views to improve testability and reusability.
 """
 
 import re
-import io
-import secrets
-import pyotp
-import qrcode
-import base64
 from typing import Optional, Tuple, Dict, Any
 
 from django.conf import settings
@@ -292,13 +287,14 @@ class AuthService:
         Returns:
             Base32 encoded secret string
         """
-        return pyotp.random_base32()
+        from board.services.two_factor_setup_service import TwoFactorSetupService
+        return TwoFactorSetupService.create_totp_secret()
 
     @staticmethod
     def create_recovery_key() -> str:
-        return ''.join(
-            secrets.choice(AuthService.RECOVERY_KEY_ALPHABET)
-            for _ in range(45)
+        from board.services.two_factor_setup_service import TwoFactorSetupService
+        return TwoFactorSetupService.create_recovery_key(
+            AuthService.RECOVERY_KEY_ALPHABET,
         )
 
     @staticmethod
@@ -336,28 +332,8 @@ class AuthService:
         Returns:
             Base64 encoded QR code image data URL, or None if 2FA not set up
         """
-        try:
-            two_factor_auth = TwoFactorAuth.objects.get(user=user)
-            provisioning_uri = two_factor_auth.get_provisioning_uri()
-
-            if not provisioning_uri:
-                return None
-
-            # Generate QR code
-            qr = qrcode.QRCode(version=1, box_size=10, border=5)
-            qr.add_data(provisioning_uri)
-            qr.make(fit=True)
-
-            img = qr.make_image(fill_color="black", back_color="white")
-
-            # Convert to base64
-            buffer = io.BytesIO()
-            img.save(buffer, format='PNG')
-            img_str = base64.b64encode(buffer.getvalue()).decode()
-
-            return f"data:image/png;base64,{img_str}"
-        except TwoFactorAuth.DoesNotExist:
-            return None
+        from board.services.two_factor_setup_service import TwoFactorSetupService
+        return TwoFactorSetupService.get_totp_qr_code(user)
 
     @staticmethod
     def validate_username_change_restriction(user: User) -> None:

--- a/backend/src/board/services/two_factor_setup_service.py
+++ b/backend/src/board/services/two_factor_setup_service.py
@@ -1,0 +1,210 @@
+"""Typed 2FA setup, activation, inspection, and disable use cases."""
+
+from __future__ import annotations
+
+import base64
+import io
+import secrets
+
+from dataclasses import dataclass
+from typing import ClassVar, Mapping, MutableMapping, TypedDict, cast
+
+import pyotp
+import qrcode
+
+from django.contrib.auth.models import User
+from django.db import transaction
+
+from board.models import TwoFactorAuth
+from board.modules.response import ErrorCode
+
+
+class TwoFactorSetupSession(TypedDict):
+    secret: str
+    recovery_key: str
+    user_id: int
+
+
+class TwoFactorSetupError(Exception):
+    """A typed failure that the API view converts to its legacy envelope."""
+
+    def __init__(self, code: ErrorCode, message: str = ''):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+@dataclass(frozen=True)
+class TwoFactorSetupResult:
+    qr_code: str
+    recovery_key: str
+
+
+@dataclass(frozen=True)
+class TwoFactorSecurityResult:
+    qr_code: str
+    has_recovery_key: bool
+
+
+class TwoFactorSetupService:
+    """Coordinate 2FA setup state without depending on HTTP request objects."""
+
+    SESSION_KEY: ClassVar[str] = 'totp_setup'
+    RECOVERY_KEY_ALPHABET: ClassVar[str] = (
+        '0123456789abcdefghijklnmopqrstuvwxyzABCDEFGHIJKLNMOPQRSTUVWXYZ'
+    )
+
+    @staticmethod
+    def create_totp_secret() -> str:
+        return pyotp.random_base32()
+
+    @classmethod
+    def create_recovery_key(cls, alphabet: str | None = None) -> str:
+        selected_alphabet = alphabet if alphabet is not None else cls.RECOVERY_KEY_ALPHABET
+        return ''.join(
+            secrets.choice(selected_alphabet)
+            for _ in range(45)
+        )
+
+    @staticmethod
+    def generate_qr_code(provisioning_uri: str) -> str:
+        qr = qrcode.QRCode(version=1, box_size=10, border=5)
+        qr.add_data(provisioning_uri)
+        qr.make(fit=True)
+
+        image = qr.make_image(fill_color='black', back_color='white')
+        buffer = io.BytesIO()
+        image.save(buffer, format='PNG')
+        encoded_image = base64.b64encode(buffer.getvalue()).decode()
+        return f'data:image/png;base64,{encoded_image}'
+
+    @classmethod
+    def get_totp_qr_code(cls, user: User) -> str | None:
+        try:
+            two_factor_auth = TwoFactorAuth.objects.get(user=user)
+        except TwoFactorAuth.DoesNotExist:
+            return None
+
+        provisioning_uri = two_factor_auth.get_provisioning_uri()
+        if not provisioning_uri:
+            return None
+        return cls.generate_qr_code(provisioning_uri)
+
+    @classmethod
+    def get_security(cls, user: User) -> TwoFactorSecurityResult:
+        if not hasattr(user, 'twofactorauth'):
+            raise TwoFactorSetupError(ErrorCode.NOT_FOUND)
+
+        two_factor_auth = user.twofactorauth
+        qr_code = cls.get_totp_qr_code(user)
+        if not qr_code:
+            raise TwoFactorSetupError(ErrorCode.NOT_FOUND)
+
+        return TwoFactorSecurityResult(
+            qr_code=qr_code,
+            has_recovery_key=bool(two_factor_auth.recovery_key),
+        )
+
+    @classmethod
+    def initialize(
+        cls,
+        user: User,
+        session: MutableMapping[str, object],
+    ) -> TwoFactorSetupResult:
+        try:
+            if hasattr(user, 'twofactorauth'):
+                raise TwoFactorSetupError(ErrorCode.ALREADY_CONNECTED)
+
+            secret = cls.create_totp_secret()
+            recovery_key = cls.create_recovery_key()
+            setup_session = TwoFactorSetupSession(
+                secret=secret,
+                recovery_key=recovery_key,
+                user_id=user.id,
+            )
+            session[cls.SESSION_KEY] = setup_session
+
+            provisioning_uri = pyotp.TOTP(secret).provisioning_uri(
+                name=user.email,
+                issuer_name='BLEX',
+            )
+            return TwoFactorSetupResult(
+                qr_code=cls.generate_qr_code(provisioning_uri),
+                recovery_key=recovery_key,
+            )
+        except TwoFactorSetupError:
+            raise
+        except Exception as error:
+            raise TwoFactorSetupError(
+                ErrorCode.REJECT,
+                f'2FA 설정 초기화에 실패했습니다: {str(error)}',
+            ) from error
+
+    @staticmethod
+    def disable(user: User) -> None:
+        if not hasattr(user, 'twofactorauth'):
+            raise TwoFactorSetupError(ErrorCode.ALREADY_DISCONNECTED)
+
+        if not user.twofactorauth.has_been_a_day():
+            raise TwoFactorSetupError(
+                ErrorCode.REJECT,
+                '24시간 동안 해제할 수 없습니다.',
+            )
+
+        user.twofactorauth.delete()
+
+    @classmethod
+    @transaction.atomic
+    def activate(
+        cls,
+        user: User,
+        session: MutableMapping[str, object],
+        code: object,
+    ) -> None:
+        try:
+            raw_setup_data = session.get(cls.SESSION_KEY)
+            if not raw_setup_data:
+                raise TwoFactorSetupError(
+                    ErrorCode.EXPIRED,
+                    '2FA 설정 세션이 만료되었습니다. 다시 시도해주세요.',
+                )
+
+            setup_data = cast(Mapping[str, object], raw_setup_data)
+            if setup_data['user_id'] != user.id:
+                raise TwoFactorSetupError(
+                    ErrorCode.AUTHENTICATION,
+                    '잘못된 세션입니다.',
+                )
+
+            if hasattr(user, 'twofactorauth'):
+                del session[cls.SESSION_KEY]
+                raise TwoFactorSetupError(ErrorCode.ALREADY_CONNECTED)
+
+            normalized_code = cast(str, code).strip()
+            if not normalized_code:
+                raise TwoFactorSetupError(
+                    ErrorCode.INVALID_PARAMETER,
+                    '인증 코드를 입력해주세요.',
+                )
+
+            secret = cast(str, setup_data['secret'])
+            if not pyotp.TOTP(secret).verify(normalized_code, valid_window=1):
+                raise TwoFactorSetupError(
+                    ErrorCode.REJECT,
+                    '잘못된 인증 코드입니다.',
+                )
+
+            two_factor_auth = TwoFactorAuth(
+                user=user,
+                totp_secret=secret,
+                recovery_key=cast(str, setup_data['recovery_key']),
+            )
+            two_factor_auth.save()
+            del session[cls.SESSION_KEY]
+        except TwoFactorSetupError:
+            raise
+        except Exception as error:
+            raise TwoFactorSetupError(
+                ErrorCode.REJECT,
+                f'2FA 활성화에 실패했습니다: {str(error)}',
+            ) from error

--- a/backend/src/board/tests/api/test_two_factor_auth.py
+++ b/backend/src/board/tests/api/test_two_factor_auth.py
@@ -1,5 +1,7 @@
+import base64
 import json
 import pyotp
+import time
 
 from unittest.mock import patch
 from datetime import timedelta
@@ -9,6 +11,7 @@ from django.test import TestCase, override_settings
 from django.utils import timezone
 
 from board.models import User, Profile, Config, TwoFactorAuth
+from board.services.auth_service import AuthService
 from board.services.two_factor_auth_secret_service import TwoFactorAuthSecretService
 
 
@@ -32,6 +35,11 @@ class TwoFactorAuthTestCase(TestCase):
         cache.clear()
         super().tearDown()
 
+    @patch.object(AuthService, 'RECOVERY_KEY_ALPHABET', 'x')
+    def test_auth_service_recovery_key_facade_keeps_configurable_alphabet(self):
+        """기존 AuthService 상수를 바꾸는 호출자도 같은 결과를 얻는다."""
+        self.assertEqual(AuthService.create_recovery_key(), 'x' * 45)
+
     def test_enable_2fa_success(self):
         """2FA 활성화 성공 테스트"""
         self.client.login(username='test2fa', password='test2fa')
@@ -46,6 +54,8 @@ class TwoFactorAuthTestCase(TestCase):
         self.assertIn('qrCode', content['body'])
         self.assertIn('recoveryKey', content['body'])
         self.assertTrue(content['body']['qrCode'].startswith('data:image/png;base64,'))
+        qr_png = base64.b64decode(content['body']['qrCode'].split(',', 1)[1])
+        self.assertTrue(qr_png.startswith(b'\x89PNG\r\n\x1a\n'))
         self.assertEqual(len(content['body']['recoveryKey']), 45)
         recovery_key = content['body']['recoveryKey']
 
@@ -56,7 +66,11 @@ class TwoFactorAuthTestCase(TestCase):
         # Step 2: Verify with TOTP code
         # Get the secret from session and generate valid code
         session = self.client.session
-        totp_secret = session['totp_setup']['secret']
+        setup_session = session['totp_setup']
+        self.assertEqual(set(setup_session), {'secret', 'recovery_key', 'user_id'})
+        self.assertEqual(setup_session['user_id'], user.id)
+        self.assertEqual(setup_session['recovery_key'], recovery_key)
+        totp_secret = setup_session['secret']
         totp = pyotp.TOTP(totp_secret)
         valid_code = totp.now()
 
@@ -67,7 +81,11 @@ class TwoFactorAuthTestCase(TestCase):
         )
         self.assertEqual(response.status_code, 200)
         content = json.loads(response.content)
-        self.assertEqual(content['status'], 'DONE')
+        self.assertEqual(content, {
+            'status': 'DONE',
+            'body': {'message': '2차 인증이 활성화되었습니다.'},
+        })
+        self.assertNotIn('totp_setup', self.client.session)
 
         # NOW the TwoFactorAuth record should be created
         user = User.objects.get(username='test2fa')
@@ -80,6 +98,133 @@ class TwoFactorAuthTestCase(TestCase):
             TwoFactorAuthSecretService.decrypt_totp_secret(user.twofactorauth.totp_secret),
             totp_secret,
         )
+
+    def test_enable_2fa_accepts_previous_totp_window(self):
+        """setup 검증은 기존처럼 앞선 한 TOTP window를 허용한다."""
+        self.client.login(username='test2fa', password='test2fa')
+        self.client.post('/v1/auth/security')
+        secret = self.client.session['totp_setup']['secret']
+        previous_window_code = pyotp.TOTP(secret).at(time.time() - 30)
+
+        response = self.client.post(
+            '/v1/auth/security/verify',
+            data=json.dumps({'code': previous_window_code}),
+            content_type='application/json',
+        )
+
+        self.assertEqual(json.loads(response.content)['status'], 'DONE')
+        self.assertTrue(TwoFactorAuth.objects.filter(user__username='test2fa').exists())
+
+    def test_enable_2fa_expired_setup_session_keeps_error_contract(self):
+        """setup session이 없으면 기존 만료 코드와 메시지를 반환한다."""
+        self.client.login(username='test2fa', password='test2fa')
+
+        response = self.client.post(
+            '/v1/auth/security/verify',
+            data=json.dumps({'code': '123456'}),
+            content_type='application/json',
+        )
+
+        self.assertEqual(json.loads(response.content), {
+            'status': 'ERROR',
+            'errorCode': 'error:EP',
+            'errorMessage': '2FA 설정 세션이 만료되었습니다. 다시 시도해주세요.',
+        })
+
+    def test_enable_2fa_rejects_setup_session_owned_by_another_user(self):
+        """다른 user_id의 setup session은 기존 인증 오류로 거부한다."""
+        self.client.login(username='test2fa', password='test2fa')
+        session = self.client.session
+        session['totp_setup'] = {
+            'secret': pyotp.random_base32(),
+            'recovery_key': 'r' * 45,
+            'user_id': User.objects.get(username='test2fa').id + 1,
+        }
+        session.save()
+
+        response = self.client.post(
+            '/v1/auth/security/verify',
+            data=json.dumps({'code': '123456'}),
+            content_type='application/json',
+        )
+
+        self.assertEqual(json.loads(response.content), {
+            'status': 'ERROR',
+            'errorCode': 'error:AT',
+            'errorMessage': '잘못된 세션입니다.',
+        })
+        self.assertIn('totp_setup', self.client.session)
+
+    def test_enable_2fa_already_connected_verify_clears_setup_session(self):
+        """verify 전에 이미 활성화됐다면 setup session을 지우고 기존 오류를 반환한다."""
+        self.client.login(username='test2fa', password='test2fa')
+        self.client.post('/v1/auth/security')
+        user = User.objects.get(username='test2fa')
+        TwoFactorAuth.objects.create(
+            user=user,
+            recovery_key='x' * 45,
+            totp_secret=pyotp.random_base32(),
+        )
+
+        response = self.client.post(
+            '/v1/auth/security/verify',
+            data=json.dumps({'code': '123456'}),
+            content_type='application/json',
+        )
+
+        self.assertEqual(json.loads(response.content), {
+            'status': 'ERROR',
+            'errorCode': 'error:AC',
+            'errorMessage': '',
+        })
+        self.assertNotIn('totp_setup', self.client.session)
+
+    @patch(
+        'board.services.two_factor_setup_service.TwoFactorSetupService.generate_qr_code',
+        side_effect=ValueError('QR unavailable'),
+    )
+    def test_enable_2fa_qr_failure_keeps_legacy_error_and_setup_session(self, mock_qr):
+        """QR 생성 실패 응답과 QR 전 session 저장 순서를 보존한다."""
+        self.client.login(username='test2fa', password='test2fa')
+
+        response = self.client.post('/v1/auth/security')
+
+        self.assertEqual(json.loads(response.content), {
+            'status': 'ERROR',
+            'errorCode': 'error:RJ',
+            'errorMessage': '2FA 설정 초기화에 실패했습니다: QR unavailable',
+        })
+        self.assertIn('totp_setup', self.client.session)
+
+    def test_enable_2fa_save_failure_rolls_back_partial_activation(self):
+        """모델 저장 후 실패해도 2FA row가 남지 않고 setup session을 유지한다."""
+        self.client.login(username='test2fa', password='test2fa')
+        self.client.post('/v1/auth/security')
+        setup_session = self.client.session['totp_setup']
+        valid_code = pyotp.TOTP(setup_session['secret']).now()
+        original_save = TwoFactorAuth.save
+
+        def fail_after_save(instance, *args, **kwargs):
+            original_save(instance, *args, **kwargs)
+            raise RuntimeError('persistence failed')
+
+        with patch(
+            'board.services.two_factor_setup_service.TwoFactorAuth.save',
+            new=fail_after_save,
+        ):
+            response = self.client.post(
+                '/v1/auth/security/verify',
+                data=json.dumps({'code': valid_code}),
+                content_type='application/json',
+            )
+
+        self.assertEqual(json.loads(response.content), {
+            'status': 'ERROR',
+            'errorCode': 'error:RJ',
+            'errorMessage': '2FA 활성화에 실패했습니다: persistence failed',
+        })
+        self.assertFalse(TwoFactorAuth.objects.filter(user__username='test2fa').exists())
+        self.assertIn('totp_setup', self.client.session)
 
     def test_enable_2fa_invalid_verification_code(self):
         """잘못된 TOTP 코드로 2FA 설정 완료 시도 테스트"""
@@ -97,8 +242,12 @@ class TwoFactorAuthTestCase(TestCase):
         )
         self.assertEqual(response.status_code, 200)
         content = json.loads(response.content)
-        self.assertEqual(content['status'], 'ERROR')
-        self.assertEqual(content['errorCode'], 'error:RJ')
+        self.assertEqual(content, {
+            'status': 'ERROR',
+            'errorCode': 'error:RJ',
+            'errorMessage': '잘못된 인증 코드입니다.',
+        })
+        self.assertIn('totp_setup', self.client.session)
 
         # 2FA should not be saved
         user = User.objects.get(username='test2fa')
@@ -241,8 +390,11 @@ class TwoFactorAuthTestCase(TestCase):
         response = self.client.delete('/v1/auth/security')
         self.assertEqual(response.status_code, 200)
         content = json.loads(response.content)
-        self.assertEqual(content['status'], 'ERROR')
-        self.assertEqual(content['errorCode'], 'error:RJ')
+        self.assertEqual(content, {
+            'status': 'ERROR',
+            'errorCode': 'error:RJ',
+            'errorMessage': '24시간 동안 해제할 수 없습니다.',
+        })
 
     def test_disable_2fa_after_24_hours(self):
         """2FA 활성화 후 24시간 이후 비활성화 테스트"""
@@ -274,8 +426,11 @@ class TwoFactorAuthTestCase(TestCase):
         response = self.client.delete('/v1/auth/security')
         self.assertEqual(response.status_code, 200)
         content = json.loads(response.content)
-        self.assertEqual(content['status'], 'ERROR')
-        self.assertEqual(content['errorCode'], 'error:AU')
+        self.assertEqual(content, {
+            'status': 'ERROR',
+            'errorCode': 'error:AU',
+            'errorMessage': '',
+        })
 
     @override_settings(DEBUG=False)
     def test_login_with_recovery_key(self):

--- a/backend/src/board/tests/test_backend_compatibility_contract.py
+++ b/backend/src/board/tests/test_backend_compatibility_contract.py
@@ -9,7 +9,16 @@ from django.utils import timezone
 
 import board.models as board_models
 from board import urls as board_urls
-from board.models import Config, Post, PostConfig, PostContent, PostLikes, Profile, User
+from board.models import (
+    Config,
+    Post,
+    PostConfig,
+    PostContent,
+    PostLikes,
+    Profile,
+    TwoFactorAuth,
+    User,
+)
 from board.modules.response import ErrorCode, StatusDone, StatusError
 from board.services.auth_service import AuthService
 from board.services.post_service import PostService
@@ -523,6 +532,31 @@ class PythonImportCompatibilityContractTests(SimpleTestCase):
             parameter.kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
             for parameter in parameters
         ))
+
+    def test_two_factor_facade_and_model_method_signatures_are_stable(self):
+        expected_signatures = (
+            (AuthService.create_totp_secret, ()),
+            (AuthService.create_recovery_key, ()),
+            (AuthService.verify_totp_token, ('user', 'token')),
+            (AuthService.get_totp_qr_code, ('user',)),
+            (TwoFactorAuth.has_been_a_day, ('self',)),
+            (TwoFactorAuth.get_totp_secret, ('self',)),
+            (TwoFactorAuth.verify_recovery_key, ('self', 'token')),
+            (TwoFactorAuth.verify_totp, ('self', 'token')),
+            (TwoFactorAuth.get_provisioning_uri, ('self',)),
+        )
+
+        for method, expected_names in expected_signatures:
+            with self.subTest(method=method.__qualname__):
+                parameters = tuple(inspect.signature(method).parameters.values())
+                self.assertEqual(
+                    tuple(parameter.name for parameter in parameters),
+                    expected_names,
+                )
+                self.assertTrue(all(
+                    parameter.kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+                    for parameter in parameters
+                ))
 
     def test_post_service_facade_parameter_names_order_and_defaults_are_stable(self):
         for method_name, expected_parameters in EXPECTED_POST_SERVICE_SIGNATURES.items():

--- a/backend/src/board/views/api/v1/auth.py
+++ b/backend/src/board/views/api/v1/auth.py
@@ -1,9 +1,4 @@
 import datetime
-import traceback
-import io
-import pyotp
-import qrcode
-import base64
 
 from django.contrib import auth
 from django.contrib.auth.models import User
@@ -13,7 +8,7 @@ from django.shortcuts import get_object_or_404
 from django.utils import timezone
 
 from board.models import (
-    TwoFactorAuth, Config, Profile, Post,
+    Config, Profile, Post,
     UsernameChangeLog, TelegramSync)
 from board.modules.notify import create_notify
 from board.modules.response import StatusDone, StatusError, ErrorCode
@@ -29,6 +24,10 @@ from board.services.social_signup_service import (
     SocialSignupError,
     SocialSignupErrorKind,
     SocialSignupService,
+)
+from board.services.two_factor_setup_service import (
+    TwoFactorSetupError,
+    TwoFactorSetupService,
 )
 from modules.challenge import auth_hcaptcha
 from modules.sub_task import SubTaskProcessor
@@ -198,62 +197,33 @@ def security(request):
         return StatusError(ErrorCode.NEED_LOGIN)
 
     if request.method == 'GET':
-        if hasattr(request.user, 'twofactorauth'):
-            two_factor_auth = request.user.twofactorauth
-            qr_code = AuthService.get_totp_qr_code(request.user)
-            if qr_code:
-                return StatusDone({
-                    'qr_code': qr_code,
-                    'has_recovery_key': bool(two_factor_auth.recovery_key),
-                })
-        return StatusError(ErrorCode.NOT_FOUND)
+        try:
+            result = TwoFactorSetupService.get_security(request.user)
+        except TwoFactorSetupError as error:
+            return StatusError(error.code, error.message)
+        return StatusDone({
+            'qr_code': result.qr_code,
+            'has_recovery_key': result.has_recovery_key,
+        })
 
     if request.method == 'POST':
         try:
-            if hasattr(request.user, 'twofactorauth'):
-                return StatusError(ErrorCode.ALREADY_CONNECTED)
-
-            totp_secret = AuthService.create_totp_secret()
-            recovery_key = AuthService.create_recovery_key()
-
-            request.session['totp_setup'] = {
-                'secret': totp_secret,
-                'recovery_key': recovery_key,
-                'user_id': request.user.id
-            }
-
-            totp = pyotp.TOTP(totp_secret)
-            provisioning_uri = totp.provisioning_uri(
-                name=request.user.email,
-                issuer_name='BLEX'
+            result = TwoFactorSetupService.initialize(
+                request.user,
+                request.session,
             )
-
-            qr = qrcode.QRCode(version=1, box_size=10, border=5)
-            qr.add_data(provisioning_uri)
-            qr.make(fit=True)
-
-            img = qr.make_image(fill_color="black", back_color="white")
-            buffer = io.BytesIO()
-            img.save(buffer, format='PNG')
-            img_str = base64.b64encode(buffer.getvalue()).decode()
-            qr_code = f"data:image/png;base64,{img_str}"
-
-            return StatusDone({
-                'qr_code': qr_code,
-                'recovery_key': recovery_key
-            })
-        except Exception as e:
-            traceback.print_exc()
-            return StatusError(ErrorCode.REJECT, f'2FA 설정 초기화에 실패했습니다: {str(e)}')
+        except TwoFactorSetupError as error:
+            return StatusError(error.code, error.message)
+        return StatusDone({
+            'qr_code': result.qr_code,
+            'recovery_key': result.recovery_key,
+        })
 
     if request.method == 'DELETE':
-        if not hasattr(request.user, 'twofactorauth'):
-            return StatusError(ErrorCode.ALREADY_DISCONNECTED)
-
-        if not request.user.twofactorauth.has_been_a_day():
-            return StatusError(ErrorCode.REJECT, '24시간 동안 해제할 수 없습니다.')
-
-        request.user.twofactorauth.delete()
+        try:
+            TwoFactorSetupService.disable(request.user)
+        except TwoFactorSetupError as error:
+            return StatusError(error.code, error.message)
         return StatusDone()
 
     raise Http404
@@ -265,40 +235,16 @@ def security_verify(request):
         return StatusError(ErrorCode.NEED_LOGIN)
 
     if request.method == 'POST':
+        data = ApiRequestBodyService.parse_json_or_empty_for_legacy_only(request)
         try:
-            setup_data = request.session.get('totp_setup')
-            if not setup_data:
-                return StatusError(ErrorCode.EXPIRED, '2FA 설정 세션이 만료되었습니다. 다시 시도해주세요.')
-
-            if setup_data['user_id'] != request.user.id:
-                return StatusError(ErrorCode.AUTHENTICATION, '잘못된 세션입니다.')
-
-            if hasattr(request.user, 'twofactorauth'):
-                del request.session['totp_setup']
-                return StatusError(ErrorCode.ALREADY_CONNECTED)
-
-            data = ApiRequestBodyService.parse_json_or_empty_for_legacy_only(request)
-            code = data.get('code', '').strip()
-
-            if not code:
-                return StatusError(ErrorCode.INVALID_PARAMETER, '인증 코드를 입력해주세요.')
-
-            totp = pyotp.TOTP(setup_data['secret'])
-            if not totp.verify(code, valid_window=1):
-                return StatusError(ErrorCode.REJECT, '잘못된 인증 코드입니다.')
-
-            two_factor_auth = TwoFactorAuth(user=request.user)
-            two_factor_auth.totp_secret = setup_data['secret']
-            two_factor_auth.recovery_key = setup_data['recovery_key']
-            two_factor_auth.save()
-
-            del request.session['totp_setup']
-
-            return StatusDone({'message': '2차 인증이 활성화되었습니다.'})
-
-        except Exception as e:
-            traceback.print_exc()
-            return StatusError(ErrorCode.REJECT, f'2FA 활성화에 실패했습니다: {str(e)}')
+            TwoFactorSetupService.activate(
+                request.user,
+                request.session,
+                data.get('code', ''),
+            )
+        except TwoFactorSetupError as error:
+            return StatusError(error.code, error.message)
+        return StatusDone({'message': '2차 인증이 활성화되었습니다.'})
 
     raise Http404
 


### PR DESCRIPTION
## Goal

- Move 2FA setup, QR generation, session validation, activation, and disable rules into a typed service without changing the API contract.
- Prevent a failed activation from leaving a partial TwoFactorAuth database row.

## Core Changes

- Add typed 2FA setup/session/result/error orchestration.
- Move secret and recovery-key generation, QR PNG data URLs, session ownership/expiry checks, TOTP verification, and disable policy out of the view.
- Wrap activation persistence in a database transaction.
- Keep AuthService 2FA helpers as backward-compatible facades.
- Add regression coverage for QR decoding, session shape/ownership/expiry, valid windows, exact errors, rollback, encryption, recovery login, and legacy plaintext values.

## Key Decisions

- Preserve the totp_setup key, payload fields, QR-before/after session mutation order, and current response envelopes.
- Preserve valid_window=1, the 24-hour disable restriction, and the existing model encryption/hash hooks.
- Preserve AuthService helper signatures, configurable recovery alphabet behavior, and all TwoFactorAuth public methods.
- Keep rate-limit and login behavior unchanged.

## Verification Guide

- Related 2FA, auth-login, and compatibility suites: 39 tests passed.
- Full backend suite: 1,083 tests passed in 138.342s.
- Migration drift check: no changes detected.
- git diff --check: passed.

## Checklist

- [x] Backward-compatible paths, methods, payloads, messages, and errors are covered.
- [x] Activation persistence failure leaves no partial TwoFactorAuth row.
- [x] Stored secret and recovery-key material remains protected and undisclosed.
- [x] No schema or migration changes.
- [x] Full backend test suite passes locally.
- [x] Migration drift check passes locally.