### PR TITLE
♻️ Surface background task failures safely

### DIFF
--- a/backend/src/board/services/notification_delivery_service.py
+++ b/backend/src/board/services/notification_delivery_service.py
@@ -28,7 +28,11 @@ class NotificationDeliveryService:
             return
 
         bot = TelegramBot(bot_token)
-        SubTaskProcessor.process(lambda: bot.send_messages(telegram_id, [
-            SiteUrlService.configured_absolute_url(str(notify.url)),
-            notify.content,
-        ]))
+        SubTaskProcessor.process(
+            bot.send_messages,
+            telegram_id,
+            [
+                SiteUrlService.configured_absolute_url(str(notify.url)),
+                notify.content,
+            ],
+        )

--- a/backend/src/board/services/webhook_service.py
+++ b/backend/src/board/services/webhook_service.py
@@ -65,8 +65,13 @@ class WebhookService:
             )
             response.raise_for_status()
             return True
-        except requests.RequestException as e:
-            logger.warning(f'Failed to send webhook to {url}: {e}')
+        except requests.RequestException as error:
+            exception_type = type(error).__name__
+            logger.warning(
+                'Webhook delivery failed exception_type=%s',
+                exception_type,
+                extra={'webhook_exception_type': exception_type},
+            )
             return False
 
     @staticmethod

--- a/backend/src/board/tests/api/test_telegram_api.py
+++ b/backend/src/board/tests/api/test_telegram_api.py
@@ -166,6 +166,12 @@ class TelegramAPITestCase(TestCase):
         sync.refresh_from_db()
         self.assertEqual(sync.get_decrypted_tid(), '987654321')
         self.assertEqual(sync.auth_token, '')  # Token should be cleared
+        mock_subtask.assert_called_once_with(
+            mock_bot.send_message,
+            987654321,
+            '정상적으로 연동되었습니다.',
+        )
+        mock_bot.send_message.assert_not_called()
 
     @override_settings(SITE_URL='https://test.com')
     @patch('board.views.api.v1.telegram.TelegramBot')

--- a/backend/src/board/tests/models/test_notify_model_methods.py
+++ b/backend/src/board/tests/models/test_notify_model_methods.py
@@ -77,8 +77,8 @@ class NotifySendNotifyTestCase(TestCase):
         mock_bot.assert_called_once_with('token')
         mock_process.assert_called_once()
 
