### PR TITLE
♻️ Strengthen settings accessibility contracts

### DIFF
--- a/backend/islands/apps/remotes/src/components/CodeEditor.monaco.tsx
+++ b/backend/islands/apps/remotes/src/components/CodeEditor.monaco.tsx
@@ -7,6 +7,7 @@ interface CodeEditorMonacoProps {
     onChange: (value: string) => void;
     height?: string;
     readOnly?: boolean;
+    ariaLabel?: string;
 }
 
 const CodeEditorMonaco = ({
@@ -14,7 +15,8 @@ const CodeEditorMonaco = ({
     value,
     onChange,
     height = '300px',
-    readOnly
+    readOnly,
+    ariaLabel
 }: CodeEditorMonacoProps) => {
     const resolvedTheme = useResolvedTheme();
 
@@ -35,6 +37,7 @@ const CodeEditorMonaco = ({
                     scrollBeyondLastLine: false,
                     automaticLayout: true,
                     readOnly,
+                    ariaLabel,
                     padding: {
                         top: 8,
                         bottom: 8

--- a/backend/islands/apps/remotes/src/components/CodeEditor.tsx
+++ b/backend/islands/apps/remotes/src/components/CodeEditor.tsx
@@ -9,6 +9,7 @@ interface CodeEditorProps {
     height?: string;
     error?: string;
     readOnly?: boolean;
+    ariaLabel?: string;
 }
 
 export const CodeEditor = ({ error, ...props }: CodeEditorProps) => {
@@ -19,6 +20,8 @@ export const CodeEditor = ({ error, ...props }: CodeEditorProps) => {
             <Suspense
                 fallback={
                     <div
+                        role="status"
+                        aria-label={props.ariaLabel ? `${props.ariaLabel} 불러오는 중` : '코드 편집기 불러오는 중'}
                         className="rounded-lg border border-line bg-surface-subtle animate-pulse"
                         style={{ height }}
                     />

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/SettingsListItem.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/SettingsListItem.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import type { KeyboardEvent, ReactNode } from 'react';
 import type { DraggableAttributes } from '@dnd-kit/core';
 import type { SyntheticListenerMap } from '@dnd-kit/core/dist/hooks/utilities';
 import {
@@ -31,10 +31,24 @@ const SettingsListItem = ({
     actions,
     children
 }: SettingsListItemProps) => {
+    const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+        if (!onClick || event.target !== event.currentTarget) return;
+
+        if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            onClick();
+        }
+    };
+
     return (
         <div
-            className={getCardClass(onClick ? 'cursor-pointer' : '')}
-            onClick={onClick}>
+            className={getCardClass(onClick
+                ? 'cursor-pointer hover:ring-line focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-line-strong'
+                : '')}
+            onClick={onClick}
+            onKeyDown={handleKeyDown}
+            role={onClick ? 'button' : undefined}
+            tabIndex={onClick ? 0 : undefined}>
             <div className={CARD_PADDING}>
                 <div className={`${FLEX_ROW}${className ? ` ${className}` : ''}`}>
                     {dragHandleProps && (

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/SettingsNavigation.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/SettingsNavigation.tsx
@@ -276,6 +276,7 @@ export const SettingsMobileNavigation = ({ currentPath }: SettingsNavigationProp
         basePath,
         canUseTelegramIntegration
     } = router.options.context as SettingsRouterContext;
+    const settingsLabel = settingsMode === 'admin' ? '관리자 설정' : '설정';
     const navigationSections = getNavigationSections(settingsMode);
     const handleNavClick = (item: NavigationItem) => {
         setMobileMenuOpen(false);
@@ -345,6 +346,8 @@ export const SettingsMobileNavigation = ({ currentPath }: SettingsNavigationProp
                 <Dialog.Root open={mobileMenuOpen} onOpenChange={setMobileMenuOpen}>
                     <Dialog.Trigger asChild>
                         <button
+                            type="button"
+                            aria-label={`${settingsLabel} 메뉴 열기`}
                             className={`w-11 h-11 flex items-center justify-center rounded-full hover:bg-action/5 active:bg-action/10 active:scale-95 transition-all ${INTERACTION_DURATION}`}>
                             <i className="fas fa-bars text-content" />
                         </button>
@@ -353,13 +356,15 @@ export const SettingsMobileNavigation = ({ currentPath }: SettingsNavigationProp
                         <Dialog.Overlay className={`fixed inset-0 ${DIM_OVERLAY_SOFT} z-40 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0`} />
                         <Dialog.Content className={`fixed z-50 bg-surface shadow-2xl transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left ${ENTRANCE_DURATION} inset-y-0 left-0 h-full w-[280px] overflow-y-auto outline-none`}>
                             <div className="p-6">
-                                <Dialog.Title className="sr-only">Navigation Menu</Dialog.Title>
+                                <Dialog.Title className="sr-only">{settingsLabel} 메뉴</Dialog.Title>
                                 <div className="flex items-center justify-between mb-8">
                                     <h2 className="text-2xl font-bold text-content tracking-tight">
                                         {settingsMode === 'admin' ? '관리자 설정' : '설정'}
                                     </h2>
                                     <Dialog.Close asChild>
                                         <button
+                                            type="button"
+                                            aria-label={`${settingsLabel} 메뉴 닫기`}
                                             className={`w-11 h-11 flex items-center justify-center rounded-full hover:bg-surface-subtle active:bg-line active:scale-95 transition-all ${INTERACTION_DURATION}`}>
                                             <i className="fas fa-times text-content-secondary" />
                                         </button>
@@ -381,7 +386,7 @@ export const SettingsMobileNavigation = ({ currentPath }: SettingsNavigationProp
                 </Dialog.Root>
 
                 <h1 className="text-lg font-bold text-content">
-                    {settingsMode === 'admin' ? '관리자 설정' : '설정'}
+                    {settingsLabel}
                 </h1>
                 <div className="w-10" />
             </div>
@@ -399,6 +404,7 @@ export const SettingsDesktopNavigation = ({ currentPath }: SettingsNavigationPro
         basePath,
         canUseTelegramIntegration
     } = router.options.context as SettingsRouterContext;
+    const settingsLabel = settingsMode === 'admin' ? '관리자 설정' : '설정';
     const navigationSections = getNavigationSections(settingsMode);
     const handleNavClick = (item: NavigationItem) => {
         if (item.path === 'admin' && adminUrl) {
@@ -466,7 +472,7 @@ export const SettingsDesktopNavigation = ({ currentPath }: SettingsNavigationPro
         <aside className="hidden xl:block w-72 flex-shrink-0 mt-8 self-start sticky top-24">
             <div className="px-5 mb-6">
                 <h2 className="text-2xl font-semibold text-content tracking-tight">
-                    {settingsMode === 'admin' ? '관리자 설정' : '설정'}
+                    {settingsLabel}
                 </h2>
                 {isStaff && (
                     <div className="mt-3">

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/AccountSetting/components/AccountInfoSection.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/AccountSetting/components/AccountInfoSection.tsx
@@ -18,6 +18,7 @@ const AccountInfoSection = ({ createdDate, email }: AccountInfoSectionProps) => 
                 }
                 className="mb-6">
                 <Input
+                    aria-label="가입일"
                     value={createdDate}
                     readOnly
                 />
@@ -34,6 +35,7 @@ const AccountInfoSection = ({ createdDate, email }: AccountInfoSectionProps) => 
                 }
                 className="mb-6">
                 <Input
+                    aria-label="이메일"
                     value={email}
                     readOnly
                 />

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/AccountSetting/components/NameSection.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/AccountSetting/components/NameSection.tsx
@@ -36,6 +36,7 @@ const NameSection = ({ initialName, isLoading, onSubmit }: NameSectionProps) => 
                 <div className="mb-4">
                     <Input
                         type="text"
+                        aria-label="사용자 이름"
                         placeholder="사용자 실명"
                         maxLength={30}
                         error={errors.name?.message}

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/AccountSetting/components/TwoFactorModal.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/AccountSetting/components/TwoFactorModal.tsx
@@ -75,10 +75,11 @@ const TwoFactorModal = ({
                 </Alert>
 
                 <div>
-                    <label className="block text-sm font-medium text-content mb-2">
+                    <label htmlFor="two-factor-verification-code" className="block text-sm font-medium text-content mb-2">
                         인증 앱에 표시된 6자리 코드를 입력하세요
                     </label>
                     <Input
+                        id="two-factor-verification-code"
                         type="text"
                         placeholder="000000"
                         maxLength={6}

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/AccountSetting/components/UsernameSection.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/AccountSetting/components/UsernameSection.tsx
@@ -39,6 +39,7 @@ const UsernameSection = ({ initialUsername, isLoading, onSubmit }: UsernameSecti
                 <div className="mb-4">
                     <Input
                         type="text"
+                        aria-label="사용자 필명"
                         placeholder="사용자 필명"
                         maxLength={30}
                         error={errors.username?.message}

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/NotifySetting/components/NotifyConfigModal.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/NotifySetting/components/NotifyConfigModal.tsx
@@ -85,6 +85,7 @@ const NotifyConfigModal = ({
                             <label className="relative inline-flex items-center cursor-pointer">
                                 <input
                                     type="checkbox"
+                                    aria-label={getNotifyLabel(item.name)}
                                     className="sr-only peer"
                                     checked={item.value}
                                     onChange={() => handleToggleConfig(item.name as keyof typeof NOTIFY_CONFIG_LABEL)}

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/PostCard.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/PostCard.tsx
@@ -173,6 +173,7 @@ const PostCard = ({
                         </div>
                         <Input
                             type="text"
+                            aria-label={`${post.title} 태그`}
                             placeholder="태그를 입력하세요..."
                             value={post.tag}
                             onChange={(e) => onTagChange(post.url, e.target.value)}

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/PostsFilter.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/PostsFilter.tsx
@@ -112,6 +112,7 @@ const PostsFilter = ({
                     <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-4">
                         <Input
                             type="text"
+                            aria-label="포스트 제목 검색"
                             placeholder="포스트 제목 검색..."
                             defaultValue={filters.search}
                             onChange={onSearchChange}

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/ProfileSetting/ProfileSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/ProfileSetting/ProfileSetting.tsx
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useConfirm } from '~/hooks/useConfirm';
+import { getStaticPath } from '~/modules/static.module';
 import { SettingsHeader } from '../../components';
 import { Button, Input, Card, ImageCropDialog } from '~/components/shared';
 import {
@@ -45,8 +46,10 @@ const IMAGE_CROP_CONFIG = {
     }
 } as const;
 
+const getDefaultAvatarPath = () => getStaticPath('assets/images/default-avatar.jpg');
+
 const ProfileSetting = () => {
-    const [avatar, setAvatar] = useState('/resources/staticfiles/images/default-avatar.jpg');
+    const [avatar, setAvatar] = useState(getDefaultAvatarPath);
     const [cover, setCover] = useState<string | null>(null);
     const [isLoading, setIsLoading] = useState(false);
     const [imageCropState, setImageCropState] = useState<ImageCropState | null>(null);
@@ -67,7 +70,7 @@ const ProfileSetting = () => {
 
     useEffect(() => {
         if (profileData) {
-            setAvatar(profileData.avatar || '/resources/staticfiles/images/default-avatar.jpg');
+            setAvatar(profileData.avatar || getDefaultAvatarPath());
             setCover(profileData.cover || null);
             reset({
                 bio: profileData.bio || '',
@@ -211,19 +214,24 @@ const ProfileSetting = () => {
                                 alt="프로필 이미지"
                                 className="w-full h-full rounded-full object-cover border-4 border-line-light shadow-lg"
                             />
-                            <div className="absolute bottom-0 right-0 bg-action w-8 h-8 sm:w-10 sm:h-10 rounded-full flex items-center justify-center cursor-pointer shadow-md hover:bg-action transition-colors">
-                                <label htmlFor="avatar-input" className="text-content-inverted cursor-pointer w-full h-full flex items-center justify-center">
-                                    <svg className="w-4 h-4 sm:w-5 sm:h-5" fill="currentColor" viewBox="0 0 20 20">
-                                        <path fillRule="evenodd" d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z" clipRule="evenodd" />
-                                    </svg>
+                            <div className="absolute -bottom-1 -right-1">
+                                <label
+                                    htmlFor="avatar-input"
+                                    className="group flex h-11 w-11 cursor-pointer items-center justify-center rounded-full">
+                                    <span className="sr-only">프로필 이미지 변경</span>
+                                    <span className="flex h-8 w-8 items-center justify-center rounded-full bg-action text-content-inverted shadow-md transition-colors group-hover:bg-action-hover group-focus-within:ring-2 group-focus-within:ring-line-strong group-focus-within:ring-offset-2 group-focus-within:ring-offset-surface sm:h-10 sm:w-10">
+                                        <svg className="w-4 h-4 sm:w-5 sm:h-5" fill="currentColor" viewBox="0 0 20 20">
+                                            <path fillRule="evenodd" d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z" clipRule="evenodd" />
+                                        </svg>
+                                    </span>
+                                    <input
+                                        id="avatar-input"
+                                        type="file"
+                                        accept="image/*"
+                                        onChange={handleAvatarChange}
+                                        className="sr-only"
+                                    />
                                 </label>
-                                <input
-                                    id="avatar-input"
-                                    type="file"
-                                    accept="image/*"
-                                    onChange={handleAvatarChange}
-                                    className="hidden"
-                                />
                             </div>
                         </div>
                         <div className="text-center sm:text-left">
@@ -246,23 +254,23 @@ const ProfileSetting = () => {
                                         className="w-full h-full object-cover"
                                     />
                                 </div>
-                                <div className="absolute inset-0 bg-action bg-opacity-0 group-hover:bg-opacity-40 transition-all duration-200 rounded-2xl flex items-center justify-center opacity-0 group-hover:opacity-100">
+                                <div className="absolute inset-0 bg-action bg-opacity-0 group-hover:bg-opacity-40 group-focus-within:bg-opacity-40 transition-all duration-200 rounded-2xl flex items-center justify-center opacity-0 group-hover:opacity-100 group-focus-within:opacity-100">
                                     <label
                                         htmlFor="cover-input"
-                                        className="px-6 py-3 bg-surface hover:bg-surface-subtle rounded-xl text-sm font-semibold text-content cursor-pointer transition-colors shadow-lg">
+                                        className="px-6 py-3 bg-surface hover:bg-surface-subtle rounded-xl text-sm font-semibold text-content cursor-pointer transition-colors shadow-lg focus-within:ring-2 focus-within:ring-line-strong">
                                         이미지 변경
+                                        <input
+                                            id="cover-input"
+                                            type="file"
+                                            accept="image/*"
+                                            onChange={handleCoverChange}
+                                            className="sr-only"
+                                        />
                                     </label>
                                 </div>
-                                <input
-                                    id="cover-input"
-                                    type="file"
-                                    accept="image/*"
-                                    onChange={handleCoverChange}
-                                    className="hidden"
-                                />
                             </div>
                         ) : (
-                            <label htmlFor="cover-input-empty" className="block">
+                            <label htmlFor="cover-input-empty" className="block rounded-2xl focus-within:ring-2 focus-within:ring-line-strong">
                                 <div className="aspect-[3/1] w-full rounded-2xl border-2 border-dashed border-line hover:border-line hover:bg-surface-subtle transition-all duration-200 cursor-pointer flex flex-col items-center justify-center gap-3 group">
                                     <svg className="w-12 h-12 text-content-hint group-hover:text-content-hint transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
@@ -277,7 +285,7 @@ const ProfileSetting = () => {
                                     type="file"
                                     accept="image/*"
                                     onChange={handleCoverChange}
-                                    className="hidden"
+                                    className="sr-only"
                                 />
                             </label>
                         )}
@@ -286,7 +294,7 @@ const ProfileSetting = () => {
                                 <button
                                     type="button"
                                     onClick={handleCoverDelete}
-                                    className="inline-flex items-center gap-2 rounded-xl border border-danger-line px-4 py-2 text-sm font-semibold text-danger transition-colors hover:bg-danger-surface">
+                                    className="inline-flex min-h-11 items-center gap-2 rounded-xl border border-danger-line px-4 py-2 text-sm font-semibold text-danger transition-colors hover:bg-danger-surface">
                                     <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M9 7V4a1 1 0 011-1h4a1 1 0 011 1v3m-9 0h10" />
                                     </svg>

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SeoAeoSetting/SeoAeoSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SeoAeoSetting/SeoAeoSetting.tsx
@@ -314,7 +314,7 @@ const SeoAeoSetting = () => {
 
                     <div className="space-y-2">
                         <div>
-                            <label className="block text-sm font-semibold text-content">
+                            <label htmlFor="robots-extra-rules" className="block text-sm font-semibold text-content">
                                 추가 규칙
                             </label>
                             <p className="mt-1 text-xs leading-relaxed text-content-secondary">
@@ -322,6 +322,7 @@ const SeoAeoSetting = () => {
                             </p>
                         </div>
                         <Input
+                            id="robots-extra-rules"
                             multiline
                             rows={7}
                             value={robotsTxtExtraRules}

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SeriesSetting/components/PostSelector.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SeriesSetting/components/PostSelector.tsx
@@ -58,6 +58,7 @@ const PostSelector = ({ posts, selectedPostIds, onChange }: PostSelectorProps) =
                         <div className="min-w-0 flex-1">
                             <Input
                                 type="text"
+                                aria-label="포함할 포스트 검색"
                                 value={query}
                                 onChange={(event) => setQuery(event.target.value)}
                                 placeholder="포스트 제목 검색"

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SiteSettingSetting/SiteSettingSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SiteSettingSetting/SiteSettingSetting.tsx
@@ -433,10 +433,11 @@ const SiteSettingSetting = () => {
                             모든 공개 페이지에 영향을 줍니다. 분석 스크립트나 검증 메타 태그처럼 꼭 필요한 코드만 넣어주세요.
                         </p>
                         <div className="space-y-2">
-                            <label className="block text-sm font-semibold text-content">
+                            <div className="block text-sm font-semibold text-content">
                                 Head 영역 코드
-                            </label>
+                            </div>
                             <CodeEditor
+                                ariaLabel="Head 영역 코드"
                                 language="html"
                                 value={headerScript}
                                 onChange={setHeaderScript}
@@ -445,10 +446,11 @@ const SiteSettingSetting = () => {
                             <p className="text-xs text-content-secondary">{'<head>'} 태그 안에 삽입됩니다.</p>
                         </div>
                         <div className="space-y-2">
-                            <label className="block text-sm font-semibold text-content">
+                            <div className="block text-sm font-semibold text-content">
                                 Body 하단 코드
-                            </label>
+                            </div>
                             <CodeEditor
+                                ariaLabel="Body 하단 코드"
                                 language="html"
                                 value={footerScript}
                                 onChange={setFooterScript}

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SocialLinksSetting/SocialLinksSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SocialLinksSetting/SocialLinksSetting.tsx
@@ -104,6 +104,8 @@ const SocialLinkItem = ({ social, index, onRemove, onChange }: SocialLinkItemPro
     ];
 
     const currentPlatform = platformOptions.find(opt => opt.value === social.name);
+    const platformInputId = `social-platform-${social.id}`;
+    const linkInputId = `social-link-${social.id}`;
 
     return (
         <div ref={setNodeRef} style={style} className="mb-4">
@@ -127,6 +129,7 @@ const SocialLinkItem = ({ social, index, onRemove, onChange }: SocialLinkItemPro
                     </div>
                     <button
                         type="button"
+                        aria-label="소셜 링크 삭제"
                         className="w-8 h-8 flex items-center justify-center rounded-lg text-content-hint hover:text-content-secondary hover:bg-surface-subtle transition-all duration-200"
                         onClick={() => onRemove(social.id)}>
                         <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
@@ -155,10 +158,10 @@ const SocialLinkItem = ({ social, index, onRemove, onChange }: SocialLinkItemPro
 
                     {/* 플랫폼 선택 */}
                     <div className="w-full sm:w-44 flex-shrink-0">
-                        <label className="block text-xs font-medium text-content-secondary mb-2 sm:hidden">플랫폼 선택</label>
+                        <label htmlFor={platformInputId} className="block text-xs font-medium text-content-secondary mb-2 sm:hidden">플랫폼 선택</label>
                         <Dropdown
                             trigger={
-                                <button type="button" className={`${baseInputStyles} flex items-center justify-between`}>
+                                <button id={platformInputId} type="button" className={`${baseInputStyles} flex items-center justify-between`}>
                                     <span className={!social.name ? 'text-content-hint' : 'text-content'}>
                                         {currentPlatform?.label || '아이콘 선택'}
                                     </span>
@@ -176,8 +179,9 @@ const SocialLinkItem = ({ social, index, onRemove, onChange }: SocialLinkItemPro
 
                     {/* 링크 주소 */}
                     <div className="flex-1">
-                        <label className="block text-xs font-medium text-content-secondary mb-2 sm:hidden">링크 주소</label>
+                        <label htmlFor={linkInputId} className="block text-xs font-medium text-content-secondary mb-2 sm:hidden">링크 주소</label>
                         <Input
+                            id={linkInputId}
                             type="url"
                             placeholder="https://example.com"
                             value={social.value}
@@ -188,6 +192,7 @@ const SocialLinkItem = ({ social, index, onRemove, onChange }: SocialLinkItemPro
                     {/* 삭제 버튼 - 데스크톱에서만 표시 */}
                     <button
                         type="button"
+                        aria-label="소셜 링크 삭제"
                         className="hidden sm:flex w-10 h-10 items-center justify-center rounded-lg text-content-hint hover:text-content-secondary hover:bg-surface-subtle transition-all duration-200 group/btn flex-shrink-0"
                         onClick={() => onRemove(social.id)}>
                         <svg className="w-4 h-4 group-hover/btn:scale-110 transition-transform" fill="currentColor" viewBox="0 0 20 20">

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/StaticPagesSetting/components/StaticPageEditor.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/StaticPagesSetting/components/StaticPageEditor.tsx
@@ -325,6 +325,7 @@ const StaticPageEditor = ({ pageId }: StaticPageEditorProps) => {
 
                     {activePanel === 'code' ? (
                         <CodeEditor
+                            ariaLabel="정적 페이지 HTML"
                             language="html"
                             value={content}
                             onChange={handleContentChange}
@@ -501,6 +502,7 @@ const StaticPageEditor = ({ pageId }: StaticPageEditorProps) => {
                                             </div>
                                             <input
                                                 type="number"
+                                                aria-label="푸터 메뉴 표시 순서"
                                                 value={order}
                                                 onChange={(e) => {
                                                     setOrder(parseInt(e.target.value) || 0);

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/UserManagementSetting/index.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/UserManagementSetting/index.tsx
@@ -391,6 +391,7 @@ const UserManagementSetting = () => {
                 icon={<i className="fas fa-users" />}>
                 <div className="mb-6 grid gap-3 lg:grid-cols-[minmax(0,1fr)_180px_180px_auto]">
                     <Input
+                        aria-label="사용자 검색"
                         placeholder="사용자 검색"
                         value={query}
                         onChange={(event) => setQuery(event.target.value)}

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/shared/BannerEditorBase.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/shared/BannerEditorBase.tsx
@@ -364,12 +364,13 @@ const BannerEditorBase = ({ scope, bannerId }: BannerEditorBaseProps) => {
             </div>
 
             <div className="space-y-2">
-                <label className="block text-sm font-semibold text-content">배너 HTML</label>
+                <div className="block text-sm font-semibold text-content">배너 HTML</div>
                 <Controller
                     name="contentHtml"
                     control={control}
                     render={({ field }) => (
                         <CodeEditor
+                            ariaLabel="배너 HTML"
                             language="html"
                             value={field.value}
                             onChange={field.onChange}

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/shared/NoticeSettingBase.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/shared/NoticeSettingBase.tsx
@@ -234,10 +234,13 @@ const NoticeSettingBase = ({ scope }: NoticeSettingBaseProps) => {
                     </h3>
                     <div className="space-y-4">
                         <div className="space-y-2">
-                            <label className="block text-sm font-medium text-content">
+                            <label
+                                htmlFor={isGlobal ? 'global-notice-title' : 'notice-title'}
+                                className="block text-sm font-medium text-content">
                                 공지 제목
                             </label>
                             <Input
+                                id={isGlobal ? 'global-notice-title' : 'notice-title'}
                                 placeholder="공지 제목을 입력하세요"
                                 className="text-base"
                                 error={errors.title?.message}
@@ -246,10 +249,13 @@ const NoticeSettingBase = ({ scope }: NoticeSettingBaseProps) => {
                         </div>
 
                         <div className="space-y-2">
-                            <label className="block text-sm font-medium text-content">
+                            <label
+                                htmlFor={isGlobal ? 'global-notice-url' : 'notice-url'}
+                                className="block text-sm font-medium text-content">
                                 URL
                             </label>
                             <Input
+                                id={isGlobal ? 'global-notice-url' : 'notice-url'}
                                 placeholder="https://example.com/notice"
                                 className="text-base"
                                 error={errors.url?.message}

--- a/backend/islands/apps/remotes/src/styles/settingsStyles.ts
+++ b/backend/islands/apps/remotes/src/styles/settingsStyles.ts
@@ -6,7 +6,7 @@
  */
 
 // Card styles - Clean, modern design with subtle shadows
-export const CARD_BASE = 'bg-surface ring-1 ring-line/60 rounded-2xl hover:ring-line transition-all motion-interaction';
+export const CARD_BASE = 'bg-surface ring-1 ring-line/60 rounded-2xl transition-all motion-interaction';
 export const CARD_PADDING = 'p-5';
 
 // Icon container styles - Minimal grayscale design

--- a/backend/islands/packages/ui/src/components/Input.tsx
+++ b/backend/islands/packages/ui/src/components/Input.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from 'react';
+import { forwardRef, useId } from 'react';
 import type { InputHTMLAttributes, ReactNode, ForwardedRef } from 'react';
 import { AlertCircle } from 'lucide-react';
 import { cx } from '../lib/classnames';
@@ -30,12 +30,19 @@ const Input = forwardRef<HTMLInputElement | HTMLTextAreaElement, InputProps>(
             id,
             required,
             readOnly,
+            'aria-describedby': ariaDescribedBy,
             ...props
         },
         ref
     ) => {
-        const inputId = id || `input-${Math.random().toString(36).substr(2, 9)}`;
+        const generatedId = useId();
+        const inputId = id ?? `input-${generatedId}`;
         const errorId = `${inputId}-error`;
+        const helperId = `${inputId}-helper`;
+        const describedBy = [
+            ariaDescribedBy,
+            error ? errorId : helperText ? helperId : undefined
+        ].filter(Boolean).join(' ') || undefined;
         const errorStyles = error ? 'border-danger-line focus:border-danger focus:ring-danger/20 bg-danger-surface/70' : '';
         const readOnlyStyles = readOnly ? '!bg-surface-subtle !text-content-hint cursor-default focus:!ring-0 focus:!border-line' : '';
 
@@ -79,7 +86,7 @@ const Input = forwardRef<HTMLInputElement | HTMLTextAreaElement, InputProps>(
                             readOnly={readOnly}
                             className={inputClasses}
                             aria-invalid={!!error}
-                            aria-describedby={error ? errorId : undefined}
+                            aria-describedby={describedBy}
                             {...(props as InputHTMLAttributes<HTMLTextAreaElement>)}
                         />
                     ) : (
@@ -89,7 +96,7 @@ const Input = forwardRef<HTMLInputElement | HTMLTextAreaElement, InputProps>(
                             readOnly={readOnly}
                             className={inputClasses}
                             aria-invalid={!!error}
-                            aria-describedby={error ? errorId : undefined}
+                            aria-describedby={describedBy}
                             {...(props as InputHTMLAttributes<HTMLInputElement>)}
                         />
                     )}
@@ -109,7 +116,7 @@ const Input = forwardRef<HTMLInputElement | HTMLTextAreaElement, InputProps>(
                 )}
 
                 {helperText && !error && (
-                    <p className="text-content-secondary text-xs mt-1.5 ml-1">{helperText}</p>
+                    <p id={helperId} className="text-content-secondary text-xs mt-1.5 ml-1">{helperText}</p>
                 )}
             </div>
         );


### PR DESCRIPTION
## 🎯 Goal
- Make settings labels, helper/error text, navigation controls, and upload controls expose the same meaning to keyboard and assistive-technology users.
- Preserve every existing URL, API payload, save result, UI prop, and mouse/touch interaction while strengthening the shared accessibility contract.

## 🔧 Core Changes
- Stabilize shared `Input` IDs with React `useId()` and compose caller-provided descriptions with helper/error relationships.
- Give settings inputs and code editors programmatic names, and add accessible names plus focus-safe behavior to the mobile settings menu.
- Add keyboard activation only to clickable `SettingsListItem` rows while removing the misleading hover ring from non-interactive rows.
- Make profile upload controls keyboard reachable with a real 44px mobile avatar hit area, and align the initial default-avatar fallback with the configured resource prefix to eliminate its transient 404.

## 🤔 Key Decisions
- Keep all existing public props, including `SettingsListItem.onClick`; repository-wide call-site inspection found active consumers, so behavior was extended rather than removed.
- Preserve explicit `Input` IDs and external `aria-describedby` values, adding generated IDs only when callers do not provide one.
- Keep the visible upload artwork at its current size while enlarging the actual label target, avoiding an unnecessary visual redesign.
- Keep URL, API, form submission, and save-state contracts untouched; this PR changes only frontend semantics and interaction affordances.

## 🧪 Verification Guide
### How to verify
1. At 375px, open and close `/settings/account` navigation with keyboard controls; confirm the trigger names are announced and focus returns to the open button.
2. Click the "새 비밀번호" label, submit an invalid short value, and inspect that focus reaches its input and the error ID is referenced by `aria-describedby`.
3. Open `/admin-settings/site-settings` and confirm the site-name helper and code-editor accessible names are exposed.
4. Open `/settings/profile` in light and dark themes; confirm the avatar upload is keyboard reachable, its target is 44×44px, and the default avatar loads without a failed asset request.
5. Confirm non-interactive settings list rows no longer show a hover ring, while clickable rows activate with Enter and Space.

### Expected result
- Settings semantics and keyboard behavior are available without changing routes, payloads, save behavior, or existing pointer interactions; no island asset request fails.

## ✅ Checklist
- [x] Lint completed (`npm run islands:lint`; existing warnings only)
- [x] Type-check completed (`npm run islands:type-check`)
- [x] Tests completed (`npm run islands:build`, entry budgets, Playwright smoke 10/10, authenticated production-asset smoke)
- [x] Documentation updated (Ocean Brain task log updated; no repository documentation change needed)
