### PR TITLE
🐛 Preserve quoted resource URL compatibility

### DIFF
--- a/backend/src/board/tests/test_runtime_settings.py
+++ b/backend/src/board/tests/test_runtime_settings.py
@@ -20,10 +20,19 @@ class RuntimeSettingsTestCase(SimpleTestCase):
 
     def test_get_env_optional_returns_none_for_empty_values(self):
         """빈 문자열 환경변수는 미설정처럼 처리한다."""
-        for value in ['', '   ']:
+        for value in ['', '   ', '""', "''", '"  "']:
             with patch.dict(os.environ, {'BLEX_TEST_OPTIONAL': value}):
                 self.assertIsNone(
                     runtime_settings.get_env_optional('BLEX_TEST_OPTIONAL'),
+                )
+
+    def test_get_env_optional_unquotes_env_file_values(self):
+        """Docker env-file의 따옴표 값은 실제 설정값으로 정규화한다."""
+        for value in ['"https://cdn.example.com/"', "'https://cdn.example.com/'"]:
+            with patch.dict(os.environ, {'BLEX_TEST_OPTIONAL': value}):
+                self.assertEqual(
+                    runtime_settings.get_env_optional('BLEX_TEST_OPTIONAL'),
+                    'https://cdn.example.com/',
                 )
 
     def test_session_cookie_domain_ignores_loopback_hosts(self):
@@ -175,6 +184,39 @@ class RuntimeSettingsTestCase(SimpleTestCase):
         )
 
         self.assertEqual(result.stdout.strip(), '/resources/')
+
+    def test_runtime_resource_url_accepts_legacy_quoted_empty_value(self):
+        """기존 샘플의 RESOURCE_URL=""도 로컬 리소스 경로로 호환한다."""
+        env = {
+            **os.environ,
+            'SECRET_KEY': 'test-secret',
+            'CIPHER_KEY': 'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
+            'DEBUG': 'FALSE',
+            'RESOURCE_URL': '""',
+            'SITE_URL': 'https://blex.example',
+            'TZ': 'Asia/Seoul',
+        }
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                '-c',
+                (
+                    'from main import settings; '
+                    'print(settings.RESOURCE_URL, settings.STATIC_URL, settings.MEDIA_URL)'
+                ),
+            ],
+            cwd=runtime_settings.BASE_DIR,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+        self.assertEqual(
+            result.stdout.strip(),
+            '/resources/ /resources/staticfiles/ /resources/media/',
+        )
 
     def test_runtime_secure_cookies_default_to_enabled_outside_debug(self):
         """운영 모드에서는 외부 HTTPS 프록시 뒤에서 쓸 Secure 쿠키를 기본으로 발급한다."""

--- a/backend/src/main/settings.py
+++ b/backend/src/main/settings.py
@@ -33,10 +33,14 @@ def get_env_list(name: str, default: list[str] | None = None) -> list[str]:
 
 def get_env_optional(name: str) -> str | None:
     value = os.environ.get(name)
-    if value is None or value.strip() == '':
+    if value is None:
         return None
 
-    return value.strip()
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+        value = value[1:-1].strip()
+
+    return value or None
 
 
 def get_session_cookie_domain(name: str = 'SESSION_COOKIE_DOMAIN') -> str | None:
@@ -212,7 +216,7 @@ USE_TZ = True
 
 
 SITE_URL = os.environ.get('SITE_URL')
-RESOURCE_URL = os.environ.get('RESOURCE_URL', '').rstrip('/') + '/resources/'
+RESOURCE_URL = (get_env_optional('RESOURCE_URL') or '').rstrip('/') + '/resources/'
 
 STATIC_URL = RESOURCE_URL + 'staticfiles/'
 STATIC_ROOT = os.path.join(BASE_DIR, 'resources', 'staticfiles')


### PR DESCRIPTION
## 🎯 Goal
- Preserve existing installations that still use RESOURCE_URL="" in Docker env files.
- Prevent production CSS, JavaScript, and media URLs from receiving a literal quote prefix and returning 404.

## 🔧 Core Changes
- Normalize matching outer quotes for optional environment values.
- Resolve RESOURCE_URL through the shared optional environment parser.
- Add regression coverage for the legacy quoted-empty value and quoted CDN origins.

## 🤔 Key Decisions
- Fix runtime parsing instead of requiring users to rewrite existing env files.
- Keep the current /resources/ and CDN URL contracts unchanged.
- Limit the hotfix to runtime settings and focused tests.

## 🧪 Verification Guide
### How to verify
1. Run npm run server:test.
2. Build backend/Dockerfile and run it with DEBUG=FALSE and RESOURCE_URL="".
3. Open the home, login, and signup pages and inspect Island asset requests.

### Expected result
- RESOURCE_URL resolves to /resources/ and all CSS/JavaScript assets return 200 without a /%22%22/ prefix.

## ✅ Checklist
- [x] Lint completed (not applicable: backend-only change)
- [x] Type-check completed (not applicable: backend-only change)
- [x] Tests completed
- [x] Documentation updated (not needed; existing sample already uses the preferred empty form)