### PR TITLE
♻️ Improve post management interactions

### DIFF
--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/PostsSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/PostsSetting.tsx
@@ -80,6 +80,7 @@ const PostsSetting = () => {
     const [postCounts, setPostCounts] = useState<Partial<Record<PostStatusTab, number>>>({});
     const {
         filters,
+        searchValue,
         tags,
         series,
         isFilterExpanded,
@@ -170,6 +171,7 @@ const PostsSetting = () => {
                 <Suspense fallback={<div className="h-32 bg-surface-subtle animate-pulse rounded-lg mb-6" />}>
                     <PostsFilter
                         filters={filters}
+                        searchValue={searchValue}
                         isExpanded={isFilterExpanded}
                         showClearAction={activeCount !== undefined && activeCount > 0}
                         onExpandToggle={() => setIsFilterExpanded(!isFilterExpanded)}

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/PostCard.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/PostCard.tsx
@@ -16,7 +16,13 @@ import {
     Tag,
     Trash2
 } from '@blex/ui/icons';
-import { Button, Input, Dropdown, Select } from '~/components/shared';
+import {
+    Alert,
+    Button,
+    Input,
+    Dropdown,
+    Select
+} from '~/components/shared';
 import { getSettingsIconClass } from '~/styles/settingsStyles';
 import { getMediaPath } from '~/modules/static.module';
 import type { Post } from '../hooks';
@@ -30,8 +36,10 @@ interface PostCardProps {
     onDelete: (postUrl: string) => void;
     onTagChange: (postUrl: string, value: string) => void;
     onTagSubmit: (postUrl: string) => void;
+    isTagSaving?: boolean;
     onSeriesChange: (postUrl: string, value: string) => void;
     onSeriesSubmit: (postUrl: string) => void;
+    isSeriesSaving?: boolean;
     dateDisplay?: string;
     dateIcon?: ReactNode;
     dateIconClass?: string;
@@ -51,8 +59,10 @@ const PostCard = ({
     onDelete,
     onTagChange,
     onTagSubmit,
+    isTagSaving = false,
     onSeriesChange,
     onSeriesSubmit,
+    isSeriesSaving = false,
     dateDisplay,
     dateIcon,
     dateIconClass,
@@ -61,10 +71,10 @@ const PostCard = ({
 }: PostCardProps) => {
     const [isMetaEditorOpen, setIsMetaEditorOpen] = useState(false);
     const hasPendingChanges = !!post.hasTagChanged || !!post.hasSeriesChanged;
-
-    const handleViewPost = () => {
-        window.location.assign(`/@${username}/${post.url}`);
-    };
+    const pendingChangeLabel = [
+        post.hasTagChanged ? '태그' : '',
+        post.hasSeriesChanged ? '시리즈' : ''
+    ].filter(Boolean).join('·');
 
     const handleEditPost = () => {
         window.location.assign(`/@${username}/${post.url}/edit`);
@@ -79,111 +89,112 @@ const PostCard = ({
     return (
         <div className="bg-surface border border-line-light rounded-2xl hover:border-line transition-colors duration-200 overflow-hidden">
             {/* 헤더 */}
-            <div
-                className="p-4 border-b border-line-light cursor-pointer hover:bg-surface-subtle/50 transition-colors"
-                onClick={handleViewPost}>
-                <div className="flex items-center justify-between gap-3 sm:gap-4">
-                    <div className="flex min-w-0 flex-1 items-center gap-3">
-                        <div className="h-14 w-14 flex-shrink-0 overflow-hidden rounded-lg border border-line-light bg-surface-subtle">
-                            {post.image ? (
-                                <img
-                                    src={getMediaPath(post.image)}
-                                    alt={post.title}
-                                    loading="lazy"
-                                    className="h-full w-full object-cover"
-                                />
-                            ) : (
-                                <div className="flex h-full w-full items-center justify-center text-content-hint">
-                                    <FileText aria-hidden className="h-4 w-4" />
-                                </div>
+            <div className="flex items-stretch border-b border-line-light">
+                <a
+                    href={`/@${username}/${post.url}`}
+                    aria-label={`${post.title} 포스트 보기`}
+                    className="flex min-w-0 flex-1 items-center gap-3 p-4 transition-colors hover:bg-surface-subtle/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-action">
+                    <div className="h-14 w-14 flex-shrink-0 overflow-hidden rounded-lg border border-line-light bg-surface-subtle">
+                        {post.image ? (
+                            <img
+                                src={getMediaPath(post.image)}
+                                alt=""
+                                loading="lazy"
+                                className="h-full w-full object-cover"
+                            />
+                        ) : (
+                            <div className="flex h-full w-full items-center justify-center text-content-hint">
+                                <FileText aria-hidden className="h-4 w-4" />
+                            </div>
+                        )}
+                    </div>
+
+                    {/* 제목 영역 */}
+                    <div className="flex-1 min-w-0 py-0.5">
+                        <h3 className="text-base font-semibold text-content leading-snug line-clamp-2">
+                            {post.title}
+                        </h3>
+                        <div className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-content-secondary">
+                            <span className="inline-flex items-center gap-1.5">
+                                {dateIcon ?? (
+                                    dateIconClass
+                                        ? <i aria-hidden className={`${dateIconClass} text-content-hint`} />
+                                        : <Calendar aria-hidden className="h-3.5 w-3.5 text-content-hint" />
+                                )}
+                                {dateDisplay || formatDate(post.createdDate)}
+                            </span>
+                            <span className="inline-flex items-center gap-1.5">
+                                <Clock aria-hidden className="h-3.5 w-3.5 text-content-hint" />
+                                {post.readTime}분
+                            </span>
+                            <span className="inline-flex items-center gap-1.5">
+                                <Heart aria-hidden className="h-3.5 w-3.5 text-content-hint" />
+                                {post.countLikes}
+                            </span>
+                            <span className="inline-flex items-center gap-1.5">
+                                <MessageCircle aria-hidden className="h-3.5 w-3.5 text-content-hint" />
+                                {post.countComments}
+                            </span>
+                            {showUpdatedBadge && post.createdDate !== post.updatedDate && (
+                                <span className="text-content-hint">최근 수정</span>
+                            )}
+                            {statusLabel && (
+                                <span className="inline-flex items-center px-2 py-0.5 bg-surface-subtle text-content rounded-md font-medium">
+                                    {statusLabel}
+                                </span>
+                            )}
+                            {post.isHide && (
+                                <span className="inline-flex items-center px-2 py-0.5 bg-surface-subtle text-content rounded-md font-medium">
+                                    비공개
+                                </span>
                             )}
                         </div>
-
-                        {/* 제목 영역 */}
-                        <div className="flex-1 min-w-0 py-0.5">
-                            <h3 className="text-base font-semibold text-content leading-snug line-clamp-2">
-                                {post.title}
-                            </h3>
-                            <div className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-content-secondary">
-                                <span className="inline-flex items-center gap-1.5">
-                                    {dateIcon ?? (
-                                        dateIconClass
-                                            ? <i aria-hidden className={`${dateIconClass} text-content-hint`} />
-                                            : <Calendar aria-hidden className="h-3.5 w-3.5 text-content-hint" />
-                                    )}
-                                    {dateDisplay || formatDate(post.createdDate)}
-                                </span>
-                                <span className="inline-flex items-center gap-1.5">
-                                    <Clock aria-hidden className="h-3.5 w-3.5 text-content-hint" />
-                                    {post.readTime}분
-                                </span>
-                                <span className="inline-flex items-center gap-1.5">
-                                    <Heart aria-hidden className="h-3.5 w-3.5 text-content-hint" />
-                                    {post.countLikes}
-                                </span>
-                                <span className="inline-flex items-center gap-1.5">
-                                    <MessageCircle aria-hidden className="h-3.5 w-3.5 text-content-hint" />
-                                    {post.countComments}
-                                </span>
-                                {showUpdatedBadge && post.createdDate !== post.updatedDate && (
-                                    <span className="text-content-hint">최근 수정</span>
-                                )}
-                                {statusLabel && (
-                                    <span className="inline-flex items-center px-2 py-0.5 bg-surface-subtle text-content rounded-md font-medium">
-                                        {statusLabel}
-                                    </span>
-                                )}
-                                {post.isHide && (
-                                    <span className="inline-flex items-center px-2 py-0.5 bg-surface-subtle text-content rounded-md font-medium">
-                                        비공개
-                                    </span>
-                                )}
-                            </div>
-                        </div>
                     </div>
+                </a>
 
-                    {/* 액션 */}
-                    <div className="flex-shrink-0 self-center" onClick={(e) => e.stopPropagation()}>
-                        <Dropdown
-                            triggerAriaLabel={`${post.title} 포스트 메뉴 열기`}
-                            triggerClassName="min-h-11 min-w-11"
-                            items={[
-                                {
-                                    label: '포스트 편집',
-                                    icon: <Pencil aria-hidden className="h-4 w-4" />,
-                                    onClick: handleEditPost
-                                },
-                                {
-                                    label: post.isHide ? '공개로 변경' : '비공개로 변경',
-                                    icon: post.isHide
-                                        ? <Eye aria-hidden className="h-4 w-4" />
-                                        : <EyeOff aria-hidden className="h-4 w-4" />,
-                                    onClick: () => onVisibilityToggle(post.url)
-                                },
-                                {
-                                    label: '휴지통으로 이동',
-                                    icon: <Trash2 aria-hidden className="h-4 w-4" />,
-                                    onClick: () => onDelete(post.url),
-                                    variant: 'danger'
-                                }
-                            ]}
-                        />
-                    </div>
+                {/* 액션 */}
+                <div className="flex flex-shrink-0 items-center pr-3 sm:pr-4">
+                    <Dropdown
+                        triggerAriaLabel={`${post.title} 포스트 메뉴 열기`}
+                        triggerClassName="min-h-11 min-w-11 focus-visible:ring-2 focus-visible:ring-action focus-visible:ring-offset-1"
+                        items={[
+                            {
+                                label: '포스트 편집',
+                                icon: <Pencil aria-hidden className="h-4 w-4" />,
+                                onClick: handleEditPost
+                            },
+                            {
+                                label: post.isHide ? '공개로 변경' : '비공개로 변경',
+                                icon: post.isHide
+                                    ? <Eye aria-hidden className="h-4 w-4" />
+                                    : <EyeOff aria-hidden className="h-4 w-4" />,
+                                onClick: () => onVisibilityToggle(post.url)
+                            },
+                            {
+                                label: '휴지통으로 이동',
+                                icon: <Trash2 aria-hidden className="h-4 w-4" />,
+                                onClick: () => onDelete(post.url),
+                                variant: 'danger'
+                            }
+                        ]}
+                    />
                 </div>
             </div>
 
-            <div className="px-4 py-2.5 bg-surface-subtle/40 border-t border-line-light flex justify-end">
+            <div className="flex justify-end bg-surface-subtle/40 px-4 py-2.5">
                 <button
                     type="button"
-                    title="태그/시리즈 편집"
                     aria-label={isMetaEditorOpen ? '태그 및 시리즈 편집 닫기' : '태그 및 시리즈 편집 열기'}
                     onClick={() => setIsMetaEditorOpen(prev => !prev)}
                     className="inline-flex min-h-11 items-center gap-2 rounded-lg px-2.5 py-1.5 text-content-secondary hover:text-content hover:bg-surface-subtle transition-colors">
                     <SlidersHorizontal aria-hidden className="h-3.5 w-3.5" />
+                    <span className="text-xs font-medium">태그·시리즈</span>
                     <span className="inline-flex items-center gap-2">
                         {hasPendingChanges && (
-                            <span className="text-[11px] px-2 py-0.5 rounded bg-action text-content-inverted">
-                                저장 필요
+                            <span
+                                role="status"
+                                className="rounded bg-action px-2 py-0.5 text-[11px] text-content-inverted">
+                                {pendingChangeLabel} 저장 필요
                             </span>
                         )}
                         {isMetaEditorOpen
@@ -196,7 +207,7 @@ const PostCard = ({
             {isMetaEditorOpen && (
                 <div className="p-4 pt-3 space-y-3 bg-surface-subtle/40 border-t border-line-light">
                     {/* 태그 */}
-                    <div className="flex items-center gap-3">
+                    <div className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3 sm:grid-cols-[auto_minmax(0,1fr)_auto]">
                         <div className={getSettingsIconClass('light')}>
                             <Tag aria-hidden className="h-4 w-4" />
                         </div>
@@ -206,22 +217,23 @@ const PostCard = ({
                             placeholder="태그를 입력하세요..."
                             value={post.tag}
                             onChange={(e) => onTagChange(post.url, e.target.value)}
-                            className="flex-1"
+                            className="w-full"
                         />
-                        {post.hasTagChanged && (
+                        {(post.hasTagChanged || isTagSaving) && (
                             <Button
                                 variant="primary"
                                 size="md"
-                                className="min-h-11!"
+                                isLoading={isTagSaving}
+                                className="col-start-2 min-h-11! w-full sm:col-start-auto sm:w-auto"
                                 leftIcon={<Save aria-hidden className="h-4 w-4" />}
                                 onClick={() => onTagSubmit(post.url)}>
-                                저장
+                                태그 저장
                             </Button>
                         )}
                     </div>
 
                     {/* 시리즈 */}
-                    <div className="flex items-center gap-3">
+                    <div className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3 sm:grid-cols-[auto_minmax(0,1fr)_auto]">
                         <div className={getSettingsIconClass('light')}>
                             <BookOpen aria-hidden className="h-4 w-4" />
                         </div>
@@ -229,6 +241,7 @@ const PostCard = ({
                             <Select
                                 value={post.series || ''}
                                 onValueChange={(value) => onSeriesChange(post.url, value)}
+                                ariaLabel={`${post.title} 시리즈 선택`}
                                 items={[
                                     {
                                         value: '',
@@ -242,26 +255,25 @@ const PostCard = ({
                                 placeholder="시리즈 선택 안함"
                             />
                         </div>
-                        {post.hasSeriesChanged && (
+                        {(post.hasSeriesChanged || isSeriesSaving) && (
                             <Button
                                 variant="primary"
                                 size="md"
-                                className="min-h-11!"
+                                isLoading={isSeriesSaving}
+                                className="col-start-2 min-h-11! w-full sm:col-start-auto sm:w-auto"
                                 leftIcon={<Save aria-hidden className="h-4 w-4" />}
                                 onClick={() => onSeriesSubmit(post.url)}>
-                                저장
+                                시리즈 저장
                             </Button>
                         )}
                     </div>
 
                     {post.readTime > 30 && (
-                        <Button
-                            variant="secondary"
-                            size="sm"
-                            disabled
-                            className="w-full justify-start text-content-secondary border-dashed">
-                            긴 포스트 주의: 읽는데 {post.readTime}분이 걸립니다.
-                        </Button>
+                        <div role="note" aria-label="긴 포스트 안내">
+                            <Alert variant="warning" title="긴 포스트">
+                                예상 읽기 시간은 {post.readTime}분입니다.
+                            </Alert>
+                        </div>
                     )}
                 </div>
             )}

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/PostListContent.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/PostListContent.tsx
@@ -40,7 +40,9 @@ export const PostListContent = ({
         handleTagChange,
         handleTagSubmit,
         handleSeriesChange,
-        handleSeriesSubmit
+        handleSeriesSubmit,
+        savingTagPostUrls,
+        savingSeriesPostUrls
     } = usePostsActions({
         username: postsData?.username || '',
         posts,
@@ -73,8 +75,10 @@ export const PostListContent = ({
                             onDelete={handleDelete}
                             onTagChange={handleTagChange}
                             onTagSubmit={handleTagSubmit}
+                            isTagSaving={savingTagPostUrls.has(post.url)}
                             onSeriesChange={handleSeriesChange}
                             onSeriesSubmit={handleSeriesSubmit}
+                            isSeriesSaving={savingSeriesPostUrls.has(post.url)}
                             dateDisplay={isScheduled ? `예약 ${post.createdDate}` : undefined}
                             dateIcon={isScheduled
                                 ? <CalendarDays aria-hidden className="h-3.5 w-3.5 text-content-hint" />

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/PostsFilter.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/PostsFilter.tsx
@@ -17,6 +17,7 @@ import type { Tag, Series } from '~/lib/api/settings';
 
 interface PostsFilterProps {
     filters: FilterOptions;
+    searchValue: string;
     isExpanded: boolean;
     showClearAction?: boolean;
     onExpandToggle: () => void;
@@ -33,6 +34,7 @@ const hasActiveFilters = (filters: FilterOptions) => {
 
 const PostsFilter = ({
     filters,
+    searchValue,
     isExpanded,
     showClearAction = true,
     onExpandToggle,
@@ -142,7 +144,7 @@ const PostsFilter = ({
                             type="text"
                             aria-label="포스트 제목 검색"
                             placeholder="포스트 제목 검색..."
-                            defaultValue={filters.search}
+                            value={searchValue}
                             onChange={onSearchChange}
                             leftIcon={<Search aria-hidden className="h-4 w-4" />}
                         />

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/hooks/usePostsActions.ts
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/hooks/usePostsActions.ts
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { toast } from '~/utils/toast';
 import { useConfirm } from '~/hooks/useConfirm';
 import {
@@ -22,6 +23,8 @@ interface UsePostsActionsReturn {
     handleTagSubmit: (postUrl: string) => Promise<void>;
     handleSeriesChange: (postUrl: string, value: string) => void;
     handleSeriesSubmit: (postUrl: string) => Promise<void>;
+    savingTagPostUrls: ReadonlySet<string>;
+    savingSeriesPostUrls: ReadonlySet<string>;
 }
 
 export const usePostsActions = ({
@@ -31,6 +34,8 @@ export const usePostsActions = ({
     refetch
 }: UsePostsActionsProps): UsePostsActionsReturn => {
     const { confirm } = useConfirm();
+    const [savingTagPostUrls, setSavingTagPostUrls] = useState<Set<string>>(new Set());
+    const [savingSeriesPostUrls, setSavingSeriesPostUrls] = useState<Set<string>>(new Set());
 
     const handleVisibilityToggle = async (postUrl: string) => {
         try {
@@ -84,7 +89,7 @@ export const usePostsActions = ({
                 ? {
                     ...post,
                     tag: value,
-                    hasTagChanged: post.tag !== value
+                    hasTagChanged: post.persistedTag !== value
                 }
                 : post
         ));
@@ -92,27 +97,42 @@ export const usePostsActions = ({
 
     const handleTagSubmit = async (postUrl: string) => {
         const post = posts.find(p => p.url === postUrl);
-        if (!post) return;
+        if (!post || savingTagPostUrls.has(postUrl)) return;
+
+        const submittedTag = post.tag;
+        setSavingTagPostUrls(prev => new Set(prev).add(postUrl));
 
         try {
-            const { data } = await updatePostTags(username, postUrl, post.tag);
+            const { data } = await updatePostTags(username, postUrl, submittedTag);
 
             if (data.status === 'DONE') {
-                setPosts(prev => prev.map(p =>
-                    p.url === postUrl
-                        ? {
-                            ...p,
-                            tag: data.body.tag || '',
-                            hasTagChanged: false
-                        }
-                        : p
-                ));
+                const persistedTag = data.body.tag || '';
+                setPosts(prev => prev.map(currentPost => {
+                    if (currentPost.url !== postUrl) return currentPost;
+
+                    const tag = currentPost.tag === submittedTag
+                        ? persistedTag
+                        : currentPost.tag;
+
+                    return {
+                        ...currentPost,
+                        tag,
+                        persistedTag,
+                        hasTagChanged: tag !== persistedTag
+                    };
+                }));
                 toast.success('태그가 수정되었습니다.');
             } else {
                 throw new Error('Failed to update tag');
             }
         } catch {
             toast.error('태그 수정에 실패했습니다.');
+        } finally {
+            setSavingTagPostUrls(prev => {
+                const next = new Set(prev);
+                next.delete(postUrl);
+                return next;
+            });
         }
     };
 
@@ -122,7 +142,7 @@ export const usePostsActions = ({
                 ? {
                     ...post,
                     series: value,
-                    hasSeriesChanged: post.series !== value
+                    hasSeriesChanged: post.persistedSeries !== value
                 }
                 : post
         ));
@@ -130,27 +150,42 @@ export const usePostsActions = ({
 
     const handleSeriesSubmit = async (postUrl: string) => {
         const post = posts.find(p => p.url === postUrl);
-        if (!post) return;
+        if (!post || savingSeriesPostUrls.has(postUrl)) return;
+
+        const submittedSeries = post.series || '';
+        setSavingSeriesPostUrls(prev => new Set(prev).add(postUrl));
 
         try {
-            const { data } = await updatePostSeries(username, postUrl, post.series || '');
+            const { data } = await updatePostSeries(username, postUrl, submittedSeries);
 
             if (data.status === 'DONE') {
-                setPosts(prev => prev.map(p =>
-                    p.url === postUrl
-                        ? {
-                            ...p,
-                            series: data.body.series || '',
-                            hasSeriesChanged: false
-                        }
-                        : p
-                ));
+                const persistedSeries = data.body.series || '';
+                setPosts(prev => prev.map(currentPost => {
+                    if (currentPost.url !== postUrl) return currentPost;
+
+                    const series = (currentPost.series || '') === submittedSeries
+                        ? persistedSeries
+                        : currentPost.series || '';
+
+                    return {
+                        ...currentPost,
+                        series,
+                        persistedSeries,
+                        hasSeriesChanged: series !== persistedSeries
+                    };
+                }));
                 toast.success('시리즈가 수정되었습니다.');
             } else {
                 throw new Error('Failed to update series');
             }
         } catch {
             toast.error('시리즈 수정에 실패했습니다.');
+        } finally {
+            setSavingSeriesPostUrls(prev => {
+                const next = new Set(prev);
+                next.delete(postUrl);
+                return next;
+            });
         }
     };
 
@@ -160,6 +195,8 @@ export const usePostsActions = ({
         handleTagChange,
         handleTagSubmit,
         handleSeriesChange,
-        handleSeriesSubmit
+        handleSeriesSubmit,
+        savingTagPostUrls,
+        savingSeriesPostUrls
     };
 };

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/hooks/usePostsData.ts
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/hooks/usePostsData.ts
@@ -5,6 +5,8 @@ import { getPosts, getReservedPosts, type Post as ApiPost } from '~/lib/api/post
 import { getTags, getSeries } from '~/lib/api/settings';
 
 export interface Post extends ApiPost {
+    persistedTag: string;
+    persistedSeries: string;
     hasTagChanged?: boolean;
     hasSeriesChanged?: boolean;
     isPinned?: boolean;
@@ -105,6 +107,7 @@ const syncFiltersToURL = (filters: FilterOptions) => {
 
 export const usePostsFilterState = () => {
     const [filters, setFilters] = useState<FilterOptions>(getFiltersFromURL());
+    const [searchValue, setSearchValue] = useState(filters.search);
     const [isFilterExpanded, setIsFilterExpanded] = useState(true);
     const searchDebounce = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -135,7 +138,23 @@ export const usePostsFilterState = () => {
         syncFiltersToURL(filters);
     }, [filters]);
 
+    useEffect(() => {
+        return () => {
+            if (searchDebounce.current) {
+                clearTimeout(searchDebounce.current);
+            }
+        };
+    }, []);
+
     const handleFilterChange = (key: keyof FilterOptions, value: string) => {
+        if (key === 'search') {
+            if (searchDebounce.current) {
+                clearTimeout(searchDebounce.current);
+                searchDebounce.current = null;
+            }
+            setSearchValue(value);
+        }
+
         setFilters(prev => ({
             ...prev,
             [key]: value,
@@ -145,17 +164,28 @@ export const usePostsFilterState = () => {
 
     const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         const value = e.target.value;
+        setSearchValue(value);
 
         if (searchDebounce.current) {
             clearTimeout(searchDebounce.current);
         }
 
         searchDebounce.current = setTimeout(() => {
-            handleFilterChange('search', value);
+            setFilters(prev => ({
+                ...prev,
+                search: value,
+                page: '1'
+            }));
+            searchDebounce.current = null;
         }, 300);
     };
 
     const clearFilters = () => {
+        if (searchDebounce.current) {
+            clearTimeout(searchDebounce.current);
+            searchDebounce.current = null;
+        }
+        setSearchValue('');
         setFilters({
             search: '',
             tag: '',
@@ -168,6 +198,7 @@ export const usePostsFilterState = () => {
 
     return {
         filters,
+        searchValue,
         isFilterExpanded,
         setIsFilterExpanded,
         handleFilterChange,
@@ -204,7 +235,11 @@ export const usePostsQuery = (filters: FilterOptions, source: PostsSource = 'pub
 
     useEffect(() => {
         if (postsData?.posts) {
-            setPosts(postsData.posts);
+            setPosts(postsData.posts.map(post => ({
+                ...post,
+                persistedTag: post.tag,
+                persistedSeries: post.series || ''
+            })));
         }
     }, [postsData]);
 

--- a/backend/islands/packages/ui/src/components/Dropdown.tsx
+++ b/backend/islands/packages/ui/src/components/Dropdown.tsx
@@ -44,6 +44,7 @@ const Dropdown = ({
                     trigger
                 ) : (
                     <button
+                        type="button"
                         className={`p-2 text-content-secondary hover:text-content hover:bg-surface-subtle rounded-lg transition-colors outline-none ${triggerClassName}`}
                         aria-label={triggerAriaLabel}>
                         <EllipsisVertical aria-hidden="true" className="h-4 w-4" />

--- a/backend/islands/packages/ui/src/components/Select.tsx
+++ b/backend/islands/packages/ui/src/components/Select.tsx
@@ -12,6 +12,7 @@ interface SelectProps {
     value: string;
     onValueChange: (value: string) => void;
     items: SelectItem[];
+    ariaLabel?: string;
     placeholder?: string;
     error?: string;
     className?: string;
@@ -22,6 +23,7 @@ const Select = ({
     value,
     onValueChange,
     items,
+    ariaLabel,
     placeholder = '선택하세요',
     error,
     className = '',
@@ -49,6 +51,7 @@ const Select = ({
         <div>
             <RadixSelect.Root value={internalValue} onValueChange={handleValueChange} disabled={disabled}>
                 <RadixSelect.Trigger
+                    aria-label={ariaLabel}
                     aria-invalid={!!error}
                     className={`
                         w-full flex items-center justify-between px-4 py-3


### PR DESCRIPTION
## 🎯 Goal
- 포스트 관리 목록에서 검색 초기화가 입력값과 어긋나고, 카드 헤더·액션 메뉴의 상호작용 경계가 불명확한 문제를 해결합니다.
- 태그·시리즈 편집의 저장 상태와 긴 글 안내를 직관적이고 접근 가능한 표현으로 정리합니다.

## 🔧 Core Changes
- 검색 표시값과 debounce된 필터 상태를 동기화하고 초기화 시 대기 중 검색도 취소했습니다.
- 카드 헤더를 실제 포스트 링크로 바꾸고 액션 메뉴를 링크 밖으로 분리했습니다.
- 태그·시리즈의 마지막 저장값과 저장 중 상태를 각각 추적해 dirty 표시와 저장 버튼을 명확히 했습니다.
- 저장 중 추가 편집이 이전 서버 응답에 덮이지 않도록 보존합니다.
- 긴 글 안내를 disabled 버튼 대신 공용 warning Alert 기반 note로 바꿨습니다.
- 공용 Select에 선택적 접근성 이름을, Dropdown 기본 버튼에 안전한 `type="button"`을 추가했습니다.

## 🤔 Key Decisions
- 백엔드 endpoint, 요청·응답, 필터 query와 기존 태그·시리즈 저장 API 호출은 변경하지 않았습니다.
- 카드 전체의 프로그래밍 방식 이동 대신 표준 링크 의미를 사용해 마우스·키보드·보조기기 동작을 함께 보장했습니다.
- UI 변경 가이드와 E2E 비대화 우려에 따라 영구 E2E 시나리오는 추가하지 않고 실제 브라우저 일회성 검증 후 데이터를 정리했습니다.

## 🧪 Verification Guide
### How to verify
1. `/settings/posts`에서 제목 검색 후 `필터 초기화`를 눌러 입력값, URL query, 결과 목록이 함께 초기화되는지 확인합니다.
2. 포스트 제목 링크를 키보드 Enter로 열고, 우측 메뉴를 열어 포스트 이동이 함께 발생하지 않는지 확인합니다.
3. 태그·시리즈 편집에서 값을 바꾸고 원래 값으로 되돌릴 때 dirty 표시가 사라지는지, 각 저장 버튼과 로딩 상태가 독립적인지 확인합니다.
4. 30분 초과 포스트 안내가 비활성 버튼이 아니라 안내 note로 읽히는지 확인합니다.

### Expected result
- 기존 공개 URL과 저장 API 계약을 유지하면서 검색, 링크, 메뉴, dirty/save 상태가 데스크톱·모바일·키보드에서 일관되게 동작합니다.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed (`islands:build`, entry budgets, actual desktop/mobile/keyboard smoke)
- [x] Documentation updated (Ocean Brain task log)
