### PR TITLE
♻️ Extract related post ranking service

### DIFF
--- a/backend/src/board/services/post_service.py
+++ b/backend/src/board/services/post_service.py
@@ -27,6 +27,7 @@ from board.modules.response import ErrorCode
 from board.services.post_content_service import PostContentService
 from board.services.authoring_permission_service import AuthoringPermissionService
 from board.services.public_post_service import PublicPostService
+from board.services.related_post_service import RelatedPostService
 from board.services.webhook_service import WebhookService
 
 
@@ -490,91 +491,32 @@ class PostService:
         ), author__username=username, url=url)
 
     @staticmethod
-    def _calculate_tag_score(candidate_tags: set, current_tag_set: set) -> int:
-        """Calculate score based on tag overlap (max 10)."""
-        tag_overlap = len(current_tag_set & candidate_tags)
-        return min(tag_overlap * 3, 10), tag_overlap
+    def _calculate_tag_score(
+        candidate_tags: set[str],
+        current_tag_set: set[str],
+    ) -> tuple[int, int]:
+        return RelatedPostService.calculate_tag_score(
+            candidate_tags,
+            current_tag_set,
+        )
 
     @staticmethod
     def _calculate_popularity_score(likes_count: int, comments_count: int) -> int:
-        """Calculate score based on engagement (max 10)."""
-        popularity = (likes_count * 2) + comments_count
-        return min(popularity, 10)
+        return RelatedPostService.calculate_popularity_score(
+            likes_count,
+            comments_count,
+        )
 
     @staticmethod
-    def _calculate_recency_score(created_date, now) -> int:
-        """Calculate score based on post age."""
-        days_old = (now - created_date).days
-        if days_old < 7:
-            return 5
-        elif days_old < 30:
-            return 3
-        elif days_old < 90:
-            return 1
-        return 0
+    def _calculate_recency_score(created_date: datetime, now: datetime) -> int:
+        return RelatedPostService.calculate_recency_score(created_date, now)
 
     @staticmethod
     def get_related_posts(post: Post) -> List[Post]:
-        """
-        Get related posts based on tags and popularity.
-
-        Args:
-            post: Reference post
-
-        Returns:
-            List of related posts
-        """
-        if not post.tags.exists():
-            return []
-
-        current_tags = list(post.tags.values_list('value', flat=True))
-        current_tag_set = set(current_tags)
-
-        candidates = PublicPostService.filter_public_posts(
-            Post.objects.select_related(
-                'author', 'author__profile', 'config'
-            ).prefetch_related('tags').filter(
-                tags__value__in=current_tags,
-            )
-        ).exclude(
-            id=post.id
-        ).annotate(
-            author_username=F('author__username'),
-            author_name=F('author__first_name'),
-            author_image=F('author__profile__avatar'),
-            likes_count=Count('likes', distinct=True),
-            comments_count=Count('comments', distinct=True),
-        ).distinct()
-
-        scored_posts = []
-        now = timezone.now()
-
-        for candidate in candidates:
-            candidate_tags = set(tag.value for tag in candidate.tags.all())
-            tag_score, tag_overlap = PostService._calculate_tag_score(
-                candidate_tags, current_tag_set
-            )
-            popularity_score = PostService._calculate_popularity_score(
-                candidate.likes_count, candidate.comments_count
-            )
-            recency_score = PostService._calculate_recency_score(
-                candidate.published_date, now
-            )
-
-            score = tag_score + popularity_score + recency_score
-            if candidate.author.id == post.author.id:
-                score -= 5
-            score += random.uniform(-3, 3)
-
-            scored_posts.append({
-                'post': candidate,
-                'score': score,
-                'tag_overlap': tag_overlap,
-            })
-
-        scored_posts.sort(key=lambda x: (x['score'], x['tag_overlap']), reverse=True)
-
-        return [x['post'] for x in scored_posts[:8]]
+        return RelatedPostService.get_related_posts(
+            post,
+            jitter=random.uniform,
+        )
 
     @staticmethod
     @transaction.atomic