-        callback = mock_process.call_args.args[0]
-        callback()
+        callback, *args = mock_process.call_args.args
+        callback(*args, **mock_process.call_args.kwargs)
 
         mock_bot.return_value.send_messages.assert_called_once_with(
             '123456',

--- a/backend/src/board/tests/test_sub_task_processor.py
+++ b/backend/src/board/tests/test_sub_task_processor.py
@@ -1,0 +1,173 @@
+import inspect
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import Mock, patch
+
+import requests
+from django.test import SimpleTestCase
+
+import modules.sub_task as sub_task_module
+from board.services.webhook_service import WebhookService
+from modules.sub_task import SubTaskProcessor
+
+
+class SensitiveTask:
+    def __init__(self, secret: str):
+        self.secret = secret
+
+    def __repr__(self):
+        return self.secret
+
+    def __call__(self):
+        raise RuntimeError('literal-exception-secret ' + self.secret)
+
+
+class SubTaskProcessorTestCase(SimpleTestCase):
+    def create_executor(self) -> ThreadPoolExecutor:
+        executor = ThreadPoolExecutor(max_workers=1)
+        self.addCleanup(
+            executor.shutdown,
+            wait=True,
+            cancel_futures=False,
+        )
+        return executor
+
+    def test_process_signature_and_non_blocking_return_are_stable(self):
+        signature = inspect.signature(SubTaskProcessor.process)
+        parameters = tuple(signature.parameters.values())
+        self.assertEqual(
+            tuple((parameter.name, parameter.kind) for parameter in parameters),
+            (
+                ('func', inspect.Parameter.POSITIONAL_OR_KEYWORD),
+                ('args', inspect.Parameter.VAR_POSITIONAL),
+                ('kwargs', inspect.Parameter.VAR_KEYWORD),
+            ),
+        )
+        self.assertIs(signature.return_annotation, None)
+
+        executor = self.create_executor()
+        started = threading.Event()
+        release = threading.Event()
+        finished = threading.Event()
+        self.addCleanup(release.set)
+
+        def blocking_task():
+            started.set()
+            release.wait(timeout=2)
+            finished.set()
+
+        with patch.object(sub_task_module, '_executor', executor):
+            start = time.perf_counter()
+            result = SubTaskProcessor.process(blocking_task)
+            elapsed = time.perf_counter() - start
+
+            self.assertIsNone(result)
+            self.assertLess(elapsed, 0.5)
+            self.assertTrue(started.wait(timeout=1))
+            self.assertFalse(finished.is_set())
+
+            release.set()
+            self.assertTrue(finished.wait(timeout=1))
+
+    def test_execution_failure_is_redacted_and_does_not_block_next_task(self):
+        executor = self.create_executor()
+        next_task_completed = threading.Event()
+        bot_token = 'bot-token-secret'
+        webhook_url = 'https://discord.example/webhook/private-secret'
+        telegram_id = '987654321'
+        literal_secret = 'literal-exception-secret'
+        secret = f'{bot_token} {webhook_url} {telegram_id}'
+
+        with patch.object(sub_task_module, '_executor', executor):
+            with self.assertLogs('board.sub_task', level='ERROR') as captured:
+                SubTaskProcessor.process(SensitiveTask(secret))
+                SubTaskProcessor.process(next_task_completed.set)
+                self.assertTrue(next_task_completed.wait(timeout=2))
+
+        output = '\n'.join(captured.output)
+        self.assertIn('Background task failed', output)
+        self.assertIn('task_name=SensitiveTask', output)
+        self.assertIn('stage=execute', output)
+        self.assertIn('exception_type=RuntimeError', output)
+        self.assertNotIn(bot_token, output)
+        self.assertNotIn(webhook_url, output)
+        self.assertNotIn(telegram_id, output)
+        self.assertNotIn(literal_secret, output)
+
+        failure_record = captured.records[0]
+        self.assertTrue(failure_record.background_task_id.startswith('background-task-'))
+        self.assertEqual(failure_record.background_task_name, 'SensitiveTask')
+        self.assertEqual(failure_record.background_task_module, __name__)
+        self.assertEqual(failure_record.background_task_kind, 'SensitiveTask')
+        self.assertEqual(failure_record.background_task_stage, 'execute')
+        self.assertEqual(failure_record.background_task_exception_type, 'RuntimeError')
+
+    def test_submit_failure_is_redacted_and_not_raised_to_caller(self):
+        executor = Mock()
+        bot_token = 'submit-bot-token-secret'
+        webhook_url = 'https://discord.example/webhook/submit-secret'
+        telegram_id = '123456789'
+        executor.submit.side_effect = RuntimeError(
+            f'{bot_token} {webhook_url} {telegram_id}'
+        )
+
+        with patch.object(sub_task_module, '_executor', executor):
+            with self.assertLogs('board.sub_task', level='ERROR') as captured:
+                result = SubTaskProcessor.process(
+                    lambda value: value,
+                    bot_token,
+                    webhook_url=webhook_url,
+                    telegram_id=telegram_id,
+                )
+
+        self.assertIsNone(result)
+        output = '\n'.join(captured.output)
+        self.assertIn('stage=submit', output)
+        self.assertIn('exception_type=RuntimeError', output)
+        self.assertNotIn(bot_token, output)
+        self.assertNotIn(webhook_url, output)
+        self.assertNotIn(telegram_id, output)
+
+        failure_record = captured.records[0]
+        self.assertEqual(failure_record.background_task_stage, 'submit')
+        self.assertEqual(failure_record.background_task_exception_type, 'RuntimeError')
+
+    def test_shutdown_waits_for_queued_tasks_without_cancelling_them(self):
+        executor = self.create_executor()
+        completed_tasks = []
+
+        with patch.object(sub_task_module, '_executor', executor):
+            SubTaskProcessor.process(lambda: completed_tasks.append('first'))
+            SubTaskProcessor.process(lambda: completed_tasks.append('second'))
+            SubTaskProcessor._shutdown()
+
+        self.assertEqual(completed_tasks, ['first', 'second'])
+
+    @patch('board.services.webhook_service.requests.post')
+    def test_webhook_request_failure_does_not_log_webhook_url(self, mock_post):
+        webhook_url = 'https://discord.example/webhook/private-secret'
+        error_secret = 'request-error-secret'
+        mock_post.side_effect = requests.RequestException(
+            f'{webhook_url} {error_secret}'
+        )
+
+        with self.assertLogs(
+            'board.services.webhook_service',
+            level='WARNING',
+        ) as captured:
+            result = WebhookService.send_webhook(
+                webhook_url,
+                'content',
+                'https://blex.example/@author/post',
+            )
+
+        self.assertFalse(result)
+        output = '\n'.join(captured.output)
+        self.assertIn('exception_type=RequestException', output)
+        self.assertNotIn(webhook_url, output)
+        self.assertNotIn(error_secret, output)
+        self.assertEqual(
+            captured.records[0].webhook_exception_type,
+            'RequestException',
+        )

--- a/backend/src/board/views/api/v1/telegram.py
+++ b/backend/src/board/views/api/v1/telegram.py
@@ -32,18 +32,27 @@ def telegram(request, parameter):
                         telegram_sync.auth_token = ''
                         telegram_sync.save()
                         SubTaskProcessor.process(
-                            lambda: bot.send_message(req_userid, '정상적으로 연동되었습니다.'))
+                            bot.send_message,
+                            req_userid,
+                            '정상적으로 연동되었습니다.',
+                        )
                     else:
                         telegram_sync.auth_token = ''
                         telegram_sync.save()
