### PR TITLE
♻️ Prioritize developer token workflows

### DIFF
--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/DeveloperApiSetting/DeveloperApiSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/DeveloperApiSetting/DeveloperApiSetting.tsx
@@ -4,9 +4,11 @@ import { useRouter } from '@tanstack/react-router';
 import {
     Ban,
     BookOpen,
+    ChevronDown,
     Copy,
     KeyRound,
-    Route
+    Route,
+    ShieldCheck
 } from '@blex/ui/icons';
 import { Button, Card, Checkbox, Input } from '~/components/shared';
 import { useConfirm } from '~/hooks/useConfirm';
@@ -49,6 +51,8 @@ const scopeOptions: Array<{
         requiresEditor: true
     }
 ];
+
+const headerLinkClassName = 'inline-flex min-h-11 w-full items-center justify-center gap-2 whitespace-nowrap rounded-lg border border-line-strong bg-surface-elevated px-3 py-2 text-xs font-semibold text-content shadow-sm transition-colors hover:border-line hover:bg-surface-subtle focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-line-strong/70';
 
 const formatDateTime = (value: string | null) => {
     if (!value) return '없음';
@@ -94,6 +98,79 @@ const scopeLabel = (scope: DeveloperTokenScope) => {
     if (scope === 'posts:write') return '포스트 작성';
     return scope;
 };
+
+interface TokenListProps {
+    tokens: DeveloperTokenData[];
+    revokingTokenId?: number;
+    onRevoke: (token: DeveloperTokenData) => void;
+}
+
+const TokenList = ({ tokens, revokingTokenId, onRevoke }: TokenListProps) => (
+    <div className="divide-y divide-line rounded-xl border border-line">
+        {tokens.map((token) => {
+            const status = tokenStatus(token);
+            const canRevoke = !token.revokedAt && !isExpired(token);
+            const isRevoking = revokingTokenId === token.id;
+
+            return (
+                <div key={token.id} className="flex flex-col gap-4 p-4 sm:flex-row sm:items-start sm:justify-between sm:p-5">
+                    <div className="min-w-0 flex-1 space-y-3">
+                        <div className="min-w-0">
+                            <div className="flex flex-wrap items-center gap-2">
+                                <h3 className="text-sm font-semibold text-content">{token.name}</h3>
+                                <span className={`inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-semibold ${status.className}`}>
+                                    {status.label}
+                                </span>
+                            </div>
+                            <code className="mt-1 block break-all font-mono text-xs text-content-hint">
+                                blex_pat_{token.tokenPrefix}_...
+                            </code>
+                        </div>
+
+                        <div className="flex flex-wrap gap-1.5">
+                            {token.scopes.map((scope) => (
+                                <span key={scope} className="rounded-md bg-surface-subtle px-2 py-1 text-xs font-medium text-content-secondary">
+                                    {scopeLabel(scope)}
+                                </span>
+                            ))}
+                        </div>
+
+                        <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-content-secondary">
+                            <span>
+                                <span className="font-semibold text-content-hint">생성</span>
+                                {' '}
+                                {formatDateTime(token.createdAt)}
+                            </span>
+                            <span>
+                                <span className="font-semibold text-content-hint">만료</span>
+                                {' '}
+                                {formatDateTime(token.expiresAt)}
+                            </span>
+                            <span>
+                                <span className="font-semibold text-content-hint">마지막 사용</span>
+                                {' '}
+                                {formatDateTime(token.lastUsedAt)}
+                            </span>
+                        </div>
+                    </div>
+
+                    {canRevoke && (
+                        <Button
+                            type="button"
+                            variant="danger"
+                            size="sm"
+                            className="min-h-11! w-full sm:w-auto"
+                            isLoading={isRevoking}
+                            onClick={() => onRevoke(token)}
+                            leftIcon={!isRevoking ? <Ban aria-hidden className="h-4 w-4" /> : undefined}>
+                            폐기
+                        </Button>
+                    )}
+                </div>
+            );
+        })}
+    </div>
+);
 
 const DeveloperApiSetting = () => {
     const queryClient = useQueryClient();
@@ -219,7 +296,11 @@ const DeveloperApiSetting = () => {
         revokeTokenMutation.mutate(token.id);
     };
 
-    const activeTokenCount = tokens.filter((token) => !token.revokedAt && !isExpired(token)).length;
+    const activeTokens = tokens.filter((token) => !token.revokedAt && !isExpired(token));
+    const inactiveTokens = tokens.filter((token) => token.revokedAt || isExpired(token));
+    const revokingTokenId = revokeTokenMutation.isPending
+        ? revokeTokenMutation.variables
+        : undefined;
 
     return (
         <div className="space-y-6">
@@ -228,85 +309,23 @@ const DeveloperApiSetting = () => {
                 description="외부 도구에서 내 포스트를 읽거나 작성할 수 있는 개인 API 토큰을 발급하고 관리합니다."
                 actionPosition="right"
                 action={(
-                    <div className="flex flex-wrap gap-2">
-                        <a href="/docs/developer-api/quickstart">
-                            <Button
-                                type="button"
-                                variant="secondary"
-                                size="sm"
-                                leftIcon={<Route aria-hidden className="h-4 w-4" />}>
-                                빠른 시작
-                            </Button>
+                    <div className="grid w-full grid-cols-2 gap-2 sm:flex sm:w-auto">
+                        <a href="/docs/developer-api/quickstart" className={headerLinkClassName}>
+                            <Route aria-hidden className="h-4 w-4" />
+                            빠른 시작
                         </a>
-                        <a href="/api/developer/v1/docs">
-                            <Button
-                                type="button"
-                                variant="secondary"
-                                size="sm"
-                                leftIcon={<BookOpen aria-hidden className="h-4 w-4" />}>
-                                API 문서
-                            </Button>
+                        <a href="/api/developer/v1/docs" className={headerLinkClassName}>
+                            <BookOpen aria-hidden className="h-4 w-4" />
+                            API 문서
                         </a>
                     </div>
                 )}
             />
 
-            <section className="rounded-2xl border border-line bg-surface-subtle px-5 py-4">
-                <div className="grid divide-y divide-line md:grid-cols-3 md:divide-x md:divide-y-0">
-                    <div className="pb-4 md:pb-0 md:pr-5">
-                        <div className="text-xs font-semibold text-content-hint">용도</div>
-                        <p className="mt-1 text-sm font-semibold text-content">외부 도구 연결</p>
-                        <p className="mt-1 text-xs leading-relaxed text-content-secondary">
-                            자동화 도구나 개인 클라이언트에서 내 포스트 API를 사용할 때 발급합니다.
-                        </p>
-                    </div>
-                    <div className="py-4 md:px-5 md:py-0">
-                        <div className="text-xs font-semibold text-content-hint">권한</div>
-                        <p className="mt-1 text-sm font-semibold text-content">필요한 작업만 허용</p>
-                        <p className="mt-1 text-xs leading-relaxed text-content-secondary">
-                            읽기와 작성 권한을 분리해서 토큰마다 접근 범위를 제한합니다.
-                        </p>
-                    </div>
-                    <div className="pt-4 md:pl-5 md:pt-0">
-                        <div className="text-xs font-semibold text-content-hint">보관</div>
-                        <p className="mt-1 text-sm font-semibold text-content">전체 토큰은 한 번만 표시</p>
-                        <p className="mt-1 text-xs leading-relaxed text-content-secondary">
-                            발급 직후 복사해두고, 분실하면 새 토큰을 발급한 뒤 기존 토큰을 폐기하세요.
-                        </p>
-                    </div>
-                </div>
-            </section>
-
-            {createdToken && (
-                <Card
-                    title="토큰이 발급되었습니다"
-                    subtitle="전체 토큰 값은 지금 한 번만 확인할 수 있습니다.">
-                    <div className="space-y-4">
-                        <div className="rounded-lg border border-line bg-surface-subtle p-4">
-                            <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
-                                <code className="min-w-0 flex-1 break-all font-mono text-sm text-content">
-                                    {createdToken.token}
-                                </code>
-                                <Button
-                                    type="button"
-                                    variant="secondary"
-                                    size="sm"
-                                    onClick={() => handleCopy(createdToken.token)}
-                                    leftIcon={<Copy aria-hidden className="h-4 w-4" />}>
-                                    복사
-                                </Button>
-                            </div>
-                        </div>
-                        <p className="text-xs leading-relaxed text-content-secondary">
-                            이 값을 저장하지 않으면 다시 확인할 수 없습니다. 분실한 경우 새 토큰을 발급하고 기존 토큰을 폐기하세요.
-                        </p>
-                    </div>
-                </Card>
-            )}
-
             <Card
                 title="새 토큰 발급"
-                subtitle="외부 도구 하나당 토큰 하나를 발급하면 추적과 폐기가 쉽습니다.">
+                subtitle="이름, 권한, 만료 기간을 정하고 외부 도구별로 발급합니다."
+                icon={<KeyRound aria-hidden className="h-4 w-4" />}>
                 <div className="space-y-5">
                     <Input
                         label="토큰 이름"
@@ -352,10 +371,21 @@ const DeveloperApiSetting = () => {
                         helperText="1일부터 365일까지 설정할 수 있습니다."
                     />
 
+                    <div className="flex gap-3 rounded-xl border border-line bg-surface-subtle p-4">
+                        <ShieldCheck
+                            aria-hidden
+                            className="mt-0.5 h-5 w-5 shrink-0 text-content-secondary"
+                        />
+                        <p className="text-xs leading-relaxed text-content-secondary">
+                            전체 토큰 값은 발급 직후 한 번만 표시됩니다. 필요한 최소 권한과 사용 기간만 선택하고 안전한 곳에 보관하세요.
+                        </p>
+                    </div>
+
                     <div className="flex justify-end">
                         <Button
                             type="button"
                             variant="primary"
+                            className="min-h-11! w-full sm:w-auto"
                             isLoading={createTokenMutation.isPending}
                             onClick={handleCreateToken}
                             leftIcon={!createTokenMutation.isPending ? <KeyRound aria-hidden className="h-4 w-4" /> : undefined}>
@@ -365,79 +395,72 @@ const DeveloperApiSetting = () => {
                 </div>
             </Card>
 
-            <Card
-                title="발급된 토큰"
-                subtitle={tokens.length === 0 ? '아직 발급된 토큰이 없습니다.' : `활성 ${activeTokenCount}개 / 전체 ${tokens.length}개`}>
-                {tokens.length === 0 ? (
-                    <div className="rounded-lg border border-dashed border-line px-4 py-6 text-center">
-                        <h3 className="text-sm font-semibold text-content">발급된 토큰이 없습니다</h3>
-                        <p className="mt-2 text-sm text-content-secondary">
-                            외부 도구를 연결할 때 새 토큰을 발급하세요.
-                        </p>
-                    </div>
-                ) : (
-                    <div className="divide-y divide-line rounded-xl border border-line">
-                        {tokens.map((token) => {
-                            const status = tokenStatus(token);
-                            const canRevoke = !token.revokedAt && !isExpired(token);
-                            return (
-                                <div key={token.id} className="flex flex-col gap-4 p-4 sm:flex-row sm:items-start sm:justify-between sm:p-5">
-                                    <div className="min-w-0 flex-1 space-y-3">
-                                        <div className="min-w-0">
-                                            <div className="flex flex-wrap items-center gap-2">
-                                                <h3 className="text-sm font-semibold text-content">{token.name}</h3>
-                                                <span className={`inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-semibold ${status.className}`}>
-                                                    {status.label}
-                                                </span>
-                                            </div>
-                                            <code className="mt-1 block break-all font-mono text-xs text-content-hint">
-                                                blex_pat_{token.tokenPrefix}_...
-                                            </code>
-                                        </div>
-
-                                        <div className="flex flex-wrap gap-1.5">
-                                            {token.scopes.map((scope) => (
-                                                <span key={scope} className="rounded-md bg-surface-subtle px-2 py-1 text-xs font-medium text-content-secondary">
-                                                    {scopeLabel(scope)}
-                                                </span>
-                                            ))}
-                                        </div>
-
-                                        <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-content-secondary">
-                                            <span>
-                                                <span className="font-semibold text-content-hint">생성</span>
-                                                {' '}
-                                                {formatDateTime(token.createdAt)}
-                                            </span>
-                                            <span>
-                                                <span className="font-semibold text-content-hint">만료</span>
-                                                {' '}
-                                                {formatDateTime(token.expiresAt)}
-                                            </span>
-                                            <span>
-                                                <span className="font-semibold text-content-hint">마지막 사용</span>
-                                                {' '}
-                                                {formatDateTime(token.lastUsedAt)}
-                                            </span>
-                                        </div>
-                                    </div>
-
-                                    {canRevoke && (
-                                        <Button
-                                            type="button"
-                                            variant="danger"
-                                            size="sm"
-                                            isLoading={revokeTokenMutation.isPending && revokeTokenMutation.variables === token.id}
-                                            onClick={() => handleRevokeToken(token)}
-                                            leftIcon={!(revokeTokenMutation.isPending && revokeTokenMutation.variables === token.id) ? <Ban aria-hidden className="h-4 w-4" /> : undefined}>
-                                            폐기
-                                        </Button>
-                                    )}
+            {createdToken && (
+                <section aria-live="polite">
+                    <Card
+                        title="지금 토큰을 복사하세요"
+                        subtitle="전체 값은 이 화면에서 한 번만 표시됩니다."
+                        icon={<Copy aria-hidden className="h-4 w-4" />}>
+                        <div className="space-y-4">
+                            <div className="rounded-xl border border-warning-line bg-warning-surface p-4">
+                                <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+                                    <code className="min-w-0 flex-1 break-all font-mono text-sm text-content">
+                                        {createdToken.token}
+                                    </code>
+                                    <Button
+                                        type="button"
+                                        variant="secondary"
+                                        size="sm"
+                                        className="min-h-11! w-full sm:w-auto"
+                                        onClick={() => handleCopy(createdToken.token)}
+                                        leftIcon={<Copy aria-hidden className="h-4 w-4" />}>
+                                        복사
+                                    </Button>
                                 </div>
-                            );
-                        })}
-                    </div>
-                )}
+                            </div>
+                            <p className="text-xs leading-relaxed text-content-secondary">
+                                새로고침하거나 이 화면을 벗어나면 다시 확인할 수 없습니다. 분실하거나 노출했다면 아래에서 즉시 폐기하고 새로 발급하세요.
+                            </p>
+                        </div>
+                    </Card>
+                </section>
+            )}
+
+            <Card
+                title={`활성 토큰 (${activeTokens.length})`}
+                subtitle="현재 사용할 수 있는 토큰을 확인하고 필요할 때 즉시 폐기합니다.">
+                <div className="space-y-5">
+                    {activeTokens.length === 0 ? (
+                        <p className="rounded-xl border border-dashed border-line px-4 py-6 text-center text-sm text-content-secondary">
+                            현재 사용할 수 있는 토큰이 없습니다. 필요하면 위에서 새 토큰을 발급하세요.
+                        </p>
+                    ) : (
+                        <TokenList
+                            tokens={activeTokens}
+                            revokingTokenId={revokingTokenId}
+                            onRevoke={handleRevokeToken}
+                        />
+                    )}
+
+                    {inactiveTokens.length > 0 && (
+                        <details className="group border-t border-line pt-3">
+                            <summary className="flex min-h-11 cursor-pointer list-none items-center justify-between gap-3 rounded-lg px-2 text-sm font-semibold text-content-secondary transition-colors hover:bg-surface-subtle hover:text-content focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-line-strong [&::-webkit-details-marker]:hidden">
+                                <span>만료·폐기 기록 ({inactiveTokens.length})</span>
+                                <ChevronDown
+                                    aria-hidden
+                                    className="h-4 w-4 shrink-0 transition-transform group-open:rotate-180"
+                                />
+                            </summary>
+                            <div className="mt-3">
+                                <TokenList
+                                    tokens={inactiveTokens}
+                                    revokingTokenId={revokingTokenId}
+                                    onRevoke={handleRevokeToken}
+                                />
+                            </div>
+                        </details>
+                    )}
+                </div>
             </Card>
         </div>
     );


### PR DESCRIPTION
## 변경 사항

- 개발자 API 화면을 새 토큰 발급 → 1회 노출 결과 → 활성 토큰 → 만료·폐기 기록 순서로 재구성했습니다.
- 반복적인 상단 3단 설명을 제거하고 1회 노출·최소 권한·사용 기간 안내를 발급 폼에 통합했습니다.
- 활성 토큰만 우선 노출하고 만료·폐기 토큰은 키보드 접근 가능한 기록 영역으로 분리했습니다.
- 빠른 시작/API 문서 링크를 단일 interactive element와 44px hit area로 개선했습니다.

## 하위호환

- URL, deep link, token endpoint, scope, 만료 범위, request/response, 권한, 발급·복사·폐기 동작은 변경하지 않았습니다.
- 서버 데이터 정렬은 바꾸지 않고 화면에서 활성/비활성 그룹만 분리했습니다.

## 검증

- islands lint (기존 경고 8개)
- islands type-check
- islands production build
- entry budgets
- 개발자 API 계약 테스트 42개
- desktop/mobile × light/dark 브라우저 감사 4개
- mobile-dark 실제 발급 → 1회 표시 → 복사 → 폐기 → 기록 이동
- 런타임·자산 오류와 overflow 0

Ocean Brain: 1717