--- a/backend/src/board/services/related_post_service.py
+++ b/backend/src/board/services/related_post_service.py
@@ -1,0 +1,134 @@
+"""Candidate selection and scoring for related posts."""
+
+from __future__ import annotations
+
+import random
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Callable, ClassVar, cast
+
+from django.db.models import Count, F, QuerySet
+from django.utils import timezone
+
+from board.models import Post
+from board.services.public_post_service import PublicPostService
+
+
+RelatedPostJitter = Callable[[float, float], float]
+
+
+@dataclass(frozen=True)
+class ScoredRelatedPost:
+    post: Post
+    score: float
+    tag_overlap: int
+
+
+class RelatedPostService:
+    """Return public related posts using the existing scoring algorithm."""
+
+    MAX_RELATED_POSTS: ClassVar[int] = 8
+
+    @staticmethod
+    def calculate_tag_score(
+        candidate_tags: set[str],
+        current_tag_set: set[str],
+    ) -> tuple[int, int]:
+        tag_overlap = len(current_tag_set & candidate_tags)
+        return min(tag_overlap * 3, 10), tag_overlap
+
+    @staticmethod
+    def calculate_popularity_score(
+        likes_count: int,
+        comments_count: int,
+    ) -> int:
+        popularity = (likes_count * 2) + comments_count
+        return min(popularity, 10)
+
+    @staticmethod
+    def calculate_recency_score(
+        published_date: datetime,
+        now: datetime,
+    ) -> int:
+        days_old = (now - published_date).days
+        if days_old < 7:
+            return 5
+        if days_old < 30:
+            return 3
+        if days_old < 90:
+            return 1
+        return 0
+
+    @staticmethod
+    def get_candidates(post: Post, current_tags: list[str]) -> QuerySet[Post]:
+        return PublicPostService.filter_public_posts(
+            Post.objects.select_related(
+                'author', 'author__profile', 'config'
+            ).prefetch_related('tags').filter(
+                tags__value__in=current_tags,
+            )
+        ).exclude(
+            id=post.id
+        ).annotate(
+            author_username=F('author__username'),
+            author_name=F('author__first_name'),
+            author_image=F('author__profile__avatar'),
+            likes_count=Count('likes', distinct=True),
+            comments_count=Count('comments', distinct=True),
+        ).distinct()
+
+    @classmethod
+    def get_related_posts(
+        cls,
+        post: Post,
+        *,
+        jitter: RelatedPostJitter | None = None,
+    ) -> list[Post]:
+        if not post.tags.exists():
+            return []
+
+        current_tags = list(post.tags.values_list('value', flat=True))
+        current_tag_set = set(current_tags)
+        candidates = cls.get_candidates(post, current_tags)
+        scored_posts: list[ScoredRelatedPost] = []
+        now = timezone.now()
+        jitter_score = jitter if jitter is not None else random.uniform
+
+        for candidate in candidates:
+            candidate_tags = {
+                tag.value
+                for tag in candidate.tags.all()
+            }
+            tag_score, tag_overlap = cls.calculate_tag_score(
+                candidate_tags,
+                current_tag_set,
+            )
+            popularity_score = cls.calculate_popularity_score(
+                cast(int, candidate.likes_count),
+                cast(int, candidate.comments_count),
+            )
+            recency_score = cls.calculate_recency_score(
+                cast(datetime, candidate.published_date),
+                now,
+            )
+
+            score = tag_score + popularity_score + recency_score
+            if candidate.author.id == post.author.id:
+                score -= 5
+            score += jitter_score(-3, 3)
+
+            scored_posts.append(ScoredRelatedPost(
+                post=candidate,
+                score=score,
+                tag_overlap=tag_overlap,
+            ))
+
+        scored_posts.sort(
+            key=lambda item: (item.score, item.tag_overlap),
+            reverse=True,
+        )
+        return [
+            item.post
+            for item in scored_posts[:cls.MAX_RELATED_POSTS]
+        ]

