### PR TITLE
✨ Add scheduled post lifecycle actions

### DIFF
--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/EditPostEditor.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/EditPostEditor.tsx
@@ -7,7 +7,11 @@ import PostForm from './components/PostForm';
 import SettingsDrawer from './components/SettingsDrawer';
 import ScheduleStatusNotice from './components/ScheduleStatusNotice';
 import { getSeries } from '~/lib/api/settings';
-import { getPostForEdit } from '~/lib/api/posts';
+import {
+    cancelPostSchedule,
+    getPostForEdit,
+    publishScheduledPostNow
+} from '~/lib/api/posts';
 import { api } from '~/components/shared';
 import { logger } from '~/utils/logger';
 import type { Series } from './types';
@@ -70,6 +74,7 @@ const EditPostEditor = ({ username, postUrl }: EditPostEditorProps) => {
         url: ''
     });
     const [isScheduledPost, setIsScheduledPost] = useState(false);
+    const [pendingScheduleAction, setPendingScheduleAction] = useState<'cancel' | 'publish-now' | null>(null);
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [isEditorMediaUploading, setIsEditorMediaUploading] = useState(false);
 
@@ -340,6 +345,80 @@ const EditPostEditor = ({ username, postUrl }: EditPostEditorProps) => {
         }
     };
 
+    const canRunScheduleAction = () => {
+        if (hasUnsavedChanges()) {
+            toast.warning('변경 사항을 먼저 수정한 뒤 예약 상태를 변경해주세요.');
+            return false;
+        }
+
+        if (isEditorMediaUploading) {
+            toast.warning('파일 업로드가 끝난 뒤 예약 상태를 변경해주세요.');
+            return false;
+        }
+
+        return true;
+    };
+
+    const handleCancelSchedule = async () => {
+        if (!canRunScheduleAction()) return;
+
+        const confirmed = await confirm({
+            title: '예약 취소',
+            message: '예약을 취소하고 임시글로 되돌립니다. 내용과 설정은 유지되며 공개 화면에는 노출되지 않습니다.',
+            confirmText: '예약 취소'
+        });
+        if (!confirmed) return;
+
+        setPendingScheduleAction('cancel');
+        setIsSubmitting(true);
+        try {
+            const { data } = await cancelPostSchedule(username, postUrl);
+            if (data.status === 'ERROR') {
+                toast.error(data.errorMessage || '예약 취소에 실패했습니다.');
+                return;
+            }
+
+            isIntentionalSubmitRef.current = true;
+            window.location.assign(`/write?draft=${encodeURIComponent(data.body.url)}`);
+        } catch {
+            toast.error('예약 취소에 실패했습니다.');
+        } finally {
+            setPendingScheduleAction(null);
+            setIsSubmitting(false);
+        }
+    };
+
+    const handlePublishNow = async () => {
+        if (!canRunScheduleAction()) return;
+
+        const confirmed = await confirm({
+            title: '지금 발행',
+            message: formData.hide
+                ? '예약 시간을 기다리지 않고 비공개 상태로 발행합니다. 작성자 외에는 볼 수 없습니다.'
+                : '예약 시간을 기다리지 않고 지금 공개합니다. 연결된 알림 채널에도 발행 소식이 전송됩니다.',
+            confirmText: '지금 발행'
+        });
+        if (!confirmed) return;
+
+        setPendingScheduleAction('publish-now');
+        setIsSubmitting(true);
+        try {
+            const { data } = await publishScheduledPostNow(username, postUrl);
+            if (data.status === 'ERROR') {
+                toast.error(data.errorMessage || '즉시 발행에 실패했습니다.');
+                return;
+            }
+
+            isIntentionalSubmitRef.current = true;
+            window.location.assign(`/@${encodeURIComponent(username)}/${encodeURIComponent(data.body.url)}`);
+        } catch {
+            toast.error('즉시 발행에 실패했습니다.');
+        } finally {
+            setPendingScheduleAction(null);
+            setIsSubmitting(false);
+        }
+    };
+
     if (isLoading) {
         return (
             <PostEditorWrapper>
@@ -412,6 +491,9 @@ const EditPostEditor = ({ username, postUrl }: EditPostEditorProps) => {
                     [field]: value
                 }))}
                 onDelete={handleDelete}
+                onCancelSchedule={handleCancelSchedule}
+                onPublishNow={handlePublishNow}
+                pendingScheduleAction={pendingScheduleAction}
             />
         </PostEditorWrapper>
     );

