### PR TITLE
♻️ Improve post editor accessibility

### DIFF
--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/components/PostCoverEditor.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/components/PostCoverEditor.tsx
@@ -64,17 +64,34 @@ const TitleInputs = ({
                 {title.length}/65
             </p>
         )}
+        <label htmlFor="subtitle" className="sr-only">부제목</label>
         <input
             type="text"
+            id="subtitle"
             name="subtitle"
             value={subtitle}
             onChange={(event) => onSubtitleChange(event.target.value)}
+            maxLength={120}
+            aria-describedby={subtitle.length > 100 ? 'subtitle-character-count' : undefined}
             className={cx(
                 'mt-2 w-full border-0 px-0 py-0 text-lg leading-tight text-content-secondary placeholder-content-hint focus:ring-0 sm:text-xl',
                 inverted && 'bg-transparent text-white/85 placeholder:text-white/55'
             )}
             placeholder="부제목 (선택사항)"
         />
+        {subtitle.length > 100 && (
+            <p
+                id="subtitle-character-count"
+                aria-live="polite"
+                className={cx(
+                    'mt-1 text-xs',
+                    subtitle.length >= 120
+                        ? 'text-danger'
+                        : inverted ? 'text-white/70' : 'text-content-hint'
+                )}>
+                {subtitle.length}/120
+            </p>
+        )}
     </div>
 );
 

--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/components/TagManager.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/components/TagManager.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef } from 'react';
+import { Hash, Plus, X } from '@blex/ui/icons';
 import { Button } from '~/components/shared';
 
 interface TagManagerProps {
@@ -47,28 +48,27 @@ const TagManager = ({ tags, onTagsChange }: TagManagerProps) => {
             {tags.map((tag, index) => (
                 <span
                     key={tag}
-                    className="inline-flex items-center px-4 py-2 bg-surface-subtle hover:bg-action hover:text-content-inverted text-content-secondary rounded-full text-sm font-medium transition-all duration-300 border border-line-light hover:border-line-strong group">
+                    className="group inline-flex min-h-11 items-center rounded-full border border-line-light bg-surface-subtle pl-4 pr-1 text-sm font-medium text-content-secondary transition-all duration-300 hover:border-line-strong hover:bg-action hover:text-content-inverted">
                     <span className="mr-1 opacity-50">#</span>
                     <span className="break-all">{tag}</span>
                     <button
                         type="button"
                         onClick={() => handleRemoveTag(index)}
-                        className="ml-2 w-4 h-4 text-content-hint group-hover:text-content-inverted/80 transition-colors flex items-center justify-center"
+                        className="ml-1 inline-flex min-h-11 min-w-11 items-center justify-center rounded-full text-content-hint transition-colors group-hover:text-content-inverted/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-action focus-visible:ring-offset-1"
                         aria-label={`${tag} 태그 제거`}>
-                        <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
-                        </svg>
+                        <X aria-hidden className="h-3.5 w-3.5" />
                     </button>
                 </span>
             ))}
 
             {/* Inline tag input */}
             {isAdding ? (
-                <div className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-surface-subtle border border-line rounded-full">
-                    <i className="fas fa-hashtag text-xs text-content-hint" />
+                <div className="inline-flex min-h-11 items-center gap-1.5 rounded-full border border-line bg-surface-subtle px-3 py-1.5">
+                    <Hash aria-hidden className="h-3.5 w-3.5 text-content-hint" />
                     <input
                         ref={inputRef}
                         type="text"
+                        aria-label="새 태그 이름"
                         value={newTag}
                         onChange={(e) => setNewTag(e.target.value)}
                         onKeyDown={handleKeyDown}
@@ -91,11 +91,9 @@ const TagManager = ({ tags, onTagsChange }: TagManagerProps) => {
                     }}
                     variant="ghost"
                     size="sm"
-                    className="rounded-full">
-                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 4v16m8-8H4" />
-                    </svg>
-                    <span>태그 추가</span>
+                    leftIcon={<Plus aria-hidden className="h-4 w-4" />}
+                    className="min-h-11! rounded-full">
+                    태그 추가
                 </Button>
             )}
         </div>

--- a/backend/islands/packages/editor/src/TiptapEditor/components/menus/MediaFloatingMenu.tsx
+++ b/backend/islands/packages/editor/src/TiptapEditor/components/menus/MediaFloatingMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useId, useRef } from 'react';
 import type { Editor } from '@tiptap/react';
 import * as Popover from '@radix-ui/react-popover';
 
