### PR TITLE
♻️ Reduce redundant user settings guidance

### DIFF
--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/SettingsEmptyState.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/SettingsEmptyState.tsx
@@ -24,7 +24,9 @@ const SettingsEmptyState = ({
             <div className="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-surface-subtle mb-3">
                 <i className={`${iconClassName} text-lg text-content-hint`} />
             </div>
-            <h3 className="text-base font-semibold text-content mb-1">{title}</h3>
+            <h3 className={`text-base font-semibold text-content ${action && !description ? 'mb-5' : description ? 'mb-1' : ''}`}>
+                {title}
+            </h3>
             {description && (
                 <p className={`text-content-secondary text-sm ${action ? 'mb-5' : ''}`}>{description}</p>
             )}

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/WebhookChannelManager.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/WebhookChannelManager.tsx
@@ -36,7 +36,7 @@ interface WebhookChannelManagerProps {
     description: string;
     formTitle: string;
     emptyTitle: string;
-    emptyDescription: string;
+    emptyDescription?: string;
     addButtonLabel?: string;
     fetchChannels: () => Promise<AxiosResponse<ChannelsResponse>>;
     createChannel: (data: { webhook_url: string; name?: string }) => Promise<AxiosResponse<CreateResponse>>;

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/AccountSetting/components/NameSection.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/AccountSetting/components/NameSection.tsx
@@ -56,7 +56,6 @@ const NameSection = ({ initialName, isLoading, onSubmit }: NameSectionProps) => 
                 label="사용자 이름"
                 placeholder="사용자 이름"
                 maxLength={30}
-                helperText="프로필과 화면에 표시되는 이름입니다."
                 error={errors.name?.message}
                 {...register('name')}
             />

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/DraftsSetting/DraftsSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/DraftsSetting/DraftsSetting.tsx
@@ -7,7 +7,6 @@ const DraftsSetting = () => {
         <div>
             <SettingsHeader
                 title="임시 포스트"
-                description="작성 중인 임시 포스트를 이어서 작성하거나 삭제할 수 있습니다."
                 actionPosition="right"
                 action={
                     <Button

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/FormsSetting/FormsSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/FormsSetting/FormsSetting.tsx
@@ -152,7 +152,7 @@ const FormsManagement = () => {
         <div>
             <SettingsHeader
                 title={`서식 (${forms.length})`}
-                description="자주 사용하는 서식을 미리 만들어두면, 포스트를 더 빠르게 작성할 수 있어요."
+                description="새 포스트에 불러올 문구를 미리 저장합니다."
                 actionPosition="right"
                 action={
                     <Button
@@ -248,7 +248,6 @@ const FormsManagement = () => {
                 <SettingsEmptyState
                     iconClassName="fas fa-file-lines"
                     title="등록된 서식이 없습니다"
-                    description="자주 사용하는 서식을 추가해보세요."
                 />
             )}
         </div>

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/IntegrationSetting/IntegrationSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/IntegrationSetting/IntegrationSetting.tsx
@@ -104,7 +104,6 @@ const IntegrationSettings = () => {
             {isConnected ? (
                 <Card
                     title="연동 상태"
-                    subtitle={isConfigured ? '현재 텔레그램 연동 상태입니다.' : '텔레그램 연결은 유지되어 있습니다.'}
                     icon={<i className="fas fa-plug" />}>
                     <div className="flex flex-col sm:flex-row sm:items-center gap-4">
                         <div className="flex items-center gap-4 flex-1">
@@ -136,7 +135,6 @@ const IntegrationSettings = () => {
             ) : (
                 <Card
                     title="연동 방법"
-                    subtitle="아래 순서대로 진행하면 텔레그램 연동을 완료할 수 있습니다."
                     icon={<i className="fas fa-link" />}>
                     <div className="space-y-6">
                         <div className="flex items-start gap-3">

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/NotifySetting/components/NotificationsSection.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/NotifySetting/components/NotificationsSection.tsx
@@ -30,7 +30,6 @@ const NotificationsSection = ({
         <div className="space-y-8">
             <SettingsHeader
                 title="알림"
-                description="최신 알림을 확인할 수 있습니다."
                 actionPosition="right"
                 action={
                     <Button
@@ -94,7 +93,6 @@ const NotificationsSection = ({
                     <SettingsEmptyState
                         iconClassName="fas fa-bell-slash"
                         title="알림이 없습니다"
-                        description="새로운 알림이 도착하면 여기에 표시됩니다."
                     />
                 )}
             </div>

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PinnedPostsSetting/components/PinnedPostList.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PinnedPostsSetting/components/PinnedPostList.tsx
@@ -61,7 +61,6 @@ export const PinnedPostList = ({
             <SettingsEmptyState
                 iconClassName="fas fa-thumbtack"
                 title="고정된 포스트가 없습니다"
-                description="프로필에 표시할 대표 포스트를 선택해보세요."
             />
         );
     }

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PinnedPostsSetting/components/PinnedPostsPanel.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PinnedPostsSetting/components/PinnedPostsPanel.tsx
@@ -251,7 +251,7 @@ export const PinnedPostsPanel = ({
             <div>
                 <SettingsHeader
                     title={`고정 포스트 (${pinnedPosts.length}/${maxCount})`}
-                    description="프로필에 표시할 고정 포스트를 선택하세요. 드래그하여 순서를 조정할 수 있습니다."
+                    description="드래그하여 프로필에 표시되는 순서를 조정할 수 있습니다."
                     actionPosition="right"
                     action={action}
                 />
@@ -271,7 +271,7 @@ export const PinnedPostsPanel = ({
                         </span>
                     </h3>
                     <p className="text-sm leading-relaxed text-content-secondary">
-                        프로필에 표시할 포스트를 선택하고 순서를 조정하세요.
+                        드래그하여 프로필에 표시되는 순서를 조정할 수 있습니다.
                     </p>
                 </div>
                 <div className="flex-shrink-0">

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/PostsSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/PostsSetting.tsx
@@ -92,7 +92,6 @@ const PostsSetting = () => {
         <div>
             <SettingsHeader
                 title={title}
-                description="발행, 예약, 임시 포스트를 관리하세요."
                 actionPosition="right"
                 action={
                     <Button

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/DraftPostListContent.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/DraftPostListContent.tsx
@@ -67,7 +67,6 @@ export const DraftPostListContent = ({ onCountChange }: DraftPostListContentProp
             <SettingsEmptyState
                 iconClassName="fas fa-file-alt"
                 title="임시 포스트가 없습니다"
-                description="새 포스트를 작성해보세요."
             />
         );
     }

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SeriesSetting/SeriesSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SeriesSetting/SeriesSetting.tsx
@@ -211,7 +211,7 @@ const SeriesSetting = () => {
         <div>
             <SettingsHeader
                 title={`시리즈 (${series.length})`}
-                description="드래그하여 시리즈 순서를 조정하거나 새로운 시리즈를 만들어보세요."
+                description="드래그하여 표시 순서를 조정할 수 있습니다."
                 actionPosition="right"
                 action={
                     <Button
@@ -251,7 +251,6 @@ const SeriesSetting = () => {
                 <SettingsEmptyState
                     iconClassName="fas fa-book"
                     title="시리즈가 없습니다"
-                    description="첫 번째 시리즈를 만들어보세요."
                 />
             )}
         </div>

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SocialLinksSetting/SocialLinksSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SocialLinksSetting/SocialLinksSetting.tsx
@@ -351,7 +351,7 @@ const SocialLinks = () => {
         <div>
             <SettingsHeader
                 title="소셜 링크"
-                description="프로필에 표시될 소셜 미디어 링크를 추가하고 순서를 조정하세요."
+                description="프로필에 표시되며 드래그하여 순서를 조정할 수 있습니다."
             />
 
             <form onSubmit={handleSubmit}>
@@ -360,7 +360,6 @@ const SocialLinks = () => {
                         <SettingsEmptyState
                             iconClassName="fas fa-share-alt"
                             title="소셜 링크가 없습니다"
-                            description="첫 번째 소셜 링크를 추가해보세요."
                             action={(
                                 <Button type="button" variant="secondary" size="md" onClick={handleSocialAdd}>
                                     소셜 링크 추가하기

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/WebhookSetting/WebhookSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/WebhookSetting/WebhookSetting.tsx
@@ -14,7 +14,6 @@ const WebhookSetting = () => {
             description="내가 발행한 새 포스트를 Discord, Slack 또는 일반 웹훅 URL로 전송합니다."
             formTitle="새 웹훅 추가"
             emptyTitle="등록된 웹훅이 없습니다"
-            emptyDescription="전송 대상을 추가해서 내 포스트 발행 알림을 받아보세요."
             fetchChannels={getWebhookChannels}
             createChannel={addWebhookChannel}
             deleteChannel={deleteWebhookChannel}

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/shared/BannerSettingBase.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/shared/BannerSettingBase.tsx
@@ -142,7 +142,7 @@ const BannerSettingBase = ({ scope }: BannerSettingBaseProps) => {
                 description={
                     isGlobal
                         ? '사이트 전체에 표시되는 전역 배너를 관리합니다. 드래그하여 순서를 변경할 수 있습니다.'
-                        : '블로그의 상단, 하단, 사이드바에 표시될 배너를 관리합니다. 드래그하여 순서를 변경할 수 있습니다.'
+                        : '상단·하단·사이드바에 표시되며 드래그하여 순서를 조정할 수 있습니다.'
                 }
                 actionPosition="right"
                 action={
@@ -180,7 +180,7 @@ const BannerSettingBase = ({ scope }: BannerSettingBaseProps) => {
                 <SettingsEmptyState
                     iconClassName={isGlobal ? 'fas fa-rectangle-ad' : 'fas fa-shapes'}
                     title={isGlobal ? '등록된 전역 배너가 없습니다' : '등록된 배너가 없습니다'}
-                    description={isGlobal ? '첫 번째 전역 배너를 만들어보세요.' : '첫 번째 배너를 만들어보세요.'}
+                    description={isGlobal ? '첫 번째 전역 배너를 만들어보세요.' : undefined}
                 />
             )}
         </div>

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/shared/NoticeSettingBase.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/shared/NoticeSettingBase.tsx
@@ -211,7 +211,7 @@ const NoticeSettingBase = ({ scope }: NoticeSettingBaseProps) => {
                 description={
                     isGlobal
                         ? '사이트 전체에 표시되는 전역 공지를 관리합니다.'
-                        : '블로그에 표시되는 공지를 관리합니다.'
+                        : undefined
                 }
                 actionPosition="right"
                 action={
@@ -343,7 +343,7 @@ const NoticeSettingBase = ({ scope }: NoticeSettingBaseProps) => {
                 <SettingsEmptyState
                     iconClassName="fas fa-bullhorn"
                     title="등록된 공지가 없습니다"
-                    description="첫 번째 공지를 만들어보세요."
+                    description={isGlobal ? '첫 번째 전역 공지를 만들어보세요.' : undefined}
                 />
             )}
         </div>


### PR DESCRIPTION
## 🎯 Goal
- 사용자 설정에서 제목·탭·필드·버튼이 이미 전달하는 보조 문구를 줄여 핵심 작업을 더 빠르게 찾게 합니다.
- 변경 제한, 노출 위치, 삭제 결과처럼 판단에 필요한 정보는 유지하면서 기존 동작 계약을 보존합니다.

## 🔧 Core Changes
- 알림, 계정, 소셜 링크, 포스트, 시리즈, 서식, 공지, 배너, 웹훅, 고정 포스트, 임시 포스트의 중복 헤더·카드·빈 상태 문구를 정리했습니다.
- URL과 6개월 필명 변경 제한, 계정 삭제 복구 불가, 드래그 정렬, 배너 노출 위치, 웹훅 전송 목적, 일회용 인증 코드 안내는 유지했습니다.
- 설명 없는 빈 상태 CTA도 간격이 유지되도록 SettingsEmptyState를 보완했습니다.
- WebhookChannelManager의 emptyDescription은 기존 문자열 호출을 그대로 지원하면서 선택적으로 생략할 수 있게 확장했습니다.
- URL, route, 탭·필터, API endpoint, payload, 권한, 저장 시점과 결과는 변경하지 않았습니다.

## 🤔 Key Decisions
- 행동을 반복하는 “관리하세요”, “첫 번째 항목을 추가해보세요” 문구는 제목과 CTA가 대신하도록 제거했습니다.
- 기능의 결과나 숨은 상호작용을 설명하는 문구는 짧게 남겼습니다.
- 공용 컴포넌트 props를 제거하거나 바꾸지 않고 optional 확장만 사용해 기존 호출처의 하위 호환을 유지했습니다.
- 문구 취향을 영구 고정하는 E2E는 추가하지 않았습니다.

## 🧪 Verification Guide
### How to verify
1. 사용자 설정의 알림, 계정, 소셜 링크, 포스트, 시리즈, 서식, 공지, 배너, 웹훅, 고정 포스트, 임시 포스트를 확인합니다.
2. 제목·버튼과 중복되는 설명은 사라지고 제한·부작용·정렬·노출 위치 안내는 남아 있는지 확인합니다.
3. 아래 검증 명령을 실행합니다.
   - npm run islands:lint
   - npm run islands:type-check
   - npm run islands:build
   - npm run islands:check-entry-budgets
   - PORT=8001 npm run islands:e2e:smoke

### Expected result
- 사용자 설정의 정보 밀도가 낮아지되 중요한 제약과 결과는 유지됩니다.
- 1280×900 라이트와 375×812 다크에서 11개 경로에 가로 overflow나 HTTP 500이 없습니다.
- lint는 기존 경고만 남기고 통과하며 type-check/build/budget과 기존 smoke 10개가 통과합니다.
- 임시 spec·계정·세션·trace·영상·스크린샷·test-results가 저장소에 남지 않습니다.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)