### PR TITLE
♻️ Consolidate settings primitive style sources

### DIFF
--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/SettingsListItem.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/SettingsListItem.tsx
@@ -1,13 +1,12 @@
 import type { KeyboardEvent, ReactNode } from 'react';
 import type { DraggableAttributes } from '@dnd-kit/core';
 import type { SyntheticListenerMap } from '@dnd-kit/core/dist/hooks/utilities';
-import {
-    getCardClass,
-    CARD_PADDING,
-    FLEX_ROW,
-    ACTIONS_CONTAINER,
-    DRAG_HANDLE
-} from '~/components/shared';
+
+const LIST_ITEM_SHELL = 'bg-surface ring-1 ring-line/60 rounded-2xl transition-all motion-interaction';
+const LIST_ITEM_CONTENT = 'p-5';
+const LIST_ITEM_ROW = 'flex items-center gap-3';
+const LIST_ITEM_ACTIONS = 'flex gap-2 flex-shrink-0';
+const LIST_ITEM_DRAG_HANDLE = 'cursor-grab active:cursor-grabbing text-content-hint hover:text-content-secondary p-2 hover:bg-surface-subtle rounded-lg transition-colors -ml-2';
 
 interface DragHandleProps {
     attributes: DraggableAttributes;
@@ -42,18 +41,18 @@ const SettingsListItem = ({
 
     return (
         <div
-            className={getCardClass(onClick
-                ? 'cursor-pointer hover:ring-line focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-line-strong'
-                : '')}
+            className={`${LIST_ITEM_SHELL}${onClick
+                ? ' cursor-pointer hover:ring-line focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-line-strong'
+                : ''}`}
             onClick={onClick}
             onKeyDown={handleKeyDown}
             role={onClick ? 'button' : undefined}
             tabIndex={onClick ? 0 : undefined}>
-            <div className={CARD_PADDING}>
-                <div className={`${FLEX_ROW}${className ? ` ${className}` : ''}`}>
+            <div className={LIST_ITEM_CONTENT}>
+                <div className={`${LIST_ITEM_ROW}${className ? ` ${className}` : ''}`}>
                     {dragHandleProps && (
                         <div
-                            className={DRAG_HANDLE}
+                            className={LIST_ITEM_DRAG_HANDLE}
                             style={{ touchAction: 'none' }}
                             onClick={(e) => e.stopPropagation()}
                             {...dragHandleProps.attributes}
@@ -69,7 +68,7 @@ const SettingsListItem = ({
                     </div>
 
                     {actions && (
-                        <div className={ACTIONS_CONTAINER} onClick={(e) => e.stopPropagation()}>
+                        <div className={LIST_ITEM_ACTIONS} onClick={(e) => e.stopPropagation()}>
                             {actions}
                         </div>
                     )}

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/WebhookChannelManager.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/WebhookChannelManager.tsx
@@ -8,10 +8,10 @@ import { toast } from '~/utils/toast';
 import { useConfirm } from '~/hooks/useConfirm';
 import { Button, Dropdown, Input } from '~/components/shared';
 import {
-    getIconClass,
-    TITLE,
-    SUBTITLE
-} from '~/components/shared';
+    getSettingsIconClass,
+    SETTINGS_LIST_META,
+    SETTINGS_LIST_TITLE
+} from '~/styles/settingsStyles';
 import { SettingsEmptyState, SettingsHeader, SettingsListItem } from '.';
 import type { WebhookChannel } from '~/lib/api/settings';
 import type { Response } from '~/lib/http.module';
@@ -384,7 +384,7 @@ const WebhookChannelManager = ({
                         <SettingsListItem
                             key={channel.id}
                             left={
-                                <div className={getIconClass('default')}>
+                                <div className={getSettingsIconClass('default')}>
                                     <i className={`fas ${channel.isActive ? 'fa-bolt' : 'fa-exclamation-triangle'} text-sm`} />
                                 </div>
                             }
@@ -400,10 +400,10 @@ const WebhookChannelManager = ({
                                     ]}
                                 />
                             }>
-                            <h3 className={`${TITLE} mb-0.5`}>
+                            <h3 className={`${SETTINGS_LIST_TITLE} mb-0.5`}>
                                 {channel.name || '이름 없는 채널'}
                             </h3>
-                            <div className={`${SUBTITLE} flex flex-wrap items-center gap-3`}>
+                            <div className={`${SETTINGS_LIST_META} flex flex-wrap items-center gap-3`}>
                                 <span className="flex items-center truncate max-w-[200px]" title={channel.webhookUrl}>
                                     <i className="fas fa-link mr-1.5" />
                                     {channel.webhookUrl.replace(/^https?:\/\//, '').slice(0, 30)}...

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/BannerSetting/components/BannerList.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/BannerSetting/components/BannerList.tsx
@@ -18,10 +18,8 @@ import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { restrictToVerticalAxis, restrictToFirstScrollableAncestor } from '@dnd-kit/modifiers';
 
-import {
-    TITLE,
-    Dropdown
-} from '~/components/shared';
+import { Dropdown } from '~/components/shared';
+import { SETTINGS_LIST_TITLE } from '~/styles/settingsStyles';
 import { SettingsListItem } from '../../../components';
 import type { BannerData } from '~/lib/api/settings';
 
@@ -104,7 +102,7 @@ const SortableBannerItem = ({ banner, onEdit, onDelete, onToggleActive }: Sortab
                 }>
                 <div className="space-y-2">
                     <div className="flex items-center gap-2 flex-wrap">
-                        <h3 className={`${TITLE} mb-0`}>
+                        <h3 className={`${SETTINGS_LIST_TITLE} mb-0`}>
                             {banner.title}
                         </h3>
                         <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-surface-subtle text-content border border-line">

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/FormsSetting/FormsSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/FormsSetting/FormsSetting.tsx
@@ -7,9 +7,9 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { SettingsEmptyState, SettingsHeader, SettingsListItem } from '../../components';
 import { Button, Input, Dropdown } from '~/components/shared';
 import {
-    getIconClass,
-    TITLE
-} from '~/components/shared';
+    getSettingsIconClass,
+    SETTINGS_LIST_TITLE
+} from '~/styles/settingsStyles';
 import { useConfirm } from '~/hooks/useConfirm';
 import {
     getForms,
@@ -219,7 +219,7 @@ const FormsManagement = () => {
                         <SettingsListItem
                             key={form.id}
                             left={
-                                <div className={getIconClass('default')}>
+                                <div className={getSettingsIconClass('default')}>
                                     <i className="fas fa-file-lines text-sm" />
                                 </div>
                             }
@@ -240,7 +240,7 @@ const FormsManagement = () => {
                                     ]}
                                 />
                             }>
-                            <h3 className={TITLE}>{form.title}</h3>
+                            <h3 className={SETTINGS_LIST_TITLE}>{form.title}</h3>
                         </SettingsListItem>
                     ))}
                 </div>

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/GlobalBannerSetting/components/GlobalBannerList.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/GlobalBannerSetting/components/GlobalBannerList.tsx
@@ -18,10 +18,8 @@ import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { restrictToVerticalAxis, restrictToFirstScrollableAncestor } from '@dnd-kit/modifiers';
 
-import {
-    TITLE,
-    Dropdown
-} from '~/components/shared';
+import { Dropdown } from '~/components/shared';
+import { SETTINGS_LIST_TITLE } from '~/styles/settingsStyles';
 import { SettingsListItem } from '../../../components';
 import type { GlobalBannerData } from '~/lib/api/settings';
 
@@ -104,7 +102,7 @@ const SortableBannerItem = ({ banner, onEdit, onDelete, onToggleActive }: Sortab
                 }>
                 <div className="space-y-2">
                     <div className="flex items-center gap-2 flex-wrap">
-                        <h3 className={`${TITLE} mb-0`}>
+                        <h3 className={`${SETTINGS_LIST_TITLE} mb-0`}>
                             {banner.title}
                         </h3>
                         <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-surface-subtle text-content border border-line">

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/NotifySetting/components/NotificationsSection.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/NotifySetting/components/NotificationsSection.tsx
@@ -1,7 +1,5 @@
-import {
-    Button,
-    TITLE
-} from '~/components/shared';
+import { Button } from '~/components/shared';
+import { SETTINGS_LIST_TITLE } from '~/styles/settingsStyles';
 import { SettingsEmptyState, SettingsHeader, SettingsListItem } from '../../../components';
 import { markNotificationAsRead, type NotifyItem } from '~/lib/api/settings';
 
@@ -78,7 +76,7 @@ const NotificationsSection = ({
                                     <i className="fas fa-chevron-right" />
                                 </div>
                             }>
-                            <div className={`${TITLE} ${!item.isRead ? 'font-semibold text-content' : 'font-medium text-content-secondary'} mb-1.5 leading-relaxed`}>
+                            <div className={`${SETTINGS_LIST_TITLE} ${!item.isRead ? 'font-semibold text-content' : 'font-medium text-content-secondary'} mb-1.5 leading-relaxed`}>
                                 {item.content}
                             </div>
                             <div className="flex items-center gap-2 text-xs text-content-hint">

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PinnedPostsSetting/components/PinnablePostInlineList.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PinnedPostsSetting/components/PinnablePostInlineList.tsx
@@ -1,9 +1,9 @@
+import { Button } from '~/components/shared';
 import {
-    Button,
-    SUBTITLE,
-    TITLE,
-    getIconClass
-} from '~/components/shared';
+    getSettingsIconClass,
+    SETTINGS_LIST_META,
+    SETTINGS_LIST_TITLE
+} from '~/styles/settingsStyles';
 import SettingsListItem from '../../../components/SettingsListItem';
 import { getMediaPath } from '~/modules/static.module';
 import type { PinnablePostData, PinnablePostsPaginationData } from '~/lib/api/settings';
@@ -95,7 +95,7 @@ export const PinnablePostInlineList = ({
                                 key={post.url}
                                 left={
                                     post.image ? (
-                                        <div className={`${getIconClass('default')} overflow-hidden`}>
+                                        <div className={`${getSettingsIconClass('default')} overflow-hidden`}>
                                             <img
                                                 src={getMediaPath(post.image)}
                                                 alt={post.title}
@@ -103,7 +103,7 @@ export const PinnablePostInlineList = ({
                                             />
                                         </div>
                                     ) : (
-                                        <div className={getIconClass('default')}>
+                                        <div className={getSettingsIconClass('default')}>
                                             <i className="fas fa-file-alt text-sm" />
                                         </div>
                                     )
@@ -118,8 +118,8 @@ export const PinnablePostInlineList = ({
                                         고정
                                     </Button>
                                 }>
-                                <h3 className={`${TITLE} mb-1 truncate text-content`}>{post.title}</h3>
-                                <div className={`${SUBTITLE} flex items-center gap-2 text-xs`}>
+                                <h3 className={`${SETTINGS_LIST_TITLE} mb-1 truncate text-content`}>{post.title}</h3>
+                                <div className={`${SETTINGS_LIST_META} flex items-center gap-2 text-xs`}>
                                     <span className="flex items-center gap-1">
                                         <i className="far fa-calendar text-content-hint" />
                                         {new Date(post.createdDate).toLocaleDateString('ko-KR')}

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PinnedPostsSetting/components/PinnedPostItem.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PinnedPostsSetting/components/PinnedPostItem.tsx
@@ -1,11 +1,11 @@
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
+import { Button } from '~/components/shared';
 import {
-    Button,
-    TITLE,
-    SUBTITLE,
-    getIconClass
-} from '~/components/shared';
+    getSettingsIconClass,
+    SETTINGS_LIST_META,
+    SETTINGS_LIST_TITLE
+} from '~/styles/settingsStyles';
 import { SettingsListItem } from '../../../components';
 import { getMediaPath } from '~/modules/static.module';
 import type { PinnedPostData } from '~/lib/api/settings';
@@ -56,7 +56,7 @@ export const PinnedPostItem = ({
                 }}
                 left={
                     pinnedPost.post.image ? (
-                        <div className={`${getIconClass('default')} overflow-hidden`}>
+                        <div className={`${getSettingsIconClass('default')} overflow-hidden`}>
                             <img
                                 src={getMediaPath(pinnedPost.post.image)}
                                 alt={pinnedPost.post.title}
@@ -64,7 +64,7 @@ export const PinnedPostItem = ({
                             />
                         </div>
                     ) : (
-                        <div className={getIconClass('default')}>
+                        <div className={getSettingsIconClass('default')}>
                             <i className="fas fa-thumbtack text-sm" />
                         </div>
                     )
@@ -77,8 +77,8 @@ export const PinnedPostItem = ({
                         해제
                     </Button>
                 }>
-                <h3 className={`${TITLE} mb-1 truncate text-content`}>{pinnedPost.post.title}</h3>
-                <div className={`${SUBTITLE} text-xs flex items-center gap-2`}>
+                <h3 className={`${SETTINGS_LIST_TITLE} mb-1 truncate text-content`}>{pinnedPost.post.title}</h3>
+                <div className={`${SETTINGS_LIST_META} text-xs flex items-center gap-2`}>
                     <span className="flex items-center gap-1">
                         <i className="far fa-calendar text-content-hint" />
                         {new Date(pinnedPost.post.createdDate).toLocaleDateString('ko-KR')}

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/DraftPostListContent.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/DraftPostListContent.tsx
@@ -1,7 +1,12 @@
 import { useEffect } from 'react';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { SettingsEmptyState, SettingsListItem } from '../../../components';
-import { Dropdown, getIconClass, SUBTITLE, TITLE } from '~/components/shared';
+import { Dropdown } from '~/components/shared';
+import {
+    getSettingsIconClass,
+    SETTINGS_LIST_META,
+    SETTINGS_LIST_TITLE
+} from '~/styles/settingsStyles';
 import { useConfirm } from '~/hooks/useConfirm';
 import { getDraftPosts } from '~/lib/api/settings';
 import { deleteDraft } from '~/lib/api/posts';
@@ -75,7 +80,7 @@ export const DraftPostListContent = ({ onCountChange }: DraftPostListContentProp
                     onClick={() => handleContinueDraft(draftPost.url)}
                     left={
                         draftPost.image ? (
-                            <div className={`${getIconClass('default')} overflow-hidden`}>
+                            <div className={`${getSettingsIconClass('default')} overflow-hidden`}>
                                 <img
                                     src={getMediaPath(draftPost.image)}
                                     alt={draftPost.title || '제목 없음'}
@@ -84,7 +89,7 @@ export const DraftPostListContent = ({ onCountChange }: DraftPostListContentProp
                                 />
                             </div>
                         ) : (
-                            <div className={getIconClass('default')}>
+                            <div className={getSettingsIconClass('default')}>
                                 <i className="fas fa-file-alt text-sm" />
                             </div>
                         )
@@ -101,10 +106,10 @@ export const DraftPostListContent = ({ onCountChange }: DraftPostListContentProp
                             ]}
                         />
                     }>
-                    <h3 className={`${TITLE} mb-0.5`}>
+                    <h3 className={`${SETTINGS_LIST_TITLE} mb-0.5`}>
                         {draftPost.title || '제목 없음'}
                     </h3>
-                    <div className={`${SUBTITLE} flex flex-wrap items-center gap-3`}>
+                    <div className={`${SETTINGS_LIST_META} flex flex-wrap items-center gap-3`}>
                         <span className="flex items-center">
                             <i className="fas fa-clock mr-1.5" />
                             마지막 수정 {draftPost.updatedDate}

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/PostCard.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/PostCard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Button, Input, Dropdown, Select } from '~/components/shared';
-import { getIconClass } from '~/components/shared';
+import { getSettingsIconClass } from '~/styles/settingsStyles';
 import { getMediaPath } from '~/modules/static.module';
 import type { Post } from '../hooks';
 import type { Series } from '~/lib/api/settings';
@@ -168,7 +168,7 @@ const PostCard = ({
                 <div className="p-4 pt-3 space-y-3 bg-surface-subtle/40 border-t border-line-light">
                     {/* 태그 */}
                     <div className="flex items-center gap-3">
-                        <div className={getIconClass('light')}>
+                        <div className={getSettingsIconClass('light')}>
                             <i className="fas fa-tag text-sm" />
                         </div>
                         <Input
@@ -192,7 +192,7 @@ const PostCard = ({
 
                     {/* 시리즈 */}
                     <div className="flex items-center gap-3">
-                        <div className={getIconClass('light')}>
+                        <div className={getSettingsIconClass('light')}>
                             <i className="fas fa-book text-sm" />
                         </div>
                         <div className="flex-1">

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/PostsFilter.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/PostsFilter.tsx
@@ -1,5 +1,5 @@
 import { Button, Input, Dropdown } from '~/components/shared';
-import { baseInputStyles } from '~/components/shared';
+import { settingsSelectTriggerStyles } from '~/styles/settingsStyles';
 import type { FilterOptions } from '../hooks';
 import { POSTS_ORDER } from '../hooks';
 import type { Tag, Series } from '~/lib/api/settings';
@@ -123,7 +123,7 @@ const PostsFilter = ({
                         <Dropdown
                             align="left"
                             trigger={
-                                <button className={`${baseInputStyles} flex items-center justify-between text-left`}>
+                                <button className={`${settingsSelectTriggerStyles} flex items-center justify-between text-left`}>
                                     <span className="text-content font-medium">
                                         {POSTS_ORDER.find(o => o.order === filters.order)?.name || '정렬 방식'}
                                     </span>
@@ -143,7 +143,7 @@ const PostsFilter = ({
                         <Dropdown
                             align="left"
                             trigger={
-                                <button className={`${baseInputStyles} flex items-center justify-between text-left`}>
+                                <button className={`${settingsSelectTriggerStyles} flex items-center justify-between text-left`}>
                                     <span className={filters.tag ? 'text-content font-medium' : 'text-content-hint'}>
                                         {filters.tag || '태그'}
                                     </span>
@@ -168,7 +168,7 @@ const PostsFilter = ({
                         <Dropdown
                             align="left"
                             trigger={
-                                <button className={`${baseInputStyles} flex items-center justify-between text-left`}>
+                                <button className={`${settingsSelectTriggerStyles} flex items-center justify-between text-left`}>
                                     <span className={filters.series ? 'text-content font-medium' : 'text-content-hint'}>
                                         {series?.find((s) => s.url === filters.series)?.title || '시리즈'}
                                     </span>
@@ -193,7 +193,7 @@ const PostsFilter = ({
                         <Dropdown
                             align="left"
                             trigger={
-                                <button className={`${baseInputStyles} flex items-center justify-between text-left`}>
+                                <button className={`${settingsSelectTriggerStyles} flex items-center justify-between text-left`}>
                                     <span className={filters.visibility ? 'text-content font-medium' : 'text-content-hint'}>
                                         {filters.visibility === 'public' ? '공개' : filters.visibility === 'hidden' ? '숨김' : '공개 상태'}
                                     </span>

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SeriesSetting/SeriesSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SeriesSetting/SeriesSetting.tsx
@@ -24,10 +24,10 @@ import { useNavigate } from '@tanstack/react-router';
 import { SettingsEmptyState, SettingsHeader, SettingsListItem } from '../../components';
 import { Button, Dropdown } from '~/components/shared';
 import {
- getIconClass,
- TITLE,
- SUBTITLE
-} from '~/components/shared';
+    getSettingsIconClass,
+    SETTINGS_LIST_META,
+    SETTINGS_LIST_TITLE
+} from '~/styles/settingsStyles';
 import { useConfirm } from '~/hooks/useConfirm';
 import {
     getSeriesWithUsername,
@@ -86,7 +86,7 @@ const SortableSeriesItem = ({ series, username, onEdit, onDelete }: SortableSeri
                     listeners
                 }}
                 left={
-                    <div className={getIconClass('default')}>
+                    <div className={getSettingsIconClass('default')}>
                         <i className="fas fa-book text-sm" />
                     </div>
                 }
@@ -107,8 +107,8 @@ const SortableSeriesItem = ({ series, username, onEdit, onDelete }: SortableSeri
                         ]}
                     />
                 }>
-                <h3 className={`${TITLE} mb-0.5`}>{series.title}</h3>
-                <div className={SUBTITLE}>
+                <h3 className={`${SETTINGS_LIST_TITLE} mb-0.5`}>{series.title}</h3>
+                <div className={SETTINGS_LIST_META}>
                     <i className="fas fa-file-alt mr-1.5" />
                     {series.totalPosts}개의 포스트
                 </div>

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SocialLinksSetting/SocialLinksSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SocialLinksSetting/SocialLinksSetting.tsx
@@ -22,7 +22,7 @@ import { toast } from '~/utils/toast';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { SettingsEmptyState, SettingsHeader } from '../../components';
 import { Button, Input, Dropdown } from '~/components/shared';
-import { baseInputStyles } from '~/components/shared';
+import { settingsSelectTriggerStyles } from '~/styles/settingsStyles';
 import { getSocialLinks, updateSocialLinks, type SocialLink as ApiSocialLink } from '~/lib/api/settings';
 
 interface SocialLink extends ApiSocialLink {
@@ -161,7 +161,7 @@ const SocialLinkItem = ({ social, index, onRemove, onChange }: SocialLinkItemPro
                         <label htmlFor={platformInputId} className="block text-xs font-medium text-content-secondary mb-2 sm:hidden">플랫폼 선택</label>
                         <Dropdown
                             trigger={
-                                <button id={platformInputId} type="button" className={`${baseInputStyles} flex items-center justify-between`}>
+                                <button id={platformInputId} type="button" className={`${settingsSelectTriggerStyles} flex items-center justify-between`}>
                                     <span className={!social.name ? 'text-content-hint' : 'text-content'}>
                                         {currentPlatform?.label || '아이콘 선택'}
                                     </span>

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/StaticPagesSetting/components/StaticPageList.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/StaticPagesSetting/components/StaticPageList.tsx
@@ -1,8 +1,5 @@
-import {
-    TITLE,
-    SUBTITLE,
-    Dropdown
-} from '~/components/shared';
+import { Dropdown } from '~/components/shared';
+import { SETTINGS_LIST_META, SETTINGS_LIST_TITLE } from '~/styles/settingsStyles';
 import { SettingsListItem } from '../../../components';
 import type { StaticPageData } from '~/lib/api/settings';
 
@@ -39,7 +36,7 @@ export const StaticPageList = ({ pages, onView, onEdit, onDelete }: StaticPageLi
                     }>
                     <div className="space-y-1">
                         <div className="flex items-center gap-2 flex-wrap">
-                            <h3 className={`${TITLE} mb-0`}>
+                            <h3 className={`${SETTINGS_LIST_TITLE} mb-0`}>
                                 {page.title}
                             </h3>
                             <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium border ${page.isPublished ? 'bg-action text-content-inverted border-line-strong' : 'bg-surface-subtle text-content-secondary border-line-light'}`}>
@@ -51,7 +48,7 @@ export const StaticPageList = ({ pages, onView, onEdit, onDelete }: StaticPageLi
                                 </span>
                             )}
                         </div>
-                        <p className={SUBTITLE}>/static/{page.slug}</p>
+                        <p className={SETTINGS_LIST_META}>/static/{page.slug}</p>
                     </div>
                 </SettingsListItem>
             ))}

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/shared/NoticeSettingBase.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/shared/NoticeSettingBase.tsx
@@ -10,9 +10,9 @@ import {
     Button,
     Checkbox,
     Dropdown,
-    Input,
-    TITLE
+    Input
 } from '~/components/shared';
+import { SETTINGS_LIST_TITLE } from '~/styles/settingsStyles';
 import {
     getNotices,
     createNotice,
@@ -329,7 +329,7 @@ const NoticeSettingBase = ({ scope }: NoticeSettingBaseProps) => {
                             }>
                             <div className="space-y-1">
                                 <div className="flex items-center gap-2 flex-wrap">
-                                    <h3 className={`${TITLE} mb-0`}>{notice.title}</h3>
+                                    <h3 className={`${SETTINGS_LIST_TITLE} mb-0`}>{notice.title}</h3>
                                     <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium border ${notice.isActive ? 'bg-action text-content-inverted border-line-strong' : 'bg-surface-subtle text-content-secondary border-line-light'}`}>
                                         {notice.isActive ? '활성' : '비활성'}
                                     </span>

--- a/backend/islands/apps/remotes/src/components/shared/index.ts
+++ b/backend/islands/apps/remotes/src/components/shared/index.ts
@@ -20,16 +20,4 @@ export {
 
 export { TiptapEditor } from '@blex/editor/tiptap-editor';
 
-export {
-    ACTIONS_CONTAINER,
-    CARD_PADDING,
-    DRAG_HANDLE,
-    FLEX_ROW,
-    SUBTITLE,
-    TITLE,
-    baseInputStyles,
-    getCardClass,
-    getIconClass
-} from '../../styles/settingsStyles';
-
 export * as api from '../../lib/api';

--- a/backend/islands/apps/remotes/src/styles/settingsStyles.ts
+++ b/backend/islands/apps/remotes/src/styles/settingsStyles.ts
@@ -1,43 +1,18 @@
-/**
- * Settings UI Style Constants
- *
- * 일관된 설정 페이지 UI를 위한 공통 스타일 상수
- * Modern minimal design principles
- */
+/** Role-specific styles used by settings lists and dropdown triggers. */
 
-// Card styles - Clean, modern design with subtle shadows
-export const CARD_BASE = 'bg-surface ring-1 ring-line/60 rounded-2xl transition-all motion-interaction';
-export const CARD_PADDING = 'p-5';
+const SETTINGS_ICON_BASE = 'w-10 h-10 rounded-lg flex items-center justify-center flex-shrink-0';
 
-// Icon container styles - Minimal grayscale design
-export const ICON_BASE = 'w-10 h-10 rounded-lg flex items-center justify-center flex-shrink-0';
-export const ICON_SIZE = 'text-sm';
-
-// Icon styles - Clean grayscale variants
-export const ICON_VARIANTS = {
+const SETTINGS_ICON_VARIANTS = {
     default: 'bg-surface-subtle text-content-secondary',
-    dark: 'bg-action-hover text-content-inverted',
     light: 'bg-surface-subtle text-content-secondary border border-line'
 } as const;
 
-// Typography
-export const TITLE = 'text-base font-semibold text-content';
-export const SUBTITLE = 'text-xs text-content-secondary';
+export const SETTINGS_LIST_TITLE = 'text-base font-semibold text-content';
+export const SETTINGS_LIST_META = 'text-xs text-content-secondary';
 
-// Layout
-export const FLEX_ROW = 'flex items-center gap-3';
-export const ACTIONS_CONTAINER = 'flex gap-2 flex-shrink-0';
+export const getSettingsIconClass = (
+    variant: keyof typeof SETTINGS_ICON_VARIANTS = 'default'
+) => `${SETTINGS_ICON_BASE} ${SETTINGS_ICON_VARIANTS[variant]}`;
 
-// Drag handle
-export const DRAG_HANDLE = 'cursor-grab active:cursor-grabbing text-content-hint hover:text-content-secondary p-2 hover:bg-surface-subtle rounded-lg transition-colors -ml-2';
-
-// Helper function to create icon class
-export const getIconClass = (variant: keyof typeof ICON_VARIANTS = 'default') =>
-    `${ICON_BASE} ${ICON_VARIANTS[variant]}`;
-
-// Helper function to create card class
-export const getCardClass = (extraClasses = '') =>
-    `${CARD_BASE} ${extraClasses}`;
-
-// Shared Input Styles
-export const baseInputStyles = 'block w-full rounded-lg border border-line focus:border-line-strong/30 focus:ring-2 focus:ring-line/5 text-sm py-3 px-3 min-h-12 transition-all motion-interaction bg-surface placeholder-content-hint text-content';
+// These are button-based select triggers, not text inputs.
+export const settingsSelectTriggerStyles = 'block w-full rounded-lg border border-line focus:border-line-strong/30 focus:ring-2 focus:ring-line/5 text-sm py-3 px-3 min-h-12 transition-all motion-interaction bg-surface placeholder-content-hint text-content';


### PR DESCRIPTION
## 🎯 Goal
- 설정 전용 스타일의 일반적인 이름이 공용 Card/Input의 대체 기준처럼 확장되는 문제를 해소합니다.
- 실제 역할 계약을 명확히 하면서 기존 화면과 동작의 하위호환을 보장합니다.

## 🔧 Core Changes
- 설정 목록 행 shell과 padding·action·drag 스타일을 유일한 사용처인 `SettingsListItem` 내부 책임으로 좁혔습니다.
- 목록 제목·메타·아이콘 스타일을 역할 기반 이름으로 변경하고 호출처가 `settingsStyles`를 직접 참조하도록 정리했습니다.
- SocialLinks와 PostsFilter의 버튼 기반 선택 트리거를 `settingsSelectTriggerStyles`로 명명하고 기존 class와 동작을 유지했습니다.
- 미사용 icon size/dark variant와 설정 스타일의 공용 barrel 재export를 제거했습니다.

## 🤔 Key Decisions
- SocialLinks와 PostsFilter는 text input이 아니라 checked menu를 여는 버튼이므로 공용 Input/Select로 바꾸지 않았습니다. 이 예외는 필터 선택과 반응형 계약을 보존하면서 이름만 실제 역할에 맞췄습니다.
- 목록 행은 공용 Card와 달리 drag/action/선택 가능성을 갖는 별도 역할이므로 새 범용 variant를 만들지 않고 컴포넌트 내부에 캡슐화했습니다.
- 공용 Card/Input props와 전역 토큰은 변경하지 않았습니다.

## 🧪 Verification Guide
### How to verify
1. `/settings/forms` 등 목록 화면에서 비클릭 행에 hover/keyboard button affordance가 생기지 않는지 확인합니다.
2. `/settings/social-links`와 `/settings/posts`에서 선택 트리거의 focus, 메뉴 열기·선택, 48px 높이와 모바일 폭을 확인합니다.
3. 라이트 데스크톱과 다크·reduced-motion 모바일에서 레이아웃 및 콘솔/네트워크 오류를 확인합니다.

### Expected result
- 기존 시각·입력·필터·반응형 동작은 동일하고 스타일 소스의 역할과 사용 범위만 명확해집니다.

## ✅ Checklist
- [x] Lint completed (`npm run islands:lint`; 기존 warning만 존재)
- [x] Type-check completed (`npm run islands:type-check`)
- [x] Tests completed (`npm run islands:build`, entry budgets, production smoke 10/10, related browser audit)
- [x] Documentation reviewed (Ocean Brain task log updated; repository docs change not needed)