--- a/backend/src/board/tests/services/test_related_post_service.py
+++ b/backend/src/board/tests/services/test_related_post_service.py
@@ -1,0 +1,215 @@
+from datetime import timedelta
+from unittest.mock import call, patch
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.utils import timezone
+
+from board.models import Post, PostConfig, PostLikes, Profile, Tag
+from board.services.post_service import PostService
+from board.services.related_post_service import RelatedPostService
+
+
+class RelatedPostServiceTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.author = User.objects.create_user(username='related-author')
+        cls.other_author = User.objects.create_user(username='related-other')
+        Profile.objects.create(user=cls.author)
+        Profile.objects.create(user=cls.other_author)
+        cls.likers = [
+            User.objects.create_user(username=f'related-liker-{index}')
+            for index in range(5)
+        ]
+
+        cls.alpha = Tag.objects.create(value='alpha')
+        cls.beta = Tag.objects.create(value='beta')
+        cls.gamma = Tag.objects.create(value='gamma')
+        cls.delta = Tag.objects.create(value='delta')
+        now = timezone.now()
+
+        cls.reference = cls.create_post(
+            'Reference',
+            cls.author,
+            now,
+            (cls.alpha, cls.beta, cls.gamma),
+        )
+        cls.popular = cls.create_post(
+            'Popular',
+            cls.other_author,
+            now - timedelta(days=40),
+            (cls.alpha,),
+        )
+        for liker in cls.likers:
+            PostLikes.objects.create(post=cls.popular, user=liker)
+
+        cls.overlap = cls.create_post(
+            'Overlap',
+            cls.other_author,
+            now - timedelta(days=10),
+            (cls.alpha, cls.beta, cls.gamma),
+        )
+        cls.same_author = cls.create_post(
+            'Same Author',
+            cls.author,
+            now,
+            (cls.alpha, cls.beta),
+        )
+        cls.create_post(
+            'Hidden',
+            cls.other_author,
+            now,
+            (cls.alpha, cls.beta, cls.gamma),
+            hide=True,
+        )
+        cls.create_post(
+            'Draft',
+            cls.other_author,
+            None,
+            (cls.alpha, cls.beta, cls.gamma),
+        )
+        cls.create_post(
+            'Scheduled',
+            cls.other_author,
+            now + timedelta(days=1),
+            (cls.alpha, cls.beta, cls.gamma),
+        )
+        cls.create_post(
+            'Unrelated',
+            cls.other_author,
+            now,
+            (cls.delta,),
+        )
+
+    @classmethod
+    def create_post(
+        cls,
+        title: str,
+        author: User,
+        published_date,
+        tags: tuple[Tag, ...],
+        *,
+        hide: bool = False,
+    ) -> Post:
+        post = Post.objects.create(
+            title=title,
+            url=title.lower().replace(' ', '-'),
+            author=author,
+            published_date=published_date,
+        )
+        PostConfig.objects.create(post=post, hide=hide)
+        post.tags.add(*tags)
+        return post
+
+    @patch('board.services.post_service.random.uniform', side_effect=[0, 0, 0])
+    def test_facade_preserves_ranking_and_random_call_order(self, mock_uniform):
+        posts = PostService.get_related_posts(self.reference)
+
+        self.assertEqual(posts, [self.popular, self.overlap, self.same_author])
+        self.assertEqual(
+            mock_uniform.call_args_list,
+            [call(-3, 3), call(-3, 3), call(-3, 3)],
+        )
+
+    @patch('board.services.related_post_service.random.uniform', side_effect=[0, 0, 0])
+    def test_typed_service_preserves_direct_ranking(self, mock_uniform):
+        posts = RelatedPostService.get_related_posts(self.reference)
+
+        self.assertEqual(posts, [self.popular, self.overlap, self.same_author])
+        self.assertEqual(
+            mock_uniform.call_args_list,
+            [call(-3, 3), call(-3, 3), call(-3, 3)],
+        )
+
+    @patch('board.services.post_service.random.uniform', return_value=0)
+    def test_facade_preserves_same_author_penalty(self, mock_uniform):
+        penalty_tag = Tag.objects.create(value='penalty-tag')
+        reference = self.create_post(
+            'Penalty Reference',
+            self.author,
+            timezone.now(),
+            (penalty_tag,),
+        )
+        same_author = self.create_post(
+            'Penalty Same Author',
+            self.author,
+            timezone.now(),
+            (penalty_tag,),
+        )
+        other_author = self.create_post(
+            'Penalty Other Author',
+            self.other_author,
+            timezone.now(),
+            (penalty_tag,),
+        )
+
+        posts = PostService.get_related_posts(reference)
+
+        self.assertEqual(posts, [other_author, same_author])
+
+    @patch('board.services.post_service.random.uniform', return_value=0)
+    def test_candidates_preserve_public_policy_and_api_annotations(self, mock_uniform):
+        posts = PostService.get_related_posts(self.reference)
+
+        self.assertEqual({post.url for post in posts}, {
+            'popular',
+            'overlap',
+            'same-author',
+        })
+        popular = next(post for post in posts if post.url == 'popular')
+        self.assertEqual(popular.author_username, 'related-other')
+        self.assertEqual(popular.author_name, '')
+        self.assertEqual(str(popular.author_image), '')
+        self.assertEqual(popular.likes_count, 5)
+        self.assertEqual(popular.comments_count, 0)
+
+    @patch('board.services.post_service.random.uniform', return_value=0)
+    def test_facade_query_count_does_not_regress(self, mock_uniform):
+        with self.assertNumQueries(4):
+            posts = PostService.get_related_posts(self.reference)
+
+        self.assertEqual(len(posts), 3)
+
+    def test_post_without_tags_returns_empty_with_single_query(self):
+        post = self.create_post(
+            'No Tags',
+            self.author,
+            timezone.now(),
+            (),
+        )
+
+        with self.assertNumQueries(1):
+            posts = PostService.get_related_posts(post)
+
+        self.assertEqual(posts, [])
+
+    @patch('board.services.post_service.random.uniform', return_value=0)
+    def test_related_posts_keep_maximum_of_eight(self, mock_uniform):
+        for index in range(8):
+            self.create_post(
+                f'Additional {index}',
+                self.other_author,
+                timezone.now(),
+                (self.alpha,),
+            )
+
+        posts = PostService.get_related_posts(self.reference)
+
+        self.assertEqual(len(posts), 8)
+        self.assertNotIn(self.reference, posts)
+
+    def test_score_helper_boundaries_remain_stable(self):
+        self.assertEqual(
+            PostService._calculate_tag_score({'a', 'b', 'c', 'd'}, {'a', 'b', 'c', 'd'}),
+            (10, 4),
+        )
+        self.assertEqual(PostService._calculate_popularity_score(6, 3), 10)
+        now = timezone.now()
+        self.assertEqual(PostService._calculate_recency_score(now - timedelta(days=6), now), 5)
+        self.assertEqual(PostService._calculate_recency_score(now - timedelta(days=7), now), 3)
+        self.assertEqual(PostService._calculate_recency_score(now - timedelta(days=30), now), 1)
+        self.assertEqual(PostService._calculate_recency_score(now - timedelta(days=90), now), 0)
+        self.assertEqual(
+            RelatedPostService.calculate_tag_score({'a', 'b'}, {'a', 'b'}),
+            (6, 2),
+        )


