### PR TITLE
✨ Add recovery for post edits

### DIFF
--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/EditPostEditor.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/EditPostEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { toast } from '~/utils/toast';
 import { useConfirm } from '~/hooks/useConfirm';
 import PostEditorWrapper from './PostEditorWrapper';
@@ -6,6 +6,7 @@ import PostActions from './components/PostActions';
 import PostForm from './components/PostForm';
 import SettingsDrawer from './components/SettingsDrawer';
 import ScheduleStatusNotice from './components/ScheduleStatusNotice';
+import EditRecoveryNotice from './components/EditRecoveryNotice';
 import { getSeries } from '~/lib/api/settings';
 import {
     cancelPostSchedule,
@@ -22,6 +23,14 @@ import {
     toDateTimeLocalValue,
     toReservedDateValue
 } from './utils/scheduleDate';
+import {
+    clearPostEditRecovery,
+    postEditRecoverySnapshotsMatch,
+    readPostEditRecovery,
+    writePostEditRecovery,
+    type PostEditRecovery,
+    type PostEditRecoverySnapshot
+} from './utils/postEditRecovery';
 
 interface EditPostEditorProps {
     username: string;
@@ -80,13 +89,23 @@ const EditPostEditor = ({ username, postUrl }: EditPostEditorProps) => {
     const [pendingScheduleAction, setPendingScheduleAction] = useState<'cancel' | 'publish-now' | null>(null);
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [isEditorMediaUploading, setIsEditorMediaUploading] = useState(false);
+    const [availableRecovery, setAvailableRecovery] = useState<PostEditRecovery | null>(null);
+    const [recoveryEditorRevision, setRecoveryEditorRevision] = useState(0);
 
     const formRef = useRef<HTMLFormElement>(null);
     const initialDataRef = useRef<DirtySnapshot | null>(null);
+    const initialRecoverySnapshotRef = useRef<PostEditRecoverySnapshot | null>(null);
+    const baseRevisionRef = useRef('');
+    const initialImagePreviewRef = useRef<string | null>(null);
+    const initialSeriesRef = useRef<Series>({
+        id: '',
+        name: '',
+        url: ''
+    });
     const isIntentionalSubmitRef = useRef(false);
     const isSubmitLockedRef = useRef(false);
 
-    const createDirtySnapshot = (): DirtySnapshot => ({
+    const createDirtySnapshot = useCallback((): DirtySnapshot => ({
         title: formData.title,
         subtitle: formData.subtitle,
         url: formData.url,
@@ -103,7 +122,24 @@ const EditPostEditor = ({ username, postUrl }: EditPostEditorProps) => {
         seriesUrl: selectedSeries.url,
         imagePreview,
         imageDeleted
-    });
+    }), [formData, tags, selectedSeries.url, imagePreview, imageDeleted]);
+
+    const createRecoverySnapshot = useCallback((): PostEditRecoverySnapshot => ({
+        title: formData.title,
+        subtitle: formData.subtitle,
+        content: formData.content,
+        metaDescription: formData.metaDescription,
+        hide: formData.hide,
+        advertise: formData.advertise,
+        allowComments: formData.allowComments,
+        coverLayout: formData.coverLayout,
+        coverImagePosition: formData.coverImagePosition,
+        coverImageRatio: formData.coverImageRatio,
+        reservedDate: formData.reservedDate,
+        tags,
+        seriesUrl: selectedSeries.url,
+        imageDeleted
+    }), [formData, tags, selectedSeries.url, imageDeleted]);
 
     // Fetch data
     useEffect(() => {
@@ -126,7 +162,7 @@ const EditPostEditor = ({ username, postUrl }: EditPostEditorProps) => {
                 if (postResponse.status === 'DONE') {
                     const postData = postResponse.body;
                     const reservedDate = postData.isScheduled ? toDateTimeLocalValue(postData.publishedDate) : '';
-                    setFormData({
+                    const initialFormData = {
                         title: postData.title || '',
                         subtitle: postData.subtitle || '',
                         url: postData.url || '',
@@ -139,33 +175,56 @@ const EditPostEditor = ({ username, postUrl }: EditPostEditorProps) => {
                         coverImagePosition: postData.coverImagePosition || 'right',
                         coverImageRatio: postData.coverImageRatio || 'auto',
                         reservedDate
-                    });
-                    setIsScheduledPost(Boolean(postData.isScheduled));
-                    setTags(postData.tags || []);
-                    initialDataRef.current = {
-                        title: postData.title || '',
-                        subtitle: postData.subtitle || '',
-                        url: postData.url || '',
-                        content: postData.contentHtml || '',
-                        metaDescription: postData.description || '',
-                        hide: postData.isHide || false,
-                        advertise: postData.isAdvertise || false,
-                        allowComments: !(postData.blockComment ?? false),
-                        coverLayout: postData.coverLayout || 'default',
-                        coverImagePosition: postData.coverImagePosition || 'right',
-                        coverImageRatio: postData.coverImageRatio || 'auto',
-                        reservedDate,
-                        tags: postData.tags || [],
-                        seriesUrl: postData.series?.url || '',
-                        imagePreview: postData.image || null,
-                        imageDeleted: false
                     };
-                    setImagePreview(postData.image || null);
-                    setSelectedSeries({
+                    const initialTags = postData.tags || [];
+                    const initialSeries = {
                         id: postData.series?.id || '',
                         name: postData.series?.name || '',
                         url: postData.series?.url || ''
-                    });
+                    };
+                    const initialImagePreview = postData.image || null;
+                    const initialRecoverySnapshot: PostEditRecoverySnapshot = {
+                        title: initialFormData.title,
+                        subtitle: initialFormData.subtitle,
+                        content: initialFormData.content,
+                        metaDescription: initialFormData.metaDescription,
+                        hide: initialFormData.hide,
+                        advertise: initialFormData.advertise,
+                        allowComments: initialFormData.allowComments,
+                        coverLayout: initialFormData.coverLayout,
+                        coverImagePosition: initialFormData.coverImagePosition,
+                        coverImageRatio: initialFormData.coverImageRatio,
+                        reservedDate,
+                        tags: initialTags,
+                        seriesUrl: initialSeries.url,
+                        imageDeleted: false
+                    };
+                    const baseRevision = postData.updatedDate
+                        || JSON.stringify(initialRecoverySnapshot);
+
+                    setFormData(initialFormData);
+                    setIsScheduledPost(Boolean(postData.isScheduled));
+                    setTags(initialTags);
+                    initialDataRef.current = {
+                        ...initialFormData,
+                        tags: initialTags,
+                        seriesUrl: initialSeries.url,
+                        imagePreview: initialImagePreview,
+                        imageDeleted: false
+                    };
+                    initialRecoverySnapshotRef.current = initialRecoverySnapshot;
+                    baseRevisionRef.current = baseRevision;
+                    initialImagePreviewRef.current = initialImagePreview;
+                    initialSeriesRef.current = initialSeries;
+                    setImagePreview(initialImagePreview);
+                    setSelectedSeries(initialSeries);
+                    setAvailableRecovery(readPostEditRecovery({
+                        username,
+                        postUrl,
+                        baseRevision,
+                        baseline: initialRecoverySnapshot
+                    }));
+                    setImageDeleted(false);
                 }
             } catch {
                 toast.error('데이터를 불러오는데 실패했습니다.');
@@ -177,14 +236,60 @@ const EditPostEditor = ({ username, postUrl }: EditPostEditorProps) => {
         fetchData();
     }, [username, postUrl]);
 
-    const hasUnsavedChanges = () => {
+    const hasUnsavedChanges = useCallback(() => {
         if (!initialDataRef.current) return false;
         return JSON.stringify(createDirtySnapshot()) !== JSON.stringify(initialDataRef.current);
-    };
+    }, [createDirtySnapshot]);
 
     const hasReservedDateChanged = () => {
         return formData.reservedDate !== (initialDataRef.current?.reservedDate || '');
     };
+
+    const persistRecovery = useCallback(() => {
+        const baseline = initialRecoverySnapshotRef.current;
+        const baseRevision = baseRevisionRef.current;
+        if (isLoading || availableRecovery || !baseline || !baseRevision) return;
+
+        const snapshot = createRecoverySnapshot();
+        if (postEditRecoverySnapshotsMatch(snapshot, baseline)) {
+            clearPostEditRecovery({
+                username,
+                postUrl
+            });
+            return;
+        }
+
+        writePostEditRecovery({
+            username,
+            postUrl,
+            baseRevision,
+            snapshot
+        });
+    }, [isLoading, availableRecovery, createRecoverySnapshot, username, postUrl]);
+
+    useEffect(() => {
+        const baseline = initialRecoverySnapshotRef.current;
+        if (isLoading || availableRecovery || !baseline || !baseRevisionRef.current) return;
+
+        const snapshot = createRecoverySnapshot();
+        if (postEditRecoverySnapshotsMatch(snapshot, baseline)) {
+            clearPostEditRecovery({
+                username,
+                postUrl
+            });
+            return;
+        }
+
+        const timeoutId = window.setTimeout(persistRecovery, 1000);
+        return () => window.clearTimeout(timeoutId);
+    }, [
+        isLoading,
+        availableRecovery,
+        createRecoverySnapshot,
+        persistRecovery,
+        username,
+        postUrl
+    ]);
 
     // Warn on page unload if there are unsaved changes
     useEffect(() => {
@@ -193,13 +298,83 @@ const EditPostEditor = ({ username, postUrl }: EditPostEditorProps) => {
                 return;
             }
 
+            persistRecovery();
             if (hasUnsavedChanges()) {
                 e.preventDefault();
             }
         };
+        const handlePageHide = () => {
+            if (!isIntentionalSubmitRef.current) {
+                persistRecovery();
+            }
+        };
         window.addEventListener('beforeunload', handleBeforeUnload);
-        return () => window.removeEventListener('beforeunload', handleBeforeUnload);
-    });
+        window.addEventListener('pagehide', handlePageHide);
+        return () => {
+            window.removeEventListener('beforeunload', handleBeforeUnload);
+            window.removeEventListener('pagehide', handlePageHide);
+        };
+    }, [hasUnsavedChanges, persistRecovery]);
+
+    const handleRecoverEdit = () => {
+        if (!availableRecovery) return;
+
+        const recovery = availableRecovery.snapshot;
+        setFormData(prev => ({
+            ...prev,
+            title: recovery.title,
+            subtitle: recovery.subtitle,
+            content: recovery.content,
+            metaDescription: recovery.metaDescription,
+            hide: recovery.hide,
+            advertise: recovery.advertise,
+            allowComments: recovery.allowComments,
+            coverLayout: recovery.coverLayout,
+            coverImagePosition: recovery.coverImagePosition,
+            coverImageRatio: recovery.coverImageRatio,
+            reservedDate: recovery.reservedDate
+        }));
+        setTags([...recovery.tags]);
+
+        const recoveredSeries = seriesList.find(series => series.url === recovery.seriesUrl);
+        const initialSeries = initialSeriesRef.current;
+        setSelectedSeries(
+            recoveredSeries
+            || (initialSeries.url === recovery.seriesUrl ? initialSeries : {
+                id: '',
+                name: '',
+                url: ''
+            })
+        );
+
+        const imageInput = formRef.current?.querySelector<HTMLInputElement>('input[name="image"]');
+        if (imageInput) imageInput.value = '';
+        setImagePreview(recovery.imageDeleted ? null : initialImagePreviewRef.current);
+        setImageDeleted(recovery.imageDeleted);
+        setAvailableRecovery(null);
+        setRecoveryEditorRevision(revision => revision + 1);
+        toast.success('백업 내용을 복구했습니다. 수정 버튼을 눌러 저장해주세요.');
+    };
+
+    const handleDiscardRecovery = async () => {
+        if (!availableRecovery) return;
+
+        const confirmed = await confirm({
+            title: '수정 백업 삭제',
+            message: '복구하지 않은 수정 내용이 이 브라우저에서 삭제됩니다.',
+            confirmText: '백업 삭제',
+            cancelText: '취소',
+            variant: 'danger'
+        });
+        if (!confirmed) return;
+
+        clearPostEditRecovery({
+            username,
+            postUrl
+        });
+        setAvailableRecovery(null);
+        toast.info('수정 백업을 삭제했습니다.');
+    };
 
     const handleTitleChange = (title: string) => {
         setFormData(prev => ({
@@ -267,6 +442,10 @@ const EditPostEditor = ({ username, postUrl }: EditPostEditorProps) => {
     };
 
     const submitCurrentPost = async () => {
+        if (availableRecovery) {
+            toast.warning('수정 백업을 먼저 복구하거나 삭제해주세요.');
+            return;
+        }
         if (!hasUnsavedChanges() || isSubmitLockedRef.current) return;
         if (!validateForm()) return;
 
@@ -321,6 +500,10 @@ const EditPostEditor = ({ username, postUrl }: EditPostEditorProps) => {
                 return;
             }
 
+            clearPostEditRecovery({
+                username,
+                postUrl
+            });
             isIntentionalSubmitRef.current = true;
             window.location.assign(data.body.url);
         } catch {
@@ -364,6 +547,11 @@ const EditPostEditor = ({ username, postUrl }: EditPostEditorProps) => {
     };
 
     const canRunScheduleAction = () => {
+        if (availableRecovery) {
+            toast.warning('수정 백업을 먼저 복구하거나 삭제해주세요.');
+            return false;
+        }
+
         if (hasUnsavedChanges()) {
             toast.warning('변경 사항을 먼저 수정한 뒤 예약 상태를 변경해주세요.');
             return false;
@@ -396,6 +584,10 @@ const EditPostEditor = ({ username, postUrl }: EditPostEditorProps) => {
                 return;
             }
 
+            clearPostEditRecovery({
+                username,
+                postUrl
+            });
             isIntentionalSubmitRef.current = true;
             window.location.assign(`/write?draft=${encodeURIComponent(data.body.url)}`);
         } catch {
@@ -427,6 +619,10 @@ const EditPostEditor = ({ username, postUrl }: EditPostEditorProps) => {
                 return;
             }
 
+            clearPostEditRecovery({
+                username,
+                postUrl
+            });
             isIntentionalSubmitRef.current = true;
             window.location.assign(`/@${encodeURIComponent(username)}/${encodeURIComponent(data.body.url)}`);
         } catch {
@@ -452,7 +648,16 @@ const EditPostEditor = ({ username, postUrl }: EditPostEditorProps) => {
 
     return (
         <PostEditorWrapper>
+            {availableRecovery && (
+                <EditRecoveryNotice
+                    recovery={availableRecovery}
+                    onRecover={handleRecoverEdit}
+                    onDiscard={handleDiscardRecovery}
+                />
+            )}
+
             <PostForm
+                key={recoveryEditorRevision}
                 beforeContent={<ScheduleStatusNotice value={isScheduledPost ? formData.reservedDate : ''} />}
                 formRef={formRef}
                 isLoading={false}
@@ -480,7 +685,7 @@ const EditPostEditor = ({ username, postUrl }: EditPostEditorProps) => {
                 isSaving={false}
                 isSubmitting={isSubmitting}
                 isMediaUploading={isEditorMediaUploading}
-                isSubmitDisabled={!hasUnsavedChanges()}
+                isSubmitDisabled={Boolean(availableRecovery) || !hasUnsavedChanges()}
                 lastSaved={null}
                 onManualSave={() => { }}
                 onSubmit={() => handleSubmit()}

--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/components/EditRecoveryNotice.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/components/EditRecoveryNotice.tsx
@@ -1,0 +1,55 @@
+import { Alert } from '@blex/ui/alert';
+import { Button } from '@blex/ui/button';
+import { RotateCw, Trash2 } from '@blex/ui/icons';
+import type { PostEditRecovery } from '../utils/postEditRecovery';
+
+interface EditRecoveryNoticeProps {
+    recovery: PostEditRecovery;
+    onRecover: () => void;
+    onDiscard: () => void;
+}
+
+const formatSavedAt = (savedAt: string) => new Date(savedAt).toLocaleString('ko-KR', {
+    month: 'long',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit'
+});
+
+const EditRecoveryNotice = ({
+    recovery,
+    onRecover,
+    onDiscard
+}: EditRecoveryNoticeProps) => (
+    <section
+        className="mb-4"
+        aria-label="포스트 수정 백업"
+        data-post-edit-recovery>
+        <Alert variant="warning" title="저장되지 않은 수정 내용이 있습니다">
+            <p>이 브라우저에 남아 있는 편집 내용을 복구할 수 있습니다. 공개된 글은 아직 바뀌지 않았습니다.</p>
+            <p className="mt-1 text-xs text-content-hint">
+                마지막 백업 <time dateTime={recovery.savedAt}>{formatSavedAt(recovery.savedAt)}</time>
+            </p>
+            <div className="mt-3 flex flex-wrap gap-2">
+                <Button
+                    type="button"
+                    size="sm"
+                    variant="primary"
+                    onClick={onRecover}
+                    leftIcon={<RotateCw className="h-4 w-4" />}>
+                    복구
+                </Button>
+                <Button
+                    type="button"
+                    size="sm"
+                    variant="danger"
+                    onClick={onDiscard}
+                    leftIcon={<Trash2 className="h-4 w-4" />}>
+                    백업 삭제
+                </Button>
+            </div>
+        </Alert>
+    </section>
+);
+
+export default EditRecoveryNotice;

--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/utils/postEditRecovery.ts
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/utils/postEditRecovery.ts
@@ -1,0 +1,195 @@
+const POST_EDIT_RECOVERY_VERSION = 1;
+const POST_EDIT_RECOVERY_PREFIX = 'blex:post-edit-recovery';
+
+export interface PostEditRecoverySnapshot {
+    title: string;
+    subtitle: string;
+    content: string;
+    metaDescription: string;
+    hide: boolean;
+    advertise: boolean;
+    allowComments: boolean;
+    coverLayout: string;
+    coverImagePosition: string;
+    coverImageRatio: string;
+    reservedDate: string;
+    tags: string[];
+    seriesUrl: string;
+    imageDeleted: boolean;
+}
+
+export interface PostEditRecovery {
+    savedAt: string;
+    snapshot: PostEditRecoverySnapshot;
+}
+
+interface StoredPostEditRecovery extends PostEditRecovery {
+    version: number;
+    username: string;
+    postUrl: string;
+    baseRevision: string;
+}
+
+interface RecoveryIdentity {
+    username: string;
+    postUrl: string;
+}
+
+interface ReadPostEditRecoveryOptions extends RecoveryIdentity {
+    baseRevision: string;
+    baseline: PostEditRecoverySnapshot;
+}
+
+interface WritePostEditRecoveryOptions extends RecoveryIdentity {
+    baseRevision: string;
+    snapshot: PostEditRecoverySnapshot;
+}
+
+const getLocalStorage = () => {
+    if (typeof window === 'undefined') return null;
+
+    try {
+        return window.localStorage;
+    } catch {
+        return null;
+    }
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> => (
+    typeof value === 'object' && value !== null
+);
+
+const isRecoverySnapshot = (value: unknown): value is PostEditRecoverySnapshot => {
+    if (!isRecord(value)) return false;
+
+    const stringFields = [
+        'title',
+        'subtitle',
+        'content',
+        'metaDescription',
+        'coverLayout',
+        'coverImagePosition',
+        'coverImageRatio',
+        'reservedDate',
+        'seriesUrl'
+    ];
+    const booleanFields = [
+        'hide',
+        'advertise',
+        'allowComments',
+        'imageDeleted'
+    ];
+
+    return stringFields.every(field => typeof value[field] === 'string')
+        && booleanFields.every(field => typeof value[field] === 'boolean')
+        && Array.isArray(value.tags)
+        && value.tags.every(tag => typeof tag === 'string');
+};
+
+const isStoredRecovery = (value: unknown): value is StoredPostEditRecovery => (
+    isRecord(value)
+    && value.version === POST_EDIT_RECOVERY_VERSION
+    && typeof value.username === 'string'
+    && typeof value.postUrl === 'string'
+    && typeof value.baseRevision === 'string'
+    && typeof value.savedAt === 'string'
+    && !Number.isNaN(Date.parse(value.savedAt))
+    && isRecoverySnapshot(value.snapshot)
+);
+
+const snapshotsMatch = (
+    left: PostEditRecoverySnapshot,
+    right: PostEditRecoverySnapshot
+) => JSON.stringify(left) === JSON.stringify(right);
+
+export const buildPostEditRecoveryKey = ({ username, postUrl }: RecoveryIdentity) => (
+    `${POST_EDIT_RECOVERY_PREFIX}:v${POST_EDIT_RECOVERY_VERSION}:${encodeURIComponent(username)}:${encodeURIComponent(postUrl)}`
+);
+
+export const readPostEditRecovery = ({
+    username,
+    postUrl,
+    baseRevision,
+    baseline
+}: ReadPostEditRecoveryOptions): PostEditRecovery | null => {
+    const storage = getLocalStorage();
+    if (!storage) return null;
+
+    const key = buildPostEditRecoveryKey({
+        username,
+        postUrl
+    });
+    try {
+        const rawRecovery = storage.getItem(key);
+        if (!rawRecovery) return null;
+
+        const recovery: unknown = JSON.parse(rawRecovery);
+        if (
+            !isStoredRecovery(recovery)
+            || recovery.username !== username
+            || recovery.postUrl !== postUrl
+            || recovery.baseRevision !== baseRevision
+            || snapshotsMatch(recovery.snapshot, baseline)
+        ) {
+            storage.removeItem(key);
+            return null;
+        }
+
+        return {
+            savedAt: recovery.savedAt,
+            snapshot: recovery.snapshot
+        };
+    } catch {
+        try {
+            storage.removeItem(key);
+        } catch {
+            // Storage can become unavailable between reads and cleanup.
+        }
+        return null;
+    }
+};
+
+export const writePostEditRecovery = ({
+    username,
+    postUrl,
+    baseRevision,
+    snapshot
+}: WritePostEditRecoveryOptions) => {
+    const storage = getLocalStorage();
+    if (!storage) return false;
+
+    const recovery: StoredPostEditRecovery = {
+        version: POST_EDIT_RECOVERY_VERSION,
+        username,
+        postUrl,
+        baseRevision,
+        savedAt: new Date().toISOString(),
+        snapshot
+    };
+
+    try {
+        storage.setItem(
+            buildPostEditRecoveryKey({
+                username,
+                postUrl
+            }),
+            JSON.stringify(recovery)
+        );
+        return true;
+    } catch {
+        return false;
+    }
+};
+
+export const clearPostEditRecovery = (identity: RecoveryIdentity) => {
+    const storage = getLocalStorage();
+    if (!storage) return;
+
+    try {
+        storage.removeItem(buildPostEditRecoveryKey(identity));
+    } catch {
+        // Local recovery is best-effort and must never block editing.
+    }
+};
+
+export const postEditRecoverySnapshotsMatch = snapshotsMatch;

--- a/backend/islands/apps/remotes/src/lib/api/posts.ts
+++ b/backend/islands/apps/remotes/src/lib/api/posts.ts
@@ -165,12 +165,13 @@ export interface PostForEdit {
     url: string;
     contentHtml: string;
     textHtml: string;
-    image: string;
+    image: string | null;
     coverLayout: 'default' | 'split' | 'overlay' | 'none';
     coverImagePosition: 'left' | 'right';
     coverImageRatio: 'auto' | '16:9' | '4:3' | '1:1' | '3:4';
     description: string;
     publishedDate: string | null;
+    updatedDate?: string;
     isScheduled: boolean;
     tags: string[];
     series: {

--- a/backend/src/board/tests/api/test_post.py
+++ b/backend/src/board/tests/api/test_post.py
@@ -106,6 +106,10 @@ class PostTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         content = json.loads(response.content)
         self.assertTrue(content['body']['blockComment'])
+        self.assertEqual(
+            content['body']['updatedDate'],
+            post.updated_date.isoformat(),
+        )
 
     def test_get_user_post_detail_edit_mode_includes_schedule_fields(self):
         """예약 포스트 편집 데이터는 예약 여부와 발행 예정 시각을 포함한다."""

--- a/backend/src/board/views/api/v1/post.py
+++ b/backend/src/board/views/api/v1/post.py
@@ -86,6 +86,7 @@ def user_posts(request, username, url=None):
                     'url': post.url,
                     'description': post.meta_description,
                     'published_date': post.published_date.isoformat() if post.published_date else None,
+                    'updated_date': post.updated_date.isoformat(),
                     'is_scheduled': bool(post.published_date and post.published_date > timezone.now()),
                     'series': {
                         'id': str(post.series.id),


### PR DESCRIPTION
## 🎯 Goal
- Protect authors from losing unsaved changes while editing an already published post.
- Keep the published post unchanged until the author explicitly submits the recovered edit.

## 🔧 Core Changes
- Back up editable post fields locally after changes and flush the latest snapshot during page exit.
- Offer explicit recovery and deletion actions after a refresh or reopened edit session.
- Isolate backups by user, post, and server revision, then clear them after a successful save or explicit discard.
- Add the existing post revision as an additive `updatedDate` edit-response field so stale backups are not applied.

## 🤔 Key Decisions
- Use browser-local recovery instead of reusing draft autosave, because editing a published post must not mutate server state implicitly.
- Keep `updatedDate` optional in the client for rolling compatibility with an older backend during deployment.
- Recover existing image deletion intent, but do not serialize a newly selected `File`; the existing unload warning still protects that case.
- Remount only the editor form after explicit recovery so Tiptap reliably reflects the recovered body without changing normal editing behavior.

## 🧪 Verification Guide
### How to verify
1. Open a published post edit page, change the title, body, tags, series, cover settings, and visibility settings, then wait one second.
2. Refresh the page and confirm the original server values remain visible until selecting `복구`.
3. Select `복구`, confirm every backed-up field is restored, then submit the edit.
4. Repeat with `백업 삭제`, and open another post and another account to confirm isolation.

### Expected result
- Creating a backup does not change the public post or its `updatedDate`.
- Recovery restores the local edit, and a successful submit advances `updatedDate` and removes the backup.
- Explicit discard removes the backup without applying it.
- Other posts and accounts never receive the recovery prompt.

## ✅ Checklist
- [x] Lint completed (`npm run islands:lint`; existing warnings only)
- [x] Type-check completed (`npm run islands:type-check`)
- [x] Tests completed (`npm run server:test`, 1,127 tests; focused edit API tests also passed)
- [x] Production build and entry budgets completed
- [x] Migration check completed with no changes
- [x] DEBUG browser smoke completed with zero runtime or islands asset errors
- [x] Documentation updated (Ocean Brain task log)
