### PR TITLE
🐛 Preserve publishing settings in drafts

### DIFF
--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/NewPostEditor.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/NewPostEditor.tsx
@@ -186,6 +186,8 @@ const NewPostEditor = ({
         coverLayout: formData.coverLayout,
         coverImagePosition: formData.coverImagePosition,
         coverImageRatio: formData.coverImageRatio,
+        hide: formData.hide,
+        advertise: formData.advertise,
         reservedDate: formData.reservedDate,
         imageFile,
         imageDeleted
@@ -272,6 +274,8 @@ const NewPostEditor = ({
                             coverLayout: draftData.coverLayout || 'default',
                             coverImagePosition: draftData.coverImagePosition || 'right',
                             coverImageRatio: draftData.coverImageRatio || 'auto',
+                            hide: draftData.isHide ?? false,
+                            advertise: draftData.isAdvertise ?? false,
                             reservedDate: newReservedDate
                         }));
                         setCurrentDraftUrl(draftData.url || draftUrl);

--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/hooks/useAutoSave.ts
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/hooks/useAutoSave.ts
@@ -13,6 +13,8 @@ interface AutoSaveData {
     coverLayout?: string;
     coverImagePosition?: string;
     coverImageRatio?: string;
+    hide: boolean;
+    advertise: boolean;
     reservedDate?: string;
     imageFile?: File | null;
     imageDeleted?: boolean;
@@ -39,6 +41,8 @@ const buildDraftPayload = (data: AutoSaveData, useFormData: boolean) => {
         if (data.coverLayout) formData.append('cover_layout', data.coverLayout);
         if (data.coverImagePosition) formData.append('cover_image_position', data.coverImagePosition);
         if (data.coverImageRatio) formData.append('cover_image_ratio', data.coverImageRatio);
+        formData.append('is_hide', String(data.hide));
+        formData.append('is_advertise', String(data.advertise));
         if (data.reservedDate !== undefined) formData.append('reserved_date', data.reservedDate);
         if (data.imageFile) formData.append('image', data.imageFile);
         if (data.imageDeleted) formData.append('image_delete', 'true');
@@ -56,6 +60,8 @@ const buildDraftPayload = (data: AutoSaveData, useFormData: boolean) => {
         cover_layout: data.coverLayout,
         cover_image_position: data.coverImagePosition,
         cover_image_ratio: data.coverImageRatio,
+        is_hide: data.hide,
+        is_advertise: data.advertise,
         reserved_date: data.reservedDate
     };
 };
@@ -91,6 +97,8 @@ export const useAutoSave = (data: AutoSaveData, options: UseAutoSaveOptions) => 
         coverLayout: value.coverLayout,
         coverImagePosition: value.coverImagePosition,
         coverImageRatio: value.coverImageRatio,
+        hide: value.hide,
+        advertise: value.advertise,
         reservedDate: value.reservedDate
     }), []);
 