### PR DESCRIPTION
## Goal

- Move related-post candidate selection and scoring into a typed service without changing ranking or public behavior.
- Preserve the existing PostService facade and query profile.

## Core Changes

- Add RelatedPostService with typed scored items and injectable jitter.
- Move the existing public candidate queryset, annotations, scoring, sorting, and eight-post limit unchanged.
- Keep PostService.get_related_posts and private score helpers as delegation facades.
- Add deterministic ranking, visibility, annotation, maximum-size, random-call, author-penalty, and query-count tests.

## Key Decisions

- Preserve select_related, prefetch_related, annotation, distinct, and queryset evaluation timing.
- Preserve tag, popularity, recency, same-author, and random-jitter weights exactly.
- Preserve the existing board.services.post_service.random.uniform patch path for downstream tests.
- Do not add ordering, caching, personalization, or algorithm improvements.

## Verification Guide

- Related/public service, post API, and compatibility suites: 59 tests passed.
- Full backend suite: 1,091 tests passed in 138.369s.
- Query baseline: four queries with tags and one query for the no-tag early return.
- Migration drift check: no changes detected.
- git diff --check: passed.

## Checklist

- [x] Deterministic ranking and random call order are covered.
- [x] Hidden, draft, scheduled, unrelated, and reference posts stay excluded.
- [x] API-facing annotations and return type are preserved.
- [x] Query count does not increase.
- [x] No schema or migration changes.
- [x] Full backend test suite passes locally.