### PR TITLE
♻️ Extract post image lifecycle service

### DIFF
--- a/backend/src/board/services/__init__.py
+++ b/backend/src/board/services/__init__.py
@@ -11,6 +11,7 @@ _SERVICE_MODULES = {
     'PostService': 'post_service',
     'PostLikeService': 'post_like_service',
     'PostThumbnailService': 'post_thumbnail_service',
+    'PostImageService': 'post_image_service',
     'ProfileImageService': 'profile_image_service',
     'NotificationDeliveryService': 'notification_delivery_service',
     'UserConfigMetaService': 'user_config_meta_service',

--- a/backend/src/board/services/post_image_service.py
+++ b/backend/src/board/services/post_image_service.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Callable, Iterator, Protocol
+
+from board.models import Post
+
+
+class ChunkedImageFile(Protocol):
+    """Uploaded image interface required for hashing and assignment."""
+
+    def seek(self, offset: int, whence: int = 0) -> int:
+        ...
+
+    def chunks(self, chunk_size: int | None = None) -> Iterator[bytes]:
+        ...
+
+
+ImageHashComputer = Callable[[ChunkedImageFile], str]
+ImageSharedChecker = Callable[[str, int], bool]
+
+
+@dataclass(frozen=True)
+class PostImageMutationResult:
+    """Describes the in-memory image mutation performed for a post."""
+
+    changed: bool
+    reused_existing: bool
+    storage_file_deleted: bool
+
+
+class PostImageService:
+    """Owns post image hashing, deduplication, replacement, and deletion."""
+
+    @staticmethod
+    def compute_image_hash(image_file: ChunkedImageFile) -> str:
+        """Compute the existing SHA-256 image identity and reset the file."""
+        sha256 = hashlib.sha256()
+        image_file.seek(0)
+        for chunk in image_file.chunks():
+            sha256.update(chunk)
+        image_file.seek(0)
+        return sha256.hexdigest()
+
+    @staticmethod
+    def is_image_shared(image_name: str, exclude_post_id: int) -> bool:
+        """Return whether another post references the same storage path."""
+        return Post.objects.filter(
+            image=image_name,
+        ).exclude(id=exclude_post_id).exists()
+
+    @staticmethod
+    def _delete_current_if_unshared(
+        post: Post,
+        is_image_shared: ImageSharedChecker,
+    ) -> bool:
+        if not post.image:
+            return False
+        if post.pk and is_image_shared(post.image.name, post.pk):
+            return False
+
+        post.image.delete(save=False)
+        return True
+
+    @staticmethod
+    def set_image_with_dedup(
+        post: Post,
+        image: ChunkedImageFile | None = None,
+        image_delete: bool = False,
+        *,
+        compute_image_hash: ImageHashComputer | None = None,
+        is_image_shared: ImageSharedChecker | None = None,
+    ) -> PostImageMutationResult:
+        """Mutate a post image while preserving the legacy storage lifecycle."""
+        hash_image = compute_image_hash or PostImageService.compute_image_hash
+        check_shared = is_image_shared or PostImageService.is_image_shared
+
+        if image_delete:
+            changed = bool(post.image or post.image_hash)
+            storage_file_deleted = PostImageService._delete_current_if_unshared(
+                post,
+                check_shared,
+            )
+            post.image = None
+            post.image_hash = ''
+            return PostImageMutationResult(
+                changed=changed,
+                reused_existing=False,
+                storage_file_deleted=storage_file_deleted,
+            )
+
+        if image is None:
+            return PostImageMutationResult(
+                changed=False,
+                reused_existing=False,
+                storage_file_deleted=False,
+            )
+
+        new_hash = hash_image(image)
+        if (
+            post.pk
+            and post.image
+            and post.image_hash == new_hash
+            and post.image.storage.exists(post.image.name)
+        ):
+            return PostImageMutationResult(
+                changed=False,
+                reused_existing=False,
+                storage_file_deleted=False,
+            )
+
+        existing_images = Post.objects.filter(
+            image_hash=new_hash,
+        ).exclude(image='')
+        if post.pk:
+            existing_images = existing_images.exclude(pk=post.pk)
+
+        existing = existing_images.first()
+        if existing and existing.image and existing.image.storage.exists(existing.image.name):
+            storage_file_deleted = PostImageService._delete_current_if_unshared(
+                post,
+                check_shared,
+            )
+            post.image.name = existing.image.name
+            post.image_hash = new_hash
+            post._skip_thumbnail = True
+            return PostImageMutationResult(
+                changed=True,
+                reused_existing=True,
+                storage_file_deleted=storage_file_deleted,
+            )
+
+        storage_file_deleted = PostImageService._delete_current_if_unshared(
+            post,
+            check_shared,
+        )
+        post.image = image
+        post.image_hash = new_hash
+        return PostImageMutationResult(
+            changed=True,
+            reused_existing=False,
+            storage_file_deleted=storage_file_deleted,
+        )

--- a/backend/src/board/services/post_service.py
+++ b/backend/src/board/services/post_service.py
@@ -5,7 +5,6 @@ Business logic for post operations.
 Extracted from views to improve testability and reusability.
 """
 
-import hashlib
 import random
 from typing import Optional, Dict, Any, Tuple, List
 from datetime import datetime
@@ -28,6 +27,7 @@ from board.services.post_content_service import PostContentService
 from board.services.authoring_permission_service import AuthoringPermissionService
 from board.services.public_post_service import PublicPostService
 from board.services.related_post_service import RelatedPostService
+from board.services.post_image_service import PostImageService
 from board.services.webhook_service import WebhookService
 
 
@@ -273,20 +273,13 @@ class PostService:
 
     @staticmethod
     def _compute_image_hash(image_file) -> str:
-        """Compute SHA-256 hash of an uploaded image file."""
-        sha256 = hashlib.sha256()
-        image_file.seek(0)
-        for chunk in image_file.chunks():
-            sha256.update(chunk)
-        image_file.seek(0)
-        return sha256.hexdigest()
+        """Compatibility facade for post image hashing."""
+        return PostImageService.compute_image_hash(image_file)
 
     @staticmethod
     def _is_image_shared(image_name: str, exclude_post_id: int) -> bool:
-        """Check if an image file is used by other posts."""
-        return Post.objects.filter(
-            image=image_name
-        ).exclude(id=exclude_post_id).exists()
+        """Compatibility facade for shared image detection."""
+        return PostImageService.is_image_shared(image_name, exclude_post_id)
 
     @staticmethod
     def _set_image_with_dedup(
@@ -294,51 +287,14 @@ class PostService:
         image: Optional[Any] = None,
         image_delete: bool = False,
     ) -> None:
-        """
-        Handle image assignment with deduplication.
-        - image_delete=True: safely delete existing image (check shared first)
-        - image is not None: compute hash, find duplicate, reuse or assign new
-        """
-        if image_delete:
-            if post.image:
-                if not post.pk or not PostService._is_image_shared(post.image.name, post.pk):
-                    post.image.delete(save=False)
-            post.image = None
-            post.image_hash = ''
-            return
-
-        if image is not None:
-            new_hash = PostService._compute_image_hash(image)
-
-            if (
-                post.pk
-                and post.image
-                and post.image_hash == new_hash
-                and post.image.storage.exists(post.image.name)
-            ):
-                return
-
-            existing_images = Post.objects.filter(
-                image_hash=new_hash,
-            ).exclude(image='')
-            if post.pk:
-                existing_images = existing_images.exclude(pk=post.pk)
-
-            existing = existing_images.first()
-
-            if existing and existing.image and existing.image.storage.exists(existing.image.name):
-                if post.image:
-                    if not post.pk or not PostService._is_image_shared(post.image.name, post.pk):
-                        post.image.delete(save=False)
-                post.image.name = existing.image.name
-                post.image_hash = new_hash
-                post._skip_thumbnail = True
-            else:
-                if post.image:
-                    if not post.pk or not PostService._is_image_shared(post.image.name, post.pk):
-                        post.image.delete(save=False)
-                post.image = image
-                post.image_hash = new_hash
+        """Compatibility facade for the post image lifecycle service."""
+        PostImageService.set_image_with_dedup(
+            post,
+            image,
+            image_delete,
+            compute_image_hash=PostService._compute_image_hash,
+            is_image_shared=PostService._is_image_shared,
+        )
 
     @staticmethod
     def _resolve_content(

--- a/backend/src/board/tests/services/test_image_dedup.py
+++ b/backend/src/board/tests/services/test_image_dedup.py
@@ -1,3 +1,4 @@
+import hashlib
 from io import BytesIO
 from unittest.mock import patch
 
@@ -9,6 +10,10 @@ from django.core.files.storage import default_storage
 from django.utils import timezone
 
 from board.models import User, Post, PostContent, PostConfig, Profile, Config
+from board.services.post_image_service import (
+    PostImageMutationResult,
+    PostImageService,
+)
 from board.services.post_service import PostService
 
 
@@ -65,6 +70,23 @@ class ImageDedupTestCase(TestCase):
         PostService._compute_image_hash(img)
         self.assertEqual(img.tell(), 0)
 
+    def test_compute_image_hash_uses_sha256(self):
+        """이미지 해시 알고리즘이 SHA-256인지 확인"""
+        img = self._create_test_image(color='yellow')
+        expected_hash = hashlib.sha256(img.read()).hexdigest()
+
+        self.assertEqual(PostService._compute_image_hash(img), expected_hash)
+
+    @patch.object(PostImageService, 'compute_image_hash', return_value='a' * 64)
+    def test_compute_image_hash_facade_delegates_once(self, mock_compute_hash):
+        """기존 private 해시 helper는 새 서비스에 한 번만 위임"""
+        image = self._create_test_image()
+
+        result = PostService._compute_image_hash(image)
+
+        self.assertEqual(result, 'a' * 64)
+        mock_compute_hash.assert_called_once_with(image)
+
     def test_is_image_shared_no_other_posts(self):
         """다른 포스트가 이미지를 사용하지 않을 때"""
         post = Post.objects.create(
@@ -102,6 +124,46 @@ class ImageDedupTestCase(TestCase):
         PostConfig.objects.create(post=post2)
 
         self.assertTrue(PostService._is_image_shared('images/title/shared.jpg', post1.pk))
+
+    @patch.object(PostImageService, 'is_image_shared', return_value=True)
+    def test_is_image_shared_facade_delegates_once(self, mock_is_shared):
+        """기존 private 공유 확인 helper는 새 서비스에 한 번만 위임"""
+        result = PostService._is_image_shared('images/title/shared.jpg', 42)
+
+        self.assertTrue(result)
+        mock_is_shared.assert_called_once_with('images/title/shared.jpg', 42)
+
+    def test_post_image_service_returns_typed_noop_result(self):
+        """이미지 입력이 없으면 명시적인 무변경 결과를 반환"""
+        post = Post(author=self.user, title='No image mutation')
+
+        result = PostImageService.set_image_with_dedup(post)
+
+        self.assertEqual(
+            result,
+            PostImageMutationResult(
+                changed=False,
+                reused_existing=False,
+                storage_file_deleted=False,
+            ),
+        )
+
+    @patch.object(PostImageService, 'set_image_with_dedup')
+    def test_set_image_with_dedup_facade_delegates_once(self, mock_set_image):
+        """기존 private mutation helper는 호환 dependency와 함께 한 번만 위임"""
+        post = Post(author=self.user, title='Facade delegation')
+        image = self._create_test_image()
+
+        result = PostService._set_image_with_dedup(post, image, True)
+
+        self.assertIsNone(result)
+        mock_set_image.assert_called_once_with(
+            post,
+            image,
+            True,
+            compute_image_hash=PostService._compute_image_hash,
+            is_image_shared=PostService._is_image_shared,
+        )
 
     @patch('board.services.post_service.PostService._compute_image_hash')
     @patch('modules.thumbnail.make_thumbnail')
@@ -228,3 +290,142 @@ class ImageDedupTestCase(TestCase):
         self.assertEqual(post.image.name, 'images/title/current.jpg')
         self.assertFalse(mock_delete.called)
         self.assertFalse(getattr(post, '_skip_thumbnail', False))
+
+    @patch('board.services.post_service.PostService._compute_image_hash')
+    def test_set_image_with_dedup_preserves_shared_file_on_replace(self, mock_hash):
+        """공유 중인 기존 이미지를 교체해도 스토리지 파일은 삭제하지 않음"""
+        mock_hash.return_value = 'f' * 64
+        post = Post.objects.create(
+            url='shared-replace-current',
+            title='Shared Replace Current',
+            author=self.user,
+            image='images/title/shared-replace.jpg',
+            image_hash='a' * 64,
+        )
+        Post.objects.create(
+            url='shared-replace-other',
+            title='Shared Replace Other',
+            author=self.user,
+            image='images/title/shared-replace.jpg',
+            image_hash='a' * 64,
+        )
+        current_image = post.image
+
+        with patch.object(current_image, 'delete') as mock_delete:
+            PostService._set_image_with_dedup(
+                post,
+                image=self._create_test_image('replacement.jpg'),
+            )
+
+        mock_delete.assert_not_called()
+        self.assertEqual(post.image.name, 'replacement.jpg')
+        self.assertEqual(post.image_hash, 'f' * 64)
+
+    def test_set_image_with_dedup_preserves_shared_file_on_delete(self):
+        """공유 중인 이미지를 포스트에서 제거해도 스토리지 파일은 유지"""
+        post = Post.objects.create(
+            url='shared-delete-current',
+            title='Shared Delete Current',
+            author=self.user,
+            image='images/title/shared-delete.jpg',
+            image_hash='a' * 64,
+        )
+        Post.objects.create(
+            url='shared-delete-other',
+            title='Shared Delete Other',
+            author=self.user,
+            image='images/title/shared-delete.jpg',
+            image_hash='a' * 64,
+        )
+        current_image = post.image
+
+        with patch.object(current_image, 'delete') as mock_delete:
+            PostService._set_image_with_dedup(
+                post,
+                image_delete=True,
+            )
+
+        mock_delete.assert_not_called()
+        self.assertFalse(post.image)
+        self.assertEqual(post.image_hash, '')
+
+    def test_set_image_with_dedup_propagates_current_storage_exists_error(self):
+        """현재 파일 확인 실패 시 예외를 전파하고 이미지 상태를 보존"""
+        image = self._create_test_image('same-hash.jpg')
+        image_hash = PostService._compute_image_hash(image)
+        post = Post.objects.create(
+            url='storage-exists-current-error',
+            title='Storage Exists Current Error',
+            author=self.user,
+            image='images/title/current-error.jpg',
+            image_hash=image_hash,
+        )
+
+        with patch.object(
+            post.image.storage,
+            'exists',
+            side_effect=OSError('storage unavailable'),
+        ):
+            with self.assertRaisesRegex(OSError, 'storage unavailable'):
+                PostService._set_image_with_dedup(post, image=image)
+
+        self.assertEqual(post.image.name, 'images/title/current-error.jpg')
+        self.assertEqual(post.image_hash, image_hash)
+        self.assertEqual(image.tell(), 0)
+
+    @patch('board.services.post_service.PostService._compute_image_hash')
+    def test_set_image_with_dedup_propagates_duplicate_storage_exists_error(self, mock_hash):
+        """중복 후보 파일 확인 실패 시 기존 이미지 삭제나 교체를 하지 않음"""
+        mock_hash.return_value = 'b' * 64
+        post = Post.objects.create(
+            url='storage-exists-duplicate-current',
+            title='Storage Exists Duplicate Current',
+            author=self.user,
+            image='images/title/duplicate-current.jpg',
+            image_hash='a' * 64,
+        )
+        Post.objects.create(
+            url='storage-exists-duplicate-candidate',
+            title='Storage Exists Duplicate Candidate',
+            author=self.user,
+            image='images/title/duplicate-candidate.jpg',
+            image_hash='b' * 64,
+        )
+        current_image = post.image
+
+        with patch.object(
+            default_storage,
+            'exists',
+            side_effect=OSError('storage unavailable'),
+        ):
+            with patch.object(current_image, 'delete') as mock_delete:
+                with self.assertRaisesRegex(OSError, 'storage unavailable'):
+                    PostService._set_image_with_dedup(
+                        post,
+                        image=self._create_test_image('duplicate.jpg'),
+                    )
+
+        mock_delete.assert_not_called()
+        self.assertEqual(post.image.name, 'images/title/duplicate-current.jpg')
+        self.assertEqual(post.image_hash, 'a' * 64)
+
+    def test_set_image_with_dedup_propagates_storage_delete_error(self):
+        """스토리지 삭제 실패 시 예외를 전파하고 이미지 상태를 보존"""
+        post = Post.objects.create(
+            url='storage-delete-error',
+            title='Storage Delete Error',
+            author=self.user,
+            image='images/title/delete-error.jpg',
+            image_hash='c' * 64,
+        )
+
+        with patch.object(
+            post.image.storage,
+            'delete',
+            side_effect=OSError('storage delete failed'),
+        ):
+            with self.assertRaisesRegex(OSError, 'storage delete failed'):
+                PostService._set_image_with_dedup(post, image_delete=True)
+
+        self.assertEqual(post.image.name, 'images/title/delete-error.jpg')
+        self.assertEqual(post.image_hash, 'c' * 64)


### PR DESCRIPTION
## Goal

- Move post image hashing, deduplication, replacement, and deletion into a typed service without changing storage or API behavior.
- Preserve the existing PostService private helper facade and thumbnail lifecycle.

## Core Changes

- Add PostImageService with typed uploaded-file input and mutation result.
- Move SHA-256 hashing, shared-path detection, duplicate reuse, replacement, and deletion logic without reordering storage I/O or database lookups.
- Keep PostService private helper signatures and legacy mock paths as one-step delegation facades.
- Add shared-file, same-hash, new-upload, delete-flag, storage-error, facade, and SHA-256 characterization tests.

## Key Decisions

- Preserve the existing image path, hash reuse policy, and shared-file deletion guard.
- Preserve storage exception propagation and pre-mutation state when storage existence or deletion fails.
- Keep PostThumbnailService and the Post.save() thumbnail hook unchanged, including preview, minify, and original specifications.
- Do not change schemas, image formats, storage backends, request/response shapes, or public routes.

## Verification Guide

- Image lifecycle, thumbnail hook, and compatibility suites: 39 tests passed.
- Full backend suite: 1,101 tests passed.
- Migration drift check: no changes detected.
- git diff --check: passed.

## Checklist

- [x] SHA-256 hashes and uploaded-file seek reset are preserved.
- [x] Duplicate paths are reused and shared files are not deleted.
- [x] Same-hash, new-upload, replacement, and delete behavior are covered.
- [x] Storage exceptions propagate without mutating the prior in-memory image state.
- [x] PostService private helper signatures and mock paths remain compatible.
- [x] Thumbnail generation timing and specifications remain unchanged.
- [x] No schema or migration changes.
- [x] Full backend test suite passes locally.
