### PR TITLE
♻️ Declare legacy v1 API exports

### DIFF
--- a/backend/src/board/tests/test_backend_compatibility_contract.py
+++ b/backend/src/board/tests/test_backend_compatibility_contract.py
@@ -1,3 +1,4 @@
+import ast
 import inspect
 import json
 from importlib import import_module
@@ -218,6 +219,71 @@ EXPECTED_ROUTE_CONTRACT = (
     ('api/developer/v1/series', 'list_series', None),
     ('api/developer/v1/images', 'upload_image', None),
     ('api/developer/v1/', 'api-root', None),
+)
+
+
+EXPECTED_V1_API_EXPORTS = (
+    'login',
+    'logout',
+    'sign',
+    'sign_social',
+    'social_providers',
+    'security',
+    'security_verify',
+    'developer_tokens',
+    'setting',
+    'search',
+    'post_list',
+    'post_comment_list',
+    'drafts_list',
+    'drafts_detail',
+    'comment_list',
+    'user_comment',
+    'comment_detail',
+    'get_author_heatmap',
+    'users',
+    'user_posts',
+    'user_post_related',
+    'user_series',
+    'check_redirect',
+    'pinned_posts',
+    'pinned_posts_order',
+    'pinnable_posts',
+    'series_create_update',
+    'series_detail',
+    'posts_can_add_series',
+    'series_order',
+    'error_report',
+    'image',
+    'forms_list',
+    'forms_detail',
+    'telegram',
+    'banner',
+    'banner_order',
+    'notices',
+    'global_notices',
+    'global_banners',
+    'global_banner_order',
+    'site_settings',
+    'site_setting_brand_assets',
+    'login_settings',
+    'integration_settings',
+    'static_pages',
+    'markdown_to_html',
+    'managed_users',
+    'managed_user_role',
+    'author_invites',
+    'author_invite_detail',
+    'utility_stats',
+    'utility_clean_tags',
+    'utility_clean_sessions',
+    'utility_clean_logs',
+    'utility_clean_images',
+    'my_channels',
+    'delete_channel',
+    'global_channels',
+    'delete_global_channel',
+    'test_channel',
 )
 
 
@@ -484,6 +550,48 @@ class PythonImportCompatibilityContractTests(SimpleTestCase):
             with self.subTest(export_name=export_name):
                 implementation = getattr(import_module(module_path), export_name)
                 self.assertIs(getattr(api_v1, export_name), implementation)
+
+    def test_v1_package_declares_only_registered_url_endpoints(self):
+        registered_exports = tuple(dict.fromkeys(
+            pattern.callback.__name__
+            for pattern in board_urls.urlpatterns
+            if (
+                isinstance(pattern, URLPattern)
+                and str(pattern.pattern).startswith('v1/')
+            )
+        ))
+
+        self.assertEqual(api_v1.__all__, EXPECTED_V1_API_EXPORTS)
+        self.assertEqual(registered_exports, EXPECTED_V1_API_EXPORTS)
+        self.assertEqual(len(api_v1.__all__), len(set(api_v1.__all__)))
+
+        for export_name in api_v1.__all__:
+            with self.subTest(export_name=export_name):
+                self.assertIs(
+                    getattr(api_v1, export_name),
+                    next(
+                        pattern.callback
+                        for pattern in board_urls.urlpatterns
+                        if (
+                            isinstance(pattern, URLPattern)
+                            and str(pattern.pattern).startswith('v1/')
+                            and pattern.callback.__name__ == export_name
+                        )
+                    ),
+                )
+
+    def test_v1_package_initializer_has_no_wildcard_imports(self):
+        module_tree = ast.parse(inspect.getsource(api_v1))
+        wildcard_imports = [
+            node
+            for node in ast.walk(module_tree)
+            if (
+                isinstance(node, ast.ImportFrom)
+                and any(alias.name == '*' for alias in node.names)
+            )
+        ]
+
+        self.assertEqual(wildcard_imports, [])
 
     def test_setting_post_management_facade_signatures_are_stable(self):
         setting_module = import_module('board.views.api.v1.setting')

