### PR TITLE
♻️ Unify settings mobile actions and empty states

### DIFF
--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/SettingsListItem.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/SettingsListItem.tsx
@@ -6,11 +6,12 @@ const LIST_ITEM_SHELL = 'bg-surface ring-1 ring-line/60 rounded-2xl transition-a
 const LIST_ITEM_CONTENT = 'p-5';
 const LIST_ITEM_ROW = 'flex items-center gap-3';
 const LIST_ITEM_ACTIONS = 'flex gap-2 flex-shrink-0';
-const LIST_ITEM_DRAG_HANDLE = 'cursor-grab active:cursor-grabbing text-content-hint hover:text-content-secondary p-2 hover:bg-surface-subtle rounded-lg transition-colors -ml-2';
+const LIST_ITEM_DRAG_HANDLE = 'inline-flex min-h-11 min-w-11 cursor-grab items-center justify-center active:cursor-grabbing text-content-hint hover:text-content-secondary hover:bg-surface-subtle rounded-lg transition-colors -ml-2';
 
 interface DragHandleProps {
     attributes: DraggableAttributes;
     listeners: SyntheticListenerMap | undefined;
+    ariaLabel?: string;
 }
 
 interface SettingsListItemProps {
@@ -56,7 +57,8 @@ const SettingsListItem = ({
                             style={{ touchAction: 'none' }}
                             onClick={(e) => e.stopPropagation()}
                             {...dragHandleProps.attributes}
-                            {...dragHandleProps.listeners}>
+                            {...dragHandleProps.listeners}
+                            aria-label={dragHandleProps.ariaLabel || '순서 변경'}>
                             <i className="fas fa-grip-vertical" />
                         </div>
                     )}

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/WebhookChannelManager.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/WebhookChannelManager.tsx
@@ -265,24 +265,26 @@ const WebhookChannelManager = ({
         );
     };
 
+    const createAction = (
+        <Button
+            variant="primary"
+            size="md"
+            className="min-h-11! w-full sm:w-auto"
+            onClick={() => {
+                reset();
+                setShowAddForm(true);
+            }}>
+            {addButtonLabel}
+        </Button>
+    );
+
     return (
         <div>
             <SettingsHeader
                 title={title}
                 description={description}
                 actionPosition="right"
-                action={
-                    <Button
-                        variant="primary"
-                        size="md"
-                        className="w-full sm:w-auto"
-                        onClick={() => {
-                            reset();
-                            setShowAddForm(true);
-                        }}>
-                        {addButtonLabel}
-                    </Button>
-                }
+                action={channels && channels.length > 0 ? createAction : undefined}
             />
 
             {showAddForm && (
@@ -349,6 +351,7 @@ const WebhookChannelManager = ({
                                 variant="ghost"
                                 size="md"
                                 type="button"
+                                className="min-h-11!"
                                 onClick={handleCancel}
                                 disabled={isAdding || isTesting}>
                                 취소
@@ -359,6 +362,7 @@ const WebhookChannelManager = ({
                                     variant="secondary"
                                     size="md"
                                     type="button"
+                                    className="min-h-11!"
                                     isLoading={isTesting}
                                     disabled={isAdding}
                                     onClick={handleTest}>
@@ -368,6 +372,7 @@ const WebhookChannelManager = ({
                                     variant="primary"
                                     size="md"
                                     type="submit"
+                                    className="min-h-11!"
                                     isLoading={isAdding}
                                     disabled={isTesting}>
                                     {isAdding ? '추가 중...' : '추가'}
@@ -390,6 +395,8 @@ const WebhookChannelManager = ({
                             }
                             actions={
                                 <Dropdown
+                                    triggerAriaLabel={`${channel.name || '이름 없는 채널'} 웹훅 메뉴 열기`}
+                                    triggerClassName="min-h-11 min-w-11"
                                     items={[
                                         {
                                             label: '삭제',
@@ -417,13 +424,14 @@ const WebhookChannelManager = ({
                         </SettingsListItem>
                     ))}
                 </div>
-            ) : (
+            ) : !showAddForm ? (
                 <SettingsEmptyState
                     iconClassName="fas fa-bolt"
                     title={emptyTitle}
                     description={emptyDescription}
+                    action={createAction}
                 />
-            )}
+            ) : null}
         </div>
     );
 };

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/BannerSetting/components/BannerList.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/BannerSetting/components/BannerList.tsx
@@ -76,10 +76,13 @@ const SortableBannerItem = ({ banner, onEdit, onDelete, onToggleActive }: Sortab
                 onClick={() => onEdit(banner.id)}
                 dragHandleProps={{
                     attributes,
-                    listeners
+                    listeners,
+                    ariaLabel: `${banner.title} 배너 순서 변경`
                 }}
                 actions={
                     <Dropdown
+                        triggerAriaLabel={`${banner.title} 배너 메뉴 열기`}
+                        triggerClassName="min-h-11 min-w-11"
                         items={[
                             {
                                 label: banner.isActive ? '비활성화' : '활성화',

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/FormsSetting/FormsSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/FormsSetting/FormsSetting.tsx
@@ -147,6 +147,15 @@ const FormsManagement = () => {
     };
 
     const forms = formsData?.forms || [];
+    const createAction = (
+        <Button
+            variant="primary"
+            size="md"
+            className="min-h-11! w-full sm:w-auto"
+            onClick={handleCreateForm}>
+            새 서식 추가
+        </Button>
+    );
 
     return (
         <div>
@@ -154,15 +163,7 @@ const FormsManagement = () => {
                 title={`서식 (${forms.length})`}
                 description="새 포스트에 불러올 문구를 미리 저장합니다."
                 actionPosition="right"
-                action={
-                    <Button
-                        variant="primary"
-                        size="md"
-                        className="w-full sm:w-auto"
-                        onClick={handleCreateForm}>
-                        새 서식 추가
-                    </Button>
-                }
+                action={forms.length > 0 ? createAction : undefined}
             />
 
             {showForm && (
@@ -195,6 +196,7 @@ const FormsManagement = () => {
                                 type="button"
                                 variant="ghost"
                                 size="md"
+                                className="min-h-11!"
                                 onClick={closeForm}
                                 disabled={isSubmitting}>
                                 취소
@@ -204,6 +206,7 @@ const FormsManagement = () => {
                                     type="submit"
                                     variant="primary"
                                     size="md"
+                                    className="min-h-11!"
                                     isLoading={isSubmitting}>
                                     {isSubmitting ? (editingForm ? '수정 중...' : '생성 중...') : (editingForm ? '서식 수정' : '서식 생성')}
                                 </Button>
@@ -225,6 +228,8 @@ const FormsManagement = () => {
                             }
                             actions={
                                 <Dropdown
+                                    triggerAriaLabel={`${form.title} 서식 메뉴 열기`}
+                                    triggerClassName="min-h-11 min-w-11"
                                     items={[
                                         {
                                             label: '수정',
@@ -244,12 +249,13 @@ const FormsManagement = () => {
                         </SettingsListItem>
                     ))}
                 </div>
-            ) : (
+            ) : !showForm ? (
                 <SettingsEmptyState
                     iconClassName="fas fa-file-lines"
                     title="등록된 서식이 없습니다"
+                    action={createAction}
                 />
-            )}
+            ) : null}
         </div>
     );
 };

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/GlobalBannerSetting/components/GlobalBannerList.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/GlobalBannerSetting/components/GlobalBannerList.tsx
@@ -76,10 +76,13 @@ const SortableBannerItem = ({ banner, onEdit, onDelete, onToggleActive }: Sortab
                 onClick={() => onEdit(banner.id)}
                 dragHandleProps={{
                     attributes,
-                    listeners
+                    listeners,
+                    ariaLabel: `${banner.title} 전역 배너 순서 변경`
                 }}
                 actions={
                     <Dropdown
+                        triggerAriaLabel={`${banner.title} 전역 배너 메뉴 열기`}
+                        triggerClassName="min-h-11 min-w-11"
                         items={[
                             {
                                 label: banner.isActive ? '비활성화' : '활성화',

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PinnedPostsSetting/components/AddPinnedPostModal.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PinnedPostsSetting/components/AddPinnedPostModal.tsx
@@ -72,7 +72,7 @@ export const AddPinnedPostModal = ({
                         <button
                             type="button"
                             onClick={handleClose}
-                            className="inline-flex min-h-10 items-center justify-center rounded-lg px-3 text-sm font-semibold text-content-secondary transition-colors duration-150 hover:bg-surface-subtle hover:text-content active:scale-95">
+                            className="inline-flex min-h-11 items-center justify-center rounded-lg px-3 text-sm font-semibold text-content-secondary transition-colors duration-150 hover:bg-surface-subtle hover:text-content active:scale-95">
                             선택 취소
                         </button>
                     </div>

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PinnedPostsSetting/components/PinnablePostInlineList.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PinnedPostsSetting/components/PinnablePostInlineList.tsx
@@ -112,6 +112,7 @@ export const PinnablePostInlineList = ({
                                     <Button
                                         variant="secondary"
                                         size="sm"
+                                        className="min-h-11!"
                                         onClick={() => onAdd(post.url)}
                                         disabled={isActionDisabled || isLoading}
                                         isLoading={isLoading}>

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PinnedPostsSetting/components/PinnablePostsPager.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PinnedPostsSetting/components/PinnablePostsPager.tsx
@@ -54,6 +54,7 @@ export const PinnablePostsPager = ({
                     <Button
                         variant="secondary"
                         size="sm"
+                        className="min-h-11! min-w-11"
                         disabled={!pagination.hasPrevious || isLoading}
                         onClick={() => handlePageMove(1)}
                         aria-label="첫 페이지">
@@ -62,6 +63,7 @@ export const PinnablePostsPager = ({
                     <Button
                         variant="secondary"
                         size="sm"
+                        className="min-h-11! min-w-11"
                         disabled={!pagination.hasPrevious || isLoading}
                         onClick={() => handlePageMove(currentPage - 1)}
                         aria-label="이전 페이지">
@@ -72,6 +74,7 @@ export const PinnablePostsPager = ({
                             key={page}
                             variant={page === currentPage ? 'primary' : 'secondary'}
                             size="sm"
+                            className="min-h-11! min-w-11"
                             disabled={isLoading}
                             onClick={() => handlePageMove(page)}
                             aria-current={page === currentPage ? 'page' : undefined}>
@@ -81,6 +84,7 @@ export const PinnablePostsPager = ({
                     <Button
                         variant="secondary"
                         size="sm"
+                        className="min-h-11! min-w-11"
                         disabled={!pagination.hasNext || isLoading}
                         onClick={() => handlePageMove(currentPage + 1)}
                         aria-label="다음 페이지">
@@ -89,6 +93,7 @@ export const PinnablePostsPager = ({
                     <Button
                         variant="secondary"
                         size="sm"
+                        className="min-h-11! min-w-11"
                         disabled={!pagination.hasNext || isLoading}
                         onClick={() => handlePageMove(pagination.lastPage)}
                         aria-label="마지막 페이지">

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PinnedPostsSetting/components/PinnedPostItem.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PinnedPostsSetting/components/PinnedPostItem.tsx
@@ -52,7 +52,8 @@ export const PinnedPostItem = ({
                 onClick={handleView}
                 dragHandleProps={{
                     attributes,
-                    listeners
+                    listeners,
+                    ariaLabel: `${pinnedPost.post.title} 고정 포스트 순서 변경`
                 }}
                 left={
                     pinnedPost.post.image ? (
@@ -73,6 +74,7 @@ export const PinnedPostItem = ({
                     <Button
                         variant="secondary"
                         size="sm"
+                        className="min-h-11!"
                         onClick={handleRemove}>
                         해제
                     </Button>

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PinnedPostsSetting/components/PinnedPostList.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PinnedPostsSetting/components/PinnedPostList.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import {
     DndContext,
     closestCenter,
@@ -25,13 +26,15 @@ interface PinnedPostListProps {
     onReorder: (newPinnedPosts: PinnedPostData[]) => void;
     onRemove: (postUrl: string) => void;
     maxCount: number;
+    emptyAction?: ReactNode;
 }
 
 export const PinnedPostList = ({
     pinnedPosts,
     username,
     onReorder,
-    onRemove
+    onRemove,
+    emptyAction
 }: PinnedPostListProps) => {
     const sensors = useSensors(
         useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
@@ -61,6 +64,7 @@ export const PinnedPostList = ({
             <SettingsEmptyState
                 iconClassName="fas fa-thumbtack"
                 title="고정된 포스트가 없습니다"
+                action={emptyAction}
             />
         );
     }

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PinnedPostsSetting/components/PinnedPostsPanel.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PinnedPostsSetting/components/PinnedPostsPanel.tsx
@@ -213,7 +213,7 @@ export const PinnedPostsPanel = ({
         <Button
             variant="primary"
             size="md"
-            className="w-full sm:w-auto"
+            className="min-h-11! w-full sm:w-auto"
             onClick={handleOpenModal}
             disabled={!canAddMore}>
             {canAddMore ? '포스트 고정하기' : '최대 개수 도달'}
@@ -227,6 +227,7 @@ export const PinnedPostsPanel = ({
                 onReorder={handleReorder}
                 onRemove={handleRemovePinnedPost}
                 maxCount={maxCount}
+                emptyAction={!embedded ? action : undefined}
             />
 
             {!embedded && (
@@ -253,7 +254,7 @@ export const PinnedPostsPanel = ({
                     title={`고정 포스트 (${pinnedPosts.length}/${maxCount})`}
                     description="드래그하여 프로필에 표시되는 순서를 조정할 수 있습니다."
                     actionPosition="right"
-                    action={action}
+                    action={pinnedPosts.length > 0 ? action : undefined}
                 />
                 {list}
             </div>

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/PostsSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/PostsSetting.tsx
@@ -87,21 +87,34 @@ const PostsSetting = () => {
 
     const activeCount = postCounts[activeTab];
     const title = activeCount === undefined ? '포스트' : `포스트 (${activeCount})`;
+    const hasContentFilters = Boolean(
+        filters.tag || filters.series || filters.visibility || filters.search
+    );
+    const createPostAction = (
+        <Button
+            variant="primary"
+            size="md"
+            className="min-h-11! w-full sm:w-auto"
+            onClick={() => window.location.assign('/write')}>
+            새 포스트 작성
+        </Button>
+    );
+    const emptyPostAction = hasContentFilters ? (
+        <Button
+            variant="secondary"
+            size="md"
+            className="min-h-11!"
+            onClick={clearFilters}>
+            필터 초기화
+        </Button>
+    ) : createPostAction;
 
     return (
         <div>
             <SettingsHeader
                 title={title}
                 actionPosition="right"
-                action={
-                    <Button
-                        variant="primary"
-                        size="md"
-                        className="w-full sm:w-auto"
-                        onClick={() => window.location.assign('/write')}>
-                        새 포스트 작성
-                    </Button>
-                }
+                action={activeCount !== undefined && activeCount > 0 ? createPostAction : undefined}
             />
 
             <div className="mb-6 border-b border-line-light">
@@ -115,7 +128,7 @@ const PostsSetting = () => {
                                 role="tab"
                                 aria-selected={isActive}
                                 onClick={() => handleTabChange(tab.value)}
-                                className={`inline-flex flex-shrink-0 items-center gap-2 px-3 py-2.5 text-sm font-medium transition-colors ${
+                                className={`inline-flex min-h-11 flex-shrink-0 items-center gap-2 px-3 py-2.5 text-sm font-medium transition-colors ${
                                     isActive
                                         ? 'border-b-2 border-action text-content'
                                         : 'border-b-2 border-transparent text-content-secondary hover:text-content'
@@ -133,6 +146,7 @@ const PostsSetting = () => {
                     <PostsFilter
                         filters={filters}
                         isExpanded={isFilterExpanded}
+                        showClearAction={activeCount !== undefined && activeCount > 0}
                         onExpandToggle={() => setIsFilterExpanded(!isFilterExpanded)}
                         onFilterChange={handleFilterChange}
                         onSearchChange={handleSearchChange}
@@ -159,6 +173,7 @@ const PostsSetting = () => {
                             onPageChange={(page) => handleFilterChange('page', page)}
                             onCountChange={(count) => handleCountChange('published', count)}
                             emptyMessage="발행 포스트가 없습니다."
+                            emptyAction={emptyPostAction}
                         />
                     )}
                     {activeTab === 'scheduled' && (
@@ -169,11 +184,13 @@ const PostsSetting = () => {
                             onCountChange={(count) => handleCountChange('scheduled', count)}
                             source="scheduled"
                             emptyMessage="예약 포스트가 없습니다."
+                            emptyAction={emptyPostAction}
                         />
                     )}
                     {activeTab === 'drafts' && (
                         <DraftPostListContent
                             onCountChange={(count) => handleCountChange('drafts', count)}
+                            emptyAction={createPostAction}
                         />
                     )}
                 </div>

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/DraftPostListContent.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/DraftPostListContent.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { useEffect } from 'react';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { SettingsEmptyState, SettingsListItem } from '../../../components';
@@ -15,9 +16,13 @@ import { toast } from '~/utils/toast';
 
 interface DraftPostListContentProps {
     onCountChange?: (count: number) => void;
+    emptyAction?: ReactNode;
 }
 
-export const DraftPostListContent = ({ onCountChange }: DraftPostListContentProps) => {
+export const DraftPostListContent = ({
+    onCountChange,
+    emptyAction
+}: DraftPostListContentProps) => {
     const { confirm } = useConfirm();
     const { data: draftPosts, refetch } = useSuspenseQuery({
         queryKey: ['draft-posts'],
@@ -67,6 +72,7 @@ export const DraftPostListContent = ({ onCountChange }: DraftPostListContentProp
             <SettingsEmptyState
                 iconClassName="fas fa-file-alt"
                 title="임시 포스트가 없습니다"
+                action={emptyAction}
             />
         );
     }
@@ -95,6 +101,8 @@ export const DraftPostListContent = ({ onCountChange }: DraftPostListContentProp
                     }
                     actions={
                         <Dropdown
+                            triggerAriaLabel={`${draftPost.title || '제목 없음'} 임시 포스트 메뉴 열기`}
+                            triggerClassName="min-h-11 min-w-11"
                             items={[
                                 {
                                     label: '삭제',

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/Pagination.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/Pagination.tsx
@@ -33,7 +33,9 @@ const Pagination = ({ page, lastPage, onPageChange }: PaginationProps) => {
     };
 
     return (
-        <nav className="pagination-nav" aria-label="Page navigation">
+        <nav
+            className="pagination-nav [&_.pagination-link]:min-h-11 [&_.pagination-link]:min-w-11"
+            aria-label="포스트 페이지">
             <div className="pagination-action prev">
                 {currentPage > 1 ? (
                     <>
@@ -42,7 +44,7 @@ const Pagination = ({ page, lastPage, onPageChange }: PaginationProps) => {
                                 type="button"
                                 className="pagination-link"
                                 onClick={() => handlePageMove(1)}
-                                aria-label="First page">
+                                aria-label="첫 페이지">
                                 <i className="fas fa-angle-double-left" />
                             </button>
                         </div>
@@ -51,7 +53,7 @@ const Pagination = ({ page, lastPage, onPageChange }: PaginationProps) => {
                                 type="button"
                                 className="pagination-link"
                                 onClick={() => handlePageMove(currentPage - 1)}
-                                aria-label="Previous page">
+                                aria-label="이전 페이지">
                                 <i className="fas fa-angle-left" />
                             </button>
                         </div>
@@ -99,7 +101,7 @@ const Pagination = ({ page, lastPage, onPageChange }: PaginationProps) => {
                                 type="button"
                                 className="pagination-link"
                                 onClick={() => handlePageMove(currentPage + 1)}
-                                aria-label="Next page">
+                                aria-label="다음 페이지">
                                 <i className="fas fa-angle-right" />
                             </button>
                         </div>
@@ -108,7 +110,7 @@ const Pagination = ({ page, lastPage, onPageChange }: PaginationProps) => {
                                 type="button"
                                 className="pagination-link"
                                 onClick={() => handlePageMove(lastPage)}
-                                aria-label="Last page">
+                                aria-label="마지막 페이지">
                                 <i className="fas fa-angle-double-right" />
                             </button>
                         </div>

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/PostCard.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/PostCard.tsx
@@ -122,6 +122,8 @@ const PostCard = ({
                     {/* 액션 */}
                     <div className="flex-shrink-0 self-center" onClick={(e) => e.stopPropagation()}>
                         <Dropdown
+                            triggerAriaLabel={`${post.title} 포스트 메뉴 열기`}
+                            triggerClassName="min-h-11 min-w-11"
                             items={[
                                 {
                                     label: '포스트 편집',
@@ -151,7 +153,7 @@ const PostCard = ({
                     title="태그/시리즈 편집"
                     aria-label={isMetaEditorOpen ? '태그 및 시리즈 편집 닫기' : '태그 및 시리즈 편집 열기'}
                     onClick={() => setIsMetaEditorOpen(prev => !prev)}
-                    className="inline-flex items-center gap-2 rounded-lg px-2.5 py-1.5 text-content-secondary hover:text-content hover:bg-surface-subtle transition-colors">
+                    className="inline-flex min-h-11 items-center gap-2 rounded-lg px-2.5 py-1.5 text-content-secondary hover:text-content hover:bg-surface-subtle transition-colors">
                     <i className="fas fa-sliders-h text-xs" />
                     <span className="inline-flex items-center gap-2">
                         {hasPendingChanges && (
@@ -183,6 +185,7 @@ const PostCard = ({
                             <Button
                                 variant="primary"
                                 size="md"
+                                className="min-h-11!"
                                 leftIcon={<i className="fas fa-save" />}
                                 onClick={() => onTagSubmit(post.url)}>
                                 저장
@@ -216,6 +219,7 @@ const PostCard = ({
                             <Button
                                 variant="primary"
                                 size="md"
+                                className="min-h-11!"
                                 leftIcon={<i className="fas fa-save" />}
                                 onClick={() => onSeriesSubmit(post.url)}>
                                 저장

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/PostListContent.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/PostListContent.tsx
@@ -1,9 +1,11 @@
+import type { ReactNode } from 'react';
 import { useEffect } from 'react';
 import { usePostsQuery, type FilterOptions, type PostsSource } from '../hooks/usePostsData';
 import { usePostsActions } from '../hooks';
 import PostCard from './PostCard';
 import Pagination from './Pagination';
 import type { Series } from '~/lib/api/settings';
+import { SettingsEmptyState } from '../../../components';
 
 interface PostListContentProps {
     filters: FilterOptions;
@@ -12,6 +14,7 @@ interface PostListContentProps {
     onCountChange?: (count: number) => void;
     source?: PostsSource;
     emptyMessage?: string;
+    emptyAction?: ReactNode;
 }
 
 export const PostListContent = ({
@@ -20,7 +23,8 @@ export const PostListContent = ({
     onPageChange,
     onCountChange,
     source = 'published',
-    emptyMessage = '포스트가 없습니다.'
+    emptyMessage = '포스트가 없습니다.',
+    emptyAction
 }: PostListContentProps) => {
     const {
         posts,
@@ -78,9 +82,11 @@ export const PostListContent = ({
                     ))}
                 </div>
             ) : (
-                <div className="py-8 text-center text-sm text-content-secondary bg-surface-subtle rounded-lg border border-line-light border-dashed">
-                    {emptyMessage}
-                </div>
+                <SettingsEmptyState
+                    iconClassName={isScheduled ? 'fas fa-calendar-day' : 'fas fa-file-alt'}
+                    title={emptyMessage}
+                    action={emptyAction}
+                />
             )}
 
             <Pagination

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/PostsFilter.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/PostsFilter.tsx
@@ -7,6 +7,7 @@ import type { Tag, Series } from '~/lib/api/settings';
 interface PostsFilterProps {
     filters: FilterOptions;
     isExpanded: boolean;
+    showClearAction?: boolean;
     onExpandToggle: () => void;
     onFilterChange: (key: keyof FilterOptions, value: string) => void;
     onSearchChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
@@ -22,6 +23,7 @@ const hasActiveFilters = (filters: FilterOptions) => {
 const PostsFilter = ({
     filters,
     isExpanded,
+    showClearAction = true,
     onExpandToggle,
     onFilterChange,
     onSearchChange,
@@ -32,10 +34,13 @@ const PostsFilter = ({
     return (
         <div className="mb-6">
             {/* 필터 헤더 */}
-            <div className="flex items-center justify-between mb-4">
+            <div className="flex items-center justify-between gap-3 mb-4">
                 <button
+                    type="button"
                     onClick={onExpandToggle}
-                    className="flex items-center gap-2 text-lg font-semibold text-content hover:text-content transition-colors">
+                    aria-expanded={isExpanded}
+                    aria-controls="posts-filter-controls"
+                    className="flex min-h-11 items-center gap-2 text-lg font-semibold text-content hover:text-content transition-colors">
                     <i className={`fas fa-chevron-${isExpanded ? 'down' : 'right'} text-sm`} />
                     <i className="fas fa-filter" />
                     <span>필터 및 검색</span>
@@ -45,10 +50,11 @@ const PostsFilter = ({
                         </span>
                     )}
                 </button>
-                {hasActiveFilters(filters) && (
+                {showClearAction && hasActiveFilters(filters) && (
                     <Button
                         variant="secondary"
                         size="sm"
+                        className="min-h-11! flex-shrink-0"
                         leftIcon={<i className="fas fa-times" />}
                         onClick={onClearFilters}>
                         필터 초기화
@@ -60,45 +66,53 @@ const PostsFilter = ({
             {hasActiveFilters(filters) && (
                 <div className="flex flex-wrap gap-2 mb-4">
                     {filters.search && (
-                        <div className="inline-flex items-center gap-2 px-3 py-1.5 bg-surface-subtle text-content rounded-lg text-sm">
+                        <div className="inline-flex min-h-11 items-center gap-2 rounded-lg bg-surface-subtle pl-3 text-sm text-content">
                             <i className="fas fa-search text-xs" />
                             <span>검색: {filters.search}</span>
                             <button
+                                type="button"
+                                aria-label="검색 필터 제거"
                                 onClick={() => onFilterChange('search', '')}
-                                className="hover:text-content">
+                                className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-lg text-content-secondary hover:bg-surface hover:text-content">
                                 <i className="fas fa-times text-xs" />
                             </button>
                         </div>
                     )}
                     {filters.tag && (
-                        <div className="inline-flex items-center gap-2 px-3 py-1.5 bg-surface-subtle text-content rounded-lg text-sm">
+                        <div className="inline-flex min-h-11 items-center gap-2 rounded-lg bg-surface-subtle pl-3 text-sm text-content">
                             <i className="fas fa-tag text-xs" />
                             <span>{filters.tag}</span>
                             <button
+                                type="button"
+                                aria-label={`${filters.tag} 태그 필터 제거`}
                                 onClick={() => onFilterChange('tag', '')}
-                                className="hover:text-content">
+                                className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-lg text-content-secondary hover:bg-surface hover:text-content">
                                 <i className="fas fa-times text-xs" />
                             </button>
                         </div>
                     )}
                     {filters.series && (
-                        <div className="inline-flex items-center gap-2 px-3 py-1.5 bg-surface-subtle text-content rounded-lg text-sm">
+                        <div className="inline-flex min-h-11 items-center gap-2 rounded-lg bg-surface-subtle pl-3 text-sm text-content">
                             <i className="fas fa-book text-xs" />
                             <span>{series?.find((s) => s.url === filters.series)?.title}</span>
                             <button
+                                type="button"
+                                aria-label="시리즈 필터 제거"
                                 onClick={() => onFilterChange('series', '')}
-                                className="hover:text-content">
+                                className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-lg text-content-secondary hover:bg-surface hover:text-content">
                                 <i className="fas fa-times text-xs" />
                             </button>
                         </div>
                     )}
                     {filters.visibility && (
-                        <div className="inline-flex items-center gap-2 px-3 py-1.5 bg-surface-subtle text-content rounded-lg text-sm">
+                        <div className="inline-flex min-h-11 items-center gap-2 rounded-lg bg-surface-subtle pl-3 text-sm text-content">
                             <i className={`fas ${filters.visibility === 'public' ? 'fa-eye' : 'fa-eye-slash'} text-xs`} />
                             <span>{filters.visibility === 'public' ? '공개' : '숨김'}</span>
                             <button
+                                type="button"
+                                aria-label="공개 상태 필터 제거"
                                 onClick={() => onFilterChange('visibility', '')}
-                                className="hover:text-content">
+                                className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-lg text-content-secondary hover:bg-surface hover:text-content">
                                 <i className="fas fa-times text-xs" />
                             </button>
                         </div>
@@ -108,7 +122,7 @@ const PostsFilter = ({
 
             {/* 필터 컨트롤 */}
             {isExpanded && (
-                <div className="p-6 bg-surface-subtle border border-line rounded-2xl">
+                <div id="posts-filter-controls" className="p-6 bg-surface-subtle border border-line rounded-2xl">
                     <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-4">
                         <Input
                             type="text"
@@ -123,7 +137,10 @@ const PostsFilter = ({
                         <Dropdown
                             align="left"
                             trigger={
-                                <button className={`${settingsSelectTriggerStyles} flex items-center justify-between text-left`}>
+                                <button
+                                    type="button"
+                                    aria-label="포스트 정렬 방식 선택"
+                                    className={`${settingsSelectTriggerStyles} flex items-center justify-between text-left`}>
                                     <span className="text-content font-medium">
                                         {POSTS_ORDER.find(o => o.order === filters.order)?.name || '정렬 방식'}
                                     </span>
@@ -143,7 +160,10 @@ const PostsFilter = ({
                         <Dropdown
                             align="left"
                             trigger={
-                                <button className={`${settingsSelectTriggerStyles} flex items-center justify-between text-left`}>
+                                <button
+                                    type="button"
+                                    aria-label="태그 필터 선택"
+                                    className={`${settingsSelectTriggerStyles} flex items-center justify-between text-left`}>
                                     <span className={filters.tag ? 'text-content font-medium' : 'text-content-hint'}>
                                         {filters.tag || '태그'}
                                     </span>
@@ -168,7 +188,10 @@ const PostsFilter = ({
                         <Dropdown
                             align="left"
                             trigger={
-                                <button className={`${settingsSelectTriggerStyles} flex items-center justify-between text-left`}>
+                                <button
+                                    type="button"
+                                    aria-label="시리즈 필터 선택"
+                                    className={`${settingsSelectTriggerStyles} flex items-center justify-between text-left`}>
                                     <span className={filters.series ? 'text-content font-medium' : 'text-content-hint'}>
                                         {series?.find((s) => s.url === filters.series)?.title || '시리즈'}
                                     </span>
@@ -193,7 +216,10 @@ const PostsFilter = ({
                         <Dropdown
                             align="left"
                             trigger={
-                                <button className={`${settingsSelectTriggerStyles} flex items-center justify-between text-left`}>
+                                <button
+                                    type="button"
+                                    aria-label="공개 상태 필터 선택"
+                                    className={`${settingsSelectTriggerStyles} flex items-center justify-between text-left`}>
                                     <span className={filters.visibility ? 'text-content font-medium' : 'text-content-hint'}>
                                         {filters.visibility === 'public' ? '공개' : filters.visibility === 'hidden' ? '숨김' : '공개 상태'}
                                     </span>

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SeriesSetting/SeriesSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SeriesSetting/SeriesSetting.tsx
@@ -83,7 +83,8 @@ const SortableSeriesItem = ({ series, username, onEdit, onDelete }: SortableSeri
                 onClick={handleView}
                 dragHandleProps={{
                     attributes,
-                    listeners
+                    listeners,
+                    ariaLabel: `${series.title} 시리즈 순서 변경`
                 }}
                 left={
                     <div className={getSettingsIconClass('default')}>
@@ -92,6 +93,8 @@ const SortableSeriesItem = ({ series, username, onEdit, onDelete }: SortableSeri
                 }
                 actions={
                     <Dropdown
+                        triggerAriaLabel={`${series.title} 시리즈 메뉴 열기`}
+                        triggerClassName="min-h-11 min-w-11"
                         items={[
                             {
                                 label: '시리즈 편집',
@@ -207,21 +210,23 @@ const SeriesSetting = () => {
         }
     };
 
+    const createAction = (
+        <Button
+            variant="primary"
+            size="md"
+            className="min-h-11! w-full sm:w-auto"
+            onClick={handleCreateSeries}>
+            새 시리즈 생성
+        </Button>
+    );
+
     return (
         <div>
             <SettingsHeader
                 title={`시리즈 (${series.length})`}
                 description="드래그하여 표시 순서를 조정할 수 있습니다."
                 actionPosition="right"
-                action={
-                    <Button
-                        variant="primary"
-                        size="md"
-                        className="w-full sm:w-auto"
-                        onClick={handleCreateSeries}>
-                        새 시리즈 생성
-                    </Button>
-                }
+                action={series.length > 0 ? createAction : undefined}
             />
 
             {/* Series list */}
@@ -251,6 +256,7 @@ const SeriesSetting = () => {
                 <SettingsEmptyState
                     iconClassName="fas fa-book"
                     title="시리즈가 없습니다"
+                    action={createAction}
                 />
             )}
         </div>

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SocialLinksSetting/SocialLinksSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SocialLinksSetting/SocialLinksSetting.tsx
@@ -114,10 +114,11 @@ const SocialLinkItem = ({ social, index, onRemove, onChange }: SocialLinkItemPro
                 <div className="flex items-center justify-between p-4 sm:hidden bg-surface-subtle border-b border-line/60">
                     <div className="flex items-center gap-3">
                         <div
-                            className="cursor-grab active:cursor-grabbing text-content-hint hover:text-content-secondary w-8 h-8 flex items-center justify-center transition-colors touch-none hover:bg-surface-subtle rounded-lg"
+                            className="flex min-h-11 min-w-11 cursor-grab touch-none items-center justify-center rounded-lg text-content-hint transition-colors hover:bg-surface-subtle hover:text-content-secondary active:cursor-grabbing"
                             style={{ touchAction: 'none' }}
                             {...attributes}
-                            {...listeners}>
+                            {...listeners}
+                            aria-label={`소셜 링크 ${index + 1} 순서 변경`}>
                             <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
                                 <path d="M3 5h14a1 1 0 010 2H3a1 1 0 010-2zm0 4h14a1 1 0 010 2H3a1 1 0 010-2zm0 4h14a1 1 0 010 2H3a1 1 0 010-2z" />
                             </svg>
@@ -129,8 +130,8 @@ const SocialLinkItem = ({ social, index, onRemove, onChange }: SocialLinkItemPro
                     </div>
                     <button
                         type="button"
-                        aria-label="소셜 링크 삭제"
-                        className="w-8 h-8 flex items-center justify-center rounded-lg text-content-hint hover:text-content-secondary hover:bg-surface-subtle transition-all duration-200"
+                        aria-label={`${currentPlatform?.label || '소셜 링크'} 삭제`}
+                        className="flex min-h-11 min-w-11 items-center justify-center rounded-lg text-content-hint transition-all duration-200 hover:bg-surface-subtle hover:text-content-secondary"
                         onClick={() => onRemove(social.id)}>
                         <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
                             <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
@@ -142,10 +143,11 @@ const SocialLinkItem = ({ social, index, onRemove, onChange }: SocialLinkItemPro
                 <div className="p-4 flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-3">
                     {/* 드래그 핸들 - 데스크톱에서만 표시 */}
                     <div
-                        className="hidden sm:flex cursor-grab active:cursor-grabbing text-content-hint hover:text-content-secondary w-8 h-8 items-center justify-center transition-colors group-hover:text-content-secondary hover:bg-surface-subtle rounded-lg flex-shrink-0"
+                        className="hidden min-h-11 min-w-11 flex-shrink-0 cursor-grab items-center justify-center rounded-lg text-content-hint transition-colors hover:bg-surface-subtle hover:text-content-secondary group-hover:text-content-secondary active:cursor-grabbing sm:flex"
                         style={{ touchAction: 'none' }}
                         {...attributes}
-                        {...listeners}>
+                        {...listeners}
+                        aria-label={`소셜 링크 ${index + 1} 순서 변경`}>
                         <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
                             <path d="M3 5h14a1 1 0 010 2H3a1 1 0 010-2zm0 4h14a1 1 0 010 2H3a1 1 0 010-2zm0 4h14a1 1 0 010 2H3a1 1 0 010-2z" />
                         </svg>
@@ -192,8 +194,8 @@ const SocialLinkItem = ({ social, index, onRemove, onChange }: SocialLinkItemPro
                     {/* 삭제 버튼 - 데스크톱에서만 표시 */}
                     <button
                         type="button"
-                        aria-label="소셜 링크 삭제"
-                        className="hidden sm:flex w-10 h-10 items-center justify-center rounded-lg text-content-hint hover:text-content-secondary hover:bg-surface-subtle transition-all duration-200 group/btn flex-shrink-0"
+                        aria-label={`${currentPlatform?.label || '소셜 링크'} 삭제`}
+                        className="hidden min-h-11 min-w-11 flex-shrink-0 items-center justify-center rounded-lg text-content-hint transition-all duration-200 hover:bg-surface-subtle hover:text-content-secondary group/btn sm:flex"
                         onClick={() => onRemove(social.id)}>
                         <svg className="w-4 h-4 group-hover/btn:scale-110 transition-transform" fill="currentColor" viewBox="0 0 20 20">
                             <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
@@ -361,7 +363,12 @@ const SocialLinks = () => {
                             iconClassName="fas fa-share-alt"
                             title="소셜 링크가 없습니다"
                             action={(
-                                <Button type="button" variant="secondary" size="md" onClick={handleSocialAdd}>
+                                <Button
+                                    type="button"
+                                    variant="secondary"
+                                    size="md"
+                                    className="min-h-11!"
+                                    onClick={handleSocialAdd}>
                                     소셜 링크 추가하기
                                 </Button>
                             )}
@@ -397,7 +404,7 @@ const SocialLinks = () => {
                             size="md"
                             leftIcon={<i className="fas fa-plus" />}
                             onClick={handleSocialAdd}
-                            className="sm:w-auto">
+                            className="min-h-11! sm:w-auto">
                             링크 추가
                         </Button>
                         <Button
@@ -406,7 +413,7 @@ const SocialLinks = () => {
                             size="md"
                             isLoading={isLoading}
                             leftIcon={!isLoading ? <i className="fas fa-save" /> : undefined}
-                            className="sm:w-auto">
+                            className="min-h-11! sm:w-auto">
                             {isLoading ? '저장 중...' : '변경사항 저장'}
                         </Button>
                     </div>

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/StaticPagesSetting/StaticPagesSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/StaticPagesSetting/StaticPagesSetting.tsx
@@ -69,22 +69,24 @@ const StaticPagesSetting = () => {
         window.location.assign(`/static/${page.slug}`);
     };
 
+    const createAction = (
+        <Link to="/static-pages/create" className="block w-full sm:w-auto">
+            <Button
+                variant="primary"
+                size="md"
+                className="min-h-11! w-full sm:w-auto">
+                새 페이지 추가
+            </Button>
+        </Link>
+    );
+
     return (
         <div className="space-y-8">
             <SettingsHeader
                 title={`정적 페이지 (${pagesData?.length || 0})`}
                 description="사이트의 정적 페이지를 관리합니다. 이용약관, 개인정보처리방침 등을 만들 수 있습니다."
                 actionPosition="right"
-                action={
-                    <Link to="/static-pages/create">
-                        <Button
-                            variant="primary"
-                            size="md"
-                            className="w-full sm:w-auto">
-                            새 페이지 추가
-                        </Button>
-                    </Link>
-                }
+                action={pagesData && pagesData.length > 0 ? createAction : undefined}
             />
 
             {pagesData && pagesData.length > 0 ? (
@@ -98,7 +100,7 @@ const StaticPagesSetting = () => {
                 <SettingsEmptyState
                     iconClassName="fas fa-file-lines"
                     title="등록된 정적 페이지가 없습니다"
-                    description="첫 번째 정적 페이지를 만들어보세요."
+                    action={createAction}
                 />
             )}
         </div>

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/StaticPagesSetting/components/StaticPageList.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/StaticPagesSetting/components/StaticPageList.tsx
@@ -19,6 +19,8 @@ export const StaticPageList = ({ pages, onView, onEdit, onDelete }: StaticPageLi
                     onClick={() => onView(page)}
                     actions={
                         <Dropdown
+                            triggerAriaLabel={`${page.title} 페이지 메뉴 열기`}
+                            triggerClassName="min-h-11 min-w-11"
                             items={[
                                 {
                                     label: '편집',

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/shared/BannerSettingBase.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/shared/BannerSettingBase.tsx
@@ -135,6 +135,16 @@ const BannerSettingBase = ({ scope }: BannerSettingBaseProps) => {
         navigate({ to: '/banners/create' });
     };
 
+    const createAction = (
+        <Button
+            onClick={handleCreateBanner}
+            variant="primary"
+            size="md"
+            className="min-h-11! w-full sm:w-auto">
+            새 배너 추가
+        </Button>
+    );
+
     return (
         <div className="space-y-8">
             <SettingsHeader
@@ -145,15 +155,7 @@ const BannerSettingBase = ({ scope }: BannerSettingBaseProps) => {
                         : '상단·하단·사이드바에 표시되며 드래그하여 순서를 조정할 수 있습니다.'
                 }
                 actionPosition="right"
-                action={
-                    <Button
-                        onClick={handleCreateBanner}
-                        variant="primary"
-                        size="md"
-                        className="w-full sm:w-auto">
-                        새 배너 추가
-                    </Button>
-                }
+                action={bannersData && bannersData.length > 0 ? createAction : undefined}
             />
 
             {bannersData && bannersData.length > 0 ? (
@@ -180,7 +182,7 @@ const BannerSettingBase = ({ scope }: BannerSettingBaseProps) => {
                 <SettingsEmptyState
                     iconClassName={isGlobal ? 'fas fa-rectangle-ad' : 'fas fa-shapes'}
                     title={isGlobal ? '등록된 전역 배너가 없습니다' : '등록된 배너가 없습니다'}
-                    description={isGlobal ? '첫 번째 전역 배너를 만들어보세요.' : undefined}
+                    action={createAction}
                 />
             )}
         </div>

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/shared/NoticeSettingBase.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/shared/NoticeSettingBase.tsx
@@ -203,6 +203,15 @@ const NoticeSettingBase = ({ scope }: NoticeSettingBaseProps) => {
     };
 
     const isSubmitting = createMutation.isPending || updateMutation.isPending;
+    const createAction = (
+        <Button
+            onClick={handleCreate}
+            variant="primary"
+            size="md"
+            className="min-h-11! w-full sm:w-auto">
+            새 공지 추가
+        </Button>
+    );
 
     return (
         <div className="space-y-8">
@@ -214,15 +223,7 @@ const NoticeSettingBase = ({ scope }: NoticeSettingBaseProps) => {
                         : undefined
                 }
                 actionPosition="right"
-                action={
-                    <Button
-                        onClick={handleCreate}
-                        variant="primary"
-                        size="md"
-                        className="w-full sm:w-auto">
-                        새 공지 추가
-                    </Button>
-                }
+                action={noticesData && noticesData.length > 0 ? createAction : undefined}
             />
 
             {showForm && (
@@ -282,6 +283,7 @@ const NoticeSettingBase = ({ scope }: NoticeSettingBaseProps) => {
                                 type="button"
                                 variant="ghost"
                                 size="md"
+                                className="min-h-11!"
                                 onClick={closeForm}
                                 disabled={isSubmitting}>
                                 취소
@@ -291,6 +293,7 @@ const NoticeSettingBase = ({ scope }: NoticeSettingBaseProps) => {
                                     type="submit"
                                     variant="primary"
                                     size="md"
+                                    className="min-h-11!"
                                     isLoading={isSubmitting}>
                                     {isSubmitting ? '저장 중...' : editingNotice ? `${noticeLabel} 수정` : `${noticeLabel} 생성`}
                                 </Button>
@@ -307,6 +310,8 @@ const NoticeSettingBase = ({ scope }: NoticeSettingBaseProps) => {
                             key={notice.id}
                             actions={
                                 <Dropdown
+                                    triggerAriaLabel={`${notice.title} ${noticeLabel} 메뉴 열기`}
+                                    triggerClassName="min-h-11 min-w-11"
                                     items={[
                                         {
                                             label: notice.isActive ? '비활성화' : '활성화',
@@ -339,13 +344,13 @@ const NoticeSettingBase = ({ scope }: NoticeSettingBaseProps) => {
                         </SettingsListItem>
                     ))}
                 </div>
-            ) : (
+            ) : !showForm ? (
                 <SettingsEmptyState
                     iconClassName="fas fa-bullhorn"
                     title="등록된 공지가 없습니다"
-                    description={isGlobal ? '첫 번째 전역 공지를 만들어보세요.' : undefined}
+                    action={createAction}
                 />
-            )}
+            ) : null}
         </div>
     );
 };

--- a/backend/islands/packages/ui/src/components/Dropdown.tsx
+++ b/backend/islands/packages/ui/src/components/Dropdown.tsx
@@ -14,10 +14,18 @@ interface DropdownItem {
 interface DropdownProps {
     items: DropdownItem[];
     trigger?: ReactNode;
+    triggerAriaLabel?: string;
+    triggerClassName?: string;
     align?: 'start' | 'end' | 'center' | 'left' | 'right';
 }
 
-const Dropdown = ({ items, trigger, align = 'end' }: DropdownProps) => {
+const Dropdown = ({
+    items,
+    trigger,
+    triggerAriaLabel = '메뉴 열기',
+    triggerClassName = '',
+    align = 'end'
+}: DropdownProps) => {
     const [open, setOpen] = useState(false);
 
     const alignProp: 'start' | 'end' | 'center' =
@@ -35,8 +43,8 @@ const Dropdown = ({ items, trigger, align = 'end' }: DropdownProps) => {
                     trigger
                 ) : (
                     <button
-                        className="p-2 text-content-secondary hover:text-content hover:bg-surface-subtle rounded-lg transition-colors outline-none"
-                        aria-label="메뉴 열기">
+                        className={`p-2 text-content-secondary hover:text-content hover:bg-surface-subtle rounded-lg transition-colors outline-none ${triggerClassName}`}
+                        aria-label={triggerAriaLabel}>
                         <i className="fas fa-ellipsis-v" />
                     </button>
                 )}


### PR DESCRIPTION
## 🎯 Goal
- 설정 목록의 작은 조작부와 빈 상태 진입 액션을 모바일에서 바로 찾고 안전하게 누를 수 있도록 통일합니다.
- 기존 URL, API, payload, 권한, 저장 시점과 검색·필터 URL 상태는 그대로 유지합니다.

## 🔧 Core Changes
- 정적 페이지, 시리즈, 서식, 배너, 공지, 웹훅, 고정 포스트와 포스트의 빈 상태에 다음 행동 CTA를 한 곳만 배치했습니다.
- 목록 메뉴, 드래그 핸들, 필터, 소셜 링크, 고정 포스트와 페이지 이동의 실제 hit area를 최소 44px로 맞췄습니다.
- 목록 메뉴와 드래그 핸들에 항목별 접근 가능한 이름을 부여했습니다.
- 공용 `Dropdown`은 기존 props와 기본 동작을 유지하면서 선택적 trigger label/class props만 추가했습니다.

## 🤔 Key Decisions
- 공용 `Button` 크기는 바꾸지 않고 단순 설정 목록 호출처에만 44px 규칙을 적용했습니다.
- 필터 결과가 없을 때는 상단 전체 초기화와 빈 상태 CTA가 겹치지 않도록 가장 가까운 `필터 초기화` 한 개만 노출합니다.
- 영구 E2E 스펙은 추가하지 않고 기존 계약 테스트와 일회성 브라우저 감사로 검증한 뒤 모든 fixture와 산출물을 삭제했습니다.

## 🧪 Verification Guide
### How to verify
1. 빈 설정 목록에서 헤더와 빈 상태에 CTA가 중복되지 않는지 확인합니다.
2. 375px에서 목록 메뉴를 키보드로 열고 메뉴가 viewport 안에 유지되는지 확인합니다.
3. 포스트 필터, 필터 칩 제거, 일반/고정 포스트 페이지 이동과 소셜/고정 조작부를 확인합니다.

### Expected result
- 라이트·다크, 모바일·데스크톱에서 대상 액션이 44px 이상이고 키보드로 조작 가능하며 가로 overflow와 islands asset 4xx가 없습니다.
- 기존 설정 URL과 API 계약 및 저장 동작은 변하지 않습니다.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed (backend compatibility/settings 171 tests, production smoke 10 tests)
- [x] Production build and entry budgets completed
- [x] Documentation updated (Ocean Brain task 1713)