### PR TITLE
♻️ Unify settings toggle presentation and touch behavior

### DIFF
--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/components/SettingsDrawer.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/components/SettingsDrawer.tsx
@@ -411,10 +411,10 @@ const SettingsDrawer = ({
 
                                     {/* Privacy & Display Options */}
                                     <div className="space-y-1">
-                                        <div className="flex items-center justify-between py-3">
-                                            <div className="flex items-center gap-3">
+                                        <div className="flex items-center justify-between gap-4 py-3">
+                                            <div className="flex min-w-0 flex-1 items-center gap-3">
                                                 <EyeOff className="w-4 h-4 text-content-hint" />
-                                                <div>
+                                                <div className="min-w-0">
                                                     <div className="text-sm font-medium text-content">비공개</div>
                                                     <div className="text-xs text-content-secondary">본인만 볼 수 있습니다</div>
                                                 </div>
@@ -426,10 +426,10 @@ const SettingsDrawer = ({
                                             />
                                         </div>
 
-                                        <div className="flex items-center justify-between py-3">
-                                            <div className="flex items-center gap-3">
+                                        <div className="flex items-center justify-between gap-4 py-3">
+                                            <div className="flex min-w-0 flex-1 items-center gap-3">
                                                 <CircleDollarSign className="w-4 h-4 text-content-hint" />
-                                                <div>
+                                                <div className="min-w-0">
                                                     <div className="text-sm font-medium text-content">광고 표시</div>
                                                     <div className="text-xs text-content-secondary">포스트에 광고가 표시됩니다</div>
                                                 </div>

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/AdminIntegrationSetting/AdminIntegrationSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/AdminIntegrationSetting/AdminIntegrationSetting.tsx
@@ -152,24 +152,19 @@ const AdminIntegrationSetting = () => {
                 subtitle="사용자 알림을 텔레그램으로 보낼 봇을 설정합니다."
                 icon={<i className="fab fa-telegram-plane" />}>
                 <div className="space-y-5">
-                    <div className="flex flex-col gap-3 border-b border-line pb-5 sm:flex-row sm:items-center sm:justify-between">
-                        <div>
+                    <div className="flex items-start justify-between gap-4 border-b border-line pb-5">
+                        <div className="min-w-0 flex-1">
                             <div className="text-sm font-semibold text-content">텔레그램 사용</div>
                             <p className="mt-1 text-xs leading-relaxed text-content-secondary">
                                 켜면 사용자가 텔레그램을 연결하고 주요 알림을 받을 수 있습니다.
                             </p>
                         </div>
-                        <div className="flex items-center gap-3">
-                            <span className="text-xs font-medium text-content-secondary">
-                                {integrationSettings.telegramEnabled ? 'ON' : 'OFF'}
-                            </span>
-                            <Toggle
-                                checked={integrationSettings.telegramEnabled}
-                                disabled={updateMutation.isPending}
-                                onCheckedChange={(checked) => updateIntegrationSettingsForm({ telegramEnabled: checked })}
-                                aria-label="텔레그램 사용"
-                            />
-                        </div>
+                        <Toggle
+                            checked={integrationSettings.telegramEnabled}
+                            disabled={updateMutation.isPending}
+                            onCheckedChange={(checked) => updateIntegrationSettingsForm({ telegramEnabled: checked })}
+                            aria-label="텔레그램 사용"
+                        />
                     </div>
 
                     <div className="grid gap-4 md:grid-cols-2">

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/LoginSetting/LoginSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/LoginSetting/LoginSetting.tsx
@@ -277,24 +277,19 @@ const LoginSetting = () => {
                 subtitle="회원가입 시 hCaptcha 검증을 사용합니다."
                 icon={<i className="fas fa-shield-halved" />}>
                 <div className="space-y-5">
-                    <div className="flex flex-col gap-3 border-b border-line pb-5 sm:flex-row sm:items-center sm:justify-between">
-                        <div>
+                    <div className="flex items-start justify-between gap-4 border-b border-line pb-5">
+                        <div className="min-w-0 flex-1">
                             <div className="text-sm font-semibold text-content">hCaptcha 사용</div>
                             <p className="mt-1 text-xs leading-relaxed text-content-secondary">
                                 켜면 회원가입 요청에 hCaptcha 토큰 검증이 필요합니다.
                             </p>
                         </div>
-                        <div className="flex items-center gap-3">
-                            <span className="text-xs font-medium text-content-secondary">
-                                {loginSettings.hcaptchaEnabled ? 'ON' : 'OFF'}
-                            </span>
-                            <Toggle
-                                checked={loginSettings.hcaptchaEnabled}
-                                disabled={updateMutation.isPending}
-                                onCheckedChange={(checked) => updateLoginSettingsForm({ hcaptchaEnabled: checked })}
-                                aria-label="hCaptcha 사용"
-                            />
-                        </div>
+                        <Toggle
+                            checked={loginSettings.hcaptchaEnabled}
+                            disabled={updateMutation.isPending}
+                            onCheckedChange={(checked) => updateLoginSettingsForm({ hcaptchaEnabled: checked })}
+                            aria-label="hCaptcha 사용"
+                        />
                     </div>
 
                     <div className="grid gap-4 md:grid-cols-2">
@@ -357,24 +352,19 @@ const LoginSetting = () => {
 
                     {socialAuthProviders.map((provider) => (
                         <div key={provider.key} className="space-y-5 rounded-xl border border-line p-4">
-                            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                                <div>
+                            <div className="flex items-start justify-between gap-4">
+                                <div className="min-w-0 flex-1">
                                     <div className="text-sm font-semibold text-content">{provider.name}</div>
                                     <p className="mt-1 text-xs text-content-secondary">
                                         콜백 URL: /login/callback/{provider.key}
                                     </p>
                                 </div>
-                                <div className="flex items-center gap-3">
-                                    <span className="text-xs font-medium text-content-secondary">
-                                        {provider.isEnabled ? 'ON' : 'OFF'}
-                                    </span>
-                                    <Toggle
-                                        checked={provider.isEnabled}
-                                        disabled={updateMutation.isPending}
-                                        onCheckedChange={(checked) => updateSocialProvider(provider.key, { isEnabled: checked })}
-                                        aria-label={`${provider.name} 소셜 로그인 사용`}
-                                    />
-                                </div>
+                                <Toggle
+                                    checked={provider.isEnabled}
+                                    disabled={updateMutation.isPending}
+                                    onCheckedChange={(checked) => updateSocialProvider(provider.key, { isEnabled: checked })}
+                                    aria-label={`${provider.name} 소셜 로그인 사용`}
+                                />
                             </div>
 
                             <div className="grid gap-4 md:grid-cols-2">

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SeoAeoSetting/SeoAeoSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SeoAeoSetting/SeoAeoSetting.tsx
@@ -275,14 +275,9 @@ const SeoAeoSetting = () => {
                         className="rounded-xl border border-line bg-surface-elevated p-4 sm:p-5">
                         <div className="flex items-start justify-between gap-4">
                             <div className="min-w-0">
-                                <div className="flex flex-wrap items-center gap-2">
-                                    <h3 id="seo-exposure-title" className="text-sm font-semibold text-content">
-                                        SEO · 검색엔진
-                                    </h3>
-                                    <span className={`rounded-full px-2 py-1 text-xs font-semibold ${seoEnabled ? 'bg-success-surface text-success' : 'bg-surface-subtle text-content-secondary'}`}>
-                                        {seoEnabled ? '켜짐' : '꺼짐'}
-                                    </span>
-                                </div>
+                                <h3 id="seo-exposure-title" className="text-sm font-semibold text-content">
+                                    SEO · 검색엔진
+                                </h3>
                                 <p className="mt-2 text-sm leading-relaxed text-content-secondary">
                                     {seoEnabled
                                         ? '페이지 색인을 허용하고 robots.txt에서 sitemap 위치를 안내합니다.'
@@ -304,14 +299,9 @@ const SeoAeoSetting = () => {
                         className="rounded-xl border border-line bg-surface-elevated p-4 sm:p-5">
                         <div className="flex items-start justify-between gap-4">
                             <div className="min-w-0">
-                                <div className="flex flex-wrap items-center gap-2">
-                                    <h3 id="aeo-exposure-title" className="text-sm font-semibold text-content">
-                                        AEO · AI 에이전트
-                                    </h3>
-                                    <span className={`rounded-full px-2 py-1 text-xs font-semibold ${aeoEnabled ? 'bg-success-surface text-success' : 'bg-surface-subtle text-content-secondary'}`}>
-                                        {aeoEnabled ? '켜짐' : '꺼짐'}
-                                    </span>
-                                </div>
+                                <h3 id="aeo-exposure-title" className="text-sm font-semibold text-content">
+                                    AEO · AI 에이전트
+                                </h3>
                                 <p className="mt-2 text-sm leading-relaxed text-content-secondary">
                                     {aeoEnabled
                                         ? 'llms.txt와 Markdown 주소를 공개하고 발견 신호를 제공합니다.'

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/StaticPagesSetting/components/StaticPageEditor.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/StaticPagesSetting/components/StaticPageEditor.tsx
@@ -425,8 +425,8 @@ const StaticPageEditor = ({ pageId }: StaticPageEditorProps) => {
                                         게시 설정
                                     </h3>
                                     <div className="space-y-1">
-                                        <div className="flex items-center justify-between py-3">
-                                            <div>
+                                        <div className="flex items-center justify-between gap-4 py-3">
+                                            <div className="min-w-0 flex-1">
                                                 <div className="text-sm font-medium text-content">공개</div>
                                                 <div className="text-xs text-content-secondary">페이지를 공개합니다</div>
                                             </div>
@@ -437,8 +437,8 @@ const StaticPageEditor = ({ pageId }: StaticPageEditorProps) => {
                                             />
                                         </div>
 
-                                        <div className="flex items-center justify-between py-3">
-                                            <div>
+                                        <div className="flex items-center justify-between gap-4 py-3">
+                                            <div className="min-w-0 flex-1">
                                                 <div className="text-sm font-medium text-content">푸터에 표시</div>
                                                 <div className="text-xs text-content-secondary">사이트 하단 메뉴에 노출합니다</div>
                                             </div>

--- a/backend/islands/packages/ui/src/components/Toggle.tsx
+++ b/backend/islands/packages/ui/src/components/Toggle.tsx
@@ -38,7 +38,7 @@ const Toggle = ({
             disabled={disabled}
             className={cx(
                 s.root,
-                'rounded-full transition-colors duration-150 relative',
+                'relative inline-flex shrink-0 items-center rounded-full p-0 transition-colors duration-150',
                 'focus:outline-none focus:ring-2 focus:ring-action/20 focus:ring-offset-1',
                 'disabled:opacity-50 disabled:cursor-not-allowed',
                 checked ? 'bg-action' : 'bg-line-strong',

--- a/backend/islands/packages/ui/src/components/Toggle.tsx
+++ b/backend/islands/packages/ui/src/components/Toggle.tsx
@@ -20,12 +20,14 @@ const Toggle = ({
 }: ToggleProps) => {
     const sizes = {
         sm: {
-            root: 'w-8 h-5',
-            thumb: 'w-4 h-4 data-[state=checked]:translate-x-[14px]'
+            root: 'h-11 w-11 -mx-1.5 -my-3',
+            track: 'before:h-5 before:w-8',
+            thumb: 'left-1.5 w-4 h-4 data-[state=checked]:translate-x-[14px]'
         },
         md: {
-            root: 'w-11 h-6',
-            thumb: 'w-5 h-5 data-[state=checked]:translate-x-[22px]'
+            root: 'h-11 w-11 -my-2.5',
+            track: 'before:h-6 before:w-11',
+            thumb: 'left-0 w-5 h-5 data-[state=checked]:translate-x-[22px]'
         }
     };
 
@@ -38,18 +40,22 @@ const Toggle = ({
             disabled={disabled}
             className={cx(
                 s.root,
-                'relative inline-flex shrink-0 items-center rounded-full p-0 transition-colors duration-150',
-                'focus:outline-none focus:ring-2 focus:ring-action/20 focus:ring-offset-1',
-                'disabled:opacity-50 disabled:cursor-not-allowed',
-                checked ? 'bg-action' : 'bg-line-strong',
+                s.track,
+                'relative inline-flex shrink-0 cursor-pointer items-center rounded-full bg-transparent p-0',
+                'before:absolute before:left-1/2 before:top-1/2 before:-translate-x-1/2 before:-translate-y-1/2 before:rounded-full before:content-[\'\']',
+                'transition-transform duration-150 before:transition-colors before:duration-150 active:scale-95',
+                'motion-reduce:transition-none motion-reduce:before:transition-none',
+                'focus:outline-none focus-visible:before:ring-2 focus-visible:before:ring-action/20',
+                'focus-visible:before:ring-offset-1 disabled:opacity-50 disabled:cursor-not-allowed',
+                checked ? 'before:bg-action' : 'before:bg-line-strong',
                 className
             )}
             {...props}>
             <RadixSwitch.Thumb
                 className={cx(
                     s.thumb,
-                    'block rounded-full bg-surface-elevated shadow-sm transition-transform duration-150',
-                    'translate-x-0.5'
+                    'absolute top-1/2 block -translate-y-1/2 translate-x-0.5 rounded-full',
+                    'bg-surface-elevated shadow-sm transition-transform duration-150 motion-reduce:transition-none'
                 )}
             />
         </RadixSwitch.Root>


### PR DESCRIPTION
## 🎯 Goal
- 설정과 편집기마다 다르게 보이던 토글 상태 표현과 모바일 조작 영역을 통일합니다.
- 토글 자체가 상태를 전달하도록 중복 ON/OFF·켜짐/꺼짐 배지를 제거하면서 기존 저장 동작과 공개 계약을 그대로 유지합니다.

## 🔧 Core Changes
- 공용 Toggle의 실제 버튼 hit area를 44×44px로 확장했습니다.
- sm/md의 보이는 트랙 크기와 레이아웃 점유 크기는 유지했습니다.
- 설정·편집기의 Toggle 9개 호출처에서 긴 설명 정렬을 통일하고 중복 상태 텍스트를 제거했습니다.
- URL, API endpoint, payload, 권한, 저장 시점, checked/disabled/onCheckedChange/aria-label/size/className 계약은 변경하지 않았습니다.

## 🤔 Key Decisions
- 상태 텍스트를 별도로 반복하지 않고 switch의 시각 상태와 접근성 이름을 단일 정보원으로 사용했습니다.
- 기존 레이아웃을 밀지 않도록 보이는 트랙과 실제 조작 영역을 분리하되 Radix button[role=switch]를 실제 44×44px 타깃으로 유지했습니다.
- 시각 크기 자체를 키우지 않아 기존 화면 밀도와 하위 호환성을 보존했습니다.

## 🧪 Verification Guide
### How to verify
1. /settings/login, /settings/seo-aeo, /settings/integrations, /settings/static-pages/create, /write에서 토글을 포인터와 Space 키로 전환합니다.
2. 데스크톱 라이트와 375px 모바일 다크에서 설명 정렬, 가로 overflow, 토글 상태를 확인합니다.
3. 아래 검증 명령을 실행합니다.
   - npm run islands:lint
   - npm run islands:type-check
   - npm run islands:build
   - npm run islands:check-entry-budgets
   - PORT=8001 npm run islands:e2e:smoke

### Expected result
- 9개 호출처에서 토글의 실제 조작 영역이 44×44px이고 트랙 밖 여백 클릭도 동작합니다.
- 키보드 전환과 기존 설정 저장 동작이 유지되며 가로 overflow가 없습니다.
- lint는 기존 경고만 남기고 통과하며 type-check/build/budget/smoke가 모두 통과합니다.
- 일회성 브라우저 점검 spec·계정·산출물은 저장소에 남지 않습니다.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)