--- a/backend/islands/apps/remotes/src/lib/api/posts.ts
+++ b/backend/islands/apps/remotes/src/lib/api/posts.ts
@@ -115,6 +115,8 @@ export interface DraftDetail {
     coverLayout: 'default' | 'split' | 'overlay' | 'none';
     coverImagePosition: 'left' | 'right';
     coverImageRatio: 'auto' | '16:9' | '4:3' | '1:1' | '3:4';
+    isHide: boolean;
+    isAdvertise: boolean;
     reservedDate: string;
     series: {
         url: string;
@@ -130,14 +132,14 @@ export interface DraftSummary {
     updatedDate: string;
 }
 
-export const createDraft = async (data: { title: string; content: string; tags: string; subtitle?: string; description?: string; series_url?: string; cover_layout?: string; cover_image_position?: string; cover_image_ratio?: string; reserved_date?: string } | FormData) => {
+export const createDraft = async (data: { title: string; content: string; tags: string; subtitle?: string; description?: string; series_url?: string; cover_layout?: string; cover_image_position?: string; cover_image_ratio?: string; is_hide?: boolean; is_advertise?: boolean; reserved_date?: string } | FormData) => {
     if (data instanceof FormData) {
         return http.post<Response<{ url: string }>>('v1/drafts', data, { headers: { 'Content-Type': 'multipart/form-data' } });
     }
     return http.post<Response<{ url: string }>>('v1/drafts', data, { headers: { 'Content-Type': 'application/json' } });
 };
 
-export const updateDraft = async (url: string, data: { title?: string; content?: string; tags?: string; subtitle?: string; description?: string; series_url?: string; cover_layout?: string; cover_image_position?: string; cover_image_ratio?: string; reserved_date?: string } | FormData) => {
+export const updateDraft = async (url: string, data: { title?: string; content?: string; tags?: string; subtitle?: string; description?: string; series_url?: string; cover_layout?: string; cover_image_position?: string; cover_image_ratio?: string; is_hide?: boolean; is_advertise?: boolean; reserved_date?: string } | FormData) => {
     if (data instanceof FormData) {
         return http.put<Response<{ url: string }>>(`v1/drafts/${url}`, data, { headers: { 'Content-Type': 'multipart/form-data' } });
     }

--- a/backend/src/board/services/post_service.py
+++ b/backend/src/board/services/post_service.py
@@ -665,6 +665,8 @@ class PostService:
         cover_image_position: Optional[str] = None,
         cover_image_ratio: Optional[str] = None,
         reserved_date_str: Optional[str] = None,
+        is_hide: bool = False,
+        is_advertise: bool = False,
     ) -> Post:
         """
         Create a draft post (published_date=null).
@@ -723,6 +725,8 @@ class PostService:
 
         PostConfig.objects.create(
             post=post,
+            hide=is_hide,
+            advertise=is_advertise,
             **PostService.normalize_cover_options(
                 cover_layout=cover_layout,
                 cover_image_position=cover_image_position,
@@ -751,6 +755,8 @@ class PostService:
         cover_image_position: Optional[str] = None,
         cover_image_ratio: Optional[str] = None,
         reserved_date_str: Optional[str] = None,
+        is_hide: Optional[bool] = None,
+        is_advertise: Optional[bool] = None,
     ) -> Post:
         """
         Update a draft post. No notifications sent.
@@ -802,8 +808,20 @@ class PostService:
         post.updated_date = timezone.now()
         post.save()
 
-        if cover_layout is not None or cover_image_position is not None or cover_image_ratio is not None:
+        should_update_config = (
+            is_hide is not None
+            or is_advertise is not None
+            or cover_layout is not None
+            or cover_image_position is not None
+            or cover_image_ratio is not None
+        )
+
+        if should_update_config:
             post_config = post.config
+            if is_hide is not None:
+                post_config.hide = is_hide
+            if is_advertise is not None:
+                post_config.advertise = is_advertise
             PostService.apply_cover_options(
                 post_config,
                 cover_layout=cover_layout,

--- a/backend/src/board/tests/api/test_developer_posts.py
+++ b/backend/src/board/tests/api/test_developer_posts.py
@@ -105,6 +105,39 @@ class DeveloperPostsAPITestCase(TestCase):
         post = Post.objects.get(id=data['id'])
         self.assertIsNone(post.published_date)
         self.assertEqual(sorted(post.tags.values_list('value', flat=True)), ['api', 'mcp'])
+        self.assertFalse(post.config.hide)
+        self.assertFalse(post.config.advertise)
+
+    def test_draft_publishing_settings_survive_publish_without_overrides(self):
+        """Developer API의 초안 설정은 빈 발행 요청에도 그대로 유지된다."""
+        response = self.post_json('/api/developer/v1/posts', {
+            'title': 'Configured Draft',
+            'content': '# Hello',
+            'content_type': 'markdown',
+            'is_hidden': True,
+            'is_advertise': True,
+        })
+
+        self.assertEqual(response.status_code, 201)
+        draft = response.json()['data']
+        self.assertTrue(draft['is_hidden'])
+        self.assertTrue(draft['is_advertise'])
+
+        publish_response = self.client.generic(
+            'POST',
+            f"/api/developer/v1/posts/{draft['id']}/publish",
+            data=b'',
+            **self.auth_header(),
+        )
+
+        self.assertEqual(publish_response.status_code, 200)
+        published = publish_response.json()['data']
+        self.assertTrue(published['is_hidden'])
+        self.assertTrue(published['is_advertise'])
+
+        post = Post.objects.get(id=draft['id'])
+        self.assertTrue(post.config.hide)
+        self.assertTrue(post.config.advertise)
 
     def test_developer_api_persists_cover_options(self):
         response = self.post_json('/api/developer/v1/posts', {

--- a/backend/src/board/tests/api/test_draft.py
+++ b/backend/src/board/tests/api/test_draft.py
@@ -6,6 +6,7 @@ from PIL import Image
 
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
+from django.test.client import BOUNDARY, MULTIPART_CONTENT, encode_multipart
 from django.contrib.auth.models import User
 from django.utils import timezone
 
@@ -81,6 +82,34 @@ class DraftTestCase(TestCase):
         self.assertIsNone(post.published_date)
         self.assertTrue(post.is_draft())
         self.assertFalse(post.is_published())
+        self.assertFalse(post.config.hide)
+        self.assertFalse(post.config.advertise)
+
+    def test_create_draft_persists_publishing_settings(self):
+        """비공개·광고성 설정을 생성하고 상세 응답에서 복원한다."""
+        self.client.login(username='test', password='test')
+
+        response = self.client.post(
+            '/v1/drafts',
+            json.dumps({
+                'title': 'Private Advertise Draft',
+                'content': '<p>Hello world</p>',
+                'is_hide': True,
+                'is_advertise': True,
+            }),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+        body = json.loads(response.content)['body']
+        post = Post.objects.get(url=body['url'])
+        self.assertTrue(post.config.hide)
+        self.assertTrue(post.config.advertise)
+
+        detail_response = self.client.get(f"/v1/drafts/{post.url}")
+        detail = json.loads(detail_response.content)['body']
+        self.assertTrue(detail['isHide'])
+        self.assertTrue(detail['isAdvertise'])
 
     def test_create_draft_with_cover_options(self):
         """드래프트 생성 시 커버 설정을 저장하고 상세 응답에 반환한다."""
@@ -259,6 +288,83 @@ class DraftTestCase(TestCase):
         self.assertEqual(post.config.cover_layout, 'none')
         self.assertEqual(post.config.cover_image_position, 'right')
         self.assertEqual(post.config.cover_image_ratio, 'auto')
+
+    def test_update_draft_publishing_settings_preserves_omitted_values(self):
+        """설정 필드는 명시할 때만 바뀌며 false도 정상 저장한다."""
+        url = self._create_draft()
+
+        response = self.client.put(
+            f'/v1/drafts/{url}',
+            json.dumps({
+                'is_hide': True,
+                'is_advertise': True,
+            }),
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 200)
+
+        post = Post.objects.get(url=url)
+        self.assertTrue(post.config.hide)
+        self.assertTrue(post.config.advertise)
+
+        response = self.client.put(
+            f'/v1/drafts/{url}',
+            json.dumps({'title': 'Settings stay unchanged'}),
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 200)
+
+        post.refresh_from_db()
+        post.config.refresh_from_db()
+        self.assertTrue(post.config.hide)
+        self.assertTrue(post.config.advertise)
+
+        response = self.client.put(
+            f'/v1/drafts/{url}',
+            json.dumps({
+                'is_hide': False,
+                'is_advertise': False,
+            }),
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 200)
+
+        post.config.refresh_from_db()
+        self.assertFalse(post.config.hide)
+        self.assertFalse(post.config.advertise)
+
+    def test_draft_publishing_settings_support_multipart_payloads(self):
+        """이미지 자동저장이 사용하는 multipart 경로에서도 설정을 보존한다."""
+        self.client.login(username='test', password='test')
+
+        response = self.client.post('/v1/drafts', {
+            'title': 'Multipart Settings Draft',
+            'content': '<p>content</p>',
+            'is_hide': 'true',
+            'is_advertise': 'true',
+        })
+        self.assertEqual(response.status_code, 200)
+        url = json.loads(response.content)['body']['url']
+
+        post = Post.objects.get(url=url)
+        self.assertTrue(post.config.hide)
+        self.assertTrue(post.config.advertise)
+
+        payload = encode_multipart(BOUNDARY, {
+            'is_hide': 'false',
+            'is_advertise': 'false',
+        })
+        response = self.client.generic(
+            'PUT',
+            f'/v1/drafts/{url}',
+            payload,
+            content_type=MULTIPART_CONTENT,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        post.config.refresh_from_db()
+        self.assertFalse(post.config.hide)
+        self.assertFalse(post.config.advertise)
 
     def test_update_draft_reserved_date_and_clear(self):
         """드래프트 예약 시간은 수정하거나 비울 수 있다."""

--- a/backend/src/board/tests/test_backend_compatibility_contract.py
+++ b/backend/src/board/tests/test_backend_compatibility_contract.py
@@ -489,6 +489,8 @@ EXPECTED_POST_SERVICE_SIGNATURES = {
         ('cover_image_position', None),
         ('cover_image_ratio', None),
         ('reserved_date_str', None),
+        ('is_hide', False),
+        ('is_advertise', False),
     ),
     'update_draft': (
         ('post', REQUIRED),
@@ -506,6 +508,8 @@ EXPECTED_POST_SERVICE_SIGNATURES = {
         ('cover_image_position', None),
         ('cover_image_ratio', None),
         ('reserved_date_str', None),
+        ('is_hide', None),
+        ('is_advertise', None),
     ),
     'publish_draft': (
         ('post', REQUIRED),

--- a/backend/src/board/views/api/developer/v1/api.py
+++ b/backend/src/board/views/api/developer/v1/api.py
@@ -262,6 +262,8 @@ def create_post(request, payload: PostMutationPayload):
                 cover_layout=data.get('cover_layout'),
                 cover_image_position=data.get('cover_image_position'),
                 cover_image_ratio=data.get('cover_image_ratio'),
+                is_hide=DeveloperPostAPI.parse_bool(data.get('is_hidden', data.get('is_hide')), False),
+                is_advertise=DeveloperPostAPI.parse_bool(data.get('is_advertise'), False),
             )
         elif status in ('published', 'scheduled'):
             if status == 'scheduled' and not data.get('published_at'):
@@ -535,8 +537,14 @@ def publish_post(request, post_id: int, payload: PostPublishPayload | None = Bod
             series_url=DeveloperPostAPI.series_url(data, request.auth.user),
             custom_url=data.get('slug', data.get('url')) if 'slug' in data or 'url' in data else None,
             tag=DeveloperPostAPI.tags_value(data) if 'tags' in data or 'tag' in data else None,
-            is_hide=DeveloperPostAPI.parse_bool(data.get('is_hidden', data.get('is_hide')), False),
-            is_advertise=DeveloperPostAPI.parse_bool(data.get('is_advertise'), False),
+            is_hide=DeveloperPostAPI.parse_bool(
+                data.get('is_hidden', data.get('is_hide')),
+                post.config.hide,
+            ),
+            is_advertise=DeveloperPostAPI.parse_bool(
+                data.get('is_advertise'),
+                post.config.advertise,
+            ),
             reserved_date_str=data.get('published_at', ''),
             content_type=content_type,
             cover_layout=data.get('cover_layout'),

--- a/backend/src/board/views/api/developer/v1/schemas.py
+++ b/backend/src/board/views/api/developer/v1/schemas.py
@@ -112,7 +112,7 @@ class PostBodyPayload(Schema):
     series_url: str | None = Field(None, description='내 시리즈 URL입니다. series_id보다 직접 URL을 지정할 때 사용합니다.')
     slug: str | None = Field(None, description='사용자 지정 포스트 URL입니다.')
     url: str | None = Field(None, description='기존 클라이언트를 위한 포스트 URL 호환 필드입니다.')
-    is_hidden: bool | None = Field(None, description='발행 포스트를 비공개 처리할지 여부입니다.')
+    is_hidden: bool | None = Field(None, description='포스트를 비공개 처리할지 여부입니다.')
     is_hide: bool | None = Field(None, description='기존 클라이언트를 위한 비공개 호환 필드입니다.')
     is_advertise: bool | None = Field(None, description='홍보/광고성 포스트 여부입니다.')
     cover_layout: CoverLayout | None = Field(None, description='상세 화면 커버 배치입니다.')

--- a/backend/src/board/views/api/v1/draft.py
+++ b/backend/src/board/views/api/v1/draft.py
@@ -9,6 +9,18 @@ from board.services.post_service import PostService, PostValidationError
 from board.modules.response import StatusDone, StatusError
 
 
+def _optional_boolean(data, key):
+    if key not in data:
+        return None
+
+    value = data.get(key)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.lower() in ('1', 'true', 'yes', 'on')
+    return bool(value)
+
+
 @api_editor_required
 def drafts_list(request):
     if request.method == 'GET':
@@ -43,6 +55,8 @@ def drafts_list(request):
         cover_image_position = data.get('cover_image_position')
         cover_image_ratio = data.get('cover_image_ratio')
         reserved_date = data.get('reserved_date')
+        is_hide = _optional_boolean(data, 'is_hide')
+        is_advertise = _optional_boolean(data, 'is_advertise')
         image = files.get('image') if files else None
 
         try:
@@ -61,6 +75,8 @@ def drafts_list(request):
                 cover_image_position=cover_image_position,
                 cover_image_ratio=cover_image_ratio,
                 reserved_date_str=reserved_date,
+                is_hide=is_hide if is_hide is not None else False,
+                is_advertise=is_advertise if is_advertise is not None else False,
             )
 
             return StatusDone({
@@ -100,6 +116,8 @@ def drafts_detail(request, url):
             'cover_layout': draft.config.cover_layout,
             'cover_image_position': draft.config.cover_image_position,
             'cover_image_ratio': draft.config.cover_image_ratio,
+            'is_hide': draft.config.hide,
+            'is_advertise': draft.config.advertise,
             'reserved_date': PostService.get_draft_reserved_date(draft),
             'series': {
                 'url': draft.series.url,
@@ -119,6 +137,8 @@ def drafts_detail(request, url):
         image = files.get('image') if files else None
         image_delete = data.get('image_delete') == 'true'
         reserved_date = data.get('reserved_date') if 'reserved_date' in data else None
+        is_hide = _optional_boolean(data, 'is_hide')
+        is_advertise = _optional_boolean(data, 'is_advertise')
 
         try:
             PostService.update_draft(
@@ -137,6 +157,8 @@ def drafts_detail(request, url):
                 cover_image_position=data.get('cover_image_position'),
                 cover_image_ratio=data.get('cover_image_ratio'),
                 reserved_date_str=reserved_date,
+                is_hide=is_hide,
+                is_advertise=is_advertise,
             )
             return StatusDone({
                 'url': draft.url,


### PR DESCRIPTION
## 🎯 Goal
- Preserve private and promotional settings across draft autosave, reload, and publish.
- Align the internal draft flow and Developer API with their documented publishing-settings contract.

## 🔧 Core Changes
- Extend draft create, read, and update with optional is_hide and is_advertise fields for JSON and multipart requests.
- Include both settings in the editor autosave signature, payloads, and draft restoration.
- Preserve saved Developer API draft settings when publishing without explicit overrides.
- Add durable contract coverage for defaults, partial updates, false values, multipart payloads, and publish preservation.

## 🤔 Key Decisions
- Append optional service parameters so existing positional callers and omitted-field defaults remain compatible.
- Keep existing endpoints and field meanings unchanged; this is an additive response and request contract.
- Reuse PostConfig without a migration and test behavior rather than frontend implementation details.

## 🧪 Verification Guide
### How to verify
1. Create a draft, enable private and promotional settings, save, and reopen it.
2. Change another draft field without sending either setting and confirm both values remain unchanged.
3. Save a draft with an image, disable both settings, and reopen it.
4. Create a configured Developer API draft and publish it with an empty request body.

### Expected result
- Both settings survive JSON and multipart autosaves, reloads, partial updates, and Developer API publication.
- Clients that omit the new fields retain the previous false defaults.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)