--- a/backend/src/board/views/api/v1/__init__.py
+++ b/backend/src/board/views/api/v1/__init__.py
@@ -1,29 +1,121 @@
-# export
-from .auth import *
-from .author_invite import *
-from .author import *
-from .banner import *
-from .comment import *
-from .developer_token import *
-from .draft import *
-from .form import *
-from .global_banner import *
-from .global_notice import *
-from .image import *
-from .integration_setting import *
-from .login_setting import *
-from .notice import *
-from .markdown import *
-from .pinned_post import *
-from .post import *
-from .report import *
-from .search import *
-from .series import *
-from .setting import *
-from .site_setting import *
-from .static_page import *
-from .telegram import *
-from .user import *
-from .utility import *
-from .user_management import *
-from .webhook import *
+"""Stable package facade for the legacy v1 API endpoints."""
+
+from .auth import (
+    login,
+    logout,
+    security,
+    security_verify,
+    sign,
+    sign_social,
+    social_providers,
+)
+from .author_invite import author_invite_detail, author_invites
+from .author import get_author_heatmap
+from .banner import banner, banner_order
+from .comment import comment_detail, comment_list, user_comment
+from .developer_token import developer_tokens
+from .draft import drafts_detail, drafts_list
+from .form import forms_detail, forms_list
+from .global_banner import global_banner_order, global_banners
+from .global_notice import global_notices
+from .image import image
+from .integration_setting import integration_settings
+from .login_setting import login_settings
+from .notice import notices
+from .markdown import markdown_to_html
+from .pinned_post import pinnable_posts, pinned_posts, pinned_posts_order
+from .post import post_comment_list, post_list, user_post_related, user_posts
+from .report import error_report
+from .search import search
+from .series import (
+    posts_can_add_series,
+    series_create_update,
+    series_detail,
+    series_order,
+    user_series,
+)
+from .setting import setting
+from .site_setting import site_setting_brand_assets, site_settings
+from .static_page import static_pages
+from .telegram import telegram
+from .user import check_redirect, users
+from .utility import (
+    utility_clean_images,
+    utility_clean_logs,
+    utility_clean_sessions,
+    utility_clean_tags,
+    utility_stats,
+)
+from .user_management import managed_user_role, managed_users
+from .webhook import (
+    delete_channel,
+    delete_global_channel,
+    global_channels,
+    my_channels,
+    test_channel,
+)
+
+
+__all__ = (
+    'login',
+    'logout',
+    'sign',
+    'sign_social',
+    'social_providers',
+    'security',
+    'security_verify',
+    'developer_tokens',
+    'setting',
+    'search',
+    'post_list',
+    'post_comment_list',
+    'drafts_list',
+    'drafts_detail',
+    'comment_list',
+    'user_comment',
+    'comment_detail',
+    'get_author_heatmap',
+    'users',
+    'user_posts',
+    'user_post_related',
+    'user_series',
+    'check_redirect',
+    'pinned_posts',
+    'pinned_posts_order',
+    'pinnable_posts',
+    'series_create_update',
+    'series_detail',
+    'posts_can_add_series',
+    'series_order',
+    'error_report',
+    'image',
+    'forms_list',
+    'forms_detail',
+    'telegram',
+    'banner',
+    'banner_order',
+    'notices',
+    'global_notices',
+    'global_banners',
+    'global_banner_order',
+    'site_settings',
+    'site_setting_brand_assets',
+    'login_settings',
+    'integration_settings',
+    'static_pages',
+    'markdown_to_html',
+    'managed_users',
+    'managed_user_role',
+    'author_invites',
+    'author_invite_detail',
+    'utility_stats',
+    'utility_clean_tags',
+    'utility_clean_sessions',
+    'utility_clean_logs',
+    'utility_clean_images',
+    'my_channels',
+    'delete_channel',
+    'global_channels',
+    'delete_global_channel',
+    'test_channel',
+)


### PR DESCRIPTION
## Goal

- Replace wildcard imports in the legacy v1 API package with an explicit, statically inspectable endpoint facade.
- Preserve every existing /v1 route, package endpoint attribute, callable identity, method, and response behavior.

## Core Changes

- Import all 28 legacy v1 implementation modules in their existing order while naming only registered endpoint callables.
- Declare the 61 unique board.urls endpoint names in package __all__.
- Stop treating models, services, Django utilities, and internal serialization/filter helpers leaked by wildcard imports as supported exports.
- Add package import, callable identity, URL registration, duplicate export, and wildcard-free contract tests.

## Key Decisions

- Keep every endpoint in its current implementation module; no function or URL is moved or renamed.
- Preserve the from board.views.api import v1 as api_v1 access pattern.
- Keep module import timing and Django application initialization behavior unchanged.
- Derive the registered endpoint comparison directly from board.urls so future drift fails the compatibility suite.

## Verification Guide

- API and compatibility suites: 579 tests passed.
- Full backend suite: 1,103 tests passed.
- All 61 unique /v1 endpoint exports match their registered URL callback by identity.
- Migration drift check: no changes detected.
- git diff --check: passed.

## Checklist

- [x] Zero wildcard imports remain in the v1 package initializer.
- [x] Existing api_v1 endpoint attributes remain available.
- [x] URL order, path, name, and callback contracts remain unchanged.
- [x] Endpoint exports are unique and contain no unregistered helpers.
- [x] No endpoint implementation, permission, status, or response code changed.
- [x] No schema or migration changes.
- [x] Full backend test suite passes locally.