-                        SubTaskProcessor.process(lambda: bot.send_message(
-                            req_userid, '기간이 만료된 토큰입니다. 홈페이지에서 연동을 다시 시도하십시오.'))
+                        SubTaskProcessor.process(
+                            bot.send_message,
+                            req_userid,
+                            '기간이 만료된 토큰입니다. 홈페이지에서 연동을 다시 시도하십시오.',
+                        )
 
             except:
                 if req_userid:
                     message = '블렉스 다양한 정보를 살펴보세요!\n\n' + SiteUrlService.configured_absolute_url('/notion')
                     SubTaskProcessor.process(
-                        lambda: bot.send_message(req_userid, message))
+                        bot.send_message,
+                        req_userid,
+                        message,
+                    )
             return StatusDone()
 
     if parameter == 'makeToken':

--- a/backend/src/modules/sub_task.py
+++ b/backend/src/modules/sub_task.py
@@ -1,10 +1,142 @@
+import atexit
+import logging
+import traceback
 from concurrent.futures import ThreadPoolExecutor
+from itertools import count
 from typing import Any, Callable
 
 _executor = ThreadPoolExecutor(max_workers=1)
+_logger = logging.getLogger('board.sub_task')
+_task_ids = count(1)
 
 
 class SubTaskProcessor:
     @staticmethod
     def process(func: Callable, *args: Any, **kwargs: Any) -> None:
-        _executor.submit(func, *args, **kwargs)
+        task_id = f'background-task-{next(_task_ids)}'
+        task_name, task_module, task_kind = SubTaskProcessor._get_task_metadata(func)
+
+        try:
+            _executor.submit(
+                SubTaskProcessor._execute,
+                func,
+                args,
+                kwargs,
+                task_id,
+                task_name,
+                task_module,
+                task_kind,
+            )
+        except Exception as error:
+            SubTaskProcessor._log_failure(
+                error=error,
+                stage='submit',
+                task_id=task_id,
+                task_name=task_name,
+                task_module=task_module,
+                task_kind=task_kind,
+            )
+
+    @staticmethod
+    def _execute(
+        func: Callable,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+        task_id: str,
+        task_name: str,
+        task_module: str,
+        task_kind: str,
+    ) -> None:
+        try:
+            func(*args, **kwargs)
+        except BaseException as error:
+            SubTaskProcessor._log_failure(
+                error=error,
+                stage='execute',
+                task_id=task_id,
+                task_name=task_name,
+                task_module=task_module,
+                task_kind=task_kind,
+            )
+            raise
+
+        _logger.debug(
+            'Background task completed task_id=%s task_name=%s '
+            'task_module=%s task_kind=%s',
+            task_id,
+            task_name,
+            task_module,
+            task_kind,
+            extra={
+                'background_task_id': task_id,
+                'background_task_name': task_name,
+                'background_task_module': task_module,
+                'background_task_kind': task_kind,
+            },
+        )
+
+    @staticmethod
+    def _get_task_metadata(func: Callable) -> tuple[str, str, str]:
+        task_kind = func.__class__.__name__
+        task_name = getattr(func, '__qualname__', None)
+        task_module = getattr(func, '__module__', None)
+
+        if not isinstance(task_name, str) or not task_name:
+            task_name = task_kind
+        if not isinstance(task_module, str) or not task_module:
+            task_module = func.__class__.__module__
+
+        return task_name, task_module, task_kind
+
+    @staticmethod
+    def _log_failure(
+        error: BaseException,
+        stage: str,
+        task_id: str,
+        task_name: str,
+        task_module: str,
+        task_kind: str,
+    ) -> None:
+        exception_type = type(error).__name__
+        safe_stack = ' <- '.join(
+            f'{frame.filename}:{frame.lineno} in {frame.name}'
+            for frame in traceback.extract_tb(error.__traceback__)
+        )
+        log_extra = {
+            'background_task_id': task_id,
+            'background_task_name': task_name,
+            'background_task_module': task_module,
+            'background_task_kind': task_kind,
+            'background_task_stage': stage,
+            'background_task_exception_type': exception_type,
+        }
+        log_message = (
+            'Background task failed task_id=%s task_name=%s '
+            'task_module=%s task_kind=%s stage=%s exception_type=%s'
+        )
+        log_args = (
+            task_id,
+            task_name,
+            task_module,
+            task_kind,
+            stage,
+            exception_type,
+        )
+
+        if safe_stack:
+            _logger.error(
+                f'{log_message} stack=%s',
+                *log_args,
+                safe_stack,
+                extra=log_extra,
+            )
+            return
+
+        _logger.error(log_message, *log_args, extra=log_extra)
+
+    @staticmethod
+    def _shutdown() -> None:
+        _executor.shutdown(wait=True, cancel_futures=False)
+
+
+atexit.register(SubTaskProcessor._shutdown)


### PR DESCRIPTION
## 🎯 Goal
- Make uncaught in-process Telegram and webhook task failures observable instead of leaving them silently inside executor futures.
- Preserve the existing non-blocking API behavior, single-worker delivery order, payloads, retry/deactivation policy, and transaction timing.
- Implements Ocean Brain task 1696.

## 🔧 Core Changes
- Wrapped `SubTaskProcessor` execution and submission with structured `board.sub_task` failure logging.
- Added safe task identifiers and callable metadata without logging callable repr, args, kwargs, exception messages, or source lines.
- Added a safe stack containing only file, line, and function names; redacted the existing webhook warning that exposed the destination URL.
- Kept one worker and explicitly preserved queued work at process exit with `wait=True` and `cancel_futures=False`.
- Passed Telegram delivery callables and payloads through the existing `process(func, *args, **kwargs)` boundary to produce useful task names.

## 🤔 Key Decisions
- Worker exceptions are logged and re-raised only into their private Future, so later queued tasks still run and request threads never receive them.
- Submit failures are logged and return `None`, preserving user-facing API responses during executor shutdown or rejection.
- Exception messages and formatted source lines are intentionally omitted because HTTP client errors can contain bot tokens, webhook URLs, Telegram IDs, or literal secrets.

## 🧪 Verification Guide
### How to verify
1. Run `npm run server:test`.
2. Run `node scripts/manage.mjs makemigrations --check --dry-run`.
3. Run `node scripts/manage.mjs test board.tests.test_sub_task_processor board.tests.models.test_notify_model_methods board.tests.api.test_telegram_api board.tests.api.test_webhook`.

### Expected result
- All 1,111 backend tests pass and Django reports `No changes detected`.
- Success, execution failure, submit failure, sequential queue, non-blocking return, shutdown, Telegram, and webhook cases pass.
- Failure records contain task metadata and exception type while secrets and external identifiers are absent.

## ✅ Checklist
- [x] Lint completed (not applicable: backend-only; `git diff --check` passes)
- [x] Type-check completed (not applicable: no Islands changes)
- [x] Tests completed
- [x] Documentation updated (not needed; public behavior and operator configuration are unchanged)
