### PR TITLE
✨ Add rendered post previews

### DIFF
--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/NewPostEditor.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/NewPostEditor.tsx
@@ -6,6 +6,7 @@ import {
     useRef,
     useCallback
 } from 'react';
+import type { MouseEvent } from 'react';
 import { toast } from '~/utils/toast';
 import { useConfirm } from '~/hooks/useConfirm';
 import PostEditorWrapper from './PostEditorWrapper';
@@ -13,6 +14,7 @@ import PostActions from './components/PostActions';
 import PostForm from './components/PostForm';
 import DraftsPanel from './components/DraftsPanel';
 import SettingsDrawer from './components/SettingsDrawer';
+import PostPreviewDialog from './components/PostPreviewDialog';
 import PublishChecklist from './components/PublishChecklist';
 import ScheduleStatusNotice from './components/ScheduleStatusNotice';
 import { useAutoSave } from './hooks/useAutoSave';
@@ -58,10 +60,14 @@ const NewPostEditor = ({
     const [seriesList, setSeriesList] = useState<Series[]>([]);
     const [isDraftsPanelOpen, setIsDraftsPanelOpen] = useState(false);
     const [isSettingsDrawerOpen, setIsSettingsDrawerOpen] = useState(false);
+    const [isPreviewOpen, setIsPreviewOpen] = useState(false);
+    const [isPreparingPreview, setIsPreparingPreview] = useState(false);
+    const [previewUrl, setPreviewUrl] = useState<string | null>(null);
     const [isUrlAutoSync, setIsUrlAutoSync] = useState(true);
     const [currentDraftUrl, setCurrentDraftUrl] = useState(draftUrl);
     const [showPublishChecklist, setShowPublishChecklist] = useState(false);
     const [isEditorMediaUploading, setIsEditorMediaUploading] = useState(false);
+    const previewTriggerRef = useRef<HTMLButtonElement | null>(null);
 
     const [formData, setFormData] = useState({
         title: '',
@@ -377,11 +383,34 @@ const NewPostEditor = ({
             return;
         }
 
-        const success = await manualSave();
-        if (success) {
+        const savedDraftUrl = await manualSave();
+        if (savedDraftUrl) {
             toast.success('임시저장되었습니다.');
         } else {
             toast.error('임시저장에 실패했습니다.');
+        }
+    };
+
+    const handleOpenPreview = async (event: MouseEvent<HTMLButtonElement>) => {
+        previewTriggerRef.current = event.currentTarget;
+
+        if (isEditorMediaUploading) {
+            toast.warning('파일 업로드가 끝난 뒤 미리보기를 열어주세요.');
+            return;
+        }
+
+        setIsPreparingPreview(true);
+        try {
+            const savedDraftUrl = await manualSave();
+            if (!savedDraftUrl) {
+                toast.error('미리보기를 위한 임시저장에 실패했습니다.');
+                return;
+            }
+
+            setPreviewUrl(`/write/preview/${encodeURIComponent(savedDraftUrl)}`);
+            setIsPreviewOpen(true);
+        } finally {
+            setIsPreparingPreview(false);
         }
     };
 
@@ -523,6 +552,8 @@ const NewPostEditor = ({
                 onManualSave={handleManualSave}
                 onSubmit={() => handleSubmit()}
                 onOpenDrafts={() => setIsDraftsPanelOpen(true)}
+                onPreview={handleOpenPreview}
+                isPreviewing={isPreparingPreview}
                 onOpenSettings={() => setIsSettingsDrawerOpen(true)}
                 submitLabel={formData.reservedDate ? '예약' : undefined}
             />
@@ -533,6 +564,13 @@ const NewPostEditor = ({
                 isSubmitting={isSubmitting}
                 onClose={() => setShowPublishChecklist(false)}
                 onConfirm={handleConfirmPublish}
+            />
+
+            <PostPreviewDialog
+                isOpen={isPreviewOpen}
+                previewUrl={previewUrl}
+                returnFocusTo={previewTriggerRef.current}
+                onClose={() => setIsPreviewOpen(false)}
             />
 
             {/* Settings Drawer */}

--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/components/PostActions.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/components/PostActions.tsx
@@ -1,8 +1,16 @@
 import { useEffect, useState } from 'react';
+import type { MouseEvent } from 'react';
 import { Button } from '@blex/ui/button';
 import { FloatingBottomBar } from '@blex/ui/floating-bottom-bar';
 import { IconButton } from '@blex/ui/icon-button';
-import { FileText, Send, SlidersHorizontal } from '@blex/ui/icons';
+import {
+    Eye,
+    FileText,
+    Loader2,
+    Save,
+    Send,
+    SlidersHorizontal
+} from '@blex/ui/icons';
 
 interface PostActionsProps {
     mode: 'new' | 'edit' | 'draft';
@@ -17,6 +25,8 @@ interface PostActionsProps {
     onManualSave: () => void;
     onSubmit: () => void;
     onOpenDrafts?: () => void;
+    onPreview?: (event: MouseEvent<HTMLButtonElement>) => void;
+    isPreviewing?: boolean;
     onOpenSettings?: () => void;
     submitLabel?: string;
 }
@@ -43,6 +53,8 @@ const PostActions = ({
     onManualSave,
     onSubmit,
     onOpenDrafts,
+    onPreview,
+    isPreviewing = false,
     onOpenSettings,
     submitLabel
 }: PostActionsProps) => {
@@ -65,9 +77,28 @@ const PostActions = ({
                 <IconButton
                     onClick={onOpenDrafts}
                     rounded="full"
+                    className="shrink-0"
                     aria-label="임시 포스트"
                     title="임시 포스트">
                     <FileText className="w-5 h-5" />
+                </IconButton>
+            )}
+
+            {/* Rendered Preview */}
+            {onPreview && (
+                <IconButton
+                    onClick={onPreview}
+                    disabled={isBusy || isPreviewing}
+                    rounded="full"
+                    className="shrink-0"
+                    aria-label="포스트 미리보기"
+                    aria-busy={isPreviewing}
+                    title="포스트 미리보기">
+                    {isPreviewing ? (
+                        <Loader2 className="h-5 w-5 animate-spin" />
+                    ) : (
+                        <Eye className="h-5 w-5" />
+                    )}
                 </IconButton>
             )}
 
@@ -76,6 +107,7 @@ const PostActions = ({
                 <IconButton
                     onClick={onOpenSettings}
                     rounded="full"
+                    className="shrink-0"
                     aria-label="게시 설정"
                     title="게시 설정"
                     data-tour="post-settings">
@@ -86,11 +118,11 @@ const PostActions = ({
             {/* Save Section */}
             {!isEdit && (
                 <>
-                    <div className="w-px h-8 bg-line/50 mx-1" />
+                    <div className="mx-1 h-8 w-px shrink-0 bg-line/50" />
 
                     {/* Autosave Status */}
                     <div
-                        className="flex items-center gap-1.5 px-1 text-xs text-content-hint"
+                        className="hidden shrink-0 items-center gap-1.5 px-1 text-xs text-content-hint sm:flex"
                         aria-live="polite"
                         data-tour="post-autosave">
                         {isSaving ? (
@@ -127,11 +159,21 @@ const PostActions = ({
                     </div>
 
                     {/* Manual Save Button */}
+                    <IconButton
+                        size="sm"
+                        rounded="full"
+                        onClick={onManualSave}
+                        disabled={isBusy}
+                        className="shrink-0 sm:hidden"
+                        aria-label="임시 저장"
+                        title="임시 저장">
+                        <Save className="h-4 w-4" />
+                    </IconButton>
                     <button
                         type="button"
                         onClick={onManualSave}
                         disabled={isBusy}
-                        className="flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium text-content-secondary hover:text-content hover:bg-surface-subtle active:scale-95 rounded-full transition-all motion-interaction disabled:opacity-50"
+                        className="hidden shrink-0 items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium text-content-secondary transition-all hover:bg-surface-subtle hover:text-content active:scale-95 disabled:opacity-50 sm:flex motion-interaction"
                         title="임시 저장">
                         <span>임시 저장</span>
                     </button>
@@ -143,7 +185,7 @@ const PostActions = ({
                 onClick={onSubmit}
                 disabled={isBusy || isSubmitDisabled}
                 variant="primary"
-                className="!rounded-full"
+                className="min-h-11! shrink-0 !rounded-full"
                 leftIcon={<Send className="w-4 h-4" />}
                 data-tour="post-publish">
                 {actionLabel}

--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/components/PostPreviewDialog.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/components/PostPreviewDialog.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useState } from 'react';
+import { Dialog } from '@blex/ui/dialog';
+import { IconButton } from '@blex/ui/icon-button';
+import { Eye, Loader2, RotateCw, X } from '@blex/ui/icons';
+import { DIM_OVERLAY_DEFAULT, ENTRANCE_DURATION } from '@blex/ui/design-tokens';
+import { cx } from '~/lib/classnames';
+
+type PreviewViewport = 'desktop' | 'mobile';
+
+interface PostPreviewDialogProps {
+    isOpen: boolean;
+    previewUrl: string | null;
+    returnFocusTo?: HTMLButtonElement | null;
+    onClose: () => void;
+}
+
+const viewportOptions: Array<{ value: PreviewViewport; label: string }> = [
+    {
+        value: 'desktop',
+        label: '데스크톱'
+    },
+    {
+        value: 'mobile',
+        label: '모바일'
+    }
+];
+
+const PostPreviewDialog = ({
+    isOpen,
+    previewUrl,
+    returnFocusTo,
+    onClose
+}: PostPreviewDialogProps) => {
+    const [viewport, setViewport] = useState<PreviewViewport>('desktop');
+    const [refreshKey, setRefreshKey] = useState(0);
+    const [isLoading, setIsLoading] = useState(true);
+
+    useEffect(() => {
+        if (!isOpen || !previewUrl) return;
+        setIsLoading(true);
+    }, [isOpen, previewUrl]);
+
+    const handleRefresh = () => {
+        setIsLoading(true);
+        setRefreshKey(current => current + 1);
+    };
+
+    return (
+        <Dialog.Root open={isOpen} onOpenChange={(open) => !open && onClose()}>
+            <Dialog.Portal>
+                <Dialog.Overlay
+                    className={`fixed inset-0 ${DIM_OVERLAY_DEFAULT} z-[70] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0`}
+                />
+                <Dialog.Content
+                    onCloseAutoFocus={(event) => {
+                        if (!returnFocusTo?.isConnected) return;
+                        event.preventDefault();
+                        returnFocusTo.focus({ preventScroll: true });
+                    }}
+                    className={cx(
+                        'fixed inset-0 z-[80] flex flex-col overflow-hidden bg-surface shadow-2xl focus:outline-none',
+                        'sm:inset-4 sm:rounded-2xl sm:border sm:border-line',
+                        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0',
+                        `${ENTRANCE_DURATION} ease-in-out motion-reduce:animate-none motion-reduce:transition-none`
+                    )}>
+                    <div className="flex flex-col gap-3 border-b border-line bg-surface-elevated px-4 py-3 sm:flex-row sm:items-center sm:justify-between sm:px-5">
+                        <div className="min-w-0">
+                            <div className="flex items-center gap-2">
+                                <Eye className="h-5 w-5 shrink-0 text-content-hint" />
+                                <Dialog.Title className="truncate text-base font-semibold text-content sm:text-lg">
+                                    포스트 미리보기
+                                </Dialog.Title>
+                            </div>
+                            <Dialog.Description className="mt-1 text-xs text-content-secondary">
+                                마지막으로 저장된 임시 포스트를 실제 화면으로 표시합니다
+                            </Dialog.Description>
+                        </div>
+
+                        <div className="flex items-center justify-between gap-2 sm:justify-end">
+                            <div
+                                className="inline-flex rounded-xl border border-line bg-surface-subtle p-1"
+                                role="group"
+                                aria-label="미리보기 화면 크기">
+                                {viewportOptions.map((option) => {
+                                    const isActive = viewport === option.value;
+                                    return (
+                                        <button
+                                            key={option.value}
+                                            type="button"
+                                            aria-pressed={isActive}
+                                            onClick={() => setViewport(option.value)}
+                                            className={cx(
+                                                'inline-flex min-h-11 items-center justify-center rounded-lg px-3 text-sm font-medium transition-all active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-action/30',
+                                                isActive
+                                                    ? 'bg-surface-elevated text-content shadow-sm'
+                                                    : 'text-content-secondary hover:text-content'
+                                            )}>
+                                            {option.label}
+                                        </button>
+                                    );
+                                })}
+                            </div>
+                            <IconButton
+                                size="sm"
+                                aria-label="미리보기 새로고침"
+                                title="미리보기 새로고침"
+                                onClick={handleRefresh}
+                                disabled={!previewUrl || isLoading}>
+                                <RotateCw className="h-4 w-4" />
+                            </IconButton>
+                            <Dialog.Close asChild>
+                                <IconButton size="sm" aria-label="미리보기 닫기" title="미리보기 닫기">
+                                    <X className="h-5 w-5" />
+                                </IconButton>
+                            </Dialog.Close>
+                        </div>
+                    </div>
+
+                    <div className="flex min-h-0 flex-1 justify-center overflow-auto bg-surface-subtle p-2 sm:p-4">
+                        {previewUrl && (
+                            <div
+                                style={viewport === 'mobile' ? { width: 390 } : undefined}
+                                className={cx(
+                                    'relative h-full min-h-[36rem] overflow-hidden border border-line bg-surface shadow-xl transition-[width,border-radius] duration-200 motion-reduce:transition-none',
+                                    viewport === 'mobile'
+                                        ? 'max-w-full rounded-2xl'
+                                        : 'w-full rounded-xl'
+                                )}>
+                                {isLoading && (
+                                    <div
+                                        className="absolute inset-0 z-10 flex items-center justify-center bg-surface"
+                                        role="status"
+                                        aria-label="미리보기 불러오는 중">
+                                        <Loader2 className="h-6 w-6 animate-spin text-content-hint" />
+                                    </div>
+                                )}
+                                <iframe
+                                    key={`${previewUrl}:${refreshKey}`}
+                                    src={previewUrl}
+                                    title="저장된 포스트 렌더링 미리보기"
+                                    className="h-full w-full border-0 bg-surface"
+                                    sandbox="allow-same-origin allow-scripts"
+                                    referrerPolicy="same-origin"
+                                    onLoad={() => setIsLoading(false)}
+                                />
+                            </div>
+                        )}
+                    </div>
+                </Dialog.Content>
+            </Dialog.Portal>
+        </Dialog.Root>
+    );
+};
+
+export default PostPreviewDialog;

--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/hooks/useAutoSave.ts
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/hooks/useAutoSave.ts
@@ -136,12 +136,12 @@ export const useAutoSave = (data: AutoSaveData, options: UseAutoSaveOptions) => 
     const currentDataString = getDataSignature(data);
     const currentContentString = getContentSignature(data);
 
-    // Manual save - returns true on success, false on failure
-    const manualSave = useCallback(async (): Promise<boolean> => {
+    // Manual save - returns the persisted draft URL on success
+    const manualSave = useCallback(async (): Promise<string | null> => {
         const currentData = dataRef.current;
         const currentOptions = optionsRef.current;
 
-        if (isSaving || !currentOptions.enabled) return false;
+        if (isSaving || !currentOptions.enabled) return null;
 
         // Clear existing timer and countdown when manually saving
         if (autoSaveRef.current) clearTimeout(autoSaveRef.current);
@@ -183,11 +183,11 @@ export const useAutoSave = (data: AutoSaveData, options: UseAutoSaveOptions) => 
             prevContentStringRef.current = getContentSignature(currentData);
             skipNextImageResetRef.current = true;
             currentOptions.onSuccess?.();
-            return true;
+            return draftUrlRef.current || null;
         } catch (error) {
             setHasSaveError(true);
             currentOptions.onError?.(error as Error);
-            return false;
+            return null;
         } finally {
             setIsSaving(false);
         }

--- a/backend/src/board/services/post_detail_render_service.py
+++ b/backend/src/board/services/post_detail_render_service.py
@@ -1,0 +1,168 @@
+from django.contrib.auth.models import User
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import render
+from django.urls import reverse
+from django.utils import timezone
+from django.utils.cache import patch_vary_headers
+
+from board.html_utils import extract_table_of_contents
+from board.models import Post
+from board.services.agent_content_service import AgentContentService
+from board.services.banner_service import BannerService
+from board.services.brand_asset_service import BrandAssetService
+from board.services.discovery_metadata_service import DiscoveryMetadataService
+from board.services.post_service import PostService
+from board.services.public_post_service import PublicPostService
+from board.services.site_url_service import SiteUrlService
+
+
+class PostDetailRenderService:
+    @staticmethod
+    def build_context(
+        request: HttpRequest,
+        post: Post,
+        author: User,
+        *,
+        is_post_preview: bool = False,
+    ) -> dict[str, object]:
+        preview_date = post.published_date or post.updated_date or post.created_date
+        post.preview_date = preview_date
+        post.created_date_display = timezone.localtime(preview_date).strftime('%Y-%m-%d')
+        post.updated_date_display = timezone.localtime(post.updated_date).strftime('%Y-%m-%d')
+        show_post_updated_date = post.created_date_display != post.updated_date_display
+
+        author_profile = getattr(author, 'profile', None)
+        author_bio = author_profile.bio.strip() if author_profile and author_profile.bio else ''
+        author_homepage = author_profile.homepage.strip() if author_profile and author_profile.homepage else ''
+
+        post.series_total = 0
+        post.visible_series_posts = []
+        post.prev_post = None
+        post.next_post = None
+
+        if post.series and not is_post_preview:
+            post.visible_series_posts = PostService.get_visible_series_posts(post)
+
+        content_html_with_ids, table_of_contents = extract_table_of_contents(
+            post.content.content_html,
+        )
+        banners = BannerService.get_all_banners_for_author(author)
+
+        canonical_url = ''
+        if not is_post_preview:
+            canonical_url = SiteUrlService.absolute_url(
+                request,
+                post.get_absolute_url(),
+            )
+        author_url = SiteUrlService.absolute_url(
+            request,
+            reverse('user_profile', args=[author.username]),
+        )
+        post_image_url = (
+            SiteUrlService.absolute_url(request, post.image.url)
+            if post.image
+            else ''
+        )
+        logo_url = BrandAssetService.absolute_icon_png_url(request, None, 512)
+
+        aeo_enabled = AgentContentService.is_aeo_enabled()
+        is_public_post = PublicPostService.is_public(post)
+        post_visibility_status = 'draft' if is_post_preview else 'public'
+        if not is_post_preview and post.config.hide:
+            post_visibility_status = 'hidden'
+        elif not is_post_preview and not is_public_post:
+            post_visibility_status = 'scheduled'
+
+        show_post_status_notice = (
+            is_post_preview
+            or (
+                request.user.is_authenticated
+                and request.user == author
+                and post_visibility_status in {'hidden', 'scheduled'}
+            )
+        )
+        can_edit_post = (
+            not is_post_preview
+            and PostService.can_user_edit_post(request.user, post)
+        )
+        show_agent_post_markdown = (
+            not is_post_preview
+            and aeo_enabled
+            and is_public_post
+        )
+
+        post_cover_layout = post.config.cover_layout
+        if post_cover_layout not in {'default', 'split', 'overlay', 'none'}:
+            post_cover_layout = 'default'
+        if not post.image and post_cover_layout in {'split', 'overlay'}:
+            post_cover_layout = 'default'
+        post_cover_is_full_bleed = post_cover_layout in {'split', 'overlay'}
+        post_cover_template = f'board/posts/covers/{post_cover_layout}.html'
+
+        context: dict[str, object] = {
+            'post': post,
+            'banners': banners,
+            'content_html': content_html_with_ids,
+            'table_of_contents': table_of_contents,
+            'post_cover_layout': post_cover_layout,
+            'post_cover_is_full_bleed': post_cover_is_full_bleed,
+            'post_cover_template': post_cover_template,
+            'aeo_enabled': aeo_enabled,
+            'canonical_url': canonical_url,
+            'author_url': author_url,
+            'post_image_url': post_image_url,
+            'logo_url': logo_url,
+            'show_post_status_notice': show_post_status_notice,
+            'can_edit_post': can_edit_post,
+            'post_visibility_status': post_visibility_status,
+            'show_agent_post_markdown': show_agent_post_markdown,
+            'show_post_updated_date': show_post_updated_date,
+            'author_bio': author_bio,
+            'author_homepage': author_homepage,
+            'is_post_preview': is_post_preview,
+        }
+        if not is_post_preview:
+            context.update(
+                DiscoveryMetadataService.build_user_rss_feed_metadata(
+                    author,
+                    request,
+                ),
+            )
+        if show_agent_post_markdown:
+            context['post_markdown_url'] = (
+                AgentContentService.build_post_markdown_url(post, request)
+            )
+
+        return context
+
+    @staticmethod
+    def render(
+        request: HttpRequest,
+        post: Post,
+        author: User,
+        *,
+        is_post_preview: bool = False,
+    ) -> HttpResponse:
+        context = PostDetailRenderService.build_context(
+            request,
+            post,
+            author,
+            is_post_preview=is_post_preview,
+        )
+        response = render(request, 'board/posts/post_detail.html', context)
+
+        if is_post_preview:
+            response['Cache-Control'] = 'private, no-store'
+            response['Pragma'] = 'no-cache'
+            response['X-Robots-Tag'] = 'noindex, nofollow, noarchive'
+            patch_vary_headers(response, ('Cookie',))
+        elif context['show_agent_post_markdown']:
+            response['Link'] = AgentContentService.build_agent_link_header(
+                post,
+                request,
+            )
+            response['X-Llms-Txt'] = AgentContentService.build_llms_txt_url(
+                request,
+            )
+
+        return response

--- a/backend/src/board/templates/board/posts/covers/_post_meta.html
+++ b/backend/src/board/templates/board/posts/covers/_post_meta.html
@@ -11,7 +11,7 @@
             {{ post.author_username }}
         </a>
         <span class="{% if cover_inverted %}text-white/55{% else %}text-line-strong{% endif %}">·</span>
-        <span class="{% if cover_inverted %}text-white/80{% else %}text-content-secondary{% endif %}" itemprop="datePublished" content="{{ post.published_date|date:'c' }}">{{ post.created_date_display }} 발행</span>
+        <span class="{% if cover_inverted %}text-white/80{% else %}text-content-secondary{% endif %}" itemprop="datePublished" content="{{ post.preview_date|date:'c' }}">{{ post.created_date_display }} {% if is_post_preview %}미리보기{% else %}발행{% endif %}</span>
         {% if show_post_updated_date %}
         <span class="{% if cover_inverted %}text-white/55{% else %}text-line-strong{% endif %}">·</span>
         <span class="{% if cover_inverted %}text-white/80{% else %}text-content-secondary{% endif %}" itemprop="dateModified" content="{{ post.updated_date|date:'c' }}">{{ post.updated_date_display }} 수정</span>

--- a/backend/src/board/templates/board/posts/post_detail.html
+++ b/backend/src/board/templates/board/posts/post_detail.html
@@ -2,9 +2,12 @@
 {% load resource %}
 {% load island %}
 
-{% block title %}{{ post.title }} - {{ post.author_username }} | {{ site_brand.site_name }}{% endblock %}
+{% block title %}{% if is_post_preview %}미리보기 · {% endif %}{{ post.title }} - {{ post.author_username }} | {{ site_brand.site_name }}{% endblock %}
 
 {% block meta %}
+{% if is_post_preview %}
+<meta name="description" content="저장된 임시 포스트 미리보기">
+{% else %}
 <!-- Primary Meta Tags -->
 <meta name="description" content="{{ post.meta_description }}">
 <meta name="keywords" content="{% for tag in post.tags.all %}{{ tag }}{% if not forloop.last %}, {% endif %}{% endfor %}">
@@ -33,10 +36,14 @@
 {% if show_agent_post_markdown %}
 <link rel="alternate" type="text/markdown" href="{{ post_markdown_url }}">
 {% endif %}
+{% endif %}
 {% endblock %}
 
 {% block robots_meta %}
-{% if site_setting and not site_setting.seo_enabled %}
+{% if is_post_preview %}
+<meta name="robots" content="noindex,nofollow,noarchive">
+<meta name="googlebot" content="noindex,nofollow,noarchive">
+{% elif site_setting and not site_setting.seo_enabled %}
 <meta name="robots" content="noindex,nofollow">
 <meta name="googlebot" content="noindex,nofollow">
 {% else %}
@@ -44,6 +51,10 @@
 <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1">
 <meta name="googlebot" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1">
 {% endif %}
+{% endblock %}
+
+{% block feed_links %}
+{% if not is_post_preview %}{{ block.super }}{% endif %}
 {% endblock %}
 
 {% block extra_styles %}
@@ -75,7 +86,7 @@
                 <article itemscope itemtype="https://schema.org/BlogPosting" lang="{{ LANGUAGE_CODE|default:'ko' }}">
                     <meta itemprop="headline" content="{{ post.title }}">
                     <meta itemprop="description" content="{{ post.meta_description }}">
-                    <meta itemprop="datePublished" content="{{ post.published_date|date:'c' }}">
+                    <meta itemprop="datePublished" content="{{ post.preview_date|date:'c' }}">
                     <meta itemprop="dateModified" content="{{ post.updated_date|date:'c' }}">
                     {% if post.image %}
                     <meta itemprop="image" content="{{ post_image_url }}">
@@ -90,14 +101,18 @@
                             <div class="min-w-0">
                                 <p class="text-xs font-semibold uppercase text-content-hint">포스트 상태</p>
                                 <h2 class="mt-1 text-lg font-semibold text-content">
-                                    {% if post_visibility_status == 'hidden' %}
+                                    {% if post_visibility_status == 'draft' %}
+                                    임시 포스트 미리보기입니다
+                                    {% elif post_visibility_status == 'hidden' %}
                                     비공개 포스트입니다
                                     {% else %}
                                     예약 발행 포스트입니다
                                     {% endif %}
                                 </h2>
                                 <p class="mt-1 text-sm leading-relaxed text-content-secondary">
-                                    {% if post_visibility_status == 'hidden' %}
+                                    {% if post_visibility_status == 'draft' %}
+                                    마지막으로 저장된 내용을 실제 포스트 화면으로 표시합니다. 이 페이지는 작성자에게만 보이며 공개 목록과 검색에 노출되지 않습니다.
+                                    {% elif post_visibility_status == 'hidden' %}
                                     이 포스트는 작성자만 볼 수 있습니다. 공개하려면 포스트 설정에서 비공개를 해제하세요.
                                     {% else %}
                                     예약 시각 전에는 작성자만 볼 수 있습니다. 예약 시각이 되면 공개 URL, RSS, Sitemap, Markdown URL에 반영됩니다.
@@ -170,9 +185,9 @@
                                 </dd>
                             </div>
                             <div class="sm:flex sm:items-start sm:gap-6">
-                                <dt class="text-xs font-medium text-content-hint sm:w-24 sm:flex-shrink-0">최초 발행</dt>
+                                <dt class="text-xs font-medium text-content-hint sm:w-24 sm:flex-shrink-0">{% if is_post_preview %}미리보기 기준{% else %}최초 발행{% endif %}</dt>
                                 <dd class="mt-1 text-content-secondary sm:mt-0">
-                                    <time datetime="{{ post.published_date|date:'c' }}">{{ post.created_date_display }}</time>
+                                    <time datetime="{{ post.preview_date|date:'c' }}">{{ post.created_date_display }}</time>
                                 </dd>
                             </div>
                             {% if show_post_updated_date %}
@@ -196,6 +211,7 @@
                 </article>
 
                 <!-- Floating Action Bar -->
+                {% if not is_post_preview or table_of_contents %}
                 <div x-data="{
                     linkCopyMenuOpen: false,
                     linkCopyHideTimer: null,
@@ -301,11 +317,13 @@
                     <div class="pointer-events-auto post-action-bar transform transition-all motion-interaction">
 
                         <!-- Like Button -->
+                        {% if not is_post_preview %}
                         <div class="flex items-center">
                             {% include 'components/like_button.html' with post_url=post.url likes_count=post.count_likes has_liked=post.has_liked %}
                         </div>
 
                         <div class="post-action-divider"></div>
+                        {% endif %}
 
                         <!-- TOC Button (Mobile Only) -->
                         {% if table_of_contents %}
@@ -317,6 +335,7 @@
                         {% endif %}
 
                         <!-- Share / Link Copy Button -->
+                        {% if not is_post_preview %}
                         <div class="relative"
                             @mouseenter="openLinkCopyMenu()"
                             @mouseleave="scheduleCloseLinkCopyMenu()"
@@ -398,6 +417,7 @@
                                 {% endif %}
                             </div>
                         </div>
+                        {% endif %}
 
                         <!-- Edit Button -->
                         {% if can_edit_post %}
@@ -409,9 +429,10 @@
                         {% endif %}
                     </div>
                 </div>
+                {% endif %}
 
                 <!-- Series Card -->
-                {% if post.series %}
+                {% if post.series and not is_post_preview %}
                 <section class="mt-16 bg-surface rounded-2xl p-6 sm:p-8 mb-16 ring-1 ring-line/60" aria-labelledby="post-series-heading">
                     {% if not post.visible_series_posts %}
                     <div class="flex flex-col items-center justify-center text-center py-6">
@@ -500,9 +521,11 @@
                 </section>
                 {% endif %}
 
+                {% if not is_post_preview %}
                 <div>
                     {% island_component 'Comments' lazy=True postUrl=post.url %}
                 </div>
+                {% endif %}
             </div>
         </div>
 
@@ -524,11 +547,13 @@
         </aside>
         </div>
 
+        {% if not is_post_preview %}
         <div class="max-w-7xl mx-auto">
             <div class="my-16">
                 {% island_component 'RelatedPosts' lazy=True postUrl=post.url username=post.author_username %}
             </div>
         </div>
+        {% endif %}
     </div>
 </div>
 
@@ -610,6 +635,7 @@ class="xl:hidden">
 {% endblock %}
 
 {% block extra_scripts %}
+{% if not is_post_preview %}
 <!-- Structured Data for Articles (JSON-LD) -->
 <script type="application/ld+json">
 {
@@ -645,6 +671,7 @@ class="xl:hidden">
   "articleSection": {% if post.series %}"{{ post.series.name }}"{% else %}"Blog"{% endif %}
 }
 </script>
+{% endif %}
 <script type="module" src="{% island_entry 'src/scripts/syntax-highlighting.ts' %}"></script>
 
 {% endblock %}

--- a/backend/src/board/tests/templates/test_post_preview.py
+++ b/backend/src/board/tests/templates/test_post_preview.py
@@ -1,0 +1,163 @@
+from django.contrib.auth.models import User
+from django.test import TestCase, override_settings
+from django.urls import reverse
+from django.utils import timezone
+
+from board.models import Post, PostConfig, PostContent, Profile, SiteSetting
+
+
+@override_settings(SITE_URL='https://blex.example')
+class PostPreviewViewTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.owner = User.objects.create_user(
+            username='preview-owner',
+            email='preview-owner@example.com',
+            password='password123',
+        )
+        cls.other_user = User.objects.create_user(
+            username='preview-other',
+            email='preview-other@example.com',
+            password='password123',
+        )
+        Profile.objects.update_or_create(
+            user=cls.owner,
+            defaults={'role': Profile.Role.EDITOR},
+        )
+        Profile.objects.update_or_create(
+            user=cls.other_user,
+            defaults={'role': Profile.Role.EDITOR},
+        )
+
+        cls.draft = Post.objects.create(
+            author=cls.owner,
+            title='Owner Draft Preview',
+            subtitle='Preview subtitle',
+            url='owner-draft-preview',
+            meta_description='Private preview description',
+            published_date=None,
+        )
+        PostContent.objects.create(
+            post=cls.draft,
+            content_html='<h2>Saved draft heading</h2><p>Saved draft body</p>',
+        )
+        PostConfig.objects.create(
+            post=cls.draft,
+            hide=True,
+            advertise=True,
+            block_comment=True,
+            cover_layout='none',
+        )
+
+        cls.published_post = Post.objects.create(
+            author=cls.owner,
+            title='Published Post',
+            url='published-post-preview-route',
+            published_date=timezone.now(),
+        )
+        PostContent.objects.create(
+            post=cls.published_post,
+            content_html='<p>Published body</p>',
+        )
+        PostConfig.objects.create(post=cls.published_post, hide=False)
+
+    def setUp(self):
+        setting = SiteSetting.get_instance()
+        setting.seo_enabled = True
+        setting.aeo_enabled = True
+        setting.save(update_fields=['seo_enabled', 'aeo_enabled'])
+        self.preview_url = reverse(
+            'post_preview',
+            kwargs={'post_url': self.draft.url},
+        )
+
+    def test_owner_can_render_latest_saved_draft_with_private_headers(self):
+        self.client.force_login(self.owner)
+
+        response = self.client.get(self.preview_url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'board/posts/post_detail.html')
+        self.assertTrue(response.context['is_post_preview'])
+        self.assertEqual(response.context['post_visibility_status'], 'draft')
+        self.assertFalse(response.context['show_agent_post_markdown'])
+        self.assertContains(response, 'Owner Draft Preview')
+        self.assertContains(response, 'Saved draft body')
+        self.assertContains(response, '임시 포스트 미리보기입니다')
+        self.assertContains(response, 'noindex,nofollow,noarchive')
+        self.assertNotContains(response, 'rel="canonical"')
+        self.assertNotContains(response, 'application/rss+xml')
+        self.assertNotContains(response, 'application/ld+json')
+        self.assertNotContains(response, '게시물 공유 또는 링크 복사')
+        self.assertNotContains(response, 'island-component name="Comments"')
+        self.assertNotContains(response, 'island-component name="RelatedPosts"')
+        self.assertEqual(
+            response['X-Robots-Tag'],
+            'noindex, nofollow, noarchive',
+        )
+        self.assertEqual(response['X-Frame-Options'], 'SAMEORIGIN')
+        self.assertIn('private', response['Cache-Control'])
+        self.assertIn('no-store', response['Cache-Control'])
+        self.assertIn('Cookie', response['Vary'])
+        self.assertNotIn('Link', response)
+        self.assertNotIn('X-Llms-Txt', response)
+
+        self.draft.content.content_html = '<p>Newest saved preview body</p>'
+        self.draft.content.save(update_fields=['content_html'])
+
+        refreshed_response = self.client.get(self.preview_url)
+
+        self.assertContains(refreshed_response, 'Newest saved preview body')
+        self.assertNotContains(refreshed_response, 'Saved draft body')
+
+    def test_preview_rejects_anonymous_and_other_users_without_leaking_draft(self):
+        anonymous_response = self.client.get(self.preview_url)
+        self.assertEqual(anonymous_response.status_code, 404)
+
+        self.client.force_login(self.other_user)
+        other_user_response = self.client.get(self.preview_url)
+        self.assertEqual(other_user_response.status_code, 404)
+
+    def test_preview_rejects_published_posts_and_non_get_requests(self):
+        self.client.force_login(self.owner)
+
+        published_response = self.client.get(reverse(
+            'post_preview',
+            kwargs={'post_url': self.published_post.url},
+        ))
+        post_response = self.client.post(self.preview_url)
+
+        self.assertEqual(published_response.status_code, 404)
+        self.assertEqual(post_response.status_code, 405)
+
+    def test_preview_does_not_change_existing_public_discovery_contracts(self):
+        self.client.force_login(self.owner)
+
+        public_detail_response = self.client.get(reverse(
+            'post_detail',
+            kwargs={
+                'username': self.owner.username,
+                'post_url': self.draft.url,
+            },
+        ))
+        markdown_response = self.client.get(reverse(
+            'post_markdown',
+            kwargs={
+                'username': self.owner.username,
+                'post_url': self.draft.url,
+            },
+        ))
+
+        self.assertEqual(public_detail_response.status_code, 404)
+        self.assertEqual(markdown_response.status_code, 404)
+
+        for url in (
+            reverse('site_rss_feed'),
+            '/posts/sitemap.xml',
+            reverse('llms_txt'),
+        ):
+            with self.subTest(url=url):
+                response = self.client.get(url)
+                self.assertEqual(response.status_code, 200)
+                self.assertNotContains(response, self.draft.title)
+                self.assertNotContains(response, self.preview_url)

--- a/backend/src/board/tests/test_backend_compatibility_contract.py
+++ b/backend/src/board/tests/test_backend_compatibility_contract.py
@@ -72,6 +72,7 @@ EXPECTED_ROUTE_CONTRACT = (
     ('@<username>/<post_url>/edit', 'post_edit', 'board.views.post.post_editor'),
     ('@<username>/<post_url>', 'post_detail', 'board.views.post.post_detail'),
     ('@<username>', 'user_profile', 'board.views.author.author_overview'),
+    ('write/preview/<str:post_url>', 'post_preview', 'board.views.post.post_preview'),
     ('write', 'post_write', 'board.views.post.post_editor'),
     ('search', 'search', 'board.views.search.search_page'),
     ('tags', 'tag_list', 'board.views.tag.tag_list_view'),

--- a/backend/src/board/urlconfs/pages.py
+++ b/backend/src/board/urlconfs/pages.py
@@ -18,7 +18,7 @@ from board.views.author import (
 from board.views.developer_api_docs import developer_api_docs, developer_api_quickstart
 from board.views.initial_setup import initial_setup_view
 from board.views.oauth_callback import oauth_callback
-from board.views.post import post_detail, post_editor
+from board.views.post import post_detail, post_editor, post_preview
 from board.views.post_actions import like_post
 from board.views.search import search_page
 from board.views.series import series_detail
@@ -74,6 +74,7 @@ urlpatterns = [
     path('@<username>', author_overview, name='user_profile'),
 
     # Posts write
+    path('write/preview/<str:post_url>', post_preview, name='post_preview'),
     path('write', post_editor, name='post_write'),
     path('search', search_page, name='search'),
 

--- a/backend/src/board/views/post.py
+++ b/backend/src/board/views/post.py
@@ -5,19 +5,16 @@ from django.contrib.auth.models import User
 from django.db.models import Count, F, Exists, OuterRef
 from django.http import Http404
 from django.contrib import messages
-from django.utils import timezone
+from django.views.decorators.clickjacking import xframe_options_sameorigin
+from django.views.decorators.http import require_GET
 
 from board.models import Post, Series, PostLikes, UsernameChangeLog
 from board.modules.response import StatusDone, StatusError
 from board.services.post_service import PostService, PostValidationError
-from board.services.banner_service import BannerService
-from board.services.agent_content_service import AgentContentService
-from board.services.brand_asset_service import BrandAssetService
-from board.services.discovery_metadata_service import DiscoveryMetadataService
+from board.services.post_detail_render_service import PostDetailRenderService
 from board.services.public_post_service import PublicPostService
-from board.services.site_url_service import SiteUrlService
-from board.html_utils import extract_table_of_contents
 from board.decorators import editor_required
+
 
 def post_detail(request, username, post_url):
     """
@@ -45,87 +42,33 @@ def post_detail(request, username, post_url):
     ):
         raise Http404("Post does not exist")
 
-    post.created_date_display = timezone.localtime(post.published_date).strftime('%Y-%m-%d')
-    post.updated_date_display = timezone.localtime(post.updated_date).strftime('%Y-%m-%d')
-    show_post_updated_date = post.created_date_display != post.updated_date_display
+    return PostDetailRenderService.render(request, post, author)
 
-    author_profile = getattr(author, 'profile', None)
-    author_bio = author_profile.bio.strip() if author_profile and author_profile.bio else ''
-    author_homepage = author_profile.homepage.strip() if author_profile and author_profile.homepage else ''
 
-    # Initialize series attributes to avoid AttributeError
-    post.series_total = 0
-    post.visible_series_posts = []
-    post.prev_post = None
-    post.next_post = None
+@require_GET
+@xframe_options_sameorigin
+def post_preview(request, post_url):
+    if not request.user.is_authenticated:
+        raise Http404("Post does not exist")
 
-    if post.series:
-        post.visible_series_posts = PostService.get_visible_series_posts(post)
+    try:
+        post = PostService.get_post_detail(
+            request.user.username,
+            post_url,
+            request.user,
+        )
+    except Http404:
+        raise Http404("Post does not exist")
 
-    # Extract table of contents from post content
-    content_html_with_ids, table_of_contents = extract_table_of_contents(post.content.content_html)
+    if not post.is_draft():
+        raise Http404("Post does not exist")
 
-    banners = BannerService.get_all_banners_for_author(author)
-
-    post_absolute_url = post.get_absolute_url()
-    canonical_url = SiteUrlService.absolute_url(request, post_absolute_url)
-    author_url = SiteUrlService.absolute_url(request, reverse('user_profile', args=[author.username]))
-    post_image_url = SiteUrlService.absolute_url(request, post.image.url) if post.image else ''
-    logo_url = BrandAssetService.absolute_icon_png_url(request, None, 512)
-
-    aeo_enabled = AgentContentService.is_aeo_enabled()
-    is_public_post = PublicPostService.is_public(post)
-    post_visibility_status = 'public'
-    if post.config.hide:
-        post_visibility_status = 'hidden'
-    elif not is_public_post:
-        post_visibility_status = 'scheduled'
-
-    show_post_status_notice = (
-        is_owner
-        and post_visibility_status in {'hidden', 'scheduled'}
+    return PostDetailRenderService.render(
+        request,
+        post,
+        post.author,
+        is_post_preview=True,
     )
-    can_edit_post = PostService.can_user_edit_post(request.user, post)
-
-    show_agent_post_markdown = aeo_enabled and is_public_post
-    post_cover_layout = post.config.cover_layout
-    if post_cover_layout not in {'default', 'split', 'overlay', 'none'}:
-        post_cover_layout = 'default'
-    if not post.image and post_cover_layout in {'split', 'overlay'}:
-        post_cover_layout = 'default'
-    post_cover_is_full_bleed = post_cover_layout in {'split', 'overlay'}
-    post_cover_template = f'board/posts/covers/{post_cover_layout}.html'
-
-    context = {
-        'post': post,
-        'banners': banners,
-        'content_html': content_html_with_ids,
-        'table_of_contents': table_of_contents,
-        'post_cover_layout': post_cover_layout,
-        'post_cover_is_full_bleed': post_cover_is_full_bleed,
-        'post_cover_template': post_cover_template,
-        'aeo_enabled': aeo_enabled,
-        'canonical_url': canonical_url,
-        'author_url': author_url,
-        'post_image_url': post_image_url,
-        'logo_url': logo_url,
-        'show_post_status_notice': show_post_status_notice,
-        'can_edit_post': can_edit_post,
-        'post_visibility_status': post_visibility_status,
-        'show_agent_post_markdown': show_agent_post_markdown,
-        'show_post_updated_date': show_post_updated_date,
-        'author_bio': author_bio,
-        'author_homepage': author_homepage,
-        **DiscoveryMetadataService.build_user_rss_feed_metadata(author, request),
-    }
-    if show_agent_post_markdown:
-        context['post_markdown_url'] = AgentContentService.build_post_markdown_url(post, request)
-
-    response = render(request, 'board/posts/post_detail.html', context)
-    if show_agent_post_markdown:
-        response['Link'] = AgentContentService.build_agent_link_header(post, request)
-        response['X-Llms-Txt'] = AgentContentService.build_llms_txt_url(request)
-    return response
 
 
 @editor_required


### PR DESCRIPTION
## 🎯 Goal
- 발행 전에 현재 임시 포스트가 실제 공개 포스트 레이아웃과 반응형 테마에서 어떻게 보이는지 확인할 수 있게 합니다.
- 기존 공개 URL, Markdown, RSS, sitemap 계약을 바꾸지 않고 작성자에게만 안전한 미리보기를 제공합니다.

## 🔧 Core Changes
- 현재 편집 내용을 기존 draft API로 먼저 저장한 뒤 소유자 전용 렌더링 미리보기를 엽니다.
- 공개 `post_detail` 렌더링 컨텍스트와 템플릿을 재사용하고, 미리보기에서는 좋아요·공유·댓글·관련 글 등 변경 가능한 상호작용을 숨깁니다.
- 공통 Dialog와 아이콘 컴포넌트로 데스크톱/390px 모바일 전환, 새로고침, 키보드 초점 복귀를 제공합니다.
- 미리보기 응답에 `noindex`, `no-store`, `SAMEORIGIN`을 적용하고 canonical, RSS alternate, Markdown alternate, JSON-LD를 제외합니다.

## 🤔 Key Decisions
- 임시 포스트도 기존 `Post`와 content/config를 보유하므로 별도 렌더러를 복제하지 않고 공개 상세 렌더러를 공용 서비스로 추출했습니다.
- 공개 상세 URL은 작성자에게도 draft 404를 유지하고, `/write/preview/<post_url>`에서 요청 사용자 소유 draft만 조회합니다.
- 시각 클래스에 결합된 일회성 E2E 대신 권한·비노출·공개 경로 회귀를 지속 가능한 Django 계약 테스트로 고정했습니다.

## 🧪 Verification Guide
### How to verify
1. 임시 포스트 내용을 수정한 뒤 작성 화면 하단의 눈 아이콘을 누릅니다.
2. 저장된 최신 내용이 실제 포스트 화면으로 표시되는지 확인하고 데스크톱/모바일 전환 및 새로고침을 사용합니다.
3. 익명 또는 다른 계정으로 미리보기 URL에 접근하면 404인지, 기존 공개 포스트와 RSS/sitemap/Markdown이 그대로인지 확인합니다.

### Expected result
- 저장 요청이 완료된 뒤 작성자 전용 미리보기가 열리고, 375px 화면에서도 가로 넘침 없이 모든 액션이 44px 이상으로 동작합니다.
- 미리보기는 검색·공개 discovery 표면에 나타나지 않으며 기존 공개 포스트 동작은 유지됩니다.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (not needed; behavior is covered by task log and durable tests)

Verification performed:
- `npm run islands:lint`
- `npm run islands:type-check`
- `npm run islands:build`
- `npm run islands:check-entry-budgets`
- `npm run server:check-migrations`
- `npm run server:test` (1,131 tests)
- Browser verification for save-before-preview ordering, latest saved content, responsive viewport, refresh, focus restoration, light/dark themes, and private response headers