@@ -15,6 +15,8 @@ const MediaFloatingMenu = ({ editor }: MediaFloatingMenuProps) => {
     const [selectedNode, setSelectedNode] = useState<{ type: string; attrs: Record<string, unknown>; pos: number } | null>(null);
     const [isOpen, setIsOpen] = useState(false);
     const [anchorElement, setAnchorElement] = useState<HTMLElement | null>(null);
+    const altInputId = useId();
+    const captionInputId = useId();
 
     const selectedPosRef = useRef<number | null>(null);
 
@@ -73,6 +75,10 @@ const MediaFloatingMenu = ({ editor }: MediaFloatingMenuProps) => {
 
     const handleCaptionChange = (caption: string) => {
         updateAttribute('caption', caption.trim() === '' ? null : caption);
+    };
+
+    const handleAltChange = (alt: string) => {
+        updateAttribute('alt', alt.trim() === '' ? null : alt);
     };
 
     const handleToggle = (e: React.MouseEvent, attr: string) => {
@@ -146,8 +152,9 @@ const MediaFloatingMenu = ({ editor }: MediaFloatingMenuProps) => {
                     : 'text-content-secondary hover:text-content hover:bg-surface-subtle active:scale-95'
                 }
             `}
-            title={title}>
-            <i className={`${icon} text-sm`} />
+            title={title}
+            aria-label={title}>
+            <i aria-hidden className={`${icon} text-sm`} />
         </button>
     );
 
@@ -267,56 +274,80 @@ const MediaFloatingMenu = ({ editor }: MediaFloatingMenuProps) => {
                             )}
                         </div>
 
-                        <div className="flex items-center gap-2">
-                            {/* 스타일 (image, video) */}
-                            {mediaTypesWithStyle.includes(selectedNode.type) && (
-                                <>
-                                    <select
-                                        value={selectedNode.attrs.objectFit as string || 'cover'}
-                                        onChange={handleObjectFitChange}
-                                        className={fieldClassName}>
-                                        <option value="cover">맞춤</option>
-                                        <option value="contain">포함</option>
-                                        <option value="fill">채움</option>
-                                        <option value="none">원본</option>
-                                    </select>
+                        {/* 스타일 (image, video) */}
+                        {mediaTypesWithStyle.includes(selectedNode.type) && (
+                            <div className="flex items-center gap-2">
+                                <select
+                                    value={selectedNode.attrs.objectFit as string || 'cover'}
+                                    onChange={handleObjectFitChange}
+                                    className={fieldClassName}>
+                                    <option value="cover">맞춤</option>
+                                    <option value="contain">포함</option>
+                                    <option value="fill">채움</option>
+                                    <option value="none">원본</option>
+                                </select>
 
-                                    <div className={dividerClassName} />
-                                    <div className="flex gap-0.5 bg-surface-subtle rounded-lg p-0.5">
-                                        <IconButton icon="fas fa-border-all" active={!!selectedNode.attrs.border} onClick={(e) => handleToggle(e, 'border')} title="테두리" />
-                                        <IconButton icon="fas fa-clone" active={!!selectedNode.attrs.shadow} onClick={(e) => handleToggle(e, 'shadow')} title="그림자" />
-                                    </div>
+                                <div className={dividerClassName} />
+                                <div className="flex gap-0.5 bg-surface-subtle rounded-lg p-0.5">
+                                    <IconButton icon="fas fa-border-all" active={!!selectedNode.attrs.border} onClick={(e) => handleToggle(e, 'border')} title="테두리" />
+                                    <IconButton icon="fas fa-clone" active={!!selectedNode.attrs.shadow} onClick={(e) => handleToggle(e, 'shadow')} title="그림자" />
+                                </div>
 
-                                    <div className={dividerClassName} />
-                                    <select
-                                        value={selectedNode.attrs.borderRadius as string || ''}
-                                        onChange={handleBorderRadiusChange}
-                                        className={fieldClassName}>
-                                        <option value="">둥글기</option>
-                                        <option value="0">각짐</option>
-                                        <option value="4">약간</option>
-                                        <option value="8">보통</option>
-                                        <option value="16">많이</option>
-                                        <option value="9999">원형</option>
-                                    </select>
+                                <div className={dividerClassName} />
+                                <select
+                                    value={selectedNode.attrs.borderRadius as string || ''}
+                                    onChange={handleBorderRadiusChange}
+                                    className={fieldClassName}>
+                                    <option value="">둥글기</option>
+                                    <option value="0">각짐</option>
+                                    <option value="4">약간</option>
+                                    <option value="8">보통</option>
+                                    <option value="16">많이</option>
+                                    <option value="9999">원형</option>
+                                </select>
+                            </div>
+                        )}
 
-                                    <div className={dividerClassName} />
-                                </>
+                        <div className="grid gap-2">
+                            {selectedNode.type === 'image' && (
+                                <label htmlFor={altInputId} className="flex items-center gap-2">
+                                    <span className="w-20 shrink-0 text-xs font-medium text-content-secondary">
+                                        대체 텍스트
+                                    </span>
+                                    <input
+                                        id={altInputId}
+                                        type="text"
+                                        placeholder="이미지를 설명하세요"
+                                        value={selectedNode.attrs.alt as string || ''}
+                                        onChange={(e) => handleAltChange(e.target.value)}
+                                        onKeyDown={(e) => {
+                                            if (e.key === 'Enter') {
+                                                e.currentTarget.blur();
+                                            }
+                                        }}
+                                        className={`min-w-0 flex-1 ${fieldClassName}`}
+                                    />
+                                </label>
                             )}
 
-                            {/* 캡션 */}
-                            <input
-                                type="text"
-                                placeholder="캡션..."
-                                value={selectedNode.attrs.caption as string || ''}
-                                onChange={(e) => handleCaptionChange(e.target.value)}
-                                onKeyDown={(e) => {
-                                    if (e.key === 'Enter') {
-                                        e.currentTarget.blur();
-                                    }
-                                }}
-                                className={`w-36 ${fieldClassName}`}
-                            />
+                            <label htmlFor={captionInputId} className="flex items-center gap-2">
+                                <span className="w-20 shrink-0 text-xs font-medium text-content-secondary">
+                                    캡션
+                                </span>
+                                <input
+                                    id={captionInputId}
+                                    type="text"
+                                    placeholder="화면에 표시할 설명"
+                                    value={selectedNode.attrs.caption as string || ''}
+                                    onChange={(e) => handleCaptionChange(e.target.value)}
+                                    onKeyDown={(e) => {
+                                        if (e.key === 'Enter') {
+                                            e.currentTarget.blur();
+                                        }
+                                    }}
+                                    className={`min-w-0 flex-1 ${fieldClassName}`}
+                                />
+                            </label>
                         </div>
                     </Popover.Content>
                 </Popover.Portal>

--- a/backend/src/board/services/post_service.py
+++ b/backend/src/board/services/post_service.py
@@ -44,6 +44,7 @@ class PostValidationError(Exception):
 class PostService:
     """Service class for handling post-related business logic"""
     DRAFT_RESERVED_DATE_META = 'draft_reserved_date'
+    SUBTITLE_MAX_LENGTH = Post._meta.get_field('subtitle').max_length or 120
 
     @staticmethod
     def normalize_cover_options(
@@ -151,6 +152,15 @@ class PostService:
             raise PostValidationError(
                 ErrorCode.VALIDATE,
                 '내용을 입력해주세요.'
+            )
+
+    @staticmethod
+    def validate_subtitle(subtitle: Optional[str]) -> None:
+        """Keep every post mutation within the model subtitle contract."""
+        if subtitle is not None and len(subtitle) > PostService.SUBTITLE_MAX_LENGTH:
+            raise PostValidationError(
+                ErrorCode.SIZE_OVERFLOW,
+                f'부제목은 최대 {PostService.SUBTITLE_MAX_LENGTH}자까지 입력할 수 있습니다.'
             )
 
     @staticmethod
@@ -400,6 +410,7 @@ class PostService:
         PostService.validate_user_permissions(user)
 
         PostService.validate_post_data(title, text_html)
+        PostService.validate_subtitle(subtitle)
 
         resolved_html = PostService._resolve_content(text_html, content_type)
 
@@ -559,6 +570,8 @@ class PostService:
         Returns:
             Updated Post instance
         """
+        PostService.validate_subtitle(subtitle)
+
         resolved_html = None
         if text_html is not None:
             next_title = title if title is not None else post.title
@@ -796,6 +809,7 @@ class PostService:
             PostValidationError: If validation fails
         """
         PostService.validate_user_permissions(user)
+        PostService.validate_subtitle(subtitle)
 
         draft_count = Post.objects.filter(
             author=user,
@@ -883,6 +897,8 @@ class PostService:
         Returns:
             Updated Post instance
         """
+        PostService.validate_subtitle(subtitle)
+
         if title is not None:
             post.title = title or '제목 없음'
 
@@ -987,6 +1003,8 @@ class PostService:
         Raises:
             PostValidationError: If validation fails
         """
+        PostService.validate_subtitle(subtitle)
+
         if title is not None:
             post.title = title
         if subtitle is not None:

--- a/backend/src/board/tests/api/test_draft.py
+++ b/backend/src/board/tests/api/test_draft.py
@@ -86,6 +86,43 @@ class DraftTestCase(TestCase):
         self.assertFalse(post.config.advertise)
         self.assertFalse(post.config.block_comment)
 
+    def test_create_draft_enforces_subtitle_model_boundary(self):
+        """부제목은 모델 제한인 120자까지 허용하고 초과 입력은 거절한다."""
+        self.client.login(username='test', password='test')
+        accepted_subtitle = '가' * PostService.SUBTITLE_MAX_LENGTH
+
+        accepted_response = self.client.post(
+            '/v1/drafts',
+            json.dumps({
+                'title': 'Subtitle Boundary Draft',
+                'content': '<p>content</p>',
+                'subtitle': accepted_subtitle,
+            }),
+            content_type='application/json',
+        )
+        accepted_content = json.loads(accepted_response.content)
+
+        self.assertEqual(accepted_content['status'], 'DONE')
+        self.assertEqual(
+            Post.objects.get(url=accepted_content['body']['url']).subtitle,
+            accepted_subtitle,
+        )
+
+        rejected_response = self.client.post(
+            '/v1/drafts',
+            json.dumps({
+                'title': 'Subtitle Overflow Draft',
+                'content': '<p>content</p>',
+                'subtitle': accepted_subtitle + '나',
+            }),
+            content_type='application/json',
+        )
+        rejected_content = json.loads(rejected_response.content)
+
+        self.assertEqual(rejected_content['status'], 'ERROR')
+        self.assertEqual(rejected_content['errorCode'], 'error:OF')
+        self.assertFalse(Post.objects.filter(title='Subtitle Overflow Draft').exists())
+
     def test_create_draft_persists_publishing_settings(self):
         """발행 설정을 생성하고 상세 응답에서 복원한다."""
         self.client.login(username='test', password='test')
@@ -272,6 +309,27 @@ class DraftTestCase(TestCase):
         self.assertEqual(post.title, 'Updated Title')
         self.assertEqual(post.subtitle, 'My subtitle')
         self.assertIsNone(post.published_date)
+
+    def test_update_draft_rejects_overlong_subtitle_without_mutation(self):
+        """부제목 초과 수정이 기존 드래프트 값을 바꾸지 않는다."""
+        url = self._create_draft()
+        post = Post.objects.get(url=url)
+        post.subtitle = '기존 부제목'
+        post.save(update_fields=['subtitle'])
+
+        response = self.client.put(
+            f'/v1/drafts/{url}',
+            json.dumps({
+                'subtitle': '가' * (PostService.SUBTITLE_MAX_LENGTH + 1),
+            }),
+            content_type='application/json',
+        )
+        content = json.loads(response.content)
+
+        self.assertEqual(content['status'], 'ERROR')
+        self.assertEqual(content['errorCode'], 'error:OF')
+        post.refresh_from_db()
+        self.assertEqual(post.subtitle, '기존 부제목')
 
     def test_update_draft_cover_options(self):
         """드래프트 수정 시 커버 설정을 갱신한다."""

--- a/backend/src/board/tests/api/test_post.py
+++ b/backend/src/board/tests/api/test_post.py
@@ -468,6 +468,42 @@ class PostTestCase(TestCase):
         post = Post.objects.get(url='test-post-1000')
         self.assertTrue(post.config.block_comment)
 
+    def test_published_post_enforces_subtitle_model_boundary(self):
+        """발행 생성은 120자를 허용하고 초과 수정은 기존 부제목을 보존한다."""
+        self.client.login(username='author', password='author')
+        subtitle_limit = Post._meta.get_field('subtitle').max_length
+        accepted_subtitle = '가' * subtitle_limit
+
+        create_response = self.client.post('/v1/posts', {
+            'title': 'Published Subtitle Boundary',
+            'subtitle': accepted_subtitle,
+            'text_html': '<p>content</p>',
+            'is_hide': False,
+            'is_advertise': False,
+        })
+        create_content = json.loads(create_response.content)
+
+        self.assertEqual(create_content['status'], 'DONE')
+        post = Post.objects.get(url=create_content['body']['url'])
+        self.assertEqual(post.subtitle, accepted_subtitle)
+
+        update_response = self.client.post(
+            f'/v1/users/@author/posts/{post.url}',
+            {
+                'title': post.title,
+                'subtitle': accepted_subtitle + '나',
+                'text_html': post.content.content_html,
+                'is_hide': post.config.hide,
+                'is_advertise': post.config.advertise,
+            },
+        )
+        update_content = json.loads(update_response.content)
+
+        self.assertEqual(update_content['status'], 'ERROR')
+        self.assertEqual(update_content['errorCode'], 'error:OF')
+        post.refresh_from_db()
+        self.assertEqual(post.subtitle, accepted_subtitle)
+
     def test_create_post_with_cover_options(self):
         """포스트 생성 시 커버 설정을 저장한다."""
         self.client.login(username='author', password='author')

--- a/backend/src/board/tests/services/test_post_content_service.py
+++ b/backend/src/board/tests/services/test_post_content_service.py
@@ -77,6 +77,30 @@ class PostContentServiceTest(SimpleTestCase):
         SITE_URL='https://blex.example',
         MEDIA_URL='/resources/media/',
     )
+    def test_normalize_content_html_preserves_image_alt_and_caption_independently(self):
+        html = (
+            '<figure>'
+            '<img src="https://blex.example/resources/media/images/content/a.png" '
+            'alt="스크린리더용 이미지 설명">'
+            '<figcaption>화면에 표시되는 캡션</figcaption>'
+            '</figure>'
+        )
+
+        normalized = PostContentService.normalize_content_html(html)
+
+        self.assertEqual(
+            normalized,
+            '<figure>'
+            '<img src="/resources/media/images/content/a.png" '
+            'alt="스크린리더용 이미지 설명">'
+            '<figcaption>화면에 표시되는 캡션</figcaption>'
+            '</figure>',
+        )
+
+    @override_settings(
+        SITE_URL='https://blex.example',
+        MEDIA_URL='/resources/media/',
+    )
     def test_normalize_content_html_ignores_comments_and_script_text(self):
         html = (
             '<!-- <img src="https://blex.example/resources/media/images/content/comment.png"> -->'


### PR DESCRIPTION
## 🎯 Goal
- 포스트 태그·부제목·본문 이미지 입력에서 작은 터치 영역, 아이콘 혼용, 길이 제한 누락과 대체 텍스트 편집 부재를 해결합니다.
- 기존 작성·수정·임시저장·발행 계약을 유지하면서 모바일·키보드·스크린리더 사용성을 보완합니다.

## 🔧 Core Changes
- 태그의 Hash/Plus/X를 공용 아이콘으로 통일하고 제거 컨트롤에 44×44px hit area, focus ring과 명시적 접근성 이름을 적용했습니다.
- 부제목 입력을 기존 모델의 120자 제한과 맞추고 경계 안내를 추가했습니다.
- PostService의 모든 포스트 mutation 경로에서 같은 부제목 제한을 검증해 121자 요청을 기존 `error:OF` envelope로 거절하고 저장값을 보존합니다.
- 이미지 설정에서 스크린리더용 `대체 텍스트`와 화면용 `캡션`을 독립적으로 편집하도록 분리했습니다.
- 부제목 120/121 경계와 이미지 alt/figcaption 독립 보존 계약 테스트를 추가했습니다.

## 🤔 Key Decisions
- endpoint, payload/response 필드, 태그 키보드 동작과 저장 HTML 형식은 변경하지 않았습니다.
- 서버 제한은 Post 모델의 기존 `max_length`를 기준으로 삼아 세션 API와 Developer API가 같은 검증 경로를 사용합니다.
- E2E 비대화를 피하기 위해 영구 브라우저 시나리오는 추가하지 않고, 실제 DEBUG 브라우저에서 일회성 smoke 후 검증 데이터를 삭제했습니다.

## 🧪 Verification Guide
### How to verify
1. `/write`에서 부제목을 120자까지 입력하고 `120/120` 안내와 추가 입력 차단을 확인합니다.
2. 태그 추가에서 Enter, Escape, 빈 입력 Backspace를 사용하고 제거 버튼을 키보드로 탐색합니다.
3. 본문 이미지를 선택해 `설정`에서 대체 텍스트와 캡션을 서로 다른 값으로 수정한 뒤 임시 저장하고 다시 불러옵니다.
4. 동일 동작을 375px 모바일 폭에서 확인합니다.

### Expected result
- 기존 포스트 API와 저장 형식을 유지하면서 부제목 초과값은 일관되게 거절되고, 태그와 이미지 설명 입력은 터치·키보드·보조기기에서 명확하게 동작합니다.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed (관련 백엔드 84건, islands build, entry budgets, actual desktop/mobile/keyboard smoke)
- [x] Documentation updated (Ocean Brain task log)
