### PR TITLE
✨ Add per-post comment controls

### DIFF
--- a/backend/islands/apps/remotes/src/components/remotes/Comments/Comments.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/Comments/Comments.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle, RotateCw } from '@blex/ui/icons';
+import { AlertTriangle, MessageCircle, RotateCw } from '@blex/ui/icons';
 import { isLoggedIn as checkIsLoggedIn, showLoginPrompt } from '~/utils/loginPrompt';
 import { CommentList } from './components/CommentList';
 import { CommentForm } from './components/CommentForm';
@@ -33,6 +33,7 @@ const Comments = (props: CommentsProps) => {
     const isLoggedIn = checkIsLoggedIn();
     const {
         comments,
+        canComment,
         mentionableUsers,
         commentListRef,
         isError,
@@ -129,23 +130,30 @@ const Comments = (props: CommentsProps) => {
                 />
             </div>
 
-            <div className="border-t border-line-light pt-8 mt-8">
-                <div className="mb-6">
-                    <h3 className="text-sm font-medium text-content-secondary">
-                        댓글 남기기
-                    </h3>
-                </div>
+            {canComment ? (
+                <div className="border-t border-line-light pt-8 mt-8">
+                    <div className="mb-6">
+                        <h3 className="text-sm font-medium text-content-secondary">
+                            댓글 남기기
+                        </h3>
+                    </div>
 
-                <CommentForm
-                    isLoggedIn={isLoggedIn}
-                    commentText={commentText}
-                    onCommentTextChange={setCommentText}
-                    onSubmit={handleWrite}
-                    isSubmitting={isSubmitting}
-                    onShowLoginPrompt={() => showLoginPrompt('댓글 작성')}
-                    mentionableUsers={mentionableUsers}
-                />
-            </div>
+                    <CommentForm
+                        isLoggedIn={isLoggedIn}
+                        commentText={commentText}
+                        onCommentTextChange={setCommentText}
+                        onSubmit={handleWrite}
+                        isSubmitting={isSubmitting}
+                        onShowLoginPrompt={() => showLoginPrompt('댓글 작성')}
+                        mentionableUsers={mentionableUsers}
+                    />
+                </div>
+            ) : (
+                <div className="mt-8 flex items-center gap-3 rounded-xl border border-line bg-surface-subtle px-4 py-3 text-content-secondary">
+                    <MessageCircle className="h-4 w-4 shrink-0 text-content-hint" />
+                    <p className="text-sm">작성자가 새 댓글과 답글을 받지 않는 글입니다.</p>
+                </div>
+            )}
         </section>
     );
 };

--- a/backend/islands/apps/remotes/src/components/remotes/Comments/hooks/useCommentsController.ts
+++ b/backend/islands/apps/remotes/src/components/remotes/Comments/hooks/useCommentsController.ts
@@ -23,6 +23,7 @@ import {
 
 interface CommentsData {
     comments: Comment[];
+    canComment: boolean;
 }
 
 interface UseCommentsControllerOptions {
@@ -72,6 +73,7 @@ export const useCommentsController = ({
     });
 
     const comments = commentsQuery.data?.comments ?? [];
+    const canComment = commentsQuery.data?.canComment ?? true;
     const mentionableUsers = getCommentAuthors(comments);
 
     const updateComments = (updater: (comments: Comment[]) => Comment[]) => {
@@ -324,6 +326,7 @@ export const useCommentsController = ({
 
     return {
         comments,
+        canComment,
         mentionableUsers,
         commentListRef,
         isError: commentsQuery.isError,

--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/EditPostEditor.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/EditPostEditor.tsx
@@ -35,6 +35,7 @@ interface DirtySnapshot {
     metaDescription: string;
     hide: boolean;
     advertise: boolean;
+    allowComments: boolean;
     coverLayout: string;
     coverImagePosition: string;
     coverImageRatio: string;
@@ -59,6 +60,7 @@ const EditPostEditor = ({ username, postUrl }: EditPostEditorProps) => {
         metaDescription: '',
         hide: false,
         advertise: false,
+        allowComments: true,
         coverLayout: 'default',
         coverImagePosition: 'right',
         coverImageRatio: 'auto',
@@ -90,6 +92,7 @@ const EditPostEditor = ({ username, postUrl }: EditPostEditorProps) => {
         metaDescription: formData.metaDescription,
         hide: formData.hide,
         advertise: formData.advertise,
+        allowComments: formData.allowComments,
         coverLayout: formData.coverLayout,
         coverImagePosition: formData.coverImagePosition,
         coverImageRatio: formData.coverImageRatio,
@@ -129,6 +132,7 @@ const EditPostEditor = ({ username, postUrl }: EditPostEditorProps) => {
                         metaDescription: postData.description || '',
                         hide: postData.isHide || false,
                         advertise: postData.isAdvertise || false,
+                        allowComments: !(postData.blockComment ?? false),
                         coverLayout: postData.coverLayout || 'default',
                         coverImagePosition: postData.coverImagePosition || 'right',
                         coverImageRatio: postData.coverImageRatio || 'auto',
@@ -144,6 +148,7 @@ const EditPostEditor = ({ username, postUrl }: EditPostEditorProps) => {
                         metaDescription: postData.description || '',
                         hide: postData.isHide || false,
                         advertise: postData.isAdvertise || false,
+                        allowComments: !(postData.blockComment ?? false),
                         coverLayout: postData.coverLayout || 'default',
                         coverImagePosition: postData.coverImagePosition || 'right',
                         coverImageRatio: postData.coverImageRatio || 'auto',

--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/NewPostEditor.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/NewPostEditor.tsx
@@ -71,6 +71,7 @@ const NewPostEditor = ({
         metaDescription: '',
         hide: false,
         advertise: false,
+        allowComments: true,
         coverLayout: 'default',
         coverImagePosition: 'right',
         coverImageRatio: 'auto',
@@ -92,6 +93,7 @@ const NewPostEditor = ({
         metaDescription: string;
         hide: boolean;
         advertise: boolean;
+        allowComments: boolean;
         coverLayout: string;
         coverImagePosition: string;
         coverImageRatio: string;
@@ -127,6 +129,7 @@ const NewPostEditor = ({
         metaDescription: formData.metaDescription,
         hide: formData.hide,
         advertise: formData.advertise,
+        allowComments: formData.allowComments,
         coverLayout: formData.coverLayout,
         coverImagePosition: formData.coverImagePosition,
         coverImageRatio: formData.coverImageRatio,
@@ -188,6 +191,7 @@ const NewPostEditor = ({
         coverImageRatio: formData.coverImageRatio,
         hide: formData.hide,
         advertise: formData.advertise,
+        blockComment: !formData.allowComments,
         reservedDate: formData.reservedDate,
         imageFile,
         imageDeleted
@@ -276,6 +280,7 @@ const NewPostEditor = ({
                             coverImageRatio: draftData.coverImageRatio || 'auto',
                             hide: draftData.isHide ?? false,
                             advertise: draftData.isAdvertise ?? false,
+                            allowComments: !(draftData.blockComment ?? false),
                             reservedDate: newReservedDate
                         }));
                         setCurrentDraftUrl(draftData.url || draftUrl);

--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/components/PostForm.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/components/PostForm.tsx
@@ -12,6 +12,7 @@ interface PostFormData {
     metaDescription: string;
     hide: boolean;
     advertise: boolean;
+    allowComments: boolean;
     coverLayout: string;
     coverImagePosition: string;
     coverImageRatio: string;
@@ -100,6 +101,7 @@ const PostForm = ({
                 <input type="hidden" name="meta_description" value={formData.metaDescription} />
                 <input type="hidden" name="hide" value={formData.hide ? 'true' : 'false'} />
                 <input type="hidden" name="advertise" value={formData.advertise ? 'true' : 'false'} />
+                <input type="hidden" name="block_comment" value={formData.allowComments ? 'false' : 'true'} />
                 <input type="hidden" name="tag" value={tags.join(',')} />
                 {selectedSeries.id && <input type="hidden" name="series" value={selectedSeries.id} />}
             </div>

--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/components/SettingsDrawer.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/components/SettingsDrawer.tsx
@@ -10,6 +10,7 @@ import {
     FileText,
     Image,
     Info,
+    MessageCircle,
     Search,
     Send,
     SlidersHorizontal,
@@ -44,6 +45,7 @@ interface SettingsDrawerProps {
     formData: {
         hide: boolean;
         advertise: boolean;
+        allowComments: boolean;
         coverLayout: string;
         coverImagePosition: string;
         coverImageRatio: string;
@@ -443,6 +445,25 @@ const SettingsDrawer = ({
 
                                     {/* Privacy & Display Options */}
                                     <div className="space-y-1">
+                                        <div className="flex items-center justify-between gap-4 py-3">
+                                            <div className="flex min-w-0 flex-1 items-center gap-3">
+                                                <MessageCircle className="w-4 h-4 text-content-hint" />
+                                                <div className="min-w-0">
+                                                    <div className="text-sm font-medium text-content">댓글 허용</div>
+                                                    <div className="text-xs text-content-secondary">
+                                                        {formData.allowComments
+                                                            ? '독자가 새 댓글과 답글을 작성할 수 있습니다'
+                                                            : '기존 댓글은 유지하고 새 댓글과 답글을 막습니다'}
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <Toggle
+                                                checked={formData.allowComments}
+                                                onCheckedChange={(checked) => onFormDataChange('allowComments', checked)}
+                                                aria-label="댓글 허용"
+                                            />
+                                        </div>
+
                                         <div className="flex items-center justify-between gap-4 py-3">
                                             <div className="flex min-w-0 flex-1 items-center gap-3">
                                                 <EyeOff className="w-4 h-4 text-content-hint" />

--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/hooks/useAutoSave.ts
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/hooks/useAutoSave.ts
@@ -15,6 +15,7 @@ interface AutoSaveData {
     coverImageRatio?: string;
     hide: boolean;
     advertise: boolean;
+    blockComment: boolean;
     reservedDate?: string;
     imageFile?: File | null;
     imageDeleted?: boolean;
@@ -43,6 +44,7 @@ const buildDraftPayload = (data: AutoSaveData, useFormData: boolean) => {
         if (data.coverImageRatio) formData.append('cover_image_ratio', data.coverImageRatio);
         formData.append('is_hide', String(data.hide));
         formData.append('is_advertise', String(data.advertise));
+        formData.append('block_comment', String(data.blockComment));
         if (data.reservedDate !== undefined) formData.append('reserved_date', data.reservedDate);
         if (data.imageFile) formData.append('image', data.imageFile);
         if (data.imageDeleted) formData.append('image_delete', 'true');
@@ -62,6 +64,7 @@ const buildDraftPayload = (data: AutoSaveData, useFormData: boolean) => {
         cover_image_ratio: data.coverImageRatio,
         is_hide: data.hide,
         is_advertise: data.advertise,
+        block_comment: data.blockComment,
         reserved_date: data.reservedDate
     };
 };
@@ -99,6 +102,7 @@ export const useAutoSave = (data: AutoSaveData, options: UseAutoSaveOptions) => 
         coverImageRatio: value.coverImageRatio,
         hide: value.hide,
         advertise: value.advertise,
+        blockComment: value.blockComment,
         reservedDate: value.reservedDate
     }), []);
 

--- a/backend/islands/apps/remotes/src/lib/api/comments.ts
+++ b/backend/islands/apps/remotes/src/lib/api/comments.ts
@@ -44,7 +44,7 @@ export const resolveCommentPermissions = (comment: Comment): CommentPermissions 
     };
 };
 
-export type CommentsResponse = Response<{ comments: Comment[] }>;
+export type CommentsResponse = Response<{ comments: Comment[]; canComment: boolean }>;
 export type CommentResponse = Response<{ textMd: string }>;
 export type CreateCommentResponse = Response<Comment>;
 export type UpdateCommentResponse = Response<Record<string, never>>;

--- a/backend/islands/apps/remotes/src/lib/api/posts.ts
+++ b/backend/islands/apps/remotes/src/lib/api/posts.ts
@@ -117,6 +117,7 @@ export interface DraftDetail {
     coverImageRatio: 'auto' | '16:9' | '4:3' | '1:1' | '3:4';
     isHide: boolean;
     isAdvertise: boolean;
+    blockComment: boolean;
     reservedDate: string;
     series: {
         url: string;
@@ -132,14 +133,14 @@ export interface DraftSummary {
     updatedDate: string;
 }
 
-export const createDraft = async (data: { title: string; content: string; tags: string; subtitle?: string; description?: string; series_url?: string; cover_layout?: string; cover_image_position?: string; cover_image_ratio?: string; is_hide?: boolean; is_advertise?: boolean; reserved_date?: string } | FormData) => {
+export const createDraft = async (data: { title: string; content: string; tags: string; subtitle?: string; description?: string; series_url?: string; cover_layout?: string; cover_image_position?: string; cover_image_ratio?: string; is_hide?: boolean; is_advertise?: boolean; block_comment?: boolean; reserved_date?: string } | FormData) => {
     if (data instanceof FormData) {
         return http.post<Response<{ url: string }>>('v1/drafts', data, { headers: { 'Content-Type': 'multipart/form-data' } });
     }
     return http.post<Response<{ url: string }>>('v1/drafts', data, { headers: { 'Content-Type': 'application/json' } });
 };
 
-export const updateDraft = async (url: string, data: { title?: string; content?: string; tags?: string; subtitle?: string; description?: string; series_url?: string; cover_layout?: string; cover_image_position?: string; cover_image_ratio?: string; is_hide?: boolean; is_advertise?: boolean; reserved_date?: string } | FormData) => {
+export const updateDraft = async (url: string, data: { title?: string; content?: string; tags?: string; subtitle?: string; description?: string; series_url?: string; cover_layout?: string; cover_image_position?: string; cover_image_ratio?: string; is_hide?: boolean; is_advertise?: boolean; block_comment?: boolean; reserved_date?: string } | FormData) => {
     if (data instanceof FormData) {
         return http.put<Response<{ url: string }>>(`v1/drafts/${url}`, data, { headers: { 'Content-Type': 'multipart/form-data' } });
     }
@@ -179,6 +180,7 @@ export interface PostForEdit {
     } | null;
     isHide: boolean;
     isAdvertise: boolean;
+    blockComment: boolean;
 }
 
 export const getPostForEdit = async (username: string, postUrl: string) => {

--- a/backend/src/board/services/comment_list_service.py
+++ b/backend/src/board/services/comment_list_service.py
@@ -1,6 +1,6 @@
 from django.db.models import Case, Count, Exists, OuterRef, Prefetch, Value, When
 
-from board.models import Comment
+from board.models import Comment, Post
 from board.services.public_post_service import PublicPostService
 
 
@@ -58,8 +58,12 @@ class CommentListService:
         user_id = user.id if user.id else -1
         is_authenticated = user.is_authenticated
         parent_comments = CommentListService.get_post_parent_comments(post_url, user_id)
+        post = PublicPostService.filter_public_posts(
+            Post.objects.select_related('config')
+        ).filter(url=post_url).first()
 
         return {
+            'can_comment': bool(post and not post.config.block_comment),
             'comments': [
                 CommentListService.serialize_comment(
                     comment,

--- a/backend/src/board/services/post_service.py
+++ b/backend/src/board/services/post_service.py
@@ -371,6 +371,7 @@ class PostService:
         cover_layout: Optional[str] = None,
         cover_image_position: Optional[str] = None,
         cover_image_ratio: Optional[str] = None,
+        block_comment: bool = False,
     ) -> Tuple[Post, PostContent, PostConfig]:
         """
         Create a new post with all related objects.
@@ -387,6 +388,7 @@ class PostService:
             image: Post cover image (optional)
             is_hide: Hide post flag
             is_advertise: Advertisement flag
+            block_comment: Block new comments and replies
 
         Returns:
             Tuple of (Post, PostContent, PostConfig)
@@ -440,6 +442,7 @@ class PostService:
             post=post,
             hide=is_hide,
             advertise=is_advertise,
+            block_comment=block_comment,
             **PostService.normalize_cover_options(
                 cover_layout=cover_layout,
                 cover_image_position=cover_image_position,
@@ -533,6 +536,7 @@ class PostService:
         cover_image_position: Optional[str] = None,
         cover_image_ratio: Optional[str] = None,
         reserved_date_str: Optional[str] = None,
+        block_comment: Optional[bool] = None,
     ) -> Post:
         """
         Update existing post.
@@ -548,6 +552,7 @@ class PostService:
             image: New image (optional)
             is_hide: New hide flag (optional)
             is_advertise: New advertise flag (optional)
+            block_comment: New comment blocking flag (optional)
             reserved_date_str: New reserved publication date for scheduled posts (optional)
 
         Returns:
@@ -625,6 +630,7 @@ class PostService:
         should_update_config = (
             is_hide is not None
             or is_advertise is not None
+            or block_comment is not None
             or cover_layout is not None
             or cover_image_position is not None
             or cover_image_ratio is not None
@@ -636,6 +642,8 @@ class PostService:
                 post_config.hide = is_hide
             if is_advertise is not None:
                 post_config.advertise = is_advertise
+            if block_comment is not None:
+                post_config.block_comment = block_comment
             PostService.apply_cover_options(
                 post_config,
                 cover_layout=cover_layout,
@@ -706,6 +714,7 @@ class PostService:
         reserved_date_str: Optional[str] = None,
         is_hide: bool = False,
         is_advertise: bool = False,
+        block_comment: bool = False,
     ) -> Post:
         """
         Create a draft post (published_date=null).
@@ -766,6 +775,7 @@ class PostService:
             post=post,
             hide=is_hide,
             advertise=is_advertise,
+            block_comment=block_comment,
             **PostService.normalize_cover_options(
                 cover_layout=cover_layout,
                 cover_image_position=cover_image_position,
@@ -796,6 +806,7 @@ class PostService:
         reserved_date_str: Optional[str] = None,
         is_hide: Optional[bool] = None,
         is_advertise: Optional[bool] = None,
+        block_comment: Optional[bool] = None,
     ) -> Post:
         """
         Update a draft post. No notifications sent.
@@ -850,6 +861,7 @@ class PostService:
         should_update_config = (
             is_hide is not None
             or is_advertise is not None
+            or block_comment is not None
             or cover_layout is not None
             or cover_image_position is not None
             or cover_image_ratio is not None
@@ -861,6 +873,8 @@ class PostService:
                 post_config.hide = is_hide
             if is_advertise is not None:
                 post_config.advertise = is_advertise
+            if block_comment is not None:
+                post_config.block_comment = block_comment
             PostService.apply_cover_options(
                 post_config,
                 cover_layout=cover_layout,
@@ -893,6 +907,7 @@ class PostService:
         cover_layout: Optional[str] = None,
         cover_image_position: Optional[str] = None,
         cover_image_ratio: Optional[str] = None,
+        block_comment: Optional[bool] = None,
     ) -> Post:
         """
         Publish a draft by setting published_date and sending notifications.
@@ -960,6 +975,8 @@ class PostService:
         post_config = post.config
         post_config.hide = is_hide
         post_config.advertise = is_advertise
+        if block_comment is not None:
+            post_config.block_comment = block_comment
         PostService.apply_cover_options(
             post_config,
             cover_layout=cover_layout,

--- a/backend/src/board/tests/api/test_comment.py
+++ b/backend/src/board/tests/api/test_comment.py
@@ -71,6 +71,7 @@ class CommentTestCase(TestCase):
         content = json.loads(response.content)
 
         self.assertEqual(response.status_code, 200)
+        self.assertTrue(content['body']['canComment'])
         comment = content['body']['comments'][0]
         self.assertFalse(comment['isDeleted'])
         self.assertEqual(comment['permissions'], {
@@ -217,6 +218,11 @@ class CommentTestCase(TestCase):
         post.config.save()
         initial_count = Comment.objects.count()
         self.client.login(username='viewer', password='test')
+
+        list_response = self.client.get('/v1/posts/test-post/comments')
+        list_body = json.loads(list_response.content)['body']
+        self.assertFalse(list_body['canComment'])
+        self.assertEqual(len(list_body['comments']), initial_count)
 
         response = self.client.post('/v1/comments?url=test-post', {
             'comment_md': '# Blocked Comment',

--- a/backend/src/board/tests/api/test_draft.py
+++ b/backend/src/board/tests/api/test_draft.py
@@ -84,9 +84,10 @@ class DraftTestCase(TestCase):
         self.assertFalse(post.is_published())
         self.assertFalse(post.config.hide)
         self.assertFalse(post.config.advertise)
+        self.assertFalse(post.config.block_comment)
 
     def test_create_draft_persists_publishing_settings(self):
-        """비공개·광고성 설정을 생성하고 상세 응답에서 복원한다."""
+        """발행 설정을 생성하고 상세 응답에서 복원한다."""
         self.client.login(username='test', password='test')
 
         response = self.client.post(
@@ -96,6 +97,7 @@ class DraftTestCase(TestCase):
                 'content': '<p>Hello world</p>',
                 'is_hide': True,
                 'is_advertise': True,
+                'block_comment': True,
             }),
             content_type='application/json',
         )
@@ -105,11 +107,13 @@ class DraftTestCase(TestCase):
         post = Post.objects.get(url=body['url'])
         self.assertTrue(post.config.hide)
         self.assertTrue(post.config.advertise)
+        self.assertTrue(post.config.block_comment)
 
         detail_response = self.client.get(f"/v1/drafts/{post.url}")
         detail = json.loads(detail_response.content)['body']
         self.assertTrue(detail['isHide'])
         self.assertTrue(detail['isAdvertise'])
+        self.assertTrue(detail['blockComment'])
 
     def test_create_draft_with_cover_options(self):
         """드래프트 생성 시 커버 설정을 저장하고 상세 응답에 반환한다."""
@@ -298,6 +302,7 @@ class DraftTestCase(TestCase):
             json.dumps({
                 'is_hide': True,
                 'is_advertise': True,
+                'block_comment': True,
             }),
             content_type='application/json',
         )
@@ -306,6 +311,7 @@ class DraftTestCase(TestCase):
         post = Post.objects.get(url=url)
         self.assertTrue(post.config.hide)
         self.assertTrue(post.config.advertise)
+        self.assertTrue(post.config.block_comment)
 
         response = self.client.put(
             f'/v1/drafts/{url}',
@@ -318,12 +324,14 @@ class DraftTestCase(TestCase):
         post.config.refresh_from_db()
         self.assertTrue(post.config.hide)
         self.assertTrue(post.config.advertise)
+        self.assertTrue(post.config.block_comment)
 
         response = self.client.put(
             f'/v1/drafts/{url}',
             json.dumps({
                 'is_hide': False,
                 'is_advertise': False,
+                'block_comment': False,
             }),
             content_type='application/json',
         )
@@ -332,6 +340,7 @@ class DraftTestCase(TestCase):
         post.config.refresh_from_db()
         self.assertFalse(post.config.hide)
         self.assertFalse(post.config.advertise)
+        self.assertFalse(post.config.block_comment)
 
     def test_draft_publishing_settings_support_multipart_payloads(self):
         """이미지 자동저장이 사용하는 multipart 경로에서도 설정을 보존한다."""
@@ -342,6 +351,7 @@ class DraftTestCase(TestCase):
             'content': '<p>content</p>',
             'is_hide': 'true',
             'is_advertise': 'true',
+            'block_comment': 'true',
         })
         self.assertEqual(response.status_code, 200)
         url = json.loads(response.content)['body']['url']
@@ -349,10 +359,12 @@ class DraftTestCase(TestCase):
         post = Post.objects.get(url=url)
         self.assertTrue(post.config.hide)
         self.assertTrue(post.config.advertise)
+        self.assertTrue(post.config.block_comment)
 
         payload = encode_multipart(BOUNDARY, {
             'is_hide': 'false',
             'is_advertise': 'false',
+            'block_comment': 'false',
         })
         response = self.client.generic(
             'PUT',
@@ -365,6 +377,7 @@ class DraftTestCase(TestCase):
         post.config.refresh_from_db()
         self.assertFalse(post.config.hide)
         self.assertFalse(post.config.advertise)
+        self.assertFalse(post.config.block_comment)
 
     def test_update_draft_reserved_date_and_clear(self):
         """드래프트 예약 시간은 수정하거나 비울 수 있다."""
@@ -479,6 +492,40 @@ class DraftTestCase(TestCase):
             delta=1,
         )
         self.assertEqual(PostService.get_draft_reserved_date(post), '')
+
+    def test_publish_draft_preserves_or_applies_comment_setting(self):
+        """발행은 댓글 설정을 보존하고 명시된 허용 값도 적용한다."""
+        post = PostService.create_draft(
+            user=self.user,
+            title='Blocked Comments Draft',
+            text_html='<p>Draft body</p>',
+            block_comment=True,
+        )
+
+        PostService.publish_draft(
+            post=post,
+            title=post.title,
+            text_html=post.content.content_html,
+        )
+
+        post.config.refresh_from_db()
+        self.assertTrue(post.config.block_comment)
+
+        allowed_post = PostService.create_draft(
+            user=self.user,
+            title='Allowed Comments Draft',
+            text_html='<p>Draft body</p>',
+            block_comment=True,
+        )
+        PostService.publish_draft(
+            post=allowed_post,
+            title=allowed_post.title,
+            text_html=allowed_post.content.content_html,
+            block_comment=False,
+        )
+
+        allowed_post.config.refresh_from_db()
+        self.assertFalse(allowed_post.config.block_comment)
 
     def test_update_draft_custom_url_changes_lookup_key(self):
         """드래프트 URL 변경 시 식별 URL이 갱신되어야 함"""

--- a/backend/src/board/tests/api/test_post.py
+++ b/backend/src/board/tests/api/test_post.py
@@ -97,10 +97,15 @@ class PostTestCase(TestCase):
     def test_get_user_post_detail_edit_mode(self):
         """포스트 편집 모드 조회 테스트"""
         self.client.login(username='author', password='author')
+        post = Post.objects.get(url='test-post-1')
+        post.config.block_comment = True
+        post.config.save(update_fields=['block_comment'])
 
         params = {'mode': 'edit'}
         response = self.client.get('/v1/users/@author/posts/test-post-1', params)
         self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertTrue(content['body']['blockComment'])
 
     def test_get_user_post_detail_edit_mode_includes_schedule_fields(self):
         """예약 포스트 편집 데이터는 예약 여부와 발행 예정 시각을 포함한다."""
@@ -128,6 +133,8 @@ class PostTestCase(TestCase):
         self.client.login(username='author', password='author')
 
         post = Post.objects.get(url='test-post-1')
+        post.config.block_comment = True
+        post.config.save(update_fields=['block_comment'])
         response = self.client.post('/v1/users/@author/posts/test-post-1', {
             'title': f'{post.title} Updated',
             'text_html': post.content.content_html,
@@ -138,6 +145,19 @@ class PostTestCase(TestCase):
         post.refresh_from_db()
         self.assertEqual(response.status_code, 200)
         self.assertEqual(post.title, 'Test Post 1 Updated')
+        post.config.refresh_from_db()
+        self.assertTrue(post.config.block_comment)
+
+        response = self.client.post('/v1/users/@author/posts/test-post-1', {
+            'title': post.title,
+            'text_html': post.content.content_html,
+            'is_hide': post.config.hide,
+            'is_advertise': post.config.advertise,
+            'block_comment': 'false',
+        })
+        self.assertEqual(response.status_code, 200)
+        post.config.refresh_from_db()
+        self.assertFalse(post.config.block_comment)
 
     def test_update_scheduled_post_reserved_date(self):
         """예약 포스트 수정 API는 예약 시간을 변경할 수 있다."""
@@ -374,11 +394,14 @@ class PostTestCase(TestCase):
             'text_html': '# Test Post',
             'is_hide': False,
             'is_advertise': False,
+            'block_comment': 'true',
         })
         content = json.loads(response.content)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(content['body']['url'], 'test-post-1000')
+        post = Post.objects.get(url='test-post-1000')
+        self.assertTrue(post.config.block_comment)
 
     def test_create_post_with_cover_options(self):
         """포스트 생성 시 커버 설정을 저장한다."""

--- a/backend/src/board/tests/services/test_comment_list_service.py
+++ b/backend/src/board/tests/services/test_comment_list_service.py
@@ -40,6 +40,7 @@ class CommentListServiceTestCase(TestCase):
             self.viewer,
         )
 
+        self.assertTrue(payload['can_comment'])
         self.assertEqual(len(payload['comments']), 1)
         comment = payload['comments'][0]
         self.assertEqual(comment['id'], self.parent.id)
@@ -93,6 +94,7 @@ class CommentListServiceTestCase(TestCase):
             self.viewer,
         )
 
+        self.assertFalse(payload['can_comment'])
         comment = payload['comments'][0]
         self.assertEqual(comment['permissions'], {
             'can_edit': True,

--- a/backend/src/board/tests/templates/test_post_detail.py
+++ b/backend/src/board/tests/templates/test_post_detail.py
@@ -625,6 +625,7 @@ class PostEditorPublishRedirectTestCase(TestCase):
             title='Draft Title',
             text_html='<p>Draft body</p>',
             custom_url='draft-title',
+            block_comment=True,
         )
         self.client.login(username='editor', password='password123')
 
@@ -639,8 +640,10 @@ class PostEditorPublishRedirectTestCase(TestCase):
         self.assertEqual(response['Location'], '/@editor/published-draft-title')
 
         draft.refresh_from_db()
+        draft.config.refresh_from_db()
         self.assertEqual(draft.url, 'published-draft-title')
         self.assertIsNotNone(draft.published_date)
+        self.assertTrue(draft.config.block_comment)
         self.assertEqual(Post.objects.filter(author=self.user).count(), 1)
 
     def test_post_editor_redirects_draft_scheduled_publish_to_post_detail(self):

--- a/backend/src/board/tests/test_backend_compatibility_contract.py
+++ b/backend/src/board/tests/test_backend_compatibility_contract.py
@@ -466,6 +466,7 @@ EXPECTED_POST_SERVICE_SIGNATURES = {
         ('cover_layout', None),
         ('cover_image_position', None),
         ('cover_image_ratio', None),
+        ('block_comment', False),
     ),
     'update_post': (
         ('post', REQUIRED),
@@ -485,6 +486,7 @@ EXPECTED_POST_SERVICE_SIGNATURES = {
         ('cover_image_position', None),
         ('cover_image_ratio', None),
         ('reserved_date_str', None),
+        ('block_comment', None),
     ),
     'create_draft': (
         ('user', REQUIRED),
@@ -503,6 +505,7 @@ EXPECTED_POST_SERVICE_SIGNATURES = {
         ('reserved_date_str', None),
         ('is_hide', False),
         ('is_advertise', False),
+        ('block_comment', False),
     ),
     'update_draft': (
         ('post', REQUIRED),
@@ -522,6 +525,7 @@ EXPECTED_POST_SERVICE_SIGNATURES = {
         ('reserved_date_str', None),
         ('is_hide', None),
         ('is_advertise', None),
+        ('block_comment', None),
     ),
     'publish_draft': (
         ('post', REQUIRED),
@@ -541,6 +545,7 @@ EXPECTED_POST_SERVICE_SIGNATURES = {
         ('cover_layout', None),
         ('cover_image_position', None),
         ('cover_image_ratio', None),
+        ('block_comment', None),
     ),
     'get_post_detail': (('username', REQUIRED), ('url', REQUIRED), ('user', None)),
     'get_related_posts': (('post', REQUIRED),),

--- a/backend/src/board/views/api/v1/draft.py
+++ b/backend/src/board/views/api/v1/draft.py
@@ -57,6 +57,7 @@ def drafts_list(request):
         reserved_date = data.get('reserved_date')
         is_hide = _optional_boolean(data, 'is_hide')
         is_advertise = _optional_boolean(data, 'is_advertise')
+        block_comment = _optional_boolean(data, 'block_comment')
         image = files.get('image') if files else None
 
         try:
@@ -77,6 +78,7 @@ def drafts_list(request):
                 reserved_date_str=reserved_date,
                 is_hide=is_hide if is_hide is not None else False,
                 is_advertise=is_advertise if is_advertise is not None else False,
+                block_comment=block_comment if block_comment is not None else False,
             )
 
             return StatusDone({
@@ -118,6 +120,7 @@ def drafts_detail(request, url):
             'cover_image_ratio': draft.config.cover_image_ratio,
             'is_hide': draft.config.hide,
             'is_advertise': draft.config.advertise,
+            'block_comment': draft.config.block_comment,
             'reserved_date': PostService.get_draft_reserved_date(draft),
             'series': {
                 'url': draft.series.url,
@@ -139,6 +142,7 @@ def drafts_detail(request, url):
         reserved_date = data.get('reserved_date') if 'reserved_date' in data else None
         is_hide = _optional_boolean(data, 'is_hide')
         is_advertise = _optional_boolean(data, 'is_advertise')
+        block_comment = _optional_boolean(data, 'block_comment')
 
         try:
             PostService.update_draft(
@@ -159,6 +163,7 @@ def drafts_detail(request, url):
                 reserved_date_str=reserved_date,
                 is_hide=is_hide,
                 is_advertise=is_advertise,
+                block_comment=block_comment,
             )
             return StatusDone({
                 'url': draft.url,

--- a/backend/src/board/views/api/v1/post.py
+++ b/backend/src/board/views/api/v1/post.py
@@ -45,6 +45,7 @@ def post_list(request):
                 image=image,
                 is_hide=BooleanType(request.POST.get('is_hide', '')),
                 is_advertise=BooleanType(request.POST.get('is_advertise', '')),
+                block_comment=BooleanType(request.POST.get('block_comment', '')),
                 content_type=request.POST.get('content_type', 'html'),
                 cover_layout=request.POST.get('cover_layout'),
                 cover_image_position=request.POST.get('cover_image_position'),
@@ -96,6 +97,7 @@ def user_posts(request, username, url=None):
                     'tags': post.tagging(),
                     'is_hide': post.config.hide,
                     'is_advertise': post.config.advertise,
+                    'block_comment': post.config.block_comment,
                     'cover_layout': post.config.cover_layout,
                     'cover_image_position': post.config.cover_image_position,
                     'cover_image_ratio': post.config.cover_image_ratio,
@@ -154,6 +156,11 @@ def user_posts(request, username, url=None):
                     image_delete=request.POST.get('image_delete') == 'true',
                     is_hide=BooleanType(request.POST.get('is_hide', '')),
                     is_advertise=BooleanType(request.POST.get('is_advertise', '')),
+                    block_comment=(
+                        BooleanType(request.POST.get('block_comment', ''))
+                        if 'block_comment' in request.POST
+                        else None
+                    ),
                     tag=request.POST.get('tag', ''),
                     content_type=request.POST.get('content_type'),
                     cover_layout=request.POST.get('cover_layout'),

--- a/backend/src/board/views/post.py
+++ b/backend/src/board/views/post.py
@@ -193,6 +193,12 @@ def post_editor(request, username=None, post_url=None):
 
         hide = request.POST.get('hide') in ['on', 'true']
         advertise = request.POST.get('advertise') in ['on', 'true']
+        block_comment_value = request.POST.get('block_comment')
+        block_comment = (
+            block_comment_value in ['on', 'true']
+            if block_comment_value is not None
+            else None
+        )
         is_draft = request.POST.get('is_draft') == 'true'
         image_delete = request.POST.get('image_delete') == 'true' or request.POST.get('remove_image') == 'true'
         cover_layout = request.POST.get('cover_layout')
@@ -227,6 +233,7 @@ def post_editor(request, username=None, post_url=None):
                     image_delete=image_delete,
                     is_hide=hide,
                     is_advertise=advertise,
+                    block_comment=block_comment,
                     content_type=content_type,
                     cover_layout=cover_layout,
                     cover_image_position=cover_image_position,
@@ -265,6 +272,7 @@ def post_editor(request, username=None, post_url=None):
                         image_delete=image_delete,
                         is_hide=hide,
                         is_advertise=advertise,
+                        block_comment=block_comment,
                         content_type=content_type,
                         cover_layout=cover_layout,
                         cover_image_position=cover_image_position,
@@ -293,6 +301,7 @@ def post_editor(request, username=None, post_url=None):
                         image=image,
                         is_hide=hide,
                         is_advertise=advertise,
+                        block_comment=block_comment if block_comment is not None else False,
                         content_type=content_type,
                         cover_layout=cover_layout,
                         cover_image_position=cover_image_position,


### PR DESCRIPTION
## 🎯 Goal
- 글별 댓글 차단 계약을 작성·임시저장·수정 UI에 연결해 작성자가 실제로 관리할 수 있게 합니다.
- 차단된 글에서 제출 후 오류가 나던 흐름을 사전에 인지 가능한 상태 안내로 바꿉니다.

## 🔧 Core Changes
- 공용 Toggle과 라이브러리 아이콘을 사용한 긍정형 `댓글 허용` 설정을 작성·수정 화면에 추가했습니다.
- 기존 `PostConfig.block_comment`를 draft 생성·수정·조회, 발행, 발행 글 수정 경로에 연결했습니다.
- 댓글 목록 응답에 additive `canComment`를 추가하고, 차단 시 기존 댓글은 유지하면서 새 댓글 폼과 답글 액션을 숨깁니다.
- 생성·재진입·발행·수정·차단 거절과 기존 서비스 signature를 회귀 테스트로 고정했습니다.

## 🤔 Key Decisions
- 데이터 모델이나 기존 endpoint 의미를 바꾸지 않고 기존 `block_comment`를 재사용했습니다.
- 새 서비스 인자는 기존 인자 뒤에 optional로 추가했습니다. 생략 시 생성은 기존 댓글 허용 기본값을 쓰고 수정·발행은 저장 값을 보존합니다.
- UI는 이해하기 쉬운 `댓글 허용`으로 표현하되 전송 시 기존 차단 값으로 역변환합니다.
- 차단 전 작성된 댓글의 표시·수정·좋아요 정책은 변경하지 않고 새 댓글과 답글 작성만 막습니다.

## 🧪 Verification Guide
### How to verify
1. 작성 화면 게시 설정에서 댓글 허용을 끄고 자동 임시저장한 뒤 다시 열어 상태가 유지되는지 확인합니다.
2. 댓글 차단 상태로 발행하거나 기존 글을 수정한 뒤 편집 화면에서 같은 상태가 복원되는지 확인합니다.
3. 차단된 공개 글에서 기존 댓글은 보이고 댓글 작성 폼 대신 차단 안내가 표시되는지 확인합니다.
4. 직접 댓글 작성 요청이 기존 오류 계약으로 거절되는지 확인합니다.

### Expected result
- 댓글 허용·차단 값이 모든 작성 생명주기에서 보존되고, 필드 미전송 기존 호출은 동작이 바뀌지 않습니다.
- 차단 글의 기존 댓글은 유지되며 새 댓글과 답글만 작성할 수 없습니다.
- 전체 backend 1,123 tests, 관련 161 tests, islands lint/type-check/build, entry budgets, migration check가 통과합니다.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (Ocean Brain task log; no public docs change needed)