### PR TITLE
🐛 Prevent unsafe no-op post updates

### DIFF
--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/EditPostEditor.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/EditPostEditor.tsx
@@ -10,7 +10,8 @@ import { getSeries } from '~/lib/api/settings';
 import {
     cancelPostSchedule,
     getPostForEdit,
-    publishScheduledPostNow
+    publishScheduledPostNow,
+    submitPostEdit
 } from '~/lib/api/posts';
 import { api } from '~/components/shared';
 import { logger } from '~/utils/logger';
@@ -83,6 +84,7 @@ const EditPostEditor = ({ username, postUrl }: EditPostEditorProps) => {
     const formRef = useRef<HTMLFormElement>(null);
     const initialDataRef = useRef<DirtySnapshot | null>(null);
     const isIntentionalSubmitRef = useRef(false);
+    const isSubmitLockedRef = useRef(false);
 
     const createDirtySnapshot = (): DirtySnapshot => ({
         title: formData.title,
@@ -264,7 +266,8 @@ const EditPostEditor = ({ username, postUrl }: EditPostEditorProps) => {
         return true;
     };
 
-    const submitCurrentPost = async (isDraft = false) => {
+    const submitCurrentPost = async () => {
+        if (!hasUnsavedChanges() || isSubmitLockedRef.current) return;
         if (!validateForm()) return;
 
         if (isEditorMediaUploading) {
@@ -272,54 +275,64 @@ const EditPostEditor = ({ username, postUrl }: EditPostEditorProps) => {
             return;
         }
 
+        const form = formRef.current;
+        if (!form) return;
+
+        isSubmitLockedRef.current = true;
         setIsSubmitting(true);
         try {
-            const form = formRef.current;
-            if (!form) return;
+            const payload = new FormData(form);
+            payload.set('title', formData.title);
+            payload.set('subtitle', formData.subtitle);
+            payload.set('url', formData.url);
+            payload.set('content_html', formData.content);
+            payload.set('meta_description', formData.metaDescription);
+            payload.set('hide', formData.hide ? 'true' : 'false');
+            payload.set('advertise', formData.advertise ? 'true' : 'false');
+            payload.set('block_comment', formData.allowComments ? 'false' : 'true');
+            payload.set('tag', tags.join(','));
+            payload.set('cover_layout', formData.coverLayout);
+            payload.set('cover_image_position', formData.coverImagePosition);
+            payload.set('cover_image_ratio', formData.coverImageRatio);
 
-            // Add hidden fields for React data
-            const addHiddenField = (name: string, value: string) => {
-                let field = form.querySelector(`input[name="${name}"]`) as HTMLInputElement;
-                if (!field) {
-                    field = document.createElement('input');
-                    field.type = 'hidden';
-                    field.name = name;
-                    form.appendChild(field);
-                }
-                field.value = value;
-            };
-
-            addHiddenField('tag', tags.join(','));
-            addHiddenField('series', selectedSeries.id);
-            addHiddenField('content_html', formData.content);
-            addHiddenField('cover_layout', formData.coverLayout);
-            addHiddenField('cover_image_position', formData.coverImagePosition);
-            addHiddenField('cover_image_ratio', formData.coverImageRatio);
+            if (selectedSeries.id) {
+                payload.set('series', selectedSeries.id);
+            } else {
+                payload.delete('series');
+            }
 
             if (isScheduledPost && hasReservedDateChanged()) {
-                addHiddenField('reserved_date', toReservedDateValue(formData.reservedDate));
+                payload.set('reserved_date', toReservedDateValue(formData.reservedDate));
+            } else {
+                payload.delete('reserved_date');
             }
 
-            if (isDraft) {
-                addHiddenField('is_draft', 'true');
-            }
-
-            // Handle image deletion
             if (imageDeleted) {
-                addHiddenField('image_delete', 'true');
+                payload.set('image_delete', 'true');
+            } else {
+                payload.delete('image_delete');
+            }
+
+            const { data } = await submitPostEdit(username, postUrl, payload);
+            if (data.status === 'ERROR') {
+                isSubmitLockedRef.current = false;
+                setIsSubmitting(false);
+                toast.error(data.errorMessage || '포스트 수정에 실패했습니다.');
+                return;
             }
 
             isIntentionalSubmitRef.current = true;
-            form.submit();
+            window.location.assign(data.body.url);
         } catch {
+            isSubmitLockedRef.current = false;
             isIntentionalSubmitRef.current = false;
             toast.error('포스트 수정에 실패했습니다.');
             setIsSubmitting(false);
         }
     };
 
-    const handleSubmit = async (isDraft = false) => {
-        await submitCurrentPost(isDraft);
+    const handleSubmit = async () => {
+        await submitCurrentPost();
     };
 
     const handleDelete = async () => {
@@ -467,6 +480,7 @@ const EditPostEditor = ({ username, postUrl }: EditPostEditorProps) => {
                 isSaving={false}
                 isSubmitting={isSubmitting}
                 isMediaUploading={isEditorMediaUploading}
+                isSubmitDisabled={!hasUnsavedChanges()}
                 lastSaved={null}
                 onManualSave={() => { }}
                 onSubmit={() => handleSubmit()}

--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/components/PostActions.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/components/PostActions.tsx
@@ -9,6 +9,7 @@ interface PostActionsProps {
     isSaving: boolean;
     isSubmitting: boolean;
     isMediaUploading?: boolean;
+    isSubmitDisabled?: boolean;
     lastSaved: Date | null;
     hasSaveError?: boolean;
     hasPendingChanges?: boolean;
@@ -34,6 +35,7 @@ const PostActions = ({
     isSaving,
     isSubmitting,
     isMediaUploading = false,
+    isSubmitDisabled = false,
     lastSaved,
     hasSaveError = false,
     hasPendingChanges = false,
@@ -139,7 +141,7 @@ const PostActions = ({
             {/* Publish/Update Button */}
             <Button
                 onClick={onSubmit}
-                disabled={isBusy}
+                disabled={isBusy || isSubmitDisabled}
                 variant="primary"
                 className="!rounded-full"
                 leftIcon={<Send className="w-4 h-4" />}

--- a/backend/islands/apps/remotes/src/lib/api/posts.ts
+++ b/backend/islands/apps/remotes/src/lib/api/posts.ts
@@ -187,6 +187,19 @@ export const getPostForEdit = async (username: string, postUrl: string) => {
     return http.get<Response<PostForEdit>>(`v1/users/@${username}/posts/${postUrl}?mode=edit`);
 };
 
+export const submitPostEdit = async (username: string, postUrl: string, data: FormData) => {
+    return http.post<Response<{ url: string }>>(
+        `@${username}/${postUrl}/edit`,
+        data,
+        {
+            headers: {
+                'Content-Type': 'multipart/form-data',
+                'X-BLEX-Editor-Submit': 'async'
+            }
+        }
+    );
+};
+
 interface ScheduledPostActionResult {
     url: string;
     status: 'draft' | 'published';

--- a/backend/src/board/services/post_service.py
+++ b/backend/src/board/services/post_service.py
@@ -558,49 +558,13 @@ class PostService:
         Returns:
             Updated Post instance
         """
-        if title is not None:
-            post.title = title
-
-        if subtitle is not None:
-            post.subtitle = subtitle
-
-        resolved_html_for_desc = None
-
+        resolved_html = None
         if text_html is not None:
-            PostService.validate_post_data(title or post.title, text_html)
+            next_title = title if title is not None else post.title
+            PostService.validate_post_data(next_title, text_html)
+            resolved_html = PostService._resolve_content(text_html, content_type)
 
-            try:
-                post_content = post.content
-                resolved_html = PostService._resolve_content(text_html, content_type)
-                PostContentService.update_content(post_content, resolved_html)
-            except PostContent.DoesNotExist:
-                resolved_html = PostService._resolve_content(text_html, content_type)
-                PostContentService.create_for_post(
-                    post=post,
-                    content_html=resolved_html,
-                )
-            resolved_html_for_desc = resolved_html
-
-        if description is not None:
-            post.meta_description = description
-        elif resolved_html_for_desc is not None:
-            post.meta_description = create_post_description(
-                post_content_html=resolved_html_for_desc
-            )
-
-        if series_url is not None:
-            series = PostService.get_or_none_series(post.author, series_url)
-            post.series = series
-
-        if custom_url is not None:
-            url = PostService.create_post_url(post.title, custom_url)
-            post.create_unique_url(url)
-
-        if tag is not None:
-            TagService.set_post_tags(post, tag)
-
-        PostService._set_image_with_dedup(post, image, image_delete)
-
+        reserved_date = None
         if reserved_date_str is not None:
             if not reserved_date_str:
                 raise PostValidationError(
@@ -620,12 +584,6 @@ class PostService:
                     ErrorCode.VALIDATE,
                     '예약 시간을 확인해주세요.'
                 )
-            post.published_date = reserved_date
-
-        if post.published_date is not None:
-            post.updated_date = timezone.now()
-
-        post.save()
 
         should_update_config = (
             is_hide is not None
@@ -636,20 +594,112 @@ class PostService:
             or cover_image_ratio is not None
         )
 
+        post_config = post.config if should_update_config else None
+        cover_options = None
         if should_update_config:
-            post_config = post.config
-            if is_hide is not None:
-                post_config.hide = is_hide
-            if is_advertise is not None:
-                post_config.advertise = is_advertise
-            if block_comment is not None:
-                post_config.block_comment = block_comment
-            PostService.apply_cover_options(
-                post_config,
+            cover_options = PostService.normalize_cover_options(
                 cover_layout=cover_layout,
                 cover_image_position=cover_image_position,
                 cover_image_ratio=cover_image_ratio,
+                current_config=post_config,
             )
+
+        changed = False
+
+        if title is not None and post.title != title:
+            post.title = title
+            changed = True
+
+        if subtitle is not None and post.subtitle != subtitle:
+            post.subtitle = subtitle
+            changed = True
+
+        if resolved_html is not None:
+            try:
+                post_content = post.content
+                if post_content.content_html != resolved_html:
+                    PostContentService.update_content(post_content, resolved_html)
+                    changed = True
+            except PostContent.DoesNotExist:
+                PostContentService.create_for_post(
+                    post=post,
+                    content_html=resolved_html,
+                )
+                changed = True
+
+        next_description = description
+        if next_description is None and resolved_html is not None:
+            next_description = create_post_description(
+                post_content_html=resolved_html
+            )
+        if next_description is not None and post.meta_description != next_description:
+            post.meta_description = next_description
+            changed = True
+
+        if series_url is not None:
+            series = PostService.get_or_none_series(post.author, series_url)
+            if post.series_id != (series.id if series else None):
+                post.series = series
+                changed = True
+
+        if custom_url is not None:
+            url = PostService.create_post_url(post.title, custom_url)
+            if post.url != url:
+                previous_url = post.url
+                post.create_unique_url(url)
+                changed = changed or post.url != previous_url
+
+        if tag is not None:
+            current_tags = set(post.tags.values_list('value', flat=True))
+            next_tags = TagService.parse_tags(tag)
+            if current_tags != next_tags:
+                TagService.set_post_tags(post, tag)
+                changed = True
+
+        previous_image = (
+            post.image.name if post.image else '',
+            post.image_hash,
+        )
+        PostService._set_image_with_dedup(post, image, image_delete)
+        current_image = (
+            post.image.name if post.image else '',
+            post.image_hash,
+        )
+        changed = changed or previous_image != current_image
+
+        if reserved_date is not None and post.published_date != reserved_date:
+            post.published_date = reserved_date
+            changed = True
+
+        config_changed = False
+        if post_config is not None and cover_options is not None:
+            if is_hide is not None and post_config.hide != is_hide:
+                post_config.hide = is_hide
+                config_changed = True
+            if is_advertise is not None and post_config.advertise != is_advertise:
+                post_config.advertise = is_advertise
+                config_changed = True
+            if block_comment is not None and post_config.block_comment != block_comment:
+                post_config.block_comment = block_comment
+                config_changed = True
+
+            for field_name in (
+                'cover_layout',
+                'cover_image_position',
+                'cover_image_ratio',
+            ):
+                next_value = cover_options[field_name]
+                if getattr(post_config, field_name) != next_value:
+                    setattr(post_config, field_name, next_value)
+                    config_changed = True
+
+        changed = changed or config_changed
+        if changed:
+            if post.published_date is not None:
+                post.updated_date = timezone.now()
+            post.save()
+
+        if config_changed:
             post_config.save()
 
         return post

--- a/backend/src/board/tests/api/test_post.py
+++ b/backend/src/board/tests/api/test_post.py
@@ -10,7 +10,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.utils import timezone
 
 from board.models import (
-    User, Config, Post, PostContent, PostConfig, Profile, Series
+    User, Config, Post, PostContent, PostConfig, Profile, Series, Tag
 )
 
 
@@ -158,6 +158,67 @@ class PostTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         post.config.refresh_from_db()
         self.assertFalse(post.config.block_comment)
+
+    def test_update_user_post_noop_preserves_updated_date(self):
+        """동일한 수정 요청은 발행 글의 수정 시각을 바꾸지 않는다."""
+        self.client.login(username='author', password='author')
+        post = Post.objects.get(url='test-post-1')
+        tag = Tag.objects.create(value='unchanged')
+        post.tags.add(tag)
+        previous_updated_date = post.updated_date
+
+        response = self.client.post('/v1/users/@author/posts/test-post-1', {
+            'title': post.title,
+            'subtitle': post.subtitle,
+            'text_html': post.content.content_html,
+            'description': post.meta_description,
+            'series': '',
+            'tag': tag.value,
+            'is_hide': post.config.hide,
+            'is_advertise': post.config.advertise,
+            'block_comment': str(post.config.block_comment).lower(),
+            'cover_layout': post.config.cover_layout,
+            'cover_image_position': post.config.cover_image_position,
+            'cover_image_ratio': post.config.cover_image_ratio,
+        })
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.content)['status'], 'DONE')
+        post.refresh_from_db()
+        self.assertEqual(post.updated_date, previous_updated_date)
+        self.assertEqual(post.tagging(), ['unchanged'])
+
+    def test_update_user_post_change_advances_updated_date(self):
+        """실제 변경이 있는 수정 요청만 발행 글의 수정 시각을 갱신한다."""
+        self.client.login(username='author', password='author')
+        post = Post.objects.get(url='test-post-1')
+        tag = Tag.objects.create(value='changed-contract')
+        post.tags.add(tag)
+        next_updated_date = post.updated_date + timezone.timedelta(hours=1)
+
+        with patch(
+            'board.services.post_service.timezone.now',
+            return_value=next_updated_date,
+        ):
+            response = self.client.post('/v1/users/@author/posts/test-post-1', {
+                'title': 'Actually Updated Title',
+                'subtitle': post.subtitle,
+                'text_html': post.content.content_html,
+                'description': post.meta_description,
+                'series': '',
+                'tag': tag.value,
+                'is_hide': post.config.hide,
+                'is_advertise': post.config.advertise,
+                'block_comment': str(post.config.block_comment).lower(),
+                'cover_layout': post.config.cover_layout,
+                'cover_image_position': post.config.cover_image_position,
+                'cover_image_ratio': post.config.cover_image_ratio,
+            })
+
+        self.assertEqual(response.status_code, 200)
+        post.refresh_from_db()
+        self.assertEqual(post.title, 'Actually Updated Title')
+        self.assertEqual(post.updated_date, next_updated_date)
 
     def test_update_scheduled_post_reserved_date(self):
         """예약 포스트 수정 API는 예약 시간을 변경할 수 있다."""

--- a/backend/src/board/tests/templates/test_post_detail.py
+++ b/backend/src/board/tests/templates/test_post_detail.py
@@ -738,6 +738,65 @@ class PostEditorPublishRedirectTestCase(TestCase):
             delta=1,
         )
 
+    def test_post_editor_async_edit_returns_post_detail_url(self):
+        """React 편집 제출은 기존 수정 URL에서 구조화된 성공 응답을 받는다."""
+        post, _, _ = PostService.create_post(
+            user=self.user,
+            title='Async Editable Post',
+            text_html='<p>Original body</p>',
+            custom_url='async-editable-post',
+        )
+        self.client.login(username='editor', password='password123')
+
+        response = self.client.post('/@editor/async-editable-post/edit', {
+            'title': 'Async Editable Post',
+            'subtitle': '',
+            'content_html': '<p>Updated body</p>',
+            'meta_description': post.meta_description,
+            'hide': 'false',
+            'advertise': 'false',
+            'block_comment': 'false',
+        }, HTTP_X_BLEX_EDITOR_SUBMIT='async')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.content), {
+            'status': 'DONE',
+            'body': {'url': '/@editor/async-editable-post'},
+        })
+        post.refresh_from_db()
+        self.assertEqual(post.content.content_html, '<p>Updated body</p>')
+
+    def test_post_editor_async_validation_failure_preserves_post(self):
+        """비동기 검증 실패는 redirect 없이 오류를 반환하고 저장본을 건드리지 않는다."""
+        post, _, _ = PostService.create_post(
+            user=self.user,
+            title='Recoverable Edit',
+            text_html='<p>Stored body</p>',
+            custom_url='recoverable-edit',
+        )
+        previous_updated_date = post.updated_date
+        self.client.login(username='editor', password='password123')
+
+        response = self.client.post('/@editor/recoverable-edit/edit', {
+            'title': 'Unsaved Changed Title',
+            'subtitle': '',
+            'content_html': '',
+            'meta_description': post.meta_description,
+            'hide': 'false',
+            'advertise': 'false',
+            'block_comment': 'false',
+        }, HTTP_X_BLEX_EDITOR_SUBMIT='async')
+
+        self.assertEqual(response.status_code, 200)
+        body = json.loads(response.content)
+        self.assertEqual(body['status'], 'ERROR')
+        self.assertEqual(body['errorCode'], 'error:VA')
+        self.assertEqual(body['errorMessage'], '내용을 입력해주세요.')
+        post.refresh_from_db()
+        self.assertEqual(post.title, 'Recoverable Edit')
+        self.assertEqual(post.content.content_html, '<p>Stored body</p>')
+        self.assertEqual(post.updated_date, previous_updated_date)
+
     def test_post_editor_returns_to_draft_when_draft_publish_fails(self):
         """초안 발행 검증 실패 시 작성 맥락을 잃지 않고 기존 초안으로 돌아간다."""
         draft = PostService.create_draft(

--- a/backend/src/board/views/post.py
+++ b/backend/src/board/views/post.py
@@ -8,6 +8,7 @@ from django.contrib import messages
 from django.utils import timezone
 
 from board.models import Post, Series, PostLikes, UsernameChangeLog
+from board.modules.response import StatusDone, StatusError
 from board.services.post_service import PostService, PostValidationError
 from board.services.banner_service import BannerService
 from board.services.agent_content_service import AgentContentService
@@ -134,6 +135,10 @@ def post_editor(request, username=None, post_url=None):
     Used for both creating new posts and editing existing posts.
     """
     is_edit = username is not None and post_url is not None
+    is_async_edit_submit = (
+        is_edit
+        and request.headers.get('X-BLEX-Editor-Submit') == 'async'
+    )
     post = None
     draft_post = None
     series_list = []
@@ -241,6 +246,8 @@ def post_editor(request, username=None, post_url=None):
                     reserved_date_str=request.POST.get('reserved_date'),
                 )
             except PostValidationError as e:
+                if is_async_edit_submit:
+                    return StatusError(e.code, e.message)
                 messages.error(request, e.message)
                 return redirect('post_edit', username=request.user.username, post_url=post.url)
 
@@ -321,6 +328,8 @@ def post_editor(request, username=None, post_url=None):
             'username': request.user.username,
             'post_url': post.url,
         })
+        if is_async_edit_submit:
+            return StatusDone({'url': post_detail_url})
         return redirect(post_detail_url)
 
     context = {


### PR DESCRIPTION
## 🎯 Goal
- Prevent unchanged post edits from changing `updated_date`.
- Keep an author's in-progress edit intact when validation fails, while preventing duplicate submissions.

## 🔧 Core Changes
- Disable edit submission until the complete post snapshot is dirty and lock submission synchronously while a request is in flight.
- Submit React edits through the existing edit URL with an opt-in async response, preserving current input on server errors.
- Compare canonical content, metadata, tags, image identity, schedule, and post config before saving; update published-post timestamps only for real changes.
- Add durable contracts for no-op timestamps, real updates, async success, and validation failure rollback.

## 🤔 Key Decisions
- Keep every existing edit URL, form field, API field, default, and service signature unchanged. The structured response is enabled only by the internal `X-BLEX-Editor-Submit: async` header, so legacy form clients retain redirects.
- Enforce no-op safety in `PostService.update_post`, not only in the UI, so API and legacy callers cannot create false modification timestamps.
- Reuse the current form contract instead of adding another endpoint or a persistent E2E file.

## 🧪 Verification Guide
### How to verify
1. Open an existing published post for editing and confirm the `수정` button is disabled before any change.
2. Change the title or body, confirm the button becomes enabled, and submit; the post should update once and navigate to its detail page.
3. Run the focused post/editor contracts and confirm an identical payload preserves `updated_date` while a validation error returns JSON without mutating the stored post.

### Expected result
- No-op edits cannot be submitted from the editor and do not advance `updated_date` on the server.
- Failed edits stay on the edit page with current input available for retry.
- Rapid duplicate clicks send one update request.
- Published and scheduled edit behavior, public surfaces, and existing clients remain compatible.

## ✅ Checklist
- [x] Lint completed (existing warnings only)
- [x] Type-check completed
- [x] Tests completed (1,127 backend tests)
- [x] Documentation updated (if needed)