--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/components/SettingsDrawer.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/components/SettingsDrawer.tsx
@@ -4,12 +4,14 @@ import { IconButton } from '@blex/ui/icon-button';
 import { Toggle } from '@blex/ui/toggle';
 import {
     CircleDollarSign,
+    CirclePause,
     Clock,
     EyeOff,
     FileText,
     Image,
     Info,
     Search,
+    Send,
     SlidersHorizontal,
     Trash2,
     X
@@ -55,6 +57,9 @@ interface SettingsDrawerProps {
     onSeriesChange: (series: Series) => void;
     onFormDataChange: (field: string, value: boolean | string) => void;
     onDelete?: () => void;
+    onCancelSchedule?: () => void;
+    onPublishNow?: () => void;
+    pendingScheduleAction?: 'cancel' | 'publish-now' | null;
 }
 
 interface CoverPreviewProps {
@@ -187,7 +192,10 @@ const SettingsDrawer = ({
     onMetaDescriptionChange,
     onSeriesChange,
     onFormDataChange,
-    onDelete
+    onDelete,
+    onCancelSchedule,
+    onPublishNow,
+    pendingScheduleAction = null
 }: SettingsDrawerProps) => {
     const canEditSchedule = !isEdit || isScheduled;
 
@@ -373,6 +381,30 @@ const SettingsDrawer = ({
                                                 onChange={(nextValue) => onFormDataChange('reservedDate', nextValue)}
                                                 allowClear={!isScheduled}
                                             />
+                                            {isScheduled && onCancelSchedule && onPublishNow && (
+                                                <div className="mt-4 grid grid-cols-2 gap-2 border-t border-line pt-4">
+                                                    <Button
+                                                        type="button"
+                                                        variant="secondary"
+                                                        size="md"
+                                                        onClick={onCancelSchedule}
+                                                        disabled={pendingScheduleAction !== null}
+                                                        isLoading={pendingScheduleAction === 'cancel'}
+                                                        leftIcon={<CirclePause className="h-4 w-4" />}>
+                                                        예약 취소
+                                                    </Button>
+                                                    <Button
+                                                        type="button"
+                                                        variant="primary"
+                                                        size="md"
+                                                        onClick={onPublishNow}
+                                                        disabled={pendingScheduleAction !== null}
+                                                        isLoading={pendingScheduleAction === 'publish-now'}
+                                                        leftIcon={<Send className="h-4 w-4" />}>
+                                                        지금 발행
+                                                    </Button>
+                                                </div>
+                                            )}
                                         </div>
                                     )}
 

--- a/backend/islands/apps/remotes/src/lib/api/posts.ts
+++ b/backend/islands/apps/remotes/src/lib/api/posts.ts
@@ -185,6 +185,24 @@ export const getPostForEdit = async (username: string, postUrl: string) => {
     return http.get<Response<PostForEdit>>(`v1/users/@${username}/posts/${postUrl}?mode=edit`);
 };
 
+interface ScheduledPostActionResult {
+    url: string;
+    status: 'draft' | 'published';
+    publishedDate?: string;
+}
+
+export const cancelPostSchedule = async (username: string, postUrl: string) => {
+    return http.post<Response<ScheduledPostActionResult>>(
+        `v1/users/@${username}/posts/${postUrl}/schedule/cancel`
+    );
+};
+
+export const publishScheduledPostNow = async (username: string, postUrl: string) => {
+    return http.post<Response<ScheduledPostActionResult>>(
+        `v1/users/@${username}/posts/${postUrl}/schedule/publish-now`
+    );
+};
+
 export const uploadImage = async (file: File) => {
     const formData = new FormData();
     formData.append('image', file);

--- a/backend/src/board/services/post_service.py
+++ b/backend/src/board/services/post_service.py
@@ -28,6 +28,7 @@ from board.services.authoring_permission_service import AuthoringPermissionServi
 from board.services.public_post_service import PublicPostService
 from board.services.related_post_service import RelatedPostService
 from board.services.post_image_service import PostImageService
+from board.services.post_status_service import PostStatusService
 from board.services.webhook_service import WebhookService
 
 
@@ -270,6 +271,44 @@ class PostService:
         transaction.on_commit(
             lambda: WebhookService.notify_channels(post, post_config)
         )
+
+    @staticmethod
+    def _lock_scheduled_post(post: Post) -> Post:
+        try:
+            scheduled_post = Post.objects.select_for_update().get(pk=post.pk)
+        except Post.DoesNotExist as error:
+            raise PostValidationError(
+                ErrorCode.NOT_FOUND,
+                '포스트를 찾을 수 없습니다.'
+            ) from error
+        if not PostStatusService.is_scheduled(scheduled_post):
+            raise PostValidationError(
+                ErrorCode.REJECT,
+                '예약 포스트에서만 사용할 수 있습니다.'
+            )
+        return scheduled_post
+
+    @staticmethod
+    @transaction.atomic
+    def cancel_scheduled_post(post: Post) -> Post:
+        """Cancel a scheduled publication and return the post to draft state."""
+        scheduled_post = PostService._lock_scheduled_post(post)
+        scheduled_post.published_date = None
+        scheduled_post.updated_date = timezone.now()
+        scheduled_post.save(update_fields=['published_date', 'updated_date'])
+        return scheduled_post
+
+    @staticmethod
+    @transaction.atomic
+    def publish_scheduled_post_now(post: Post) -> Post:
+        """Publish a scheduled post immediately and notify configured channels."""
+        scheduled_post = PostService._lock_scheduled_post(post)
+        published_at = timezone.now()
+        scheduled_post.published_date = published_at
+        scheduled_post.updated_date = published_at
+        scheduled_post.save(update_fields=['published_date', 'updated_date'])
+        PostService.send_post_notifications(scheduled_post, scheduled_post.config)
+        return scheduled_post
 
     @staticmethod
     def _compute_image_hash(image_file) -> str:

--- a/backend/src/board/tests/api/test_post.py
+++ b/backend/src/board/tests/api/test_post.py
@@ -1,6 +1,7 @@
 import json
 import datetime
 from io import BytesIO
+from unittest.mock import patch
 
 from PIL import Image
 
@@ -55,6 +56,30 @@ class PostTestCase(TestCase):
     
     def setUp(self):
         self.client.defaults['HTTP_USER_AGENT'] = 'BLEX_TEST'
+
+    def _create_scheduled_post(
+        self,
+        url: str,
+        *,
+        hide: bool = False,
+        advertise: bool = False,
+    ) -> Post:
+        post = Post.objects.create(
+            url=url,
+            title='Scheduled Lifecycle Post',
+            author=User.objects.get(username='author'),
+            published_date=timezone.now() + timezone.timedelta(days=1),
+        )
+        PostContent.objects.create(
+            post=post,
+            content_html='<p>Scheduled lifecycle body</p>',
+        )
+        PostConfig.objects.create(
+            post=post,
+            hide=hide,
+            advertise=advertise,
+        )
+        return post
 
 
     def test_get_user_post_detail(self):
@@ -167,6 +192,120 @@ class PostTestCase(TestCase):
         content = json.loads(response.content)
         self.assertEqual(content['status'], 'ERROR')
         self.assertEqual(content['errorCode'], 'error:VA')
+
+    def test_cancel_post_schedule_returns_post_to_draft(self):
+        """예약 취소는 내용과 설정을 보존한 채 포스트를 임시글로 되돌린다."""
+        scheduled_post = self._create_scheduled_post(
+            'scheduled-cancel-post',
+            hide=True,
+            advertise=True,
+        )
+        previous_updated_date = scheduled_post.updated_date
+        self.client.login(username='author', password='author')
+
+        response = self.client.post(
+            '/v1/users/@author/posts/scheduled-cancel-post/schedule/cancel'
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'DONE')
+        self.assertEqual(content['body'], {
+            'url': 'scheduled-cancel-post',
+            'status': 'draft',
+        })
+        scheduled_post.refresh_from_db()
+        self.assertIsNone(scheduled_post.published_date)
+        self.assertGreater(scheduled_post.updated_date, previous_updated_date)
+        self.assertEqual(
+            scheduled_post.content.content_html,
+            '<p>Scheduled lifecycle body</p>',
+        )
+        self.assertTrue(scheduled_post.config.hide)
+        self.assertTrue(scheduled_post.config.advertise)
+
+        repeated_response = self.client.post(
+            '/v1/users/@author/posts/scheduled-cancel-post/schedule/cancel'
+        )
+        repeated_content = json.loads(repeated_response.content)
+        self.assertEqual(repeated_content['status'], 'ERROR')
+        self.assertEqual(repeated_content['errorCode'], 'error:RJ')
+
+    @patch('board.services.post_service.WebhookService.notify_channels')
+    def test_publish_scheduled_post_now_notifies_once(self, mock_notify):
+        """즉시 발행은 예약 포스트를 공개 상태로 바꾸고 알림을 한 번만 보낸다."""
+        scheduled_post = self._create_scheduled_post('scheduled-publish-now-post')
+        self.client.login(username='author', password='author')
+
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(
+                '/v1/users/@author/posts/scheduled-publish-now-post/schedule/publish-now'
+            )
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'DONE')
+        self.assertEqual(content['body']['status'], 'published')
+        self.assertEqual(content['body']['url'], 'scheduled-publish-now-post')
+        self.assertIn('publishedDate', content['body'])
+        scheduled_post.refresh_from_db()
+        self.assertLessEqual(scheduled_post.published_date, timezone.now())
+        mock_notify.assert_called_once()
+
+        with self.captureOnCommitCallbacks(execute=True):
+            repeated_response = self.client.post(
+                '/v1/users/@author/posts/scheduled-publish-now-post/schedule/publish-now'
+            )
+        repeated_content = json.loads(repeated_response.content)
+        self.assertEqual(repeated_content['status'], 'ERROR')
+        self.assertEqual(repeated_content['errorCode'], 'error:RJ')
+        mock_notify.assert_called_once()
+
+    def test_schedule_actions_reject_non_scheduled_posts(self):
+        """임시글과 이미 발행된 글에는 예약 상태 액션을 적용하지 않는다."""
+        draft = self._create_scheduled_post('schedule-action-draft')
+        draft.published_date = None
+        draft.save(update_fields=['published_date'])
+        published = Post.objects.get(url='test-post-2')
+        original_published_date = published.published_date
+        self.client.login(username='author', password='author')
+
+        for post in (draft, published):
+            for action in ('cancel', 'publish-now'):
+                with self.subTest(post=post.url, action=action):
+                    response = self.client.post(
+                        f'/v1/users/@author/posts/{post.url}/schedule/{action}'
+                    )
+                    content = json.loads(response.content)
+                    self.assertEqual(content['status'], 'ERROR')
+                    self.assertEqual(content['errorCode'], 'error:RJ')
+
+        draft.refresh_from_db()
+        published.refresh_from_db()
+        self.assertIsNone(draft.published_date)
+        self.assertEqual(published.published_date, original_published_date)
+
+    def test_schedule_actions_reject_another_editor(self):
+        """다른 작가는 예약 포스트의 상태를 전환할 수 없다."""
+        scheduled_post = self._create_scheduled_post('other-editor-scheduled-post')
+        other_editor = User.objects.create_user(
+            username='other-editor',
+            password='other-editor',
+            email='other-editor@example.com',
+        )
+        Profile.objects.create(user=other_editor, role=Profile.Role.EDITOR)
+        Config.objects.create(user=other_editor)
+        self.client.login(username='other-editor', password='other-editor')
+
+        for action in ('cancel', 'publish-now'):
+            with self.subTest(action=action):
+                response = self.client.post(
+                    f'/v1/users/@author/posts/{scheduled_post.url}/schedule/{action}'
+                )
+                self.assertEqual(response.status_code, 404)
+
+        scheduled_post.refresh_from_db()
+        self.assertGreater(scheduled_post.published_date, timezone.now())
 
     def test_get_user_post_detail_edit_mode_with_not_exist_post(self):
         """존재하지 않는 포스트 편집 모드 접근 시 404 에러 테스트"""

--- a/backend/src/board/tests/test_agent_content.py
+++ b/backend/src/board/tests/test_agent_content.py
@@ -323,6 +323,48 @@ class AgentContentTestCase(TestCase):
                 self.assertNotIn('Draft Agent Post', body)
                 self.assertNotIn('Future Agent Post', body)
 
+    def test_schedule_actions_keep_agent_readable_surfaces_in_sync(self):
+        """예약 상태 전환은 sitemap, RSS, Markdown의 공개 상태에 즉시 반영된다."""
+        cancelled_post = self.create_post(
+            title='Cancelled Schedule Post',
+            url='cancelled-schedule-post',
+            text_md='Cancelled schedule content',
+            published_date=timezone.now() + timedelta(days=2),
+        )
+        self.client.login(username='aeo-author', password='password123')
+
+        publish_response = self.client.post(
+            '/v1/users/@aeo-author/posts/future-agent-post/schedule/publish-now'
+        )
+        cancel_response = self.client.post(
+            '/v1/users/@aeo-author/posts/cancelled-schedule-post/schedule/cancel'
+        )
+
+        self.assertEqual(publish_response.status_code, 200)
+        self.assertEqual(cancel_response.status_code, 200)
+        self.future_post.refresh_from_db()
+        cancelled_post.refresh_from_db()
+        self.assertLessEqual(self.future_post.published_date, timezone.now())
+        self.assertIsNone(cancelled_post.published_date)
+
+        sitemap_body = self.client.get('/posts/sitemap.xml').content.decode()
+        self.assertIn('/@aeo-author/future-agent-post', sitemap_body)
+        self.assertNotIn('/@aeo-author/cancelled-schedule-post', sitemap_body)
+
+        rss_body = self.client.get('/rss').content.decode()
+        self.assertIn('Future Agent Post', rss_body)
+        self.assertNotIn('Cancelled Schedule Post', rss_body)
+
+        self.assertEqual(self.client.get('/llms.txt').status_code, 200)
+        self.assertEqual(
+            self.client.get('/@aeo-author/future-agent-post.md').status_code,
+            200,
+        )
+        self.assertEqual(
+            self.client.get('/@aeo-author/cancelled-schedule-post.md').status_code,
+            404,
+        )
+
     def test_rss_feed_items_preload_author_and_content(self):
         """RSS item 렌더링에 필요한 author/content를 미리 로드한다."""
         site_item = SitePostsFeed().items()[0]

--- a/backend/src/board/tests/test_backend_compatibility_contract.py
+++ b/backend/src/board/tests/test_backend_compatibility_contract.py
@@ -107,6 +107,16 @@ EXPECTED_ROUTE_CONTRACT = (
     ('v1/users/@<username>', None, 'board.views.api.v1.user.users'),
     ('v1/users/@<username>/posts/<url>', None, 'board.views.api.v1.post.user_posts'),
     (
+        'v1/users/@<username>/posts/<url>/schedule/cancel',
+        None,
+        'board.views.api.v1.post_schedule.cancel_post_schedule',
+    ),
+    (
+        'v1/users/@<username>/posts/<url>/schedule/publish-now',
+        None,
+        'board.views.api.v1.post_schedule.publish_scheduled_post_now',
+    ),
+    (
         'v1/users/@<username>/posts/<url>/related',
         None,
         'board.views.api.v1.post.user_post_related',
@@ -253,6 +263,8 @@ EXPECTED_V1_API_EXPORTS = (
     'get_author_heatmap',
     'users',
     'user_posts',
+    'cancel_post_schedule',
+    'publish_scheduled_post_now',
     'user_post_related',
     'user_series',
     'check_redirect',
@@ -538,6 +550,8 @@ EXPECTED_POST_SERVICE_SIGNATURES = {
     'can_user_delete_post': (('user', REQUIRED), ('post', REQUIRED)),
     'delete_post': (('post', REQUIRED),),
     'send_post_notifications': (('post', REQUIRED), ('post_config', REQUIRED)),
+    'cancel_scheduled_post': (('post', REQUIRED),),
+    'publish_scheduled_post_now': (('post', REQUIRED),),
     '_compute_image_hash': (('image_file', REQUIRED),),
     '_is_image_shared': (('image_name', REQUIRED), ('exclude_post_id', REQUIRED)),
     '_set_image_with_dedup': (

--- a/backend/src/board/urlconfs/internal_api.py
+++ b/backend/src/board/urlconfs/internal_api.py
@@ -27,6 +27,14 @@ urlpatterns = [
     path('v1/users/@<username>/heatmap', api_v1.get_author_heatmap),
     path('v1/users/@<username>', api_v1.users),
     path('v1/users/@<username>/posts/<url>', api_v1.user_posts),
+    path(
+        'v1/users/@<username>/posts/<url>/schedule/cancel',
+        api_v1.cancel_post_schedule,
+    ),
+    path(
+        'v1/users/@<username>/posts/<url>/schedule/publish-now',
+        api_v1.publish_scheduled_post_now,
+    ),
     path('v1/users/@<username>/posts/<url>/related', api_v1.user_post_related),
     path('v1/users/@<username>/series', api_v1.user_series),
     path('v1/users/@<username>/series/<url>', api_v1.user_series),

--- a/backend/src/board/views/api/v1/__init__.py
+++ b/backend/src/board/views/api/v1/__init__.py
@@ -25,6 +25,7 @@ from .notice import notices
 from .markdown import markdown_to_html
 from .pinned_post import pinnable_posts, pinned_posts, pinned_posts_order
 from .post import post_comment_list, post_list, user_post_related, user_posts
+from .post_schedule import cancel_post_schedule, publish_scheduled_post_now
 from .report import error_report
 from .search import search
 from .series import (
@@ -77,6 +78,8 @@ __all__ = (
     'get_author_heatmap',
     'users',
     'user_posts',
+    'cancel_post_schedule',
+    'publish_scheduled_post_now',
     'user_post_related',
     'user_series',
     'check_redirect',

--- a/backend/src/board/views/api/v1/post_schedule.py
+++ b/backend/src/board/views/api/v1/post_schedule.py
@@ -1,0 +1,64 @@
+from django.http import Http404, HttpRequest, HttpResponse
+from django.shortcuts import get_object_or_404
+
+from board.decorators import api_editor_required_methods
+from board.models import Post
+from board.modules.response import StatusDone, StatusError
+from board.services.post_service import PostService, PostValidationError
+
+
+@api_editor_required_methods(['POST'])
+def cancel_post_schedule(
+    request: HttpRequest,
+    username: str,
+    url: str,
+) -> HttpResponse:
+    if request.method != 'POST':
+        raise Http404
+
+    post = get_object_or_404(
+        Post.objects,
+        author__username=username,
+        url=url,
+    )
+    if not PostService.can_user_edit_post(request.user, post):
+        raise Http404
+
+    try:
+        post = PostService.cancel_scheduled_post(post)
+    except PostValidationError as error:
+        return StatusError(error.code, error.message)
+
+    return StatusDone({
+        'url': post.url,
+        'status': 'draft',
+    })
+
+
+@api_editor_required_methods(['POST'])
+def publish_scheduled_post_now(
+    request: HttpRequest,
+    username: str,
+    url: str,
+) -> HttpResponse:
+    if request.method != 'POST':
+        raise Http404
+
+    post = get_object_or_404(
+        Post.objects,
+        author__username=username,
+        url=url,
+    )
+    if not PostService.can_user_edit_post(request.user, post):
+        raise Http404
+
+    try:
+        post = PostService.publish_scheduled_post_now(post)
+    except PostValidationError as error:
+        return StatusError(error.code, error.message)
+
+    return StatusDone({
+        'url': post.url,
+        'status': 'published',
+        'published_date': post.published_date.isoformat(),
+    })


### PR DESCRIPTION
## 🎯 Goal
- Let authors cancel a scheduled publication back to a draft or publish it immediately.
- Preserve every existing post update, schedule-time edit, public URL, permission, and visibility contract.

## 🔧 Core Changes
- Add owner-only schedule/cancel and schedule/publish-now POST actions without changing the existing update endpoint.
- Serialize schedule transitions with a database row lock, preserve content and settings on cancellation, and reuse the existing publication notification policy for publish-now.
- Add clear 예약 취소 and 지금 발행 controls to the scheduled-post settings drawer using shared buttons and library icons.
- Guard lifecycle actions when editor changes are unsaved so a redirect cannot discard work.
- Cover valid transitions, repeated requests, non-scheduled states, ownership, notifications, route compatibility, and sitemap/RSS/Markdown visibility.

## 🤔 Key Decisions
- Separate action endpoints were chosen instead of treating an empty reserved_date as cancellation; the latter would change the established validation and update semantics.
- Row locking makes concurrent or repeated publish-now requests safe and prevents duplicate notification scheduling.
- Durable backend contract tests cover the lifecycle and public surfaces; no new heavyweight E2E suite was added.

## 🧪 Verification Guide
### How to verify
1. Open a scheduled post, enter 게시 설정, and confirm the existing reservation time can still be changed.
2. Select 예약 취소, confirm the action, and verify the post opens as a draft and is absent from public surfaces.
3. Schedule another post, select 지금 발행, and verify it opens as a published post immediately.

### Expected result
- Cancellation preserves the post body, URL, and settings while returning it to draft state.
- Publish-now exposes a public post immediately and schedules configured notifications once.
- Draft, already-published, repeated, and non-owner requests are rejected without state changes.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)
