### PR TITLE
♻️ Improve settings usability and post management UX

### DIFF
--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/SettingsEmptyState.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/SettingsEmptyState.tsx
@@ -19,7 +19,7 @@ const SettingsEmptyState = ({
     action,
     className = ''
 }: SettingsEmptyStateProps) => {
-    const containerClasses = ['py-10 text-center border border-dashed border-line rounded-2xl', className]
+    const containerClasses = ['rounded-2xl border border-dashed border-line py-10 text-center', className]
         .filter(Boolean)
         .join(' ');
 
@@ -27,14 +27,14 @@ const SettingsEmptyState = ({
         <div className={containerClasses}>
             <div
                 aria-hidden="true"
-                className="mb-3 inline-flex h-12 w-12 items-center justify-center rounded-xl bg-surface-subtle text-content-hint [&>svg]:h-5 [&>svg]:w-5">
+                className="mb-2.5 inline-flex h-10 w-10 items-center justify-center rounded-lg bg-surface-subtle text-content-hint [&>svg]:h-4 [&>svg]:w-4">
                 {icon ?? <i className={`${iconClassName} text-lg`} />}
             </div>
             <h3 className={`text-base font-semibold text-content ${action && !description ? 'mb-5' : description ? 'mb-1' : ''}`}>
                 {title}
             </h3>
             {description && (
-                <p className={`text-content-secondary text-sm ${action ? 'mb-5' : ''}`}>{description}</p>
+                <p className={`text-sm text-content-secondary ${action ? 'mb-5' : ''}`}>{description}</p>
             )}
             {action}
         </div>

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/SettingsHeader.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/SettingsHeader.tsx
@@ -15,30 +15,34 @@ const SettingsHeader = ({
 }: SettingsHeaderProps) => {
     if (actionPosition === 'right') {
         return (
-            <div className="mb-6">
-                <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-                    <div className="space-y-2">
-                        <h2 className="text-2xl font-semibold tracking-tight text-content">{title}</h2>
+            <div className="mb-5">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                    <div className="space-y-1">
+                        <h1 className="text-xl font-semibold tracking-tight text-content">{title}</h1>
                         {description && (
                             <p className="text-sm text-content-secondary leading-relaxed">{description}</p>
                         )}
                     </div>
-                    {action && <div className="flex-shrink-0">{action}</div>}
+                    {action && (
+                        <div className="flex flex-shrink-0 justify-end">
+                            {action}
+                        </div>
+                    )}
                 </div>
             </div>
         );
     }
 
     return (
-        <div className="mb-6">
-            <div className="space-y-2">
-                <h2 className="text-2xl font-semibold tracking-tight text-content">{title}</h2>
+        <div className="mb-5">
+            <div className="space-y-1">
+                <h1 className="text-xl font-semibold tracking-tight text-content">{title}</h1>
                 {description && (
                     <p className="text-sm text-content-secondary leading-relaxed">{description}</p>
                 )}
             </div>
             {action && (
-                <div className="mt-6">
+                <div className="mt-4">
                     {action}
                 </div>
             )}

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/SettingsHeaderAction.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/SettingsHeaderAction.tsx
@@ -1,0 +1,20 @@
+import type { ComponentProps } from 'react';
+import { Button } from '~/components/shared';
+
+type SettingsHeaderActionProps = Omit<ComponentProps<typeof Button>, 'size'>;
+
+const SettingsHeaderAction = ({
+    className = '',
+    ...props
+}: SettingsHeaderActionProps) => {
+    return (
+        <Button
+            density="compact"
+            {...props}
+            size="sm"
+            className={`min-h-11! w-auto [@media(pointer:fine)]:min-h-9! ${className}`}
+        />
+    );
+};
+
+export default SettingsHeaderAction;

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/SettingsLayout.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/SettingsLayout.tsx
@@ -10,14 +10,14 @@ export const SettingsLayout = () => {
     return (
         <div className="max-w-7xl w-full mx-auto px-4 sm:px-6">
             <SettingsMobileNavigation currentPath={currentPath} />
-            <div className="flex flex-col xl:flex-row xl:items-start gap-8 xl:gap-12">
+            <div className="flex flex-col gap-6 xl:flex-row xl:items-start xl:gap-8">
                 <SettingsDesktopNavigation currentPath={currentPath} />
                 {/* Main Content */}
-                <main className="flex-1 min-w-0 py-6">
+                <div className="flex-1 min-w-0 py-6">
                     <Suspense fallback={<LoadingState type="form" />}>
                         <Outlet />
                     </Suspense>
-                </main>
+                </div>
             </div>
         </div>
     );

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/SettingsListItem.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/SettingsListItem.tsx
@@ -7,7 +7,7 @@ const LIST_ITEM_SHELL = 'bg-surface ring-1 ring-line/60 rounded-2xl transition-a
 const LIST_ITEM_CONTENT = 'p-5';
 const LIST_ITEM_ROW = 'flex items-center gap-3';
 const LIST_ITEM_ACTIONS = 'flex gap-2 flex-shrink-0';
-const LIST_ITEM_DRAG_HANDLE = 'inline-flex min-h-11 min-w-11 cursor-grab items-center justify-center active:cursor-grabbing text-content-hint hover:text-content-secondary hover:bg-surface-subtle rounded-lg transition-colors -ml-2';
+const LIST_ITEM_DRAG_HANDLE = 'inline-flex min-h-11 min-w-11 cursor-grab items-center justify-center active:cursor-grabbing text-content-hint hover:text-content-secondary hover:bg-surface-subtle rounded-lg transition-colors -ml-2 [@media(pointer:fine)]:min-h-9 [@media(pointer:fine)]:min-w-9';
 
 interface DragHandleProps {
     attributes: DraggableAttributes;

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/SettingsNavigation.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/SettingsNavigation.tsx
@@ -289,7 +289,7 @@ const SettingsModeLink = ({
     return (
         <a
             href={href}
-            className={`inline-flex items-center gap-1.5 font-medium text-content-hint transition-colors ${INTERACTION_DURATION} hover:text-content-secondary ${mobile ? 'min-h-11 rounded-xl px-3 text-sm hover:bg-surface-subtle' : 'w-fit text-xs'}`}>
+            className={`inline-flex min-h-11 items-center gap-1.5 font-medium text-content-hint transition-colors ${INTERACTION_DURATION} hover:text-content-secondary ${mobile ? 'rounded-xl px-3 text-sm hover:bg-surface-subtle' : 'w-fit rounded-lg text-xs [@media(pointer:fine)]:min-h-9'}`}>
             <ModeIcon aria-hidden="true" className="h-3.5 w-3.5 shrink-0 text-content-hint" />
             <span>{label}</span>
             {!isAdminMode && (
@@ -338,9 +338,9 @@ export const SettingsMobileNavigation = ({ currentPath }: SettingsNavigationProp
         if (!canShowItem(item, isEditor, isStaff, canUseTelegramIntegration)) return null;
 
         const isActive = item.path !== 'admin' && normalizePath(currentPath, basePath) === normalizePath(item.path, basePath);
-        const baseClasses = `flex items-center px-4 py-3 rounded-xl transition-all ${INTERACTION_DURATION} active:scale-95 motion-reduce:transform-none motion-reduce:transition-none group`;
+        const baseClasses = `group flex min-h-11 items-center rounded-lg px-3 py-2.5 text-sm transition-all ${INTERACTION_DURATION} active:scale-95 motion-reduce:transform-none motion-reduce:transition-none`;
         const activeClasses = isActive
-            ? 'bg-surface-subtle text-content font-bold'
+            ? 'bg-surface-subtle text-content font-semibold'
             : 'text-content-secondary hover:bg-surface-subtle hover:text-content font-medium';
         const iconClasses = isActive ? 'text-content' : 'text-content-hint';
         const ItemIcon = item.icon;
@@ -389,9 +389,9 @@ export const SettingsMobileNavigation = ({ currentPath }: SettingsNavigationProp
 
         return (
             <div key={section.title}>
-                <h3 className="px-4 mb-1 text-xs font-bold text-content-hint uppercase tracking-wider">
+                <p className="px-4 mb-1 text-xs font-bold text-content-hint uppercase tracking-wider">
                     {section.title}
-                </h3>
+                </p>
                 <ul className="space-y-1">
                     {visibleItems.map(renderNavItem)}
                 </ul>
@@ -426,10 +426,10 @@ export const SettingsMobileNavigation = ({ currentPath }: SettingsNavigationProp
                     <Dialog.Content className={`fixed z-50 bg-surface shadow-2xl transition ease-in-out data-[state=open]:animate-in data-[state=open]:slide-in-from-left ${ENTRANCE_DURATION} motion-reduce:animate-none motion-reduce:transition-none inset-y-0 left-0 h-full w-[280px] overflow-y-auto outline-none`}>
                         <div className="p-6">
                             <Dialog.Title className="sr-only">{settingsLabel} 메뉴</Dialog.Title>
-                            <div className="flex items-center justify-between mb-8">
-                                <h2 className="text-2xl font-bold text-content tracking-tight">
+                            <div className="mb-6 flex items-center justify-between">
+                                <p className="text-xl font-semibold tracking-tight text-content">
                                     {settingsLabel}
-                                </h2>
+                                </p>
                                 <Dialog.Close asChild>
                                     <button
                                         type="button"
@@ -446,7 +446,7 @@ export const SettingsMobileNavigation = ({ currentPath }: SettingsNavigationProp
                                 </div>
                             )}
 
-                            <div className="space-y-8">
+                            <div className="space-y-6">
                                 {navigationSections.map(renderSection)}
                             </div>
                         </div>
@@ -479,12 +479,12 @@ export const SettingsDesktopNavigation = ({ currentPath }: SettingsNavigationPro
         if (!canShowItem(item, isEditor, isStaff, canUseTelegramIntegration)) return null;
 
         const isActive = item.path !== 'admin' && normalizePath(currentPath, basePath) === normalizePath(item.path, basePath);
-        const baseClasses = `flex items-center px-5 rounded-xl transition-all ${INTERACTION_DURATION} active:scale-95`;
+        const baseClasses = `flex min-h-11 items-center rounded-lg px-3 text-sm transition-all ${INTERACTION_DURATION} active:scale-95 [@media(pointer:fine)]:min-h-9`;
         const activeClasses = isActive
             ? 'bg-surface-subtle text-content font-semibold'
             : 'text-content-secondary hover:bg-surface-subtle hover:text-content font-medium';
         const iconClasses = isActive ? 'text-content' : 'text-content-hint';
-        const desktopClasses = 'xl:py-2 group';
+        const desktopClasses = 'group py-2';
         const ItemIcon = item.icon;
 
         if (item.path === 'admin') {
@@ -496,7 +496,7 @@ export const SettingsDesktopNavigation = ({ currentPath }: SettingsNavigationPro
                         onClick={() => handleNavClick(item)}>
                         <span
                             aria-hidden="true"
-                            className={`mr-4 inline-flex w-7 shrink-0 justify-center transition-colors ${iconClasses} group-hover:text-content-secondary`}>
+                            className={`mr-3 inline-flex w-5 shrink-0 justify-center transition-colors ${iconClasses} group-hover:text-content-secondary`}>
                             <ItemIcon className="h-4 w-4" />
                         </span>
                         <span className="min-w-0 flex-1">{item.name}</span>
@@ -514,7 +514,7 @@ export const SettingsDesktopNavigation = ({ currentPath }: SettingsNavigationPro
                     onClick={() => handleNavClick(item)}>
                     <span
                         aria-hidden="true"
-                        className={`mr-4 inline-flex w-7 shrink-0 justify-center transition-colors ${iconClasses} group-hover:text-content-secondary`}>
+                        className={`mr-3 inline-flex w-5 shrink-0 justify-center transition-colors ${iconClasses} group-hover:text-content-secondary`}>
                         <ItemIcon className="h-4 w-4" />
                     </span>
                     <span className="min-w-0 flex-1">{item.name}</span>
@@ -531,10 +531,10 @@ export const SettingsDesktopNavigation = ({ currentPath }: SettingsNavigationPro
 
         return (
             <div key={section.title}>
-                <h3 className="px-5 mb-1 text-sm font-semibold text-content-hint uppercase tracking-wider">
+                <p className="mb-1 px-3 text-xs font-semibold uppercase tracking-wider text-content-hint">
                     {section.title}
-                </h3>
-                <ul className="space-y-2">
+                </p>
+                <ul className="space-y-1">
                     {visibleItems.map(renderNavItem)}
                 </ul>
             </div>
@@ -542,11 +542,11 @@ export const SettingsDesktopNavigation = ({ currentPath }: SettingsNavigationPro
     };
 
     return (
-        <aside className="hidden xl:block w-72 flex-shrink-0 mt-8 self-start sticky top-24">
-            <div className="px-5 mb-6">
-                <h2 className="text-2xl font-semibold text-content tracking-tight">
+        <aside className="sticky top-24 mt-8 hidden w-64 flex-shrink-0 self-start xl:block">
+            <div className="mb-5 px-3">
+                <p className="text-lg font-semibold tracking-tight text-content">
                     {settingsLabel}
-                </h2>
+                </p>
                 {isStaff && (
                     <div className="mt-3">
                         <SettingsModeLink settingsMode={settingsMode} isStaff={isStaff} />
@@ -554,7 +554,7 @@ export const SettingsDesktopNavigation = ({ currentPath }: SettingsNavigationPro
                 )}
             </div>
             <div className="max-h-[calc(100vh-224px)] overflow-y-auto overscroll-contain pr-2">
-                <nav className="space-y-8 pb-4">
+                <nav className="space-y-6 pb-4">
                     {navigationSections.map(renderSection)}
                 </nav>
             </div>

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/WebhookChannelManager.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/WebhookChannelManager.tsx
@@ -23,7 +23,12 @@ import {
     SETTINGS_LIST_META,
     SETTINGS_LIST_TITLE
 } from '~/styles/settingsStyles';
-import { SettingsEmptyState, SettingsHeader, SettingsListItem } from '.';
+import {
+    SettingsEmptyState,
+    SettingsHeader,
+    SettingsHeaderAction,
+    SettingsListItem
+} from '.';
 import type { WebhookChannel } from '~/lib/api/settings';
 import type { Response } from '~/lib/http.module';
 
@@ -278,16 +283,14 @@ const WebhookChannelManager = ({
     };
 
     const createAction = (
-        <Button
+        <SettingsHeaderAction
             variant="primary"
-            size="md"
-            className="min-h-11! w-full sm:w-auto"
             onClick={() => {
                 reset();
                 setShowAddForm(true);
             }}>
             {addButtonLabel}
-        </Button>
+        </SettingsHeaderAction>
     );
 
     return (
@@ -310,6 +313,7 @@ const WebhookChannelManager = ({
                                 웹훅 URL <span className="text-danger">*</span>
                             </label>
                             <Input
+                                density="compact"
                                 id="webhookUrl"
                                 type="url"
                                 placeholder="https://example.com/webhook"
@@ -353,6 +357,7 @@ const WebhookChannelManager = ({
                                 표시 이름 (선택)
                             </label>
                             <Input
+                                density="compact"
                                 id="webhookName"
                                 type="text"
                                 placeholder="예: 새 포스트 알림"
@@ -361,10 +366,11 @@ const WebhookChannelManager = ({
                         </div>
                         <div className="flex items-center justify-between gap-3">
                             <Button
+                                density="compact"
                                 variant="ghost"
                                 size="md"
                                 type="button"
-                                className="min-h-11!"
+                                className="min-h-11! [@media(pointer:fine)]:min-h-10!"
                                 onClick={handleCancel}
                                 disabled={isAdding || isTesting}>
                                 취소
@@ -372,20 +378,22 @@ const WebhookChannelManager = ({
 
                             <div className="flex flex-wrap items-center gap-3">
                                 <Button
+                                    density="compact"
                                     variant="secondary"
                                     size="md"
                                     type="button"
-                                    className="min-h-11!"
+                                    className="min-h-11! [@media(pointer:fine)]:min-h-10!"
                                     isLoading={isTesting}
                                     disabled={isAdding}
                                     onClick={handleTest}>
                                     {isTesting ? '전송 중...' : '테스트'}
                                 </Button>
                                 <Button
+                                    density="compact"
                                     variant="primary"
                                     size="md"
                                     type="submit"
-                                    className="min-h-11!"
+                                    className="min-h-11! [@media(pointer:fine)]:min-h-10!"
                                     isLoading={isAdding}
                                     disabled={isTesting}>
                                     {isAdding ? '추가 중...' : '추가'}
@@ -410,8 +418,9 @@ const WebhookChannelManager = ({
                             }
                             actions={
                                 <Dropdown
+                                    density="compact"
                                     triggerAriaLabel={`${channel.name || '이름 없는 채널'} 웹훅 메뉴 열기`}
-                                    triggerClassName="min-h-11 min-w-11"
+                                    triggerClassName="min-h-11 min-w-11 [@media(pointer:fine)]:min-h-9 [@media(pointer:fine)]:min-w-9"
                                     items={[
                                         {
                                             label: '삭제',

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/index.ts
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/index.ts
@@ -1,4 +1,5 @@
 export { default as SettingsHeader } from './SettingsHeader';
+export { default as SettingsHeaderAction } from './SettingsHeaderAction';
 export { default as SettingsListItem } from './SettingsListItem';
 export { default as SettingsEmptyState } from './SettingsEmptyState';
 export { default as WebhookChannelManager } from './WebhookChannelManager';

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/AccountSetting/components/NameSection.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/AccountSetting/components/NameSection.tsx
@@ -52,6 +52,7 @@ const NameSection = ({ initialName, isLoading, onSubmit }: NameSectionProps) => 
             className="pt-6"
             onSubmit={handleSubmit(handleFormSubmit)}>
             <Input
+                density="compact"
                 type="text"
                 label="사용자 이름"
                 placeholder="사용자 이름"
@@ -61,10 +62,11 @@ const NameSection = ({ initialName, isLoading, onSubmit }: NameSectionProps) => 
             />
             <div className="mt-4 flex justify-end">
                 <Button
+                    density="compact"
                     type="submit"
                     variant="primary"
-                    size="lg"
-                    className="w-full sm:w-auto"
+                    size="md"
+                    className="min-h-11! [@media(pointer:fine)]:min-h-10!"
                     disabled={!isDirty || !isValid}
                     isLoading={isLoading}
                     leftIcon={!isLoading ? <Save className="h-4 w-4" /> : undefined}>

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/AccountSetting/components/PasswordSection.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/AccountSetting/components/PasswordSection.tsx
@@ -64,6 +64,7 @@ const PasswordSection = ({ isLoading, onSubmit }: PasswordSectionProps) => {
                 className="mb-6">
                 <div className="mb-4">
                     <Input
+                        density="compact"
                         label="새 비밀번호"
                         type="password"
                         placeholder="새 비밀번호"
@@ -75,6 +76,7 @@ const PasswordSection = ({ isLoading, onSubmit }: PasswordSectionProps) => {
                 </div>
                 <div className="mb-6">
                     <Input
+                        density="compact"
                         label="비밀번호 확인"
                         type="password"
                         placeholder="비밀번호 확인"
@@ -85,10 +87,11 @@ const PasswordSection = ({ isLoading, onSubmit }: PasswordSectionProps) => {
                 </div>
                 <div className="flex justify-end">
                     <Button
+                        density="compact"
                         type="submit"
                         variant="primary"
-                        size="lg"
-                        className="w-full sm:w-auto"
+                        size="md"
+                        className="min-h-11! [@media(pointer:fine)]:min-h-10!"
                         disabled={!isDirty || !isValid}
                         isLoading={isLoading}
                         leftIcon={!isLoading ? <Save className="h-4 w-4" /> : undefined}>

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/AccountSetting/components/SecuritySection.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/AccountSetting/components/SecuritySection.tsx
@@ -19,9 +19,10 @@ const SecuritySection = ({ has2fa, onToggle2FA, onDeleteAccount }: SecuritySecti
                         <p className="font-medium text-content">2차 인증</p>
                     </div>
                     <Button
+                        density="compact"
                         variant="primary"
-                        size="lg"
-                        className="w-full sm:w-auto"
+                        size="sm"
+                        className="min-h-11! self-end [@media(pointer:fine)]:min-h-9! sm:self-auto"
                         onClick={() => onToggle2FA(!has2fa)}>
                         {has2fa ? '중지' : '활성화'}
                     </Button>
@@ -33,7 +34,7 @@ const SecuritySection = ({ has2fa, onToggle2FA, onDeleteAccount }: SecuritySecti
                 className="rounded-2xl border border-danger-line bg-danger-surface/40 p-6 md:p-8">
                 <div className="flex items-center gap-3 text-danger">
                     <AlertTriangle className="h-5 w-5" />
-                    <h3 id="danger-zone-title" className="text-lg font-semibold tracking-tight">
+                    <h3 id="danger-zone-title" className="text-base font-semibold">
                         위험 영역
                     </h3>
                 </div>
@@ -43,9 +44,10 @@ const SecuritySection = ({ has2fa, onToggle2FA, onDeleteAccount }: SecuritySecti
                         <p className="text-sm text-content-secondary">모든 데이터가 영구적으로 삭제되며 복구할 수 없습니다.</p>
                     </div>
                     <Button
+                        density="compact"
                         variant="danger"
-                        size="lg"
-                        className="w-full shrink-0 sm:w-auto"
+                        size="sm"
+                        className="min-h-11! shrink-0 self-end [@media(pointer:fine)]:min-h-9! sm:self-auto"
                         leftIcon={<Trash2 className="h-4 w-4" />}
                         onClick={onDeleteAccount}>
                         삭제

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/AccountSetting/components/TwoFactorModal.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/AccountSetting/components/TwoFactorModal.tsx
@@ -79,6 +79,7 @@ const TwoFactorModal = ({
                         인증 앱에 표시된 6자리 코드를 입력하세요
                     </label>
                     <Input
+                        density="compact"
                         id="two-factor-verification-code"
                         type="text"
                         placeholder="000000"
@@ -95,15 +96,19 @@ const TwoFactorModal = ({
 
                 <div className="flex gap-3">
                     <Button
+                        density="compact"
                         variant="secondary"
                         size="md"
+                        className="min-h-11! [@media(pointer:fine)]:min-h-10!"
                         fullWidth
                         onClick={handleClose}>
                         취소
                     </Button>
                     <Button
+                        density="compact"
                         variant="primary"
                         size="md"
+                        className="min-h-11! [@media(pointer:fine)]:min-h-10!"
                         fullWidth
                         isLoading={isVerifying}
                         onClick={handleVerify}>

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/AccountSetting/components/UsernameSection.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/AccountSetting/components/UsernameSection.tsx
@@ -52,6 +52,7 @@ const UsernameSection = ({ initialUsername, isLoading, onSubmit }: UsernameSecti
             className="pb-6"
             onSubmit={handleSubmit(handleFormSubmit)}>
             <Input
+                density="compact"
                 type="text"
                 label="사용자 필명"
                 placeholder="사용자 필명"
@@ -62,10 +63,11 @@ const UsernameSection = ({ initialUsername, isLoading, onSubmit }: UsernameSecti
             />
             <div className="mt-4 flex justify-end">
                 <Button
+                    density="compact"
                     type="submit"
                     variant="primary"
-                    size="lg"
-                    className="w-full sm:w-auto"
+                    size="md"
+                    className="min-h-11! [@media(pointer:fine)]:min-h-10!"
                     disabled={!isDirty || !isValid}
                     isLoading={isLoading}
                     leftIcon={!isLoading ? <Save className="h-4 w-4" /> : undefined}>

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/AdminIntegrationSetting/AdminIntegrationSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/AdminIntegrationSetting/AdminIntegrationSetting.tsx
@@ -166,6 +166,7 @@ const AdminIntegrationSetting = () => {
 
                     <div className="grid gap-4 md:grid-cols-2">
                         <Input
+                            density="compact"
                             label="봇 사용자명"
                             name="blex_telegram_bot_public_value"
                             autoComplete="off"
@@ -180,6 +181,7 @@ const AdminIntegrationSetting = () => {
                             helperText="@ 없이 입력해도 됩니다."
                         />
                         <Input
+                            density="compact"
                             label="봇 토큰"
                             type="password"
                             name="blex_telegram_bot_private_value"
@@ -216,6 +218,7 @@ const AdminIntegrationSetting = () => {
 
             <div className="sticky bottom-0 z-10 -mx-4 flex justify-end bg-surface-page/95 px-4 py-3 backdrop-blur md:mx-0 md:px-0">
                 <Button
+                    density="compact"
                     type="submit"
                     variant="primary"
                     size="md"

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/BannerSetting/components/BannerList.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/BannerSetting/components/BannerList.tsx
@@ -82,8 +82,9 @@ const SortableBannerItem = ({ banner, onEdit, onDelete, onToggleActive }: Sortab
                 }}
                 actions={
                     <Dropdown
+                        density="compact"
                         triggerAriaLabel={`${banner.title} 배너 메뉴 열기`}
-                        triggerClassName="min-h-11 min-w-11"
+                        triggerClassName="min-h-11 min-w-11 [@media(pointer:fine)]:min-h-9 [@media(pointer:fine)]:min-w-9"
                         items={[
                             {
                                 label: banner.isActive ? '비활성화' : '활성화',

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/DeveloperApiSetting/DeveloperApiSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/DeveloperApiSetting/DeveloperApiSetting.tsx
@@ -52,7 +52,7 @@ const scopeOptions: Array<{
     }
 ];
 
-const headerLinkClassName = 'inline-flex min-h-11 w-full items-center justify-center gap-2 whitespace-nowrap rounded-lg border border-line-strong bg-surface-elevated px-3 py-2 text-xs font-semibold text-content shadow-sm transition-colors hover:border-line hover:bg-surface-subtle focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-line-strong/70';
+const headerLinkClassName = 'inline-flex min-h-11 w-full items-center justify-center gap-2 whitespace-nowrap rounded-lg border border-line-strong bg-surface-elevated px-3 py-1.5 text-xs font-semibold text-content shadow-sm transition-colors hover:border-line hover:bg-surface-subtle focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-line-strong/70 [@media(pointer:fine)]:min-h-9 sm:w-auto';
 
 const formatDateTime = (value: string | null) => {
     if (!value) return '없음';
@@ -156,10 +156,11 @@ const TokenList = ({ tokens, revokingTokenId, onRevoke }: TokenListProps) => (
 
                     {canRevoke && (
                         <Button
+                            density="compact"
                             type="button"
                             variant="danger"
                             size="sm"
-                            className="min-h-11! w-full sm:w-auto"
+                            className="min-h-11! w-full [@media(pointer:fine)]:min-h-9! sm:w-auto"
                             isLoading={isRevoking}
                             onClick={() => onRevoke(token)}
                             leftIcon={!isRevoking ? <Ban aria-hidden className="h-4 w-4" /> : undefined}>
@@ -328,6 +329,7 @@ const DeveloperApiSetting = () => {
                 icon={<KeyRound aria-hidden className="h-4 w-4" />}>
                 <div className="space-y-5">
                     <Input
+                        density="compact"
                         label="토큰 이름"
                         value={tokenName}
                         onChange={(event) => setTokenName(event.target.value)}
@@ -362,6 +364,7 @@ const DeveloperApiSetting = () => {
                     </div>
 
                     <Input
+                        density="compact"
                         label="만료 기간(일)"
                         type="number"
                         min={1}
@@ -383,9 +386,10 @@ const DeveloperApiSetting = () => {
 
                     <div className="flex justify-end">
                         <Button
+                            density="compact"
                             type="button"
                             variant="primary"
-                            className="min-h-11! w-full sm:w-auto"
+                            className="min-h-11! w-full [@media(pointer:fine)]:min-h-10! sm:w-auto"
                             isLoading={createTokenMutation.isPending}
                             onClick={handleCreateToken}
                             leftIcon={!createTokenMutation.isPending ? <KeyRound aria-hidden className="h-4 w-4" /> : undefined}>
@@ -408,10 +412,11 @@ const DeveloperApiSetting = () => {
                                         {createdToken.token}
                                     </code>
                                     <Button
+                                        density="compact"
                                         type="button"
                                         variant="secondary"
                                         size="sm"
-                                        className="min-h-11! w-full sm:w-auto"
+                                        className="min-h-11! w-full [@media(pointer:fine)]:min-h-9! sm:w-auto"
                                         onClick={() => handleCopy(createdToken.token)}
                                         leftIcon={<Copy aria-hidden className="h-4 w-4" />}>
                                         복사

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/DraftsSetting/DraftsSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/DraftsSetting/DraftsSetting.tsx
@@ -1,5 +1,4 @@
-import { SettingsHeader } from '../../components';
-import { Button } from '~/components/shared';
+import { SettingsHeader, SettingsHeaderAction } from '../../components';
 import { DraftPostListContent } from '../PostsSetting/components';
 
 const DraftsSetting = () => {
@@ -9,13 +8,11 @@ const DraftsSetting = () => {
                 title="임시 포스트"
                 actionPosition="right"
                 action={
-                    <Button
+                    <SettingsHeaderAction
                         variant="primary"
-                        size="md"
-                        className="w-full sm:w-auto"
                         onClick={() => window.location.assign('/write')}>
                         새 포스트 작성
-                    </Button>
+                    </SettingsHeaderAction>
                 }
             />
 

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/FormsSetting/FormsSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/FormsSetting/FormsSetting.tsx
@@ -5,7 +5,12 @@ import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { FileText, Pencil, Trash2 } from '@blex/ui/icons';
-import { SettingsEmptyState, SettingsHeader, SettingsListItem } from '../../components';
+import {
+    SettingsEmptyState,
+    SettingsHeader,
+    SettingsHeaderAction,
+    SettingsListItem
+} from '../../components';
 import { Button, Input, Dropdown } from '~/components/shared';
 import {
     getSettingsIconClass,
@@ -149,13 +154,11 @@ const FormsManagement = () => {
 
     const forms = formsData?.forms || [];
     const createAction = (
-        <Button
+        <SettingsHeaderAction
             variant="primary"
-            size="md"
-            className="min-h-11! w-full sm:w-auto"
             onClick={handleCreateForm}>
             새 서식 추가
-        </Button>
+        </SettingsHeaderAction>
     );
 
     return (
@@ -176,6 +179,7 @@ const FormsManagement = () => {
                     </h3>
                     <div className="space-y-4">
                         <Input
+                            density="compact"
                             label="제목"
                             type="text"
                             placeholder="서식 제목을 입력하세요"
@@ -184,6 +188,7 @@ const FormsManagement = () => {
                         />
 
                         <Input
+                            density="compact"
                             label="내용"
                             multiline
                             rows={8}
@@ -194,20 +199,22 @@ const FormsManagement = () => {
 
                         <div className="flex items-center justify-between gap-3">
                             <Button
+                                density="compact"
                                 type="button"
                                 variant="ghost"
                                 size="md"
-                                className="min-h-11!"
+                                className="min-h-11! [@media(pointer:fine)]:min-h-10!"
                                 onClick={closeForm}
                                 disabled={isSubmitting}>
                                 취소
                             </Button>
                             <div className="flex items-center gap-3">
                                 <Button
+                                    density="compact"
                                     type="submit"
                                     variant="primary"
                                     size="md"
-                                    className="min-h-11!"
+                                    className="min-h-11! [@media(pointer:fine)]:min-h-10!"
                                     isLoading={isSubmitting}>
                                     {isSubmitting ? (editingForm ? '수정 중...' : '생성 중...') : (editingForm ? '서식 수정' : '서식 생성')}
                                 </Button>
@@ -229,8 +236,9 @@ const FormsManagement = () => {
                             }
                             actions={
                                 <Dropdown
+                                    density="compact"
                                     triggerAriaLabel={`${form.title} 서식 메뉴 열기`}
-                                    triggerClassName="min-h-11 min-w-11"
+                                    triggerClassName="min-h-11 min-w-11 [@media(pointer:fine)]:min-h-9 [@media(pointer:fine)]:min-w-9"
                                     items={[
                                         {
                                             label: '수정',

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/GlobalBannerSetting/components/GlobalBannerList.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/GlobalBannerSetting/components/GlobalBannerList.tsx
@@ -82,8 +82,9 @@ const SortableBannerItem = ({ banner, onEdit, onDelete, onToggleActive }: Sortab
                 }}
                 actions={
                     <Dropdown
+                        density="compact"
                         triggerAriaLabel={`${banner.title} 전역 배너 메뉴 열기`}
-                        triggerClassName="min-h-11 min-w-11"
+                        triggerClassName="min-h-11 min-w-11 [@media(pointer:fine)]:min-h-9 [@media(pointer:fine)]:min-w-9"
                         items={[
                             {
                                 label: banner.isActive ? '비활성화' : '활성화',

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/IntegrationSetting/IntegrationSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/IntegrationSetting/IntegrationSetting.tsx
@@ -130,6 +130,7 @@ const IntegrationSettings = () => {
                             </div>
                         </div>
                         <Button
+                            density="compact"
                             variant="danger"
                             size="md"
                             isLoading={isDisconnecting}
@@ -178,6 +179,7 @@ const IntegrationSettings = () => {
                                                 {telegramToken}
                                             </code>
                                             <Button
+                                                density="compact"
                                                 type="button"
                                                 variant="secondary"
                                                 size="sm"
@@ -189,6 +191,7 @@ const IntegrationSettings = () => {
                                 ) : (
                                     <div className="rounded-xl border border-dashed border-line bg-surface-subtle p-4">
                                         <Button
+                                            density="compact"
                                             variant="primary"
                                             size="md"
                                             isLoading={isGeneratingToken}

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/LoginSetting/LoginSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/LoginSetting/LoginSetting.tsx
@@ -242,6 +242,7 @@ const ProviderCredentialFields = ({
     <div className="space-y-4">
         <div className="grid gap-4 md:grid-cols-2">
             <Input
+                density="compact"
                 label="Client ID"
                 name={`blex_${provider.key}_oauth_public_value`}
                 autoComplete="off"
@@ -255,6 +256,7 @@ const ProviderCredentialFields = ({
                 onChange={(event) => onUpdate(provider.key, { clientId: event.target.value })}
             />
             <Input
+                density="compact"
                 label="Client Secret"
                 type="password"
                 name={`blex_${provider.key}_oauth_private_value`}
@@ -532,6 +534,7 @@ const LoginSetting = () => {
                 icon={<UserCog aria-hidden="true" className="h-4 w-4" />}>
                 <div className="space-y-4">
                     <Input
+                        density="compact"
                         label="가입 환영 메시지"
                         multiline
                         rows={3}
@@ -541,12 +544,14 @@ const LoginSetting = () => {
                         helperText="{name}을 사용하면 사용자 이름으로 치환됩니다."
                     />
                     <Input
+                        density="compact"
                         label="환영 알림 클릭 URL"
                         placeholder="/"
                         value={loginSettings.welcomeUrl}
                         onChange={(event) => updateLoginSettingsForm({ welcomeUrl: event.target.value })}
                     />
                     <Input
+                        density="compact"
                         label="탈퇴 후 리다이렉트 URL"
                         placeholder="https://forms.example.com/exit-survey"
                         value={loginSettings.deletionRedirectUrl}
@@ -594,6 +599,7 @@ const LoginSetting = () => {
 
                     <div className="grid gap-4 md:grid-cols-2">
                         <Input
+                            density="compact"
                             label="Site Key"
                             name="blex_hcaptcha_public_value"
                             autoComplete="off"
@@ -607,6 +613,7 @@ const LoginSetting = () => {
                             placeholder="hCaptcha Site Key"
                         />
                         <Input
+                            density="compact"
                             label="Secret Key"
                             type="password"
                             name="blex_hcaptcha_private_value"
@@ -644,10 +651,11 @@ const LoginSetting = () => {
 
             <div className="sticky bottom-0 z-10 -mx-4 flex justify-end bg-surface-page/95 px-4 py-3 backdrop-blur md:mx-0 md:px-0">
                 <Button
+                    density="compact"
                     type="submit"
                     variant="primary"
                     size="md"
-                    className="h-11 w-full sm:w-auto"
+                    className="h-11 w-full [@media(pointer:fine)]:h-10 sm:w-auto"
                     isLoading={updateMutation.isPending}
                     disabled={!isDirty || updateMutation.isPending}
                     leftIcon={!updateMutation.isPending

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/NotifySetting/components/NotificationsSection.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/NotifySetting/components/NotificationsSection.tsx
@@ -1,4 +1,3 @@
-import { Button } from '~/components/shared';
 import {
     BellOff,
     ChevronRight,
@@ -7,7 +6,12 @@ import {
     Settings2
 } from '@blex/ui/icons';
 import { SETTINGS_LIST_TITLE } from '~/styles/settingsStyles';
-import { SettingsEmptyState, SettingsHeader, SettingsListItem } from '../../../components';
+import {
+    SettingsEmptyState,
+    SettingsHeader,
+    SettingsHeaderAction,
+    SettingsListItem
+} from '../../../components';
 import { markNotificationAsRead, type NotifyItem } from '~/lib/api/settings';
 
 interface NotificationsSectionProps {
@@ -39,13 +43,12 @@ const NotificationsSection = ({
                 title="알림"
                 actionPosition="right"
                 action={
-                    <Button
+                    <SettingsHeaderAction
                         variant="secondary"
-                        size="md"
                         leftIcon={<Settings2 aria-hidden="true" className="h-4 w-4" />}
                         onClick={onOpenConfig}>
                         설정
-                    </Button>
+                    </SettingsHeaderAction>
                 }
             />
 

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PinnedPostsSetting/components/AddPinnedPostModal.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PinnedPostsSetting/components/AddPinnedPostModal.tsx
@@ -6,7 +6,7 @@ import {
     Loader2,
     Search
 } from '@blex/ui/icons';
-import { Modal } from '~/components/shared';
+import { Input, Modal } from '~/components/shared';
 import { getMediaPath } from '~/modules/static.module';
 import type { PinnablePostData, PinnablePostsPaginationData } from '~/lib/api/settings';
 import { PinnablePostsPager } from './PinnablePostsPager';
@@ -68,7 +68,7 @@ export const AddPinnedPostModal = ({
             {presentation === 'inline' && (
                 <div className="flex items-start justify-between gap-3 border-b border-line px-5 py-4">
                     <div className="space-y-1">
-                        <h3 className="text-lg font-semibold tracking-tight text-content">
+                        <h3 className="text-base font-semibold text-content">
                             고정할 포스트 선택
                         </h3>
                         <p className="text-sm text-content-secondary">
@@ -79,7 +79,7 @@ export const AddPinnedPostModal = ({
                         <button
                             type="button"
                             onClick={handleClose}
-                            className="inline-flex min-h-11 items-center justify-center rounded-lg px-3 text-sm font-semibold text-content-secondary transition-colors duration-150 hover:bg-surface-subtle hover:text-content active:scale-95">
+                            className="inline-flex min-h-11 items-center justify-center rounded-lg px-3 text-sm font-semibold text-content-secondary transition-colors duration-150 hover:bg-surface-subtle hover:text-content active:scale-95 [@media(pointer:fine)]:min-h-9">
                             선택 취소
                         </button>
                     </div>
@@ -92,17 +92,15 @@ export const AddPinnedPostModal = ({
                         프로필에 표시할 포스트를 선택하세요.
                     </p>
                 )}
-                <div className="relative">
-                    <Search aria-hidden className="absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-content-hint" />
-                    <input
-                        type="text"
-                        aria-label="고정할 포스트 검색"
-                        placeholder="포스트 제목 검색..."
-                        value={searchQuery}
-                        onChange={(e) => onSearchQueryChange?.(e.target.value)}
-                        className="w-full rounded-xl border border-line bg-surface-subtle py-3 pl-10 pr-4 transition-all focus:border-line-strong focus:outline-none focus:ring-2 focus:ring-line/5"
-                    />
-                </div>
+                <Input
+                    type="search"
+                    density="compact"
+                    aria-label="고정할 포스트 검색"
+                    placeholder="포스트 제목 검색..."
+                    value={searchQuery}
+                    onChange={(e) => onSearchQueryChange?.(e.target.value)}
+                    leftIcon={<Search aria-hidden className="h-4 w-4" />}
+                />
             </div>
 
             <div className={`flex-1 overflow-y-auto bg-surface-subtle/30 ${presentation === 'inline' ? 'min-h-0 px-4 py-4' : 'p-4'}`}>
@@ -166,7 +164,7 @@ export const AddPinnedPostModal = ({
                                     )}
 
                                     <div className="min-w-0 flex-1">
-                                        <h4 className="mb-1 truncate text-lg font-bold text-content">
+                                        <h4 className="mb-1 truncate text-base font-semibold text-content">
                                             {post.title}
                                         </h4>
                                         <p className="flex items-center gap-2 text-sm text-content-secondary">

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PinnedPostsSetting/components/PinnablePostInlineList.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PinnedPostsSetting/components/PinnablePostInlineList.tsx
@@ -111,9 +111,10 @@ export const PinnablePostInlineList = ({
                                 }
                                 actions={
                                     <Button
+                                        density="compact"
                                         variant="secondary"
                                         size="sm"
-                                        className="min-h-11!"
+                                        className="min-h-11! [@media(pointer:fine)]:min-h-9!"
                                         onClick={() => onAdd(post.url)}
                                         disabled={isActionDisabled || isLoading}
                                         isLoading={isLoading}>

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PinnedPostsSetting/components/PinnablePostsPager.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PinnedPostsSetting/components/PinnablePostsPager.tsx
@@ -53,18 +53,20 @@ export const PinnablePostsPager = ({
             {pagination.lastPage > 1 && (
                 <div className="flex flex-wrap items-center gap-1.5">
                     <Button
+                        density="compact"
                         variant="secondary"
                         size="sm"
-                        className="min-h-11! min-w-11"
+                        className="min-h-11! min-w-11 [@media(pointer:fine)]:min-h-9! [@media(pointer:fine)]:min-w-9"
                         disabled={!pagination.hasPrevious || isLoading}
                         onClick={() => handlePageMove(1)}
                         aria-label="첫 페이지">
                         <ChevronsLeft aria-hidden className="h-4 w-4" />
                     </Button>
                     <Button
+                        density="compact"
                         variant="secondary"
                         size="sm"
-                        className="min-h-11! min-w-11"
+                        className="min-h-11! min-w-11 [@media(pointer:fine)]:min-h-9! [@media(pointer:fine)]:min-w-9"
                         disabled={!pagination.hasPrevious || isLoading}
                         onClick={() => handlePageMove(currentPage - 1)}
                         aria-label="이전 페이지">
@@ -72,10 +74,11 @@ export const PinnablePostsPager = ({
                     </Button>
                     {visiblePages.map(page => (
                         <Button
+                            density="compact"
                             key={page}
                             variant={page === currentPage ? 'primary' : 'secondary'}
                             size="sm"
-                            className="min-h-11! min-w-11"
+                            className="min-h-11! min-w-11 [@media(pointer:fine)]:min-h-9! [@media(pointer:fine)]:min-w-9"
                             disabled={isLoading}
                             onClick={() => handlePageMove(page)}
                             aria-current={page === currentPage ? 'page' : undefined}>
@@ -83,18 +86,20 @@ export const PinnablePostsPager = ({
                         </Button>
                     ))}
                     <Button
+                        density="compact"
                         variant="secondary"
                         size="sm"
-                        className="min-h-11! min-w-11"
+                        className="min-h-11! min-w-11 [@media(pointer:fine)]:min-h-9! [@media(pointer:fine)]:min-w-9"
                         disabled={!pagination.hasNext || isLoading}
                         onClick={() => handlePageMove(currentPage + 1)}
                         aria-label="다음 페이지">
                         <ChevronRight aria-hidden className="h-4 w-4" />
                     </Button>
                     <Button
+                        density="compact"
                         variant="secondary"
                         size="sm"
-                        className="min-h-11! min-w-11"
+                        className="min-h-11! min-w-11 [@media(pointer:fine)]:min-h-9! [@media(pointer:fine)]:min-w-9"
                         disabled={!pagination.hasNext || isLoading}
                         onClick={() => handlePageMove(pagination.lastPage)}
                         aria-label="마지막 페이지">

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PinnedPostsSetting/components/PinnedPostItem.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PinnedPostsSetting/components/PinnedPostItem.tsx
@@ -73,9 +73,10 @@ export const PinnedPostItem = ({
                 }
                 actions={
                     <Button
+                        density="compact"
                         variant="secondary"
                         size="sm"
-                        className="min-h-11!"
+                        className="min-h-11! [@media(pointer:fine)]:min-h-9!"
                         onClick={handleRemove}>
                         해제
                     </Button>

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PinnedPostsSetting/components/PinnedPostsPanel.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PinnedPostsSetting/components/PinnedPostsPanel.tsx
@@ -1,8 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 import { Trash2 } from '@blex/ui/icons';
-import { SettingsHeader } from '../../../components';
-import { Button } from '~/components/shared';
+import { SettingsHeader, SettingsHeaderAction } from '../../../components';
 import { toast } from '~/utils/toast';
 import {
     addPinnedPost,
@@ -216,14 +215,12 @@ export const PinnedPostsPanel = ({
     const occupiedCount = pinnedPosts.length + reservedCount;
     const canAddMore = occupiedCount < maxCount;
     const action = (
-        <Button
+        <SettingsHeaderAction
             variant="primary"
-            size="md"
-            className="min-h-11! w-full sm:w-auto"
             onClick={handleOpenModal}
             disabled={!canAddMore}>
             {canAddMore ? '포스트 고정하기' : '최대 개수 도달'}
-        </Button>
+        </SettingsHeaderAction>
     );
     const list = (
         <>
@@ -285,7 +282,7 @@ export const PinnedPostsPanel = ({
         <section id="pinned-posts" className="space-y-4">
             <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
                 <div className="space-y-1.5">
-                    <h3 className="text-lg font-semibold tracking-tight text-content">
+                    <h3 className="text-base font-semibold text-content">
                         고정 포스트
                         <span className="ml-2 text-sm font-medium text-content-secondary">
                             {occupiedCount}/{maxCount}

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/PostsSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/PostsSetting.tsx
@@ -6,7 +6,7 @@ import {
     Trash2,
     type LucideIcon
 } from '@blex/ui/icons';
-import { Button } from '~/components/shared';
+import { Button, Tabs } from '~/components/shared';
 import { SettingsHeader } from '../../components';
 import { usePostsFilterState } from './hooks/usePostsData';
 import {
@@ -113,18 +113,20 @@ const PostsSetting = () => {
     );
     const createPostAction = (
         <Button
+            density="compact"
             variant="primary"
             size="md"
-            className="min-h-11! w-full sm:w-auto"
+            className="min-h-11! w-full [@media(pointer:fine)]:min-h-10! sm:w-auto"
             onClick={() => window.location.assign('/write')}>
             새 포스트 작성
         </Button>
     );
     const emptyPostAction = hasContentFilters ? (
         <Button
+            density="compact"
             variant="secondary"
             size="md"
-            className="min-h-11!"
+            className="min-h-11! [@media(pointer:fine)]:min-h-10!"
             onClick={clearFilters}>
             필터 초기화
         </Button>
@@ -134,101 +136,95 @@ const PostsSetting = () => {
         <div>
             <SettingsHeader
                 title={title}
-                actionPosition="right"
-                action={
-                    activeTab !== 'trash' && activeCount !== undefined && activeCount > 0
-                        ? createPostAction
-                        : undefined
-                }
             />
 
-            <div className="mb-6 border-b border-line-light">
-                <div className="flex gap-1 overflow-x-auto" role="tablist" aria-label="포스트 상태">
+            <Tabs.Root
+                value={activeTab}
+                onValueChange={(value) => {
+                    if (isPostStatusTab(value)) handleTabChange(value);
+                }}>
+                <Tabs.List
+                    ariaLabel="포스트 상태"
+                    className="mb-6 gap-1 overflow-x-auto border-line-light">
                     {POST_STATUS_TABS.map((tab) => {
-                        const isActive = activeTab === tab.value;
                         const TabIcon = tab.icon;
                         return (
-                            <button
+                            <Tabs.Trigger
                                 key={tab.value}
-                                type="button"
-                                role="tab"
-                                aria-selected={isActive}
-                                onClick={() => handleTabChange(tab.value)}
-                                className={`inline-flex min-h-11 flex-shrink-0 items-center gap-2 px-3 py-2.5 text-sm font-medium transition-colors ${
-                                    isActive
-                                        ? 'border-b-2 border-action text-content'
-                                        : 'border-b-2 border-transparent text-content-secondary hover:text-content'
-                                }`}>
+                                value={tab.value}
+                                className="inline-flex min-h-11 flex-shrink-0 items-center gap-2 px-3 py-2.5 [@media(pointer:fine)]:min-h-10">
                                 <TabIcon aria-hidden className="h-3.5 w-3.5" />
                                 {tab.label}
-                            </button>
+                            </Tabs.Trigger>
                         );
                     })}
-                </div>
-            </div>
+                </Tabs.List>
 
-            {(activeTab === 'published' || activeTab === 'scheduled') && (
-                <Suspense fallback={<div className="h-32 bg-surface-subtle animate-pulse rounded-lg mb-6" />}>
-                    <PostsFilter
-                        filters={filters}
-                        searchValue={searchValue}
-                        isExpanded={isFilterExpanded}
-                        showClearAction={activeCount !== undefined && activeCount > 0}
-                        onExpandToggle={() => setIsFilterExpanded(!isFilterExpanded)}
-                        onFilterChange={handleFilterChange}
-                        onSearchChange={handleSearchChange}
-                        onClearFilters={clearFilters}
-                        tags={tags}
-                        series={series}
-                    />
-                </Suspense>
-            )}
+                <Tabs.Content value={activeTab}>
+                    {(activeTab === 'published' || activeTab === 'scheduled') && (
+                        <Suspense fallback={<div className="mb-6 h-32 animate-pulse rounded-lg bg-surface-subtle" />}>
+                            <PostsFilter
+                                filters={filters}
+                                searchValue={searchValue}
+                                isExpanded={isFilterExpanded}
+                                source={activeTab}
+                                onExpandToggle={() => setIsFilterExpanded(!isFilterExpanded)}
+                                onFilterChange={handleFilterChange}
+                                onSearchChange={handleSearchChange}
+                                onClearFilters={clearFilters}
+                                tags={tags}
+                                series={series}
+                            />
+                        </Suspense>
+                    )}
 
-            <Suspense
-                fallback={
-                    <div className="space-y-3 mt-6">
-                        {[1, 2, 3].map(i => (
-                            <div key={i} className="h-40 bg-surface-subtle animate-pulse rounded-lg border border-line-light" />
-                        ))}
-                    </div>
-                }>
-                <div className="mt-6">
-                    {activeTab === 'published' && (
-                        <PostListContent
-                            filters={filters}
-                            series={series}
-                            onPageChange={(page) => handleFilterChange('page', page)}
-                            onCountChange={(count) => handleCountChange('published', count)}
-                            emptyMessage="발행 포스트가 없습니다."
-                            emptyAction={emptyPostAction}
-                        />
-                    )}
-                    {activeTab === 'scheduled' && (
-                        <PostListContent
-                            filters={filters}
-                            series={series}
-                            onPageChange={(page) => handleFilterChange('page', page)}
-                            onCountChange={(count) => handleCountChange('scheduled', count)}
-                            source="scheduled"
-                            emptyMessage="예약 포스트가 없습니다."
-                            emptyAction={emptyPostAction}
-                        />
-                    )}
-                    {activeTab === 'drafts' && (
-                        <DraftPostListContent
-                            onCountChange={(count) => handleCountChange('drafts', count)}
-                            emptyAction={createPostAction}
-                        />
-                    )}
-                    {activeTab === 'trash' && (
-                        <TrashPostListContent
-                            page={filters.page}
-                            onPageChange={(page) => handleFilterChange('page', page)}
-                            onCountChange={(count) => handleCountChange('trash', count)}
-                        />
-                    )}
-                </div>
-            </Suspense>
+                    <Suspense
+                        fallback={
+                            <div className="mt-6 space-y-3">
+                                {[1, 2, 3].map(i => (
+                                    <div key={i} className="h-40 animate-pulse rounded-lg border border-line-light bg-surface-subtle" />
+                                ))}
+                            </div>
+                        }>
+                        <div className="mt-6">
+                            {activeTab === 'published' && (
+                                <PostListContent
+                                    filters={filters}
+                                    series={series}
+                                    onPageChange={(page) => handleFilterChange('page', page)}
+                                    onCountChange={(count) => handleCountChange('published', count)}
+                                    emptyMessage="발행 포스트가 없습니다."
+                                    emptyAction={emptyPostAction}
+                                />
+                            )}
+                            {activeTab === 'scheduled' && (
+                                <PostListContent
+                                    filters={filters}
+                                    series={series}
+                                    onPageChange={(page) => handleFilterChange('page', page)}
+                                    onCountChange={(count) => handleCountChange('scheduled', count)}
+                                    source="scheduled"
+                                    emptyMessage="예약 포스트가 없습니다."
+                                    emptyAction={emptyPostAction}
+                                />
+                            )}
+                            {activeTab === 'drafts' && (
+                                <DraftPostListContent
+                                    onCountChange={(count) => handleCountChange('drafts', count)}
+                                    emptyAction={createPostAction}
+                                />
+                            )}
+                            {activeTab === 'trash' && (
+                                <TrashPostListContent
+                                    page={filters.page}
+                                    onPageChange={(page) => handleFilterChange('page', page)}
+                                    onCountChange={(count) => handleCountChange('trash', count)}
+                                />
+                            )}
+                        </div>
+                    </Suspense>
+                </Tabs.Content>
+            </Tabs.Root>
         </div>
     );
 };

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/DraftPostListContent.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/DraftPostListContent.tsx
@@ -102,8 +102,9 @@ export const DraftPostListContent = ({
                     }
                     actions={
                         <Dropdown
+                            density="compact"
                             triggerAriaLabel={`${draftPost.title || '제목 없음'} 임시 포스트 메뉴 열기`}
-                            triggerClassName="min-h-11 min-w-11"
+                            triggerClassName="min-h-11 min-w-11 [@media(pointer:fine)]:min-h-9 [@media(pointer:fine)]:min-w-9"
                             items={[
                                 {
                                     label: '휴지통으로 이동',

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/Pagination.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/Pagination.tsx
@@ -36,7 +36,7 @@ const Pagination = ({ page, lastPage, onPageChange }: PaginationProps) => {
 
     return (
         <nav
-            className="pagination-nav [&_.pagination-link]:min-h-11 [&_.pagination-link]:min-w-11"
+            className="pagination-nav [&_.pagination-link]:min-h-11 [&_.pagination-link]:min-w-11 [@media(pointer:fine)]:[&_.pagination-link]:min-h-9 [@media(pointer:fine)]:[&_.pagination-link]:min-w-9"
             aria-label="포스트 페이지">
             <div className="pagination-action prev">
                 {currentPage > 1 ? (

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/PostCard.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/PostCard.tsx
@@ -17,7 +17,6 @@ import {
     Trash2
 } from '@blex/ui/icons';
 import {
-    Alert,
     Button,
     Input,
     Dropdown,
@@ -45,6 +44,7 @@ interface PostCardProps {
     dateIconClass?: string;
     statusLabel?: string;
     showUpdatedBadge?: boolean;
+    isScheduled?: boolean;
 }
 
 const formatDate = (dateString: string) => {
@@ -67,7 +67,8 @@ const PostCard = ({
     dateIcon,
     dateIconClass,
     statusLabel,
-    showUpdatedBadge = true
+    showUpdatedBadge = true,
+    isScheduled = false
 }: PostCardProps) => {
     const [isMetaEditorOpen, setIsMetaEditorOpen] = useState(false);
     const hasPendingChanges = !!post.hasTagChanged || !!post.hasSeriesChanged;
@@ -75,6 +76,17 @@ const PostCard = ({
         post.hasTagChanged ? '태그' : '',
         post.hasSeriesChanged ? '시리즈' : ''
     ].filter(Boolean).join('·');
+    const tagCount = post.tag
+        .split(',')
+        .map(tag => tag.trim())
+        .filter(Boolean).length;
+    const seriesTitle = series?.find(item => item.url === post.series)?.title;
+    const classificationSummary = [
+        tagCount > 0 ? `태그 ${tagCount}개` : '',
+        seriesTitle || ''
+    ].filter(Boolean).join(' · ');
+    const visibilityTarget = post.isHide ? '공개' : '비공개';
+    const visibilityActionLabel = `${isScheduled ? '발행 시 ' : ''}${visibilityTarget}로 변경`;
 
     const handleEditPost = () => {
         window.location.assign(`/@${username}/${post.url}/edit`);
@@ -145,7 +157,7 @@ const PostCard = ({
                             )}
                             {post.isHide && (
                                 <span className="inline-flex items-center px-2 py-0.5 bg-surface-subtle text-content rounded-md font-medium">
-                                    비공개
+                                    {isScheduled ? '발행 후 비공개' : '비공개'}
                                 </span>
                             )}
                         </div>
@@ -155,8 +167,9 @@ const PostCard = ({
                 {/* 액션 */}
                 <div className="flex flex-shrink-0 items-center pr-3 sm:pr-4">
                     <Dropdown
+                        density="compact"
                         triggerAriaLabel={`${post.title} 포스트 메뉴 열기`}
-                        triggerClassName="min-h-11 min-w-11 focus-visible:ring-2 focus-visible:ring-action focus-visible:ring-offset-1"
+                        triggerClassName="min-h-11 min-w-11 focus-visible:ring-2 focus-visible:ring-action focus-visible:ring-offset-1 [@media(pointer:fine)]:min-h-9 [@media(pointer:fine)]:min-w-9"
                         items={[
                             {
                                 label: '포스트 편집',
@@ -164,7 +177,7 @@ const PostCard = ({
                                 onClick: handleEditPost
                             },
                             {
-                                label: post.isHide ? '공개로 변경' : '비공개로 변경',
+                                label: visibilityActionLabel,
                                 icon: post.isHide
                                     ? <Eye aria-hidden className="h-4 w-4" />
                                     : <EyeOff aria-hidden className="h-4 w-4" />,
@@ -181,12 +194,17 @@ const PostCard = ({
                 </div>
             </div>
 
-            <div className="flex justify-end bg-surface-subtle/40 px-4 py-2.5">
+            <div className="flex items-center gap-3 bg-surface-subtle/40 px-4 py-2.5">
+                {!isMetaEditorOpen && classificationSummary && (
+                    <span className="min-w-0 truncate text-xs text-content-hint">
+                        {classificationSummary}
+                    </span>
+                )}
                 <button
                     type="button"
                     aria-label={isMetaEditorOpen ? '태그 및 시리즈 편집 닫기' : '태그 및 시리즈 편집 열기'}
                     onClick={() => setIsMetaEditorOpen(prev => !prev)}
-                    className="inline-flex min-h-11 items-center gap-2 rounded-lg px-2.5 py-1.5 text-content-secondary hover:text-content hover:bg-surface-subtle transition-colors">
+                    className="ml-auto inline-flex min-h-11 flex-shrink-0 items-center gap-2 rounded-lg px-2.5 py-1.5 text-content-secondary transition-colors hover:bg-surface-subtle hover:text-content [@media(pointer:fine)]:min-h-9">
                     <SlidersHorizontal aria-hidden className="h-3.5 w-3.5" />
                     <span className="text-xs font-medium">태그·시리즈</span>
                     <span className="inline-flex items-center gap-2">
@@ -212,6 +230,7 @@ const PostCard = ({
                             <Tag aria-hidden className="h-4 w-4" />
                         </div>
                         <Input
+                            density="compact"
                             type="text"
                             aria-label={`${post.title} 태그`}
                             placeholder="태그를 입력하세요..."
@@ -221,10 +240,11 @@ const PostCard = ({
                         />
                         {(post.hasTagChanged || isTagSaving) && (
                             <Button
+                                density="compact"
                                 variant="primary"
                                 size="md"
                                 isLoading={isTagSaving}
-                                className="col-start-2 min-h-11! w-full sm:col-start-auto sm:w-auto"
+                                className="col-start-2 min-h-11! w-full sm:col-start-auto [@media(pointer:fine)]:min-h-10! sm:w-auto"
                                 leftIcon={<Save aria-hidden className="h-4 w-4" />}
                                 onClick={() => onTagSubmit(post.url)}>
                                 태그 저장
@@ -239,6 +259,7 @@ const PostCard = ({
                         </div>
                         <div className="flex-1">
                             <Select
+                                density="compact"
                                 value={post.series || ''}
                                 onValueChange={(value) => onSeriesChange(post.url, value)}
                                 ariaLabel={`${post.title} 시리즈 선택`}
@@ -257,10 +278,11 @@ const PostCard = ({
                         </div>
                         {(post.hasSeriesChanged || isSeriesSaving) && (
                             <Button
+                                density="compact"
                                 variant="primary"
                                 size="md"
                                 isLoading={isSeriesSaving}
-                                className="col-start-2 min-h-11! w-full sm:col-start-auto sm:w-auto"
+                                className="col-start-2 min-h-11! w-full sm:col-start-auto [@media(pointer:fine)]:min-h-10! sm:w-auto"
                                 leftIcon={<Save aria-hidden className="h-4 w-4" />}
                                 onClick={() => onSeriesSubmit(post.url)}>
                                 시리즈 저장
@@ -268,13 +290,6 @@ const PostCard = ({
                         )}
                     </div>
 
-                    {post.readTime > 30 && (
-                        <div role="note" aria-label="긴 포스트 안내">
-                            <Alert variant="warning" title="긴 포스트">
-                                예상 읽기 시간은 {post.readTime}분입니다.
-                            </Alert>
-                        </div>
-                    )}
                 </div>
             )}
         </div>

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/PostListContent.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/PostListContent.tsx
@@ -85,6 +85,7 @@ export const PostListContent = ({
                                 : undefined}
                             statusLabel={isScheduled ? '예약 발행' : undefined}
                             showUpdatedBadge={!isScheduled}
+                            isScheduled={isScheduled}
                         />
                     ))}
                 </div>

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/PostsFilter.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/PostsFilter.tsx
@@ -1,7 +1,6 @@
 import {
     BookOpen,
     ChevronDown,
-    ChevronRight,
     Eye,
     EyeOff,
     Search,
@@ -10,8 +9,8 @@ import {
     X
 } from '@blex/ui/icons';
 import { Button, Input, Dropdown } from '~/components/shared';
-import { settingsSelectTriggerStyles } from '~/styles/settingsStyles';
-import type { FilterOptions } from '../hooks';
+import { settingsCompactSelectTriggerStyles } from '~/styles/settingsStyles';
+import type { FilterOptions, PostsSource } from '../hooks';
 import { POSTS_ORDER } from '../hooks';
 import type { Tag, Series } from '~/lib/api/settings';
 
@@ -19,7 +18,7 @@ interface PostsFilterProps {
     filters: FilterOptions;
     searchValue: string;
     isExpanded: boolean;
-    showClearAction?: boolean;
+    source?: PostsSource;
     onExpandToggle: () => void;
     onFilterChange: (key: keyof FilterOptions, value: string) => void;
     onSearchChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
@@ -28,15 +27,17 @@ interface PostsFilterProps {
     series?: Series[];
 }
 
-const hasActiveFilters = (filters: FilterOptions) => {
-    return filters.tag || filters.series || filters.visibility || filters.search;
+const hasDetailFilters = (filters: FilterOptions) => {
+    return filters.tag || filters.series || filters.visibility;
 };
+
+const COMPACT_DROPDOWN_ITEM_CLASS = 'min-h-11 py-2! [@media(pointer:fine)]:min-h-9';
 
 const PostsFilter = ({
     filters,
     searchValue,
     isExpanded,
-    showClearAction = true,
+    source = 'published',
     onExpandToggle,
     onFilterChange,
     onSearchChange,
@@ -44,226 +45,267 @@ const PostsFilter = ({
     tags,
     series
 }: PostsFilterProps) => {
-    const ExpandIcon = isExpanded ? ChevronDown : ChevronRight;
+    const isScheduled = source === 'scheduled';
     const VisibilityIcon = filters.visibility === 'public' ? Eye : EyeOff;
+    const activeDetailFilterCount = [
+        filters.tag,
+        filters.series,
+        filters.visibility
+    ].filter(Boolean).length;
+    const validTags = tags?.filter(
+        tag => typeof tag.name === 'string' && tag.name.trim().length > 0
+    );
+    const getOrderLabel = (order: string) => {
+        if (isScheduled && order === '-published_date') return '예약 먼 순';
+        if (isScheduled && order === 'published_date') return '예약 임박순';
+        return POSTS_ORDER.find(option => option.order === order)?.name || '정렬 방식';
+    };
+    const publicLabel = isScheduled ? '발행 후 공개' : '공개';
+    const hiddenLabel = isScheduled ? '발행 후 비공개' : '숨김';
+    const orderLabel = getOrderLabel(filters.order);
+    const selectedTagLabel = filters.tag || '전체';
+    const selectedSeriesLabel = filters.series
+        ? series?.find((item) => item.url === filters.series)?.title || filters.series
+        : '전체';
+    const selectedVisibilityLabel = filters.visibility === 'public'
+        ? publicLabel
+        : filters.visibility === 'hidden' ? hiddenLabel : '전체';
 
     return (
-        <div className="mb-6">
-            {/* 필터 헤더 */}
-            <div className="flex items-center justify-between gap-3 mb-4">
-                <button
-                    type="button"
-                    onClick={onExpandToggle}
+        <div className="mb-6 space-y-3">
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-[minmax(0,1fr)_minmax(12rem,0.55fr)_auto]">
+                <div className="relative">
+                    <Input
+                        type="search"
+                        density="compact"
+                        aria-label="포스트 제목 검색"
+                        placeholder={isScheduled ? '예약 포스트 제목 검색...' : '포스트 제목 검색...'}
+                        value={searchValue}
+                        onChange={onSearchChange}
+                        leftIcon={<Search aria-hidden className="h-4 w-4" />}
+                        rightIcon={searchValue ? <span aria-hidden /> : undefined}
+                    />
+                    {searchValue && (
+                        <button
+                            type="button"
+                            aria-label="검색어 지우기"
+                            onClick={() => onFilterChange('search', '')}
+                            className="absolute inset-y-0 right-0 inline-flex min-w-11 items-center justify-center rounded-lg text-content-secondary transition-colors hover:bg-surface-subtle hover:text-content [@media(pointer:fine)]:min-w-9">
+                            <X aria-hidden className="h-3.5 w-3.5" />
+                        </button>
+                    )}
+                </div>
+
+                <Dropdown
+                    density="compact"
+                    align="left"
+                    trigger={
+                        <button
+                            type="button"
+                            aria-label={`포스트 정렬 방식 선택, 현재 ${orderLabel}`}
+                            className={`${settingsCompactSelectTriggerStyles} flex items-center justify-between text-left`}>
+                            <span className="text-content font-medium">
+                                {orderLabel}
+                            </span>
+                            <ChevronDown aria-hidden className="h-4 w-4 text-content-hint" />
+                        </button>
+                    }
+                    items={POSTS_ORDER.map((orderOption) => ({
+                        label: getOrderLabel(orderOption.order),
+                        onClick: () => onFilterChange('order', orderOption.order),
+                        checked: filters.order === orderOption.order,
+                        className: COMPACT_DROPDOWN_ITEM_CLASS
+                    }))}
+                />
+
+                <Button
+                    density="compact"
+                    variant="ghost"
+                    size="sm"
+                    className="min-h-11! self-center justify-self-end sm:col-span-2 [@media(pointer:fine)]:min-h-9! lg:col-span-1"
                     aria-expanded={isExpanded}
                     aria-controls="posts-filter-controls"
-                    className="flex min-h-11 items-center gap-2 text-lg font-semibold text-content hover:text-content transition-colors">
-                    <ExpandIcon aria-hidden className="h-4 w-4" />
-                    <SlidersHorizontal aria-hidden className="h-4 w-4" />
-                    <span>필터 및 검색</span>
-                    {hasActiveFilters(filters) && (
-                        <span className="ml-2 px-2 py-0.5 bg-line text-content text-xs font-medium rounded-full">
-                            활성
+                    leftIcon={<SlidersHorizontal aria-hidden className="h-4 w-4" />}
+                    rightIcon={
+                        <ChevronDown
+                            aria-hidden
+                            className={`h-4 w-4 transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+                        />
+                    }
+                    onClick={onExpandToggle}>
+                    <span>{isExpanded ? '필터 접기' : '필터 더보기'}</span>
+                    {activeDetailFilterCount > 0 && (
+                        <span className="rounded-full bg-surface-subtle px-2 py-0.5 text-xs text-content-secondary">
+                            {activeDetailFilterCount}개 적용
                         </span>
                     )}
-                </button>
-                {showClearAction && hasActiveFilters(filters) && (
-                    <Button
-                        variant="secondary"
-                        size="sm"
-                        className="min-h-11! flex-shrink-0"
-                        leftIcon={<X aria-hidden className="h-4 w-4" />}
-                        onClick={onClearFilters}>
-                        필터 초기화
-                    </Button>
-                )}
+                </Button>
             </div>
 
             {/* 활성 필터 뱃지 */}
-            {hasActiveFilters(filters) && (
-                <div className="flex flex-wrap gap-2 mb-4">
-                    {filters.search && (
-                        <div className="inline-flex min-h-11 items-center gap-2 rounded-lg bg-surface-subtle pl-3 text-sm text-content">
-                            <Search aria-hidden className="h-3.5 w-3.5" />
-                            <span>검색: {filters.search}</span>
-                            <button
-                                type="button"
-                                aria-label="검색 필터 제거"
-                                onClick={() => onFilterChange('search', '')}
-                                className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-lg text-content-secondary hover:bg-surface hover:text-content">
-                                <X aria-hidden className="h-3.5 w-3.5" />
-                            </button>
-                        </div>
-                    )}
+            {hasDetailFilters(filters) && (
+                <div className="flex flex-wrap items-center gap-2">
                     {filters.tag && (
-                        <div className="inline-flex min-h-11 items-center gap-2 rounded-lg bg-surface-subtle pl-3 text-sm text-content">
+                        <div className="inline-flex min-h-11 items-center gap-2 rounded-lg bg-surface-subtle pl-3 text-sm text-content [@media(pointer:fine)]:min-h-9">
                             <TagIcon aria-hidden className="h-3.5 w-3.5" />
                             <span>{filters.tag}</span>
                             <button
                                 type="button"
                                 aria-label={`${filters.tag} 태그 필터 제거`}
                                 onClick={() => onFilterChange('tag', '')}
-                                className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-lg text-content-secondary hover:bg-surface hover:text-content">
+                                className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-lg text-content-secondary hover:bg-surface hover:text-content [@media(pointer:fine)]:min-h-9 [@media(pointer:fine)]:min-w-9">
                                 <X aria-hidden className="h-3.5 w-3.5" />
                             </button>
                         </div>
                     )}
                     {filters.series && (
-                        <div className="inline-flex min-h-11 items-center gap-2 rounded-lg bg-surface-subtle pl-3 text-sm text-content">
+                        <div className="inline-flex min-h-11 items-center gap-2 rounded-lg bg-surface-subtle pl-3 text-sm text-content [@media(pointer:fine)]:min-h-9">
                             <BookOpen aria-hidden className="h-3.5 w-3.5" />
-                            <span>{series?.find((s) => s.url === filters.series)?.title}</span>
+                            <span>{series?.find((s) => s.url === filters.series)?.title || filters.series}</span>
                             <button
                                 type="button"
                                 aria-label="시리즈 필터 제거"
                                 onClick={() => onFilterChange('series', '')}
-                                className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-lg text-content-secondary hover:bg-surface hover:text-content">
+                                className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-lg text-content-secondary hover:bg-surface hover:text-content [@media(pointer:fine)]:min-h-9 [@media(pointer:fine)]:min-w-9">
                                 <X aria-hidden className="h-3.5 w-3.5" />
                             </button>
                         </div>
                     )}
                     {filters.visibility && (
-                        <div className="inline-flex min-h-11 items-center gap-2 rounded-lg bg-surface-subtle pl-3 text-sm text-content">
+                        <div className="inline-flex min-h-11 items-center gap-2 rounded-lg bg-surface-subtle pl-3 text-sm text-content [@media(pointer:fine)]:min-h-9">
                             <VisibilityIcon aria-hidden className="h-3.5 w-3.5" />
-                            <span>{filters.visibility === 'public' ? '공개' : '숨김'}</span>
+                            <span>{filters.visibility === 'public' ? publicLabel : hiddenLabel}</span>
                             <button
                                 type="button"
                                 aria-label="공개 상태 필터 제거"
                                 onClick={() => onFilterChange('visibility', '')}
-                                className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-lg text-content-secondary hover:bg-surface hover:text-content">
+                                className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-lg text-content-secondary hover:bg-surface hover:text-content [@media(pointer:fine)]:min-h-9 [@media(pointer:fine)]:min-w-9">
                                 <X aria-hidden className="h-3.5 w-3.5" />
                             </button>
                         </div>
                     )}
+                    <Button
+                        density="compact"
+                        variant="ghost"
+                        size="sm"
+                        className="min-h-11! [@media(pointer:fine)]:min-h-9!"
+                        leftIcon={<X aria-hidden className="h-4 w-4" />}
+                        onClick={onClearFilters}>
+                        필터 초기화
+                    </Button>
                 </div>
             )}
 
             {/* 필터 컨트롤 */}
-            {isExpanded && (
-                <div id="posts-filter-controls" className="p-6 bg-surface-subtle border border-line rounded-2xl">
-                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-4">
-                        <Input
-                            type="text"
-                            aria-label="포스트 제목 검색"
-                            placeholder="포스트 제목 검색..."
-                            value={searchValue}
-                            onChange={onSearchChange}
-                            leftIcon={<Search aria-hidden className="h-4 w-4" />}
-                        />
-
-                        {/* 정렬 */}
-                        <Dropdown
-                            align="left"
-                            trigger={
-                                <button
-                                    type="button"
-                                    aria-label="포스트 정렬 방식 선택"
-                                    className={`${settingsSelectTriggerStyles} flex items-center justify-between text-left`}>
-                                    <span className="text-content font-medium">
-                                        {POSTS_ORDER.find(o => o.order === filters.order)?.name || '정렬 방식'}
-                                    </span>
-                                    <ChevronDown aria-hidden className="h-4 w-4 text-content-hint" />
-                                </button>
+            <div
+                id="posts-filter-controls"
+                hidden={!isExpanded}
+                className="rounded-2xl border border-line bg-surface-subtle p-6">
+                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                    {/* 태그 필터 */}
+                    <Dropdown
+                        density="compact"
+                        align="left"
+                        trigger={
+                            <button
+                                type="button"
+                                aria-label={`태그 필터 선택, 현재 ${selectedTagLabel}`}
+                                className={`${settingsCompactSelectTriggerStyles} flex items-center justify-between text-left`}>
+                                <span className={filters.tag ? 'text-content font-medium' : 'text-content-hint'}>
+                                    {filters.tag || '태그'}
+                                </span>
+                                <ChevronDown aria-hidden className="h-4 w-4 text-content-hint" />
+                            </button>
                             }
-                            items={POSTS_ORDER.map((orderOption) => ({
-                                label: orderOption.name,
-                                onClick: () => onFilterChange('order', orderOption.order),
-                                checked: filters.order === orderOption.order
-                            }))}
-                        />
-                    </div>
-
-                    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-                        {/* 태그 필터 */}
-                        <Dropdown
-                            align="left"
-                            trigger={
-                                <button
-                                    type="button"
-                                    aria-label="태그 필터 선택"
-                                    className={`${settingsSelectTriggerStyles} flex items-center justify-between text-left`}>
-                                    <span className={filters.tag ? 'text-content font-medium' : 'text-content-hint'}>
-                                        {filters.tag || '태그'}
-                                    </span>
-                                    <ChevronDown aria-hidden className="h-4 w-4 text-content-hint" />
-                                </button>
-                            }
-                            items={[
+                        items={[
                                 {
                                     label: '전체',
                                     onClick: () => onFilterChange('tag', ''),
-                                    checked: filters.tag === ''
+                                    checked: filters.tag === '',
+                                    className: COMPACT_DROPDOWN_ITEM_CLASS
                                 },
-                                ...(tags?.map((tag) => ({
-                                    label: `${tag.name} (${tag.count})`,
+                                ...(validTags?.map((tag) => ({
+                                    label: tag.name,
                                     onClick: () => onFilterChange('tag', tag.name),
-                                    checked: filters.tag === tag.name
+                                    checked: filters.tag === tag.name,
+                                    className: COMPACT_DROPDOWN_ITEM_CLASS
                                 })) || [])
                             ]}
-                        />
+                    />
 
-                        {/* 시리즈 필터 */}
-                        <Dropdown
-                            align="left"
-                            trigger={
-                                <button
-                                    type="button"
-                                    aria-label="시리즈 필터 선택"
-                                    className={`${settingsSelectTriggerStyles} flex items-center justify-between text-left`}>
-                                    <span className={filters.series ? 'text-content font-medium' : 'text-content-hint'}>
-                                        {series?.find((s) => s.url === filters.series)?.title || '시리즈'}
-                                    </span>
-                                    <ChevronDown aria-hidden className="h-4 w-4 text-content-hint" />
-                                </button>
+                    {/* 시리즈 필터 */}
+                    <Dropdown
+                        density="compact"
+                        align="left"
+                        trigger={
+                            <button
+                                type="button"
+                                aria-label={`시리즈 필터 선택, 현재 ${selectedSeriesLabel}`}
+                                className={`${settingsCompactSelectTriggerStyles} flex items-center justify-between text-left`}>
+                                <span className={filters.series ? 'text-content font-medium' : 'text-content-hint'}>
+                                    {filters.series ? selectedSeriesLabel : '시리즈'}
+                                </span>
+                                <ChevronDown aria-hidden className="h-4 w-4 text-content-hint" />
+                            </button>
                             }
-                            items={[
+                        items={[
                                 {
                                     label: '전체',
                                     onClick: () => onFilterChange('series', ''),
-                                    checked: filters.series === ''
+                                    checked: filters.series === '',
+                                    className: COMPACT_DROPDOWN_ITEM_CLASS
                                 },
                                 ...(series?.map((item) => ({
-                                    label: `${item.title} (${item.totalPosts})`,
+                                    label: item.title,
                                     onClick: () => onFilterChange('series', item.url),
-                                    checked: filters.series === item.url
+                                    checked: filters.series === item.url,
+                                    className: COMPACT_DROPDOWN_ITEM_CLASS
                                 })) || [])
                             ]}
-                        />
+                    />
 
-                        {/* 공개 상태 필터 */}
-                        <Dropdown
-                            align="left"
-                            trigger={
-                                <button
-                                    type="button"
-                                    aria-label="공개 상태 필터 선택"
-                                    className={`${settingsSelectTriggerStyles} flex items-center justify-between text-left`}>
-                                    <span className={filters.visibility ? 'text-content font-medium' : 'text-content-hint'}>
-                                        {filters.visibility === 'public' ? '공개' : filters.visibility === 'hidden' ? '숨김' : '공개 상태'}
-                                    </span>
-                                    <ChevronDown aria-hidden className="h-4 w-4 text-content-hint" />
-                                </button>
+                    {/* 공개 상태 필터 */}
+                    <Dropdown
+                        density="compact"
+                        align="left"
+                        trigger={
+                            <button
+                                type="button"
+                                aria-label={`공개 상태 필터 선택, 현재 ${selectedVisibilityLabel}`}
+                                className={`${settingsCompactSelectTriggerStyles} flex items-center justify-between text-left`}>
+                                <span className={filters.visibility ? 'text-content font-medium' : 'text-content-hint'}>
+                                    {filters.visibility === 'public'
+                                            ? publicLabel
+                                            : filters.visibility === 'hidden'
+                                                ? hiddenLabel
+                                                : isScheduled ? '발행 후 공개 상태' : '공개 상태'}
+                                </span>
+                                <ChevronDown aria-hidden className="h-4 w-4 text-content-hint" />
+                            </button>
                             }
-                            items={[
+                        items={[
                                 {
                                     label: '전체',
                                     onClick: () => onFilterChange('visibility', ''),
-                                    checked: filters.visibility === ''
+                                    checked: filters.visibility === '',
+                                    className: COMPACT_DROPDOWN_ITEM_CLASS
                                 },
                                 {
-                                    label: '공개',
+                                    label: publicLabel,
                                     onClick: () => onFilterChange('visibility', 'public'),
-                                    checked: filters.visibility === 'public'
+                                    checked: filters.visibility === 'public',
+                                    className: COMPACT_DROPDOWN_ITEM_CLASS
                                 },
                                 {
-                                    label: '숨김',
+                                    label: hiddenLabel,
                                     onClick: () => onFilterChange('visibility', 'hidden'),
-                                    checked: filters.visibility === 'hidden'
+                                    checked: filters.visibility === 'hidden',
+                                    className: COMPACT_DROPDOWN_ITEM_CLASS
                                 }
                             ]}
-                        />
-
-                    </div>
+                    />
                 </div>
-            )}
+            </div>
         </div>
     );
 };

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/TrashPostListContent.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/components/TrashPostListContent.tsx
@@ -155,8 +155,9 @@ export const TrashPostListContent = ({
                         )}
                         actions={(
                             <Dropdown
+                                density="compact"
                                 triggerAriaLabel={`${post.title || '제목 없음'} 휴지통 메뉴 열기`}
-                                triggerClassName="min-h-11 min-w-11"
+                                triggerClassName="min-h-11 min-w-11 [@media(pointer:fine)]:min-h-9 [@media(pointer:fine)]:min-w-9"
                                 items={[
                                     {
                                         label: '복원',

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/hooks/usePostsActions.ts
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/hooks/usePostsActions.ts
@@ -7,7 +7,10 @@ import {
     updatePostTags,
     updatePostSeries
 } from '~/lib/api/posts';
-import type { Post } from './usePostsData';
+import {
+    clearPostClassificationDraft,
+    type Post
+} from './usePostsData';
 
 interface UsePostsActionsProps {
     username: string;
@@ -73,6 +76,7 @@ export const usePostsActions = ({
             const { data } = await deletePost(username, postUrl);
 
             if (data.status === 'DONE') {
+                clearPostClassificationDraft(username, postUrl);
                 toast.success('포스트를 휴지통으로 옮겼습니다.');
                 refetch();
             } else {
@@ -84,15 +88,14 @@ export const usePostsActions = ({
     };
 
     const handleTagChange = (postUrl: string, value: string) => {
-        setPosts(prev => prev.map(post =>
-            post.url === postUrl
-                ? {
-                    ...post,
-                    tag: value,
-                    hasTagChanged: post.persistedTag !== value
-                }
-                : post
-        ));
+        setPosts(prev => prev.map(post => {
+            if (post.url !== postUrl) return post;
+            return {
+                ...post,
+                tag: value,
+                hasTagChanged: post.persistedTag !== value
+            };
+        }));
     };
 
     const handleTagSubmit = async (postUrl: string) => {
@@ -137,15 +140,14 @@ export const usePostsActions = ({
     };
 
     const handleSeriesChange = (postUrl: string, value: string) => {
-        setPosts(prev => prev.map(post =>
-            post.url === postUrl
-                ? {
-                    ...post,
-                    series: value,
-                    hasSeriesChanged: post.persistedSeries !== value
-                }
-                : post
-        ));
+        setPosts(prev => prev.map(post => {
+            if (post.url !== postUrl) return post;
+            return {
+                ...post,
+                series: value,
+                hasSeriesChanged: post.persistedSeries !== value
+            };
+        }));
     };
 
     const handleSeriesSubmit = async (postUrl: string) => {

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/hooks/usePostsData.ts
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/PostsSetting/hooks/usePostsData.ts
@@ -23,14 +23,120 @@ export interface FilterOptions {
 
 export type PostsSource = 'published' | 'scheduled';
 
+interface PostClassificationDraft {
+    tag: string;
+    series: string;
+    hasTagChanged: boolean;
+    hasSeriesChanged: boolean;
+}
+
+const POST_CLASSIFICATION_DRAFTS_KEY = 'blex:settings-post-classification-drafts';
+
+const getPostClassificationDraftKey = (
+    username: string,
+    postUrl: string
+) => `${username}:${postUrl}`;
+
+const isPostClassificationDraft = (value: unknown): value is PostClassificationDraft => {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+
+    const draft = value as Record<string, unknown>;
+    return typeof draft.tag === 'string'
+        && typeof draft.series === 'string'
+        && typeof draft.hasTagChanged === 'boolean'
+        && typeof draft.hasSeriesChanged === 'boolean';
+};
+
+const readPostClassificationDrafts = (): Record<string, PostClassificationDraft> => {
+    if (typeof window === 'undefined') return {};
+
+    try {
+        const storedDrafts = window.sessionStorage.getItem(POST_CLASSIFICATION_DRAFTS_KEY);
+        if (!storedDrafts) return {};
+
+        const parsedDrafts: unknown = JSON.parse(storedDrafts);
+        if (typeof parsedDrafts !== 'object' || parsedDrafts === null || Array.isArray(parsedDrafts)) {
+            return {};
+        }
+
+        return Object.entries(parsedDrafts).reduce<Record<string, PostClassificationDraft>>(
+            (drafts, [key, draft]) => {
+                if (isPostClassificationDraft(draft)) drafts[key] = draft;
+                return drafts;
+            },
+            {}
+        );
+    } catch {
+        return {};
+    }
+};
+
+const writePostClassificationDrafts = (drafts: Record<string, PostClassificationDraft>) => {
+    if (typeof window === 'undefined') return;
+
+    try {
+        if (Object.keys(drafts).length === 0) {
+            window.sessionStorage.removeItem(POST_CLASSIFICATION_DRAFTS_KEY);
+            return;
+        }
+        window.sessionStorage.setItem(POST_CLASSIFICATION_DRAFTS_KEY, JSON.stringify(drafts));
+    } catch {
+        // Storage can be unavailable in restricted browser contexts. In-memory editing still works.
+    }
+};
+
+export const getPostClassificationDraft = (
+    username: string,
+    postUrl: string
+) => readPostClassificationDrafts()[getPostClassificationDraftKey(username, postUrl)];
+
+export const syncPostClassificationDraft = (
+    username: string,
+    post: Post
+) => {
+    const drafts = readPostClassificationDrafts();
+    const draftKey = getPostClassificationDraftKey(username, post.url);
+
+    if (!post.hasTagChanged && !post.hasSeriesChanged) {
+        delete drafts[draftKey];
+        writePostClassificationDrafts(drafts);
+        return;
+    }
+
+    drafts[draftKey] = {
+        tag: post.tag,
+        series: post.series || '',
+        hasTagChanged: Boolean(post.hasTagChanged),
+        hasSeriesChanged: Boolean(post.hasSeriesChanged)
+    };
+    writePostClassificationDrafts(drafts);
+};
+
+export const clearPostClassificationDraft = (
+    username: string,
+    postUrl: string
+) => {
+    const drafts = readPostClassificationDrafts();
+    delete drafts[getPostClassificationDraftKey(username, postUrl)];
+    writePostClassificationDrafts(drafts);
+};
+
 export const POSTS_ORDER = [
     {
-        name: '최신순',
+        name: '최근 발행순',
         order: '-published_date'
     },
     {
-        name: '오래된순',
+        name: '오래된 발행순',
         order: 'published_date'
+    },
+    {
+        name: '최근 수정순',
+        order: '-updated_date'
+    },
+    {
+        name: '오래된 수정순',
+        order: 'updated_date'
     },
     {
         name: '제목순',
@@ -47,6 +153,14 @@ export const POSTS_ORDER = [
     {
         name: '좋아요 적은순',
         order: 'count_likes'
+    },
+    {
+        name: '댓글 많은순',
+        order: '-count_comments'
+    },
+    {
+        name: '댓글 적은순',
+        order: 'count_comments'
     },
     {
         name: '분량 적은순',
@@ -68,19 +182,25 @@ const DEFAULT_FILTERS: FilterOptions = {
 };
 
 const FILTER_KEYS = Object.keys(DEFAULT_FILTERS) as (keyof FilterOptions)[];
+const VALID_ORDERS = new Set(POSTS_ORDER.map(({ order }) => order));
+const VALID_VISIBILITY = new Set(['public', 'hidden']);
 
 // URL에서 필터 초기값 읽기
 const getFiltersFromURL = (): FilterOptions => {
     if (typeof window === 'undefined') return DEFAULT_FILTERS;
 
     const params = new URLSearchParams(window.location.search);
+    const order = params.get('order') || DEFAULT_FILTERS.order;
+    const page = params.get('page') || DEFAULT_FILTERS.page;
+    const visibility = params.get('visibility') || DEFAULT_FILTERS.visibility;
+
     return {
         search: params.get('search') || '',
         tag: params.get('tag') || '',
         series: params.get('series') || '',
-        order: params.get('order') || '-published_date',
-        page: params.get('page') || '1',
-        visibility: params.get('visibility') || ''
+        order: VALID_ORDERS.has(order) ? order : DEFAULT_FILTERS.order,
+        page: /^[1-9]\d*$/.test(page) ? page : DEFAULT_FILTERS.page,
+        visibility: VALID_VISIBILITY.has(visibility) ? visibility : DEFAULT_FILTERS.visibility
     };
 };
 
@@ -108,7 +228,9 @@ const syncFiltersToURL = (filters: FilterOptions) => {
 export const usePostsFilterState = () => {
     const [filters, setFilters] = useState<FilterOptions>(getFiltersFromURL());
     const [searchValue, setSearchValue] = useState(filters.search);
-    const [isFilterExpanded, setIsFilterExpanded] = useState(true);
+    const [isFilterExpanded, setIsFilterExpanded] = useState(
+        () => Boolean(filters.tag || filters.series || filters.visibility)
+    );
     const searchDebounce = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     const { data: tags } = useSuspenseQuery({
@@ -235,13 +357,31 @@ export const usePostsQuery = (filters: FilterOptions, source: PostsSource = 'pub
 
     useEffect(() => {
         if (postsData?.posts) {
-            setPosts(postsData.posts.map(post => ({
-                ...post,
-                persistedTag: post.tag,
-                persistedSeries: post.series || ''
-            })));
+            setPosts(postsData.posts.map(post => {
+                const persistedTag = post.tag;
+                const persistedSeries = post.series || '';
+                const draft = getPostClassificationDraft(postsData.username, post.url);
+                const tag = draft?.hasTagChanged ? draft.tag : persistedTag;
+                const series = draft?.hasSeriesChanged ? draft.series : persistedSeries;
+                const nextPost: Post = {
+                    ...post,
+                    tag,
+                    series,
+                    persistedTag,
+                    persistedSeries,
+                    hasTagChanged: tag !== persistedTag,
+                    hasSeriesChanged: series !== persistedSeries
+                };
+
+                return nextPost;
+            }));
         }
-    }, [postsData]);
+    }, [postsData, source]);
+
+    useEffect(() => {
+        if (!postsData?.username) return;
+        posts.forEach(post => syncPostClassificationDraft(postsData.username, post));
+    }, [posts, postsData?.username]);
 
     return {
         posts,

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/ProfileSetting/ProfileSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/ProfileSetting/ProfileSetting.tsx
@@ -315,7 +315,7 @@ const ProfileSetting = () => {
                                 <button
                                     type="button"
                                     onClick={handleCoverDelete}
-                                    className="inline-flex min-h-11 items-center gap-2 rounded-xl border border-danger-line px-4 py-2 text-sm font-semibold text-danger transition-colors hover:bg-danger-surface">
+                                    className="inline-flex min-h-11 items-center gap-2 rounded-xl border border-danger-line px-4 py-2 text-sm font-semibold text-danger transition-colors hover:bg-danger-surface [@media(pointer:fine)]:min-h-9">
                                     <Trash2 aria-hidden="true" className="h-4 w-4" />
                                     커버 이미지 삭제
                                 </button>
@@ -336,6 +336,7 @@ const ProfileSetting = () => {
                     className="mb-6">
                     <div className="mb-6">
                         <Input
+                            density="compact"
                             label="소개"
                             leftIcon={<UserRound aria-hidden="true" className="h-4 w-4" />}
                             multiline
@@ -347,6 +348,7 @@ const ProfileSetting = () => {
                     </div>
 
                     <Input
+                        density="compact"
                         label="홈페이지"
                         leftIcon={<Link aria-hidden="true" className="h-4 w-4" />}
                         type="url"
@@ -358,10 +360,11 @@ const ProfileSetting = () => {
 
                 <div className="flex justify-end">
                     <Button
+                        density="compact"
                         type="submit"
                         variant="primary"
-                        size="lg"
-                        className="w-full sm:w-auto"
+                        size="md"
+                        className="min-h-11! [@media(pointer:fine)]:min-h-10!"
                         disabled={!isDirty || !isValid || isLoading}
                         isLoading={isLoading}
                         leftIcon={

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SeoAeoSetting/SeoAeoSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SeoAeoSetting/SeoAeoSetting.tsx
@@ -402,6 +402,7 @@ const SeoAeoSetting = () => {
 
                         <div className="flex flex-col gap-2 sm:flex-row sm:justify-end">
                             <Button
+                                density="compact"
                                 variant="secondary"
                                 size="md"
                                 disabled={!normalizedRobotsTxtExtraRules || robotsMutation.isPending}
@@ -410,6 +411,7 @@ const SeoAeoSetting = () => {
                                 추가 규칙 비우기
                             </Button>
                             <Button
+                                density="compact"
                                 variant="primary"
                                 size="md"
                                 isLoading={robotsMutation.isPending}

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SeriesSetting/SeriesSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SeriesSetting/SeriesSetting.tsx
@@ -22,8 +22,13 @@ import { restrictToVerticalAxis, restrictToFirstScrollableAncestor } from '@dnd-
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { BookOpen, FileText, Pencil, Trash2 } from '@blex/ui/icons';
-import { SettingsEmptyState, SettingsHeader, SettingsListItem } from '../../components';
-import { Button, Dropdown } from '~/components/shared';
+import {
+    SettingsEmptyState,
+    SettingsHeader,
+    SettingsHeaderAction,
+    SettingsListItem
+} from '../../components';
+import { Dropdown } from '~/components/shared';
 import {
     getSettingsIconClass,
     SETTINGS_LIST_META,
@@ -94,8 +99,9 @@ const SortableSeriesItem = ({ series, username, onEdit, onDelete }: SortableSeri
                 }
                 actions={
                     <Dropdown
+                        density="compact"
                         triggerAriaLabel={`${series.title} 시리즈 메뉴 열기`}
-                        triggerClassName="min-h-11 min-w-11"
+                        triggerClassName="min-h-11 min-w-11 [@media(pointer:fine)]:min-h-9 [@media(pointer:fine)]:min-w-9"
                         items={[
                             {
                                 label: '시리즈 편집',
@@ -212,13 +218,11 @@ const SeriesSetting = () => {
     };
 
     const createAction = (
-        <Button
+        <SettingsHeaderAction
             variant="primary"
-            size="md"
-            className="min-h-11! w-full sm:w-auto"
             onClick={handleCreateSeries}>
             새 시리즈 생성
-        </Button>
+        </SettingsHeaderAction>
     );
 
     return (

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SeriesSetting/components/PostSelector.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SeriesSetting/components/PostSelector.tsx
@@ -57,6 +57,7 @@ const PostSelector = ({ posts, selectedPostIds, onChange }: PostSelectorProps) =
                     <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
                         <div className="min-w-0 flex-1">
                             <Input
+                                density="compact"
                                 type="text"
                                 aria-label="포함할 포스트 검색"
                                 value={query}
@@ -70,14 +71,14 @@ const PostSelector = ({ posts, selectedPostIds, onChange }: PostSelectorProps) =
                                 type="button"
                                 onClick={handleToggleAll}
                                 disabled={safePosts.length === 0}
-                                className="inline-flex min-h-11 items-center rounded-md px-2 text-sm font-medium text-content-secondary transition-colors duration-150 hover:text-content active:text-content disabled:cursor-not-allowed disabled:opacity-40">
+                                className="inline-flex min-h-11 items-center rounded-md px-2 text-sm font-medium text-content-secondary transition-colors duration-150 hover:text-content active:text-content disabled:cursor-not-allowed disabled:opacity-40 [@media(pointer:fine)]:min-h-9">
                                 {isAllSelected ? '전체 해제' : '전체 선택'}
                             </button>
                             {isSearchActive && (
                                 <button
                                     type="button"
                                     onClick={() => setQuery('')}
-                                    className="inline-flex min-h-11 items-center rounded-md px-2 text-sm font-medium text-content-secondary transition-colors duration-150 hover:text-content active:text-content">
+                                    className="inline-flex min-h-11 items-center rounded-md px-2 text-sm font-medium text-content-secondary transition-colors duration-150 hover:text-content active:text-content [@media(pointer:fine)]:min-h-9">
                                     검색 지우기
                                 </button>
                             )}

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SeriesSetting/components/SeriesEditor.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SeriesSetting/components/SeriesEditor.tsx
@@ -271,152 +271,159 @@ const SeriesEditor = ({ seriesId }: SeriesEditorProps) => {
     };
 
     return (
-        <form onSubmit={handleSubmit(onSubmit)} className="min-h-screen bg-surface pb-20">
-            <div className="sticky top-0 z-10 bg-surface border-b border-line">
-                <div className="max-w-4xl mx-auto px-4 md:px-6 h-14 flex items-center justify-between">
-                    <Link
-                        to="/series"
-                        className="flex items-center gap-2 py-2 text-sm text-content-secondary hover:text-content active:text-content-secondary transition-colors">
-                        <ArrowLeft aria-hidden className="h-4 w-4" />
-                        <span>목록으로</span>
-                    </Link>
-                </div>
-            </div>
-
-            <div className="max-w-4xl mx-auto px-4 md:px-6 pt-10 pb-10 space-y-10">
-                <section className="space-y-4">
-                    <h1 className="sr-only">
-                        {isEditMode ? '시리즈 수정' : '시리즈 생성'}
-                    </h1>
-
-                    <div className="space-y-2">
-                        <label
-                            htmlFor="series-name"
-                            className="ml-1 block text-sm font-medium text-content-secondary">
-                            시리즈 제목
-                        </label>
-                        <div className="relative rounded-lg border border-line bg-surface-elevated px-3 py-3 transition-all duration-150 focus-within:border-line-strong focus-within:ring-2 focus-within:ring-line/70">
-                            <input
-                                id="series-name"
-                                type="text"
-                                maxLength={50}
-                                placeholder="시리즈 제목을 입력해주세요"
-                                className="w-full border-none bg-transparent pr-20 text-2xl font-bold text-content outline-none placeholder-content-hint"
-                                {...register('name')}
-                            />
-                            <span className={`absolute right-3 top-1/2 -translate-y-1/2 text-xs font-medium ${titleValue.length > 40 ? 'text-danger' : 'text-content-hint'}`}>
-                                {titleValue.length}/50
-                            </span>
-                        </div>
+        <div className="min-h-screen bg-surface pb-20">
+            <form onSubmit={handleSubmit(onSubmit)}>
+                <div className="sticky top-0 z-10 bg-surface border-b border-line">
+                    <div className="max-w-4xl mx-auto px-4 md:px-6 h-14 flex items-center justify-between">
+                        <Link
+                            to="/series"
+                            className="flex min-h-11 items-center gap-2 py-2 text-sm text-content-secondary transition-colors hover:text-content active:text-content-secondary [@media(pointer:fine)]:min-h-9">
+                            <ArrowLeft aria-hidden className="h-4 w-4" />
+                            <span>목록으로</span>
+                        </Link>
                     </div>
-                    {errors.name?.message && (
-                        <p className="text-sm text-danger">{errors.name.message}</p>
-                    )}
-                </section>
+                </div>
 
-                <PostSelector
-                    posts={availablePosts}
-                    selectedPostIds={selectedPostIds}
-                    onChange={(postIds) => {
-                        setValue('postIds', postIds, { shouldDirty: true });
-                    }}
-                />
+                <div className="max-w-4xl mx-auto px-4 md:px-6 pt-10 pb-10 space-y-10">
+                    <section className="space-y-4">
+                        <h1 className="sr-only">
+                            {isEditMode ? '시리즈 수정' : '시리즈 생성'}
+                        </h1>
 
-                <section>
-                    <Input
-                        label="시리즈 설명"
-                        multiline
-                        rows={5}
-                        placeholder="이 시리즈에서 다루는 내용을 입력해주세요."
-                        maxLength={500}
-                        error={errors.description?.message}
-                        helperText="시리즈 상단에 표시됩니다. 선택 입력입니다."
-                        {...register('description')}
+                        <div className="space-y-2">
+                            <label
+                                htmlFor="series-name"
+                                className="ml-1 block text-sm font-medium text-content-secondary">
+                                시리즈 제목
+                            </label>
+                            <div className="relative rounded-lg border border-line bg-surface-elevated px-3 py-3 transition-all duration-150 focus-within:border-line-strong focus-within:ring-2 focus-within:ring-line/70">
+                                <input
+                                    id="series-name"
+                                    type="text"
+                                    maxLength={50}
+                                    placeholder="시리즈 제목을 입력해주세요"
+                                    className="w-full border-none bg-transparent pr-20 text-2xl font-bold text-content outline-none placeholder-content-hint"
+                                    {...register('name')}
+                                />
+                                <span className={`absolute right-3 top-1/2 -translate-y-1/2 text-xs font-medium ${titleValue.length > 40 ? 'text-danger' : 'text-content-hint'}`}>
+                                    {titleValue.length}/50
+                                </span>
+                            </div>
+                        </div>
+                        {errors.name?.message && (
+                            <p className="text-sm text-danger">{errors.name.message}</p>
+                        )}
+                    </section>
+
+                    <PostSelector
+                        posts={availablePosts}
+                        selectedPostIds={selectedPostIds}
+                        onChange={(postIds) => {
+                            setValue('postIds', postIds, { shouldDirty: true });
+                        }}
                     />
-                </section>
 
-                <section className="space-y-3 border-t border-line-light pt-5">
-                    <div className="flex items-center justify-between gap-3">
-                        <h2 className="text-sm font-semibold text-content-secondary">시리즈 URL</h2>
-                        {isEditMode && (
+                    <section>
+                        <Input
+                            density="compact"
+                            label="시리즈 설명"
+                            multiline
+                            rows={5}
+                            placeholder="이 시리즈에서 다루는 내용을 입력해주세요."
+                            maxLength={500}
+                            error={errors.description?.message}
+                            helperText="시리즈 상단에 표시됩니다. 선택 입력입니다."
+                            {...register('description')}
+                        />
+                    </section>
+
+                    <section className="space-y-3 border-t border-line-light pt-5">
+                        <div className="flex items-center justify-between gap-3">
+                            <h2 className="text-sm font-semibold text-content-secondary">시리즈 URL</h2>
+                            {isEditMode && (
+                                <Button
+                                    density="compact"
+                                    type="button"
+                                    variant="ghost"
+                                    size="sm"
+                                    className="h-10 shrink-0"
+                                    onClick={handleCopySeriesUrl}>
+                                    복사
+                                </Button>
+                            )}
+                        </div>
+
+                        {!isEditMode && (
+                            <details className="group">
+                                <summary className="flex min-h-11 cursor-pointer list-none items-center text-sm text-content-secondary transition-colors hover:text-content [@media(pointer:fine)]:min-h-9">
+                                    URL 직접 설정
+                                    <ChevronDown aria-hidden className="ml-2 inline h-3.5 w-3.5 transition-transform group-open:rotate-180" />
+                                </summary>
+                                <div className="mt-3 space-y-2">
+                                    <Input
+                                        density="compact"
+                                        label="URL (선택)"
+                                        value={customUrlValue}
+                                        onChange={(e) => {
+                                            setValue('customUrl', normalizeSeriesUrlInput(e.target.value), {
+                                                shouldDirty: true,
+                                                shouldValidate: true
+                                            });
+                                        }}
+                                        placeholder="series-url"
+                                    />
+                                    {errors.customUrl?.message && (
+                                        <p className="text-sm text-danger">{errors.customUrl.message}</p>
+                                    )}
+                                    <p className="text-xs text-content-secondary">
+                                        영문/숫자/한글/하이픈(`-`)만 사용할 수 있습니다.
+                                    </p>
+                                </div>
+                            </details>
+                        )}
+
+                        <div className="break-all text-xs font-mono text-content-hint">
+                            {seriesPath}
+                        </div>
+
+                        <p className="text-xs text-content-secondary">
+                            {isEditMode ? '시리즈 이름을 수정해도 URL은 유지됩니다.' : customSlug ? '직접 입력한 URL로 시리즈가 생성됩니다.' : 'URL을 비워두면 제목 기반 자동 URL로 시리즈가 생성됩니다.'}
+                        </p>
+                    </section>
+
+                </div>
+
+                <FloatingBottomBar>
+                    {isEditMode && (
+                        <>
                             <Button
+                                density="compact"
                                 type="button"
                                 variant="ghost"
-                                size="sm"
-                                className="h-10 shrink-0"
-                                onClick={handleCopySeriesUrl}>
-                                복사
+                                size="md"
+                                isLoading={deleteMutation.isPending}
+                                disabled={isSaving}
+                                onClick={handleDelete}
+                                className="!rounded-full !text-danger hover:!text-danger hover:!bg-danger-surface">
+                                삭제
                             </Button>
-                        )}
-                    </div>
-
-                    {!isEditMode && (
-                        <details className="group">
-                            <summary className="cursor-pointer list-none text-sm text-content-secondary transition-colors hover:text-content">
-                                URL 직접 설정
-                                <ChevronDown aria-hidden className="ml-2 inline h-3.5 w-3.5 transition-transform group-open:rotate-180" />
-                            </summary>
-                            <div className="mt-3 space-y-2">
-                                <Input
-                                    label="URL (선택)"
-                                    value={customUrlValue}
-                                    onChange={(e) => {
-                                        setValue('customUrl', normalizeSeriesUrlInput(e.target.value), {
-                                            shouldDirty: true,
-                                            shouldValidate: true
-                                        });
-                                    }}
-                                    placeholder="series-url"
-                                />
-                                {errors.customUrl?.message && (
-                                    <p className="text-sm text-danger">{errors.customUrl.message}</p>
-                                )}
-                                <p className="text-xs text-content-secondary">
-                                    영문/숫자/한글/하이픈(`-`)만 사용할 수 있습니다.
-                                </p>
-                            </div>
-                        </details>
+                            <div className="w-px h-8 bg-line/60 mx-1" />
+                        </>
                     )}
 
-                    <div className="break-all text-xs font-mono text-content-hint">
-                        {seriesPath}
-                    </div>
-
-                    <p className="text-xs text-content-secondary">
-                        {isEditMode ? '시리즈 이름을 수정해도 URL은 유지됩니다.' : customSlug ? '직접 입력한 URL로 시리즈가 생성됩니다.' : 'URL을 비워두면 제목 기반 자동 URL로 시리즈가 생성됩니다.'}
-                    </p>
-                </section>
-
-            </div>
-
-            <FloatingBottomBar>
-                {isEditMode && (
-                    <>
-                        <Button
-                            type="button"
-                            variant="ghost"
-                            size="md"
-                            isLoading={deleteMutation.isPending}
-                            disabled={isSaving}
-                            onClick={handleDelete}
-                            className="!rounded-full !text-danger hover:!text-danger hover:!bg-danger-surface">
-                            삭제
-                        </Button>
-                        <div className="w-px h-8 bg-line/60 mx-1" />
-                    </>
-                )}
-
-                <Button
-                    type="submit"
-                    variant="primary"
-                    className="!rounded-full"
-                    leftIcon={!isSaving ? <Send className="w-4 h-4" /> : undefined}
-                    isLoading={isSaving}
-                    disabled={deleteMutation.isPending}>
-                    {isSaving ? '저장 중...' : isEditMode ? '수정' : '생성'}
-                </Button>
-            </FloatingBottomBar>
-        </form>
+                    <Button
+                        density="compact"
+                        type="submit"
+                        variant="primary"
+                        className="!rounded-full"
+                        leftIcon={!isSaving ? <Send className="w-4 h-4" /> : undefined}
+                        isLoading={isSaving}
+                        disabled={deleteMutation.isPending}>
+                        {isSaving ? '저장 중...' : isEditMode ? '수정' : '생성'}
+                    </Button>
+                </FloatingBottomBar>
+            </form>
+        </div>
     );
 };
 

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SiteSettingSetting/SiteSettingSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SiteSettingSetting/SiteSettingSetting.tsx
@@ -131,9 +131,10 @@ const AssetUploadButton = ({ label, disabled, onUpload }: AssetUploadButtonProps
                 onChange={onUpload}
             />
             <Button
+                density="compact"
                 variant="secondary"
                 size="sm"
-                className="h-11 flex-1 sm:flex-none"
+                className="h-11 flex-1 [@media(pointer:fine)]:h-9 sm:flex-none"
                 disabled={disabled}
                 leftIcon={<Upload aria-hidden="true" className="h-3.5 w-3.5" />}
                 onClick={() => inputRef.current?.click()}>
@@ -178,10 +179,11 @@ const BrandAssetSlot = ({
             />
             {hasAsset && (
                 <Button
+                    density="compact"
                     variant="danger"
                     size="sm"
                     disabled={deleteDisabled}
-                    className="h-11 flex-1 sm:flex-none"
+                    className="h-11 flex-1 [@media(pointer:fine)]:h-9 sm:flex-none"
                     onClick={onDelete}>
                     삭제
                 </Button>
@@ -406,6 +408,7 @@ const SiteSettingSetting = () => {
                 </h2>
                 <Card>
                     <Input
+                        density="compact"
                         label="사이트 이름"
                         maxLength={80}
                         placeholder="BLEX"
@@ -518,10 +521,11 @@ const SiteSettingSetting = () => {
 
             <div className="sticky bottom-0 z-10 -mx-4 flex justify-end bg-surface-page/95 px-4 py-3 backdrop-blur md:mx-0 md:px-0">
                 <Button
+                    density="compact"
                     type="submit"
                     variant="primary"
                     size="md"
-                    className="h-11 w-full sm:w-auto"
+                    className="h-11 w-full [@media(pointer:fine)]:h-10 sm:w-auto"
                     isLoading={updateMutation.isPending}
                     disabled={saveDisabled}
                     leftIcon={!updateMutation.isPending

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SocialLinksSetting/SocialLinksSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SocialLinksSetting/SocialLinksSetting.tsx
@@ -39,7 +39,7 @@ import { toast } from '~/utils/toast';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { SettingsEmptyState, SettingsHeader } from '../../components';
 import { Button, Input, Dropdown } from '~/components/shared';
-import { settingsSelectTriggerStyles } from '~/styles/settingsStyles';
+import { settingsCompactSelectTriggerStyles } from '~/styles/settingsStyles';
 import { getSocialLinks, updateSocialLinks, type SocialLink as ApiSocialLink } from '~/lib/api/settings';
 
 interface SocialLink extends ApiSocialLink {
@@ -157,7 +157,7 @@ const SocialLinkItem = ({ social, index, onRemove, onChange }: SocialLinkItemPro
                 <div className="p-4 flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-3">
                     {/* 드래그 핸들 - 데스크톱에서만 표시 */}
                     <div
-                        className="hidden min-h-11 min-w-11 flex-shrink-0 cursor-grab items-center justify-center rounded-lg text-content-hint transition-colors hover:bg-surface-subtle hover:text-content-secondary group-hover:text-content-secondary active:cursor-grabbing sm:flex"
+                        className="hidden min-h-11 min-w-11 flex-shrink-0 cursor-grab items-center justify-center rounded-lg text-content-hint transition-colors hover:bg-surface-subtle hover:text-content-secondary group-hover:text-content-secondary active:cursor-grabbing sm:flex [@media(pointer:fine)]:min-h-9 [@media(pointer:fine)]:min-w-9"
                         style={{ touchAction: 'none' }}
                         {...attributes}
                         {...listeners}
@@ -177,8 +177,9 @@ const SocialLinkItem = ({ social, index, onRemove, onChange }: SocialLinkItemPro
                     <div className="w-full sm:w-44 flex-shrink-0">
                         <label htmlFor={platformInputId} className="block text-xs font-medium text-content-secondary mb-2 sm:hidden">플랫폼 선택</label>
                         <Dropdown
+                            density="compact"
                             trigger={
-                                <button id={platformInputId} type="button" className={`${settingsSelectTriggerStyles} flex items-center justify-between`}>
+                                <button id={platformInputId} type="button" className={`${settingsCompactSelectTriggerStyles} flex items-center justify-between`}>
                                     <span className={!social.name ? 'text-content-hint' : 'text-content'}>
                                         {currentPlatform?.label || '아이콘 선택'}
                                     </span>
@@ -200,6 +201,7 @@ const SocialLinkItem = ({ social, index, onRemove, onChange }: SocialLinkItemPro
                         <Input
                             id={linkInputId}
                             type="url"
+                            density="compact"
                             placeholder="https://example.com"
                             value={social.value}
                             onChange={(e) => onChange(index, 'value', e.target.value)}
@@ -210,7 +212,7 @@ const SocialLinkItem = ({ social, index, onRemove, onChange }: SocialLinkItemPro
                     <button
                         type="button"
                         aria-label={`${currentPlatform?.label || '소셜 링크'} 삭제`}
-                        className="hidden min-h-11 min-w-11 flex-shrink-0 items-center justify-center rounded-lg text-content-hint transition-all duration-200 hover:bg-surface-subtle hover:text-content-secondary group/btn sm:flex"
+                        className="hidden min-h-11 min-w-11 flex-shrink-0 items-center justify-center rounded-lg text-content-hint transition-all duration-200 hover:bg-surface-subtle hover:text-content-secondary group/btn sm:flex [@media(pointer:fine)]:min-h-9 [@media(pointer:fine)]:min-w-9"
                         onClick={() => onRemove(social.id)}>
                         <X
                             aria-hidden="true"
@@ -380,10 +382,11 @@ const SocialLinks = () => {
                             title="소셜 링크가 없습니다"
                             action={(
                                 <Button
+                                    density="compact"
                                     type="button"
                                     variant="secondary"
                                     size="md"
-                                    className="min-h-11!"
+                                    className="min-h-11! [@media(pointer:fine)]:min-h-10!"
                                     onClick={handleSocialAdd}>
                                     소셜 링크 추가하기
                                 </Button>
@@ -415,21 +418,23 @@ const SocialLinks = () => {
                 {shouldShowActions && (
                     <div className="flex flex-col sm:flex-row gap-3 sm:justify-between border-t border-line pt-6">
                         <Button
+                            density="compact"
                             type="button"
                             variant="secondary"
                             size="md"
                             leftIcon={<Plus aria-hidden="true" className="h-4 w-4" />}
                             onClick={handleSocialAdd}
-                            className="min-h-11! sm:w-auto">
+                            className="min-h-11! [@media(pointer:fine)]:min-h-10! sm:w-auto">
                             링크 추가
                         </Button>
                         <Button
+                            density="compact"
                             type="submit"
                             variant="primary"
                             size="md"
                             isLoading={isLoading}
                             leftIcon={!isLoading ? <Save aria-hidden="true" className="h-4 w-4" /> : undefined}
-                            className="min-h-11! sm:w-auto">
+                            className="min-h-11! [@media(pointer:fine)]:min-h-10! sm:w-auto">
                             {isLoading ? '저장 중...' : '변경사항 저장'}
                         </Button>
                     </div>

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/StaticPagesSetting/StaticPagesSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/StaticPagesSetting/StaticPagesSetting.tsx
@@ -3,8 +3,10 @@ import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-q
 import { Link, useNavigate } from '@tanstack/react-router';
 import { FileText } from '@blex/ui/icons';
 import { useConfirm } from '~/hooks/useConfirm';
-import { SettingsEmptyState, SettingsHeader } from '../../components';
-import { Button } from '~/components/shared';
+import {
+    SettingsEmptyState,
+    SettingsHeader
+} from '../../components';
 import {
     getStaticPages,
     deleteStaticPage,
@@ -71,13 +73,10 @@ const StaticPagesSetting = () => {
     };
 
     const createAction = (
-        <Link to="/static-pages/create" className="block w-full sm:w-auto">
-            <Button
-                variant="primary"
-                size="md"
-                className="min-h-11! w-full sm:w-auto">
-                새 페이지 추가
-            </Button>
+        <Link
+            to="/static-pages/create"
+            className="inline-flex min-h-11 items-center justify-center rounded-lg border border-transparent bg-action px-3 py-1.5 text-xs font-semibold text-content-inverted transition-all duration-150 hover:bg-action-hover focus:outline-none focus:ring-4 focus:ring-action/20 focus:ring-offset-1 active:scale-95 [@media(pointer:fine)]:min-h-9">
+            새 페이지 추가
         </Link>
     );
 

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/StaticPagesSetting/components/StaticPageEditor.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/StaticPagesSetting/components/StaticPageEditor.tsx
@@ -230,12 +230,15 @@ const StaticPageEditor = ({ pageId }: StaticPageEditorProps) => {
 
     return (
         <div className="min-h-screen bg-surface pb-16">
+            <h1 className="sr-only">
+                {isEditMode ? '정적 페이지 수정' : '정적 페이지 생성'}
+            </h1>
             {/* Top bar */}
             <div className="sticky top-0 z-10 bg-surface border-b border-line">
                 <div className="max-w-7xl mx-auto px-4 md:px-6 flex items-center justify-between h-14">
                     <Link
                         to="/static-pages"
-                        className="flex items-center gap-2 text-sm text-content-secondary hover:text-content transition-colors">
+                        className="flex min-h-11 items-center gap-2 text-sm text-content-secondary transition-colors hover:text-content [@media(pointer:fine)]:min-h-9">
                         <ArrowLeft aria-hidden="true" className="h-4 w-4" />
                         <span>목록으로</span>
                     </Link>
@@ -244,7 +247,7 @@ const StaticPageEditor = ({ pageId }: StaticPageEditorProps) => {
                             href={pageUrlPath}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="flex items-center gap-1.5 text-sm text-content-secondary hover:text-content transition-colors">
+                            className="flex min-h-11 items-center gap-1.5 text-sm text-content-secondary transition-colors hover:text-content [@media(pointer:fine)]:min-h-9">
                             <span>{pageUrlPath}</span>
                             <ExternalLink aria-hidden="true" className="h-3.5 w-3.5" />
                         </a>
@@ -259,6 +262,7 @@ const StaticPageEditor = ({ pageId }: StaticPageEditorProps) => {
                     <div className="space-y-4">
                         <div className="space-y-2">
                             <Input
+                                density="compact"
                                 label="페이지 이름"
                                 value={title}
                                 onChange={(e) => handleTitleChange(e.target.value)}
@@ -270,7 +274,7 @@ const StaticPageEditor = ({ pageId }: StaticPageEditorProps) => {
                         </div>
 
                         <details className="group border-t border-line-light pt-4">
-                            <summary className="cursor-pointer list-none text-sm font-medium text-content-secondary transition-colors hover:text-content">
+                            <summary className="flex min-h-11 cursor-pointer list-none items-center text-sm font-medium text-content-secondary transition-colors hover:text-content [@media(pointer:fine)]:min-h-9">
                                 URL 직접 설정
                                 <ChevronDown
                                     aria-hidden="true"
@@ -279,6 +283,7 @@ const StaticPageEditor = ({ pageId }: StaticPageEditorProps) => {
                             </summary>
                             <div className="mt-3">
                                 <Input
+                                    density="compact"
                                     label="URL 슬러그"
                                     value={slug}
                                     onChange={(e) => handleSlugChange(e.target.value)}
@@ -303,8 +308,9 @@ const StaticPageEditor = ({ pageId }: StaticPageEditorProps) => {
                         <div className="inline-flex rounded-lg border border-line bg-surface p-1">
                             <button
                                 type="button"
+                                aria-pressed={activePanel === 'code'}
                                 onClick={() => setActivePanel('code')}
-                                className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+                                className={`inline-flex min-h-11 items-center rounded-md px-3 py-1.5 text-sm font-medium transition-colors [@media(pointer:fine)]:min-h-8 ${
                                     activePanel === 'code'
                                         ? 'bg-surface-subtle text-content'
                                         : 'text-content-secondary hover:text-content'
@@ -313,8 +319,9 @@ const StaticPageEditor = ({ pageId }: StaticPageEditorProps) => {
                             </button>
                             <button
                                 type="button"
+                                aria-pressed={activePanel === 'preview'}
                                 onClick={() => setActivePanel('preview')}
-                                className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+                                className={`inline-flex min-h-11 items-center rounded-md px-3 py-1.5 text-sm font-medium transition-colors [@media(pointer:fine)]:min-h-8 ${
                                     activePanel === 'preview'
                                         ? 'bg-surface-subtle text-content'
                                         : 'text-content-secondary hover:text-content'
@@ -358,6 +365,7 @@ const StaticPageEditor = ({ pageId }: StaticPageEditorProps) => {
                 {isEditMode && (
                     <>
                         <Button
+                            density="compact"
                             type="button"
                             variant="ghost"
                             size="md"
@@ -373,7 +381,9 @@ const StaticPageEditor = ({ pageId }: StaticPageEditorProps) => {
 
                 <IconButton
                     onClick={() => setIsSettingsOpen(true)}
+                    size="sm"
                     rounded="full"
+                    className="[@media(pointer:fine)]:h-9! [@media(pointer:fine)]:w-9!"
                     aria-label="페이지 설정"
                     title="페이지 설정">
                     <SlidersHorizontal className="w-5 h-5" />
@@ -382,6 +392,7 @@ const StaticPageEditor = ({ pageId }: StaticPageEditorProps) => {
                 <div className="w-px h-8 bg-line/60 mx-1" />
 
                 <Button
+                    density="compact"
                     onClick={handleSubmit}
                     disabled={isLoading || deleteMutation.isPending}
                     variant="primary"
@@ -410,7 +421,10 @@ const StaticPageEditor = ({ pageId }: StaticPageEditorProps) => {
                                 <Dialog.Title className="text-lg font-semibold text-content">페이지 설정</Dialog.Title>
                             </div>
                             <Dialog.Close asChild>
-                                <IconButton aria-label="닫기">
+                                <IconButton
+                                    size="sm"
+                                    className="[@media(pointer:fine)]:h-9! [@media(pointer:fine)]:w-9!"
+                                    aria-label="닫기">
                                     <X className="w-5 h-5" />
                                 </IconButton>
                             </Dialog.Close>
@@ -457,6 +471,7 @@ const StaticPageEditor = ({ pageId }: StaticPageEditorProps) => {
                                     <div className="space-y-4">
                                         <div>
                                             <Input
+                                                density="compact"
                                                 label="메타 설명"
                                                 multiline
                                                 rows={3}
@@ -515,6 +530,7 @@ const StaticPageEditor = ({ pageId }: StaticPageEditorProps) => {
                         {/* Footer */}
                         <div className="px-6 py-4 border-t border-line bg-surface-subtle">
                             <Button
+                                density="compact"
                                 type="button"
                                 onClick={() => setIsSettingsOpen(false)}
                                 variant="primary"

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/StaticPagesSetting/components/StaticPageList.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/StaticPagesSetting/components/StaticPageList.tsx
@@ -20,8 +20,9 @@ export const StaticPageList = ({ pages, onView, onEdit, onDelete }: StaticPageLi
                     onClick={() => onView(page)}
                     actions={
                         <Dropdown
+                            density="compact"
                             triggerAriaLabel={`${page.title} 페이지 메뉴 열기`}
-                            triggerClassName="min-h-11 min-w-11"
+                            triggerClassName="min-h-11 min-w-11 [@media(pointer:fine)]:min-h-9 [@media(pointer:fine)]:min-w-9"
                             items={[
                                 {
                                     label: '편집',

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/UserManagementSetting/index.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/UserManagementSetting/index.tsx
@@ -208,6 +208,7 @@ const MobileUserRow = ({
                         <p className="mb-2 text-xs font-medium text-content-hint">권한</p>
                         {user.canChangeRole ? (
                             <Select
+                                density="compact"
                                 value={user.role}
                                 onValueChange={(value) => onRoleChange(value as ManagedUserRole)}
                                 items={roleItems}
@@ -445,6 +446,7 @@ const UserManagementSetting = () => {
                             초대 링크는 한 번만 사용할 수 있으며, 사용 전에는 삭제할 수 있습니다.
                         </p>
                         <Button
+                            density="compact"
                             variant="primary"
                             isLoading={inviteMutation.isPending}
                             onClick={() => inviteMutation.mutate()}>
@@ -474,6 +476,7 @@ const UserManagementSetting = () => {
                                 </div>
                                 <div className="flex flex-wrap gap-2 lg:flex-shrink-0">
                                     <Button
+                                        density="compact"
                                         variant="secondary"
                                         size="sm"
                                         disabled={invite.isClaimed || !invite.isActive}
@@ -481,6 +484,7 @@ const UserManagementSetting = () => {
                                         링크 복사
                                     </Button>
                                     <Button
+                                        density="compact"
                                         variant="danger"
                                         size="sm"
                                         isLoading={deleteInviteMutation.isPending && deleteInviteMutation.variables?.id === invite.id}
@@ -506,6 +510,7 @@ const UserManagementSetting = () => {
                 icon={<Users aria-hidden="true" className="h-4 w-4" />}>
                 <div className="mb-6 grid gap-3 lg:grid-cols-[minmax(0,1fr)_180px_180px_auto]">
                     <Input
+                        density="compact"
                         aria-label="사용자 검색"
                         placeholder="아이디·이름·이메일 검색"
                         value={query}
@@ -515,21 +520,21 @@ const UserManagementSetting = () => {
                         }}
                     />
                     <Select
+                        density="compact"
                         value={roleFilter}
                         onValueChange={handleRoleFilterChange}
                         items={roleFilterItems}
-                        className="min-h-10 py-2"
                     />
                     <Select
+                        density="compact"
                         value={ordering}
                         onValueChange={handleOrderingChange}
                         items={orderingItems}
-                        className="min-h-10 py-2"
                     />
                     <div className="flex gap-2">
-                        <Button variant="secondary" onClick={handleSearch}>검색</Button>
+                        <Button density="compact" variant="secondary" onClick={handleSearch}>검색</Button>
                         {(appliedQuery || roleFilter !== 'all' || ordering !== 'username') && (
-                            <Button variant="ghost" onClick={handleReset}>초기화</Button>
+                            <Button density="compact" variant="ghost" onClick={handleReset}>초기화</Button>
                         )}
                     </div>
                 </div>
@@ -570,10 +575,10 @@ const UserManagementSetting = () => {
                                     <div className="space-y-1">
                                         {user.canChangeRole ? (
                                             <Select
+                                                density="compact"
                                                 value={user.role}
                                                 onValueChange={(value) => void handleRoleChange(user, value as ManagedUserRole)}
                                                 items={roleItems}
-                                                className="min-h-10 py-2"
                                                 disabled={roleMutation.isPending && roleMutation.variables?.user.id === user.id}
                                             />
                                         ) : (
@@ -614,6 +619,7 @@ const UserManagementSetting = () => {
                         </p>
                         <div className="flex flex-wrap items-center gap-2">
                             <Button
+                                density="compact"
                                 variant="secondary"
                                 size="sm"
                                 disabled={!pagination.hasPrevious}
@@ -622,6 +628,7 @@ const UserManagementSetting = () => {
                                 <ChevronsLeft aria-hidden="true" className="h-4 w-4" />
                             </Button>
                             <Button
+                                density="compact"
                                 variant="secondary"
                                 size="sm"
                                 disabled={!pagination.hasPrevious}
@@ -631,6 +638,7 @@ const UserManagementSetting = () => {
                             </Button>
                             {visiblePages.map(pageNumber => (
                                 <Button
+                                    density="compact"
                                     key={pageNumber}
                                     variant={pageNumber === currentPage ? 'primary' : 'secondary'}
                                     size="sm"
@@ -640,6 +648,7 @@ const UserManagementSetting = () => {
                                 </Button>
                             ))}
                             <Button
+                                density="compact"
                                 variant="secondary"
                                 size="sm"
                                 disabled={!pagination.hasNext}
@@ -648,6 +657,7 @@ const UserManagementSetting = () => {
                                 <ChevronRight aria-hidden="true" className="h-4 w-4" />
                             </Button>
                             <Button
+                                density="compact"
                                 variant="secondary"
                                 size="sm"
                                 disabled={!pagination.hasNext}

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/UtilitySetting/UtilitySetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/UtilitySetting/UtilitySetting.tsx
@@ -14,7 +14,7 @@ import {
     Trash2
 } from '@blex/ui/icons';
 import { useConfirm } from '~/hooks/useConfirm';
-import { SettingsHeader } from '../../components';
+import { SettingsHeader, SettingsHeaderAction } from '../../components';
 import {
     Alert, Button, Card, Checkbox, Select
 } from '~/components/shared';
@@ -60,9 +60,10 @@ const UtilityActionButtons = ({
 }: UtilityActionButtonsProps) => (
     <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap">
         <Button
+            density="compact"
             variant="secondary"
             size="md"
-            className="h-11 w-full sm:w-auto"
+            className="h-11 w-full [@media(pointer:fine)]:h-10 sm:w-auto"
             disabled={isPending}
             isLoading={isPreviewLoading}
             leftIcon={<Eye aria-hidden="true" className="h-4 w-4" />}
@@ -70,9 +71,10 @@ const UtilityActionButtons = ({
             1. {previewLabel}
         </Button>
         <Button
+            density="compact"
             variant={executeVariant}
             size="md"
-            className="h-11 w-full sm:w-auto"
+            className="h-11 w-full [@media(pointer:fine)]:h-10 sm:w-auto"
             disabled={!canExecute || isPending}
             isLoading={isExecuteLoading}
             leftIcon={<Trash2 aria-hidden="true" className="h-4 w-4" />}
@@ -537,15 +539,13 @@ const UtilitySetting = () => {
                 description="삭제 작업은 먼저 대상을 확인한 뒤 실행하세요."
                 actionPosition="right"
                 action={
-                    <Button
+                    <SettingsHeaderAction
                         variant="secondary"
-                        size="md"
-                        className="h-11 w-full sm:w-auto"
                         isLoading={isStatsFetching}
                         leftIcon={<RotateCw aria-hidden="true" className="h-4 w-4" />}
                         onClick={handleRefreshStats}>
                         통계 새로고침
-                    </Button>
+                    </SettingsHeaderAction>
                 }
             />
 
@@ -715,6 +715,7 @@ const UtilitySetting = () => {
                                 <div className="w-full min-w-[220px] flex-1">
                                     <label className="mb-1.5 block text-sm font-medium text-content">정리 대상</label>
                                     <Select
+                                        density="compact"
                                         value={imageTarget}
                                         onValueChange={(value) => {
                                             setImageTarget(value);

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/shared/BannerEditorBase.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/shared/BannerEditorBase.tsx
@@ -297,7 +297,7 @@ const BannerEditorBase = ({ scope, bannerId }: BannerEditorBaseProps) => {
         <div className="space-y-5">
             {!isEditMode && !hasSelectedPosition && (
                 <div className="rounded-2xl border border-warning-line bg-warning-surface px-4 py-3">
-                    <p className="text-base font-extrabold text-warning sm:text-lg">
+                    <p className="text-base font-semibold text-warning">
                         먼저 배너의 위치를 선택하세요.
                     </p>
                     <p className="mt-1 text-xs font-medium text-warning">
@@ -313,9 +313,10 @@ const BannerEditorBase = ({ scope, bannerId }: BannerEditorBaseProps) => {
                         <button
                             key={slot}
                             type="button"
+                            aria-pressed={active}
                             onClick={() => handlePositionChange(slot)}
                             className={cx(
-                                'rounded-full border px-3 py-1 text-xs font-semibold transition-colors',
+                                'min-h-11 rounded-full border px-3 py-1 text-xs font-semibold transition-colors [@media(pointer:fine)]:min-h-9',
                                 active ? 'border-line-strong bg-action text-content-inverted' : 'border-line bg-surface text-content hover:border-line-strong',
                                 !hasSelectedPosition ? 'ring-2 ring-warning-line' : ''
                             )}>
@@ -333,6 +334,7 @@ const BannerEditorBase = ({ scope, bannerId }: BannerEditorBaseProps) => {
             </div>
 
             <Input
+                density="compact"
                 label="배너 이름"
                 placeholder="예: 메인 공지 배너"
                 error={errors.title?.message}
@@ -341,6 +343,7 @@ const BannerEditorBase = ({ scope, bannerId }: BannerEditorBaseProps) => {
 
             <div className="grid gap-3 sm:grid-cols-2">
                 <Input
+                    density="compact"
                     type="number"
                     min={0}
                     label="노출 순서"
@@ -389,37 +392,39 @@ const BannerEditorBase = ({ scope, bannerId }: BannerEditorBaseProps) => {
     );
 
     return (
-        <form onSubmit={handleSubmit(onSubmit)} className="min-h-screen bg-surface pb-16">
-            <div className="sticky top-0 z-10 border-b border-line bg-surface">
-                <div className="mx-auto flex h-14 max-w-7xl items-center justify-between px-4 md:px-6">
-                    <button
-                        type="button"
-                        className="flex items-center gap-2 py-2 text-sm text-content-secondary transition-colors hover:text-content active:text-content-secondary"
-                        onClick={() => navigateToList()}>
-                        <ArrowLeft aria-hidden="true" className="h-4 w-4" />
-                        <span>목록으로</span>
-                    </button>
+        <div className="min-h-screen bg-surface pb-16">
+            <form onSubmit={handleSubmit(onSubmit)}>
+                <div className="sticky top-0 z-10 border-b border-line bg-surface">
+                    <div className="mx-auto flex h-14 max-w-7xl items-center justify-between px-4 md:px-6">
+                        <button
+                            type="button"
+                            className="flex min-h-11 items-center gap-2 py-2 text-sm text-content-secondary transition-colors hover:text-content active:text-content-secondary [@media(pointer:fine)]:min-h-9"
+                            onClick={() => navigateToList()}>
+                            <ArrowLeft aria-hidden="true" className="h-4 w-4" />
+                            <span>목록으로</span>
+                        </button>
 
-                    <span className="text-sm text-content-secondary">
-                        {isEditMode && title ? title : isEditMode ? `${bannerLabel} 수정` : `${bannerLabel} 생성`}
-                    </span>
+                        <h1 className="text-sm font-medium text-content-secondary">
+                            {isEditMode && title ? title : isEditMode ? `${bannerLabel} 수정` : `${bannerLabel} 생성`}
+                        </h1>
+                    </div>
                 </div>
-            </div>
 
-            <div className="mx-auto max-w-[1720px] space-y-6 px-4 pb-8 pt-6 md:px-6">
-                <BannerPreviewFrame
-                    contentHtml={contentHtml}
-                    position={position}
-                    hasSelectedPosition={hasSelectedPosition}
-                    onPositionChange={handlePositionChange}
-                    editorPanel={editorPanel}
-                />
-            </div>
+                <div className="mx-auto max-w-[1720px] space-y-6 px-4 pb-8 pt-6 md:px-6">
+                    <BannerPreviewFrame
+                        contentHtml={contentHtml}
+                        position={position}
+                        hasSelectedPosition={hasSelectedPosition}
+                        onPositionChange={handlePositionChange}
+                        editorPanel={editorPanel}
+                    />
+                </div>
 
-            <FloatingBottomBar>
-                {isEditMode && (
+                <FloatingBottomBar>
+                    {isEditMode && (
                     <>
                         <Button
+                            density="compact"
                             type="button"
                             variant="ghost"
                             size="md"
@@ -433,21 +438,23 @@ const BannerEditorBase = ({ scope, bannerId }: BannerEditorBaseProps) => {
                     </>
                 )}
 
-                <div className="hidden items-center px-1.5 text-xs text-content-secondary sm:flex">
-                    {typeLabels[bannerType]} · {positionLabels[position]}
-                </div>
+                    <div className="hidden items-center px-1.5 text-xs text-content-secondary sm:flex">
+                        {typeLabels[bannerType]} · {positionLabels[position]}
+                    </div>
 
-                <Button
-                    type="submit"
-                    variant="primary"
-                    className="!rounded-full"
-                    leftIcon={!isSaving ? <Send className="h-4 w-4" /> : undefined}
-                    isLoading={isSaving}
-                    disabled={deleteMutation.isPending}>
-                    {isSaving ? '저장 중...' : isEditMode ? '수정' : '생성'}
-                </Button>
-            </FloatingBottomBar>
-        </form>
+                    <Button
+                        density="compact"
+                        type="submit"
+                        variant="primary"
+                        className="!rounded-full"
+                        leftIcon={!isSaving ? <Send className="h-4 w-4" /> : undefined}
+                        isLoading={isSaving}
+                        disabled={deleteMutation.isPending}>
+                        {isSaving ? '저장 중...' : isEditMode ? '수정' : '생성'}
+                    </Button>
+                </FloatingBottomBar>
+            </form>
+        </div>
     );
 };
 

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/shared/BannerPreviewFrame.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/shared/BannerPreviewFrame.tsx
@@ -33,56 +33,74 @@ const BannerPreviewFrame = ({
 
     const renderInlineSlot = (slot: BannerPosition) => {
         const selected = hasSelectedPosition && slot === position;
-        return (
-            <button
-                type="button"
-                onClick={() => onPositionChange(slot)}
-                className="block w-full text-left">
-                {selected ? (
-                    hasHtml ? (
+
+        if (selected) {
+            return (
+                <div
+                    role="group"
+                    className="min-h-11"
+                    aria-label={`${positionLabels[slot]} 위치 선택됨`}>
+                    {hasHtml ? (
                         <div dangerouslySetInnerHTML={{ __html: contentHtml }} />
                     ) : (
                         <div className="py-2 text-xs text-content-hint">HTML을 입력하면 {positionLabels[slot]}에 배너가 표시됩니다.</div>
-                    )
-                ) : (
-                    <div
-                        className={cx(
+                    )}
+                </div>
+            );
+        }
+
+        return (
+            <button
+                type="button"
+                aria-pressed="false"
+                onClick={() => onPositionChange(slot)}
+                className="block min-h-11 w-full text-left">
+                <div
+                    className={cx(
                         'rounded-xl border border-dashed px-3 py-4 text-center text-xs font-semibold transition-colors',
                         hasSelectedPosition
                             ? 'border-line text-content-hint hover:border-line hover:text-content-hint'
                             : 'border-warning-line bg-warning-surface text-warning hover:bg-warning-surface'
                     )}>
-                        {positionLabels[slot]} 위치 선택
-                    </div>
-                )}
+                    {positionLabels[slot]} 위치 선택
+                </div>
             </button>
         );
     };
 
     const renderSidebarSlot = (slot: BannerPosition) => {
         const selected = hasSelectedPosition && slot === position;
-        return (
-            <button
-                type="button"
-                onClick={() => onPositionChange(slot)}
-                className={cx('block w-full text-left', !selected ? 'hover:opacity-80' : '')}>
-                {selected ? (
-                    hasHtml ? (
+
+        if (selected) {
+            return (
+                <div
+                    role="group"
+                    className="min-h-11"
+                    aria-label={`${positionLabels[slot]} 위치 선택됨`}>
+                    {hasHtml ? (
                         <div dangerouslySetInnerHTML={{ __html: contentHtml }} />
                     ) : (
                         <div className="py-2 text-xs text-content-hint">{positionLabels[slot]}에 배너가 표시됩니다.</div>
-                    )
-                ) : (
-                    <div
-                        className={cx(
+                    )}
+                </div>
+            );
+        }
+
+        return (
+            <button
+                type="button"
+                aria-pressed="false"
+                onClick={() => onPositionChange(slot)}
+                className="block min-h-11 w-full text-left hover:opacity-80">
+                <div
+                    className={cx(
                         'rounded-xl border border-dashed px-3 py-4 text-center text-xs font-semibold',
                         hasSelectedPosition
                             ? 'border-line text-content-hint'
                             : 'border-warning-line bg-warning-surface text-warning'
                     )}>
-                        {positionLabels[slot]} 위치 선택
-                    </div>
-                )}
+                    {positionLabels[slot]} 위치 선택
+                </div>
             </button>
         );
     };
@@ -97,8 +115,8 @@ const BannerPreviewFrame = ({
                 </aside>
 
                 <div className="post-detail-main">
-                    <div className="mt-6" role="main">
-                        <article lang="ko">
+                    <section className="mt-6" aria-label="배너 배치 미리보기">
+                        <article lang="ko" aria-label="예시 포스트">
                             <div className={cx('mb-12 transition-opacity sm:mb-16', mutedPostClass)}>
                                 <div className="mb-6 flex items-center gap-2">
                                     <span className="inline-flex items-center gap-1.5 rounded-full bg-action px-3 py-1 text-xs font-semibold text-content-inverted">
@@ -108,9 +126,9 @@ const BannerPreviewFrame = ({
                                     <span className="text-xs font-medium text-content-hint">1 / 5</span>
                                 </div>
 
-                                <h1 className="mb-3 break-words text-2xl font-bold leading-tight tracking-tight text-content sm:text-3xl lg:text-4xl">
+                                <h2 className="mb-3 break-words text-2xl font-bold leading-tight tracking-tight text-content sm:text-3xl lg:text-4xl">
                                     포스트 제목이 이 위치에 표시됩니다
-                                </h1>
+                                </h2>
                                 <p className="mb-8 text-lg font-medium leading-relaxed text-content-secondary sm:text-xl">
                                     포스트 서브타이틀 영역
                                 </p>
@@ -135,7 +153,7 @@ const BannerPreviewFrame = ({
                                 {renderInlineSlot('top')}
                             </div>
 
-                            <div className="blog-post-content mb-16 break-words">
+                            <div className="mb-16 break-words">
                                 {editorPanel}
                             </div>
 
@@ -151,7 +169,7 @@ const BannerPreviewFrame = ({
                                 {renderInlineSlot('bottom')}
                             </div>
                         </article>
-                    </div>
+                    </section>
                 </div>
 
                 <aside className="post-detail-sidebar">

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/shared/BannerSettingBase.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/shared/BannerSettingBase.tsx
@@ -3,8 +3,11 @@ import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-q
 import { useNavigate } from '@tanstack/react-router';
 import { Ad, Layers3 } from '@blex/ui/icons';
 import { useConfirm } from '~/hooks/useConfirm';
-import { SettingsEmptyState, SettingsHeader } from '../../components';
-import { Button } from '~/components/shared';
+import {
+    SettingsEmptyState,
+    SettingsHeader,
+    SettingsHeaderAction
+} from '../../components';
 import {
     getBanners,
     updateBanner,
@@ -137,13 +140,11 @@ const BannerSettingBase = ({ scope }: BannerSettingBaseProps) => {
     };
 
     const createAction = (
-        <Button
+        <SettingsHeaderAction
             onClick={handleCreateBanner}
-            variant="primary"
-            size="md"
-            className="min-h-11! w-full sm:w-auto">
+            variant="primary">
             새 배너 추가
-        </Button>
+        </SettingsHeaderAction>
     );
 
     return (

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/shared/NoticeSettingBase.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/shared/NoticeSettingBase.tsx
@@ -6,7 +6,12 @@ import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useConfirm } from '~/hooks/useConfirm';
-import { SettingsEmptyState, SettingsHeader, SettingsListItem } from '../../components';
+import {
+    SettingsEmptyState,
+    SettingsHeader,
+    SettingsHeaderAction,
+    SettingsListItem
+} from '../../components';
 import {
     Button,
     Checkbox,
@@ -205,13 +210,11 @@ const NoticeSettingBase = ({ scope }: NoticeSettingBaseProps) => {
 
     const isSubmitting = createMutation.isPending || updateMutation.isPending;
     const createAction = (
-        <Button
+        <SettingsHeaderAction
             onClick={handleCreate}
-            variant="primary"
-            size="md"
-            className="min-h-11! w-full sm:w-auto">
+            variant="primary">
             새 공지 추가
-        </Button>
+        </SettingsHeaderAction>
     );
 
     return (
@@ -242,9 +245,9 @@ const NoticeSettingBase = ({ scope }: NoticeSettingBaseProps) => {
                                 공지 제목
                             </label>
                             <Input
+                                density="compact"
                                 id={isGlobal ? 'global-notice-title' : 'notice-title'}
                                 placeholder="공지 제목을 입력하세요"
-                                className="text-base"
                                 error={errors.title?.message}
                                 {...register('title')}
                             />
@@ -257,9 +260,9 @@ const NoticeSettingBase = ({ scope }: NoticeSettingBaseProps) => {
                                 URL
                             </label>
                             <Input
+                                density="compact"
                                 id={isGlobal ? 'global-notice-url' : 'notice-url'}
                                 placeholder="https://example.com/notice"
-                                className="text-base"
                                 error={errors.url?.message}
                                 {...register('url')}
                             />
@@ -283,20 +286,22 @@ const NoticeSettingBase = ({ scope }: NoticeSettingBaseProps) => {
 
                         <div className="flex items-center justify-between gap-3">
                             <Button
+                                density="compact"
                                 type="button"
                                 variant="ghost"
                                 size="md"
-                                className="min-h-11!"
+                                className="min-h-11! [@media(pointer:fine)]:min-h-10!"
                                 onClick={closeForm}
                                 disabled={isSubmitting}>
                                 취소
                             </Button>
                             <div className="flex items-center gap-3">
                                 <Button
+                                    density="compact"
                                     type="submit"
                                     variant="primary"
                                     size="md"
-                                    className="min-h-11!"
+                                    className="min-h-11! [@media(pointer:fine)]:min-h-10!"
                                     isLoading={isSubmitting}>
                                     {isSubmitting ? '저장 중...' : editingNotice ? `${noticeLabel} 수정` : `${noticeLabel} 생성`}
                                 </Button>
@@ -313,8 +318,9 @@ const NoticeSettingBase = ({ scope }: NoticeSettingBaseProps) => {
                             key={notice.id}
                             actions={
                                 <Dropdown
+                                    density="compact"
                                     triggerAriaLabel={`${notice.title} ${noticeLabel} 메뉴 열기`}
-                                    triggerClassName="min-h-11 min-w-11"
+                                    triggerClassName="min-h-11 min-w-11 [@media(pointer:fine)]:min-h-9 [@media(pointer:fine)]:min-w-9"
                                     items={[
                                         {
                                             label: notice.isActive ? '비활성화' : '활성화',

--- a/backend/islands/apps/remotes/src/components/shared/index.ts
+++ b/backend/islands/apps/remotes/src/components/shared/index.ts
@@ -7,6 +7,7 @@ export { Input } from '@blex/ui/input';
 export { LoadingState } from '@blex/ui/loading-state';
 export { Modal } from '@blex/ui/modal';
 export { Select } from '@blex/ui/select';
+export { Tabs } from '@blex/ui/tabs';
 export { ImageCropDialog } from './ImageCropDialog';
 
 export {

--- a/backend/islands/apps/remotes/src/styles/settingsStyles.ts
+++ b/backend/islands/apps/remotes/src/styles/settingsStyles.ts
@@ -15,4 +15,7 @@ export const getSettingsIconClass = (
 ) => `${SETTINGS_ICON_BASE} ${SETTINGS_ICON_VARIANTS[variant]}`;
 
 // These are button-based select triggers, not text inputs.
-export const settingsSelectTriggerStyles = 'block w-full rounded-lg border border-line focus:border-line-strong/30 focus:ring-2 focus:ring-line/5 text-sm py-3 px-3 min-h-12 transition-all motion-interaction bg-surface placeholder-content-hint text-content';
+const SETTINGS_SELECT_TRIGGER_BASE = 'block w-full rounded-lg border border-line focus:border-line-strong/30 focus:ring-2 focus:ring-line/5 text-sm px-3 transition-all motion-interaction bg-surface placeholder-content-hint text-content';
+
+export const settingsSelectTriggerStyles = `${SETTINGS_SELECT_TRIGGER_BASE} min-h-11 py-2.5`;
+export const settingsCompactSelectTriggerStyles = `${SETTINGS_SELECT_TRIGGER_BASE} min-h-11 py-2 [@media(pointer:fine)]:min-h-10`;

--- a/backend/islands/packages/ui/src/components/Button.tsx
+++ b/backend/islands/packages/ui/src/components/Button.tsx
@@ -6,6 +6,7 @@ import { INTERACTION_DURATION } from '../lib/designTokens';
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
     variant?: 'primary' | 'secondary' | 'danger' | 'danger-solid' | 'ghost';
     size?: 'sm' | 'md' | 'lg';
+    density?: 'default' | 'compact';
     isLoading?: boolean;
     leftIcon?: ReactNode;
     rightIcon?: ReactNode;
@@ -16,6 +17,7 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 const Button = ({
     variant = 'primary',
     size = 'md',
+    density = 'default',
     isLoading = false,
     leftIcon,
     rightIcon,
@@ -37,16 +39,35 @@ const Button = ({
     };
 
     const sizeStyles = {
-        sm: 'px-3 py-1.5 text-xs rounded-lg min-h-[36px]',
-        md: 'px-4.5 py-2 text-sm rounded-lg min-h-[40px]',
-        lg: 'px-6 py-2.5 text-base rounded-lg min-h-[44px]'
+        sm: 'px-3 py-1.5 text-xs rounded-lg',
+        md: 'px-4.5 py-2 text-sm rounded-lg',
+        lg: 'px-6 py-2.5 text-base rounded-lg'
+    };
+    const heightStyles = {
+        default: {
+            sm: 'min-h-[36px]',
+            md: 'min-h-[40px]',
+            lg: 'min-h-[44px]'
+        },
+        compact: {
+            sm: 'min-h-11 [@media(pointer:fine)]:min-h-[36px]',
+            md: 'min-h-11 [@media(pointer:fine)]:min-h-[40px]',
+            lg: 'min-h-11'
+        }
     };
 
     const widthStyle = fullWidth ? 'w-full' : '';
 
     return (
         <button
-            className={cx(baseStyles, variantStyles[variant], sizeStyles[size], widthStyle, className)}
+            className={cx(
+                baseStyles,
+                variantStyles[variant],
+                sizeStyles[size],
+                heightStyles[density][size],
+                widthStyle,
+                className
+            )}
             disabled={disabled || isLoading}
             type={type}
             {...props}>

--- a/backend/islands/packages/ui/src/components/Card.tsx
+++ b/backend/islands/packages/ui/src/components/Card.tsx
@@ -28,7 +28,7 @@ const Card = ({
                             </div>
                         )}
                         <div className="flex-1 min-w-0 pt-1">
-                            {title && <h3 className="text-lg font-semibold text-content tracking-tight">{title}</h3>}
+                            {title && <h2 className="text-base font-semibold text-content">{title}</h2>}
                             {subtitle && <p className="text-sm text-content-secondary mt-1 leading-relaxed">{subtitle}</p>}
                         </div>
                     </div>

--- a/backend/islands/packages/ui/src/components/Dropdown.tsx
+++ b/backend/islands/packages/ui/src/components/Dropdown.tsx
@@ -18,14 +18,21 @@ interface DropdownProps {
     triggerAriaLabel?: string;
     triggerClassName?: string;
     align?: 'start' | 'end' | 'center' | 'left' | 'right';
+    density?: 'default' | 'compact';
 }
+
+const dropdownItemDensityStyles = {
+    default: 'px-4 py-2.5',
+    compact: 'min-h-11 px-4 py-2 [@media(pointer:fine)]:min-h-10'
+} as const;
 
 const Dropdown = ({
     items,
     trigger,
     triggerAriaLabel = '메뉴 열기',
     triggerClassName = '',
-    align = 'end'
+    align = 'end',
+    density = 'default'
 }: DropdownProps) => {
     const [open, setOpen] = useState(false);
 
@@ -33,6 +40,38 @@ const Dropdown = ({
         align === 'right' ? 'end' :
         align === 'left' ? 'start' :
         align;
+    const hasSelectionItems = items.some(item => item.checked !== undefined);
+    const selectedItemValue = String(items.findIndex(item => item.checked));
+
+    const getItemClassName = (item: DropdownItem) => `
+        relative flex items-center text-sm gap-3 cursor-pointer select-none outline-none
+        transition-colors
+        ${dropdownItemDensityStyles[density]}
+        ${item.variant === 'danger'
+            ? 'text-danger focus:bg-danger-surface hover:bg-danger-surface'
+            : 'text-content-secondary focus:bg-surface-subtle hover:bg-surface-subtle'
+        }
+        ${item.checked ? 'bg-surface-subtle text-content font-medium' : ''}
+        ${item.className || ''}
+    `;
+
+    const renderItemContent = (item: DropdownItem) => (
+        <>
+            {typeof item.icon === 'string' ? (
+                <i className={`${item.icon} w-4 text-center`} />
+            ) : item.icon ? (
+                <span
+                    aria-hidden="true"
+                    className="inline-flex w-4 shrink-0 items-center justify-center [&>svg]:h-4 [&>svg]:w-4">
+                    {item.icon}
+                </span>
+            ) : null}
+            <span className="flex-1">{item.label}</span>
+            {item.checked && (
+                <Check aria-hidden="true" className="ml-2 h-3.5 w-3.5 text-content-secondary" />
+            )}
+        </>
+    );
 
     return (
         <DropdownMenu.Root open={open} modal={false} onOpenChange={setOpen}>
@@ -45,7 +84,7 @@ const Dropdown = ({
                 ) : (
                     <button
                         type="button"
-                        className={`p-2 text-content-secondary hover:text-content hover:bg-surface-subtle rounded-lg transition-colors outline-none ${triggerClassName}`}
+                        className={`inline-flex items-center justify-center rounded-lg p-2 text-content-secondary outline-none transition-colors hover:bg-surface-subtle hover:text-content focus-visible:ring-2 focus-visible:ring-line-strong focus-visible:ring-offset-2 ${triggerClassName}`}
                         aria-label={triggerAriaLabel}>
                         <EllipsisVertical aria-hidden="true" className="h-4 w-4" />
                     </button>
@@ -58,33 +97,24 @@ const Dropdown = ({
                     align={alignProp}
                     sideOffset={5}
                     onClick={(e) => e.stopPropagation()}>
-                    {items.map((item, index) => (
+                    {hasSelectionItems ? (
+                        <DropdownMenu.RadioGroup value={selectedItemValue}>
+                            {items.map((item, index) => (
+                                <DropdownMenu.RadioItem
+                                    key={index}
+                                    value={String(index)}
+                                    onSelect={item.onClick}
+                                    className={getItemClassName(item)}>
+                                    {renderItemContent(item)}
+                                </DropdownMenu.RadioItem>
+                            ))}
+                        </DropdownMenu.RadioGroup>
+                    ) : items.map((item, index) => (
                         <DropdownMenu.Item
                             key={index}
-                            onClick={item.onClick}
-                            className={`
-                                relative flex items-center px-4 py-2.5 text-sm gap-3 cursor-pointer select-none outline-none
-                                transition-colors
-                                ${item.variant === 'danger'
-                                    ? 'text-danger focus:bg-danger-surface hover:bg-danger-surface'
-                                    : 'text-content-secondary focus:bg-surface-subtle hover:bg-surface-subtle'
-                                }
-                                ${item.checked ? 'bg-surface-subtle text-content font-medium' : ''}
-                                ${item.className || ''}
-                            `}>
-                            {typeof item.icon === 'string' ? (
-                                <i className={`${item.icon} w-4 text-center`} />
-                            ) : item.icon ? (
-                                <span
-                                    aria-hidden="true"
-                                    className="inline-flex w-4 shrink-0 items-center justify-center [&>svg]:h-4 [&>svg]:w-4">
-                                    {item.icon}
-                                </span>
-                            ) : null}
-                            <span className="flex-1">{item.label}</span>
-                            {item.checked && (
-                                <Check aria-hidden="true" className="ml-2 h-3.5 w-3.5 text-content-secondary" />
-                            )}
+                            onSelect={item.onClick}
+                            className={getItemClassName(item)}>
+                            {renderItemContent(item)}
                         </DropdownMenu.Item>
                     ))}
                 </DropdownMenu.Content>

--- a/backend/islands/packages/ui/src/components/Input.tsx
+++ b/backend/islands/packages/ui/src/components/Input.tsx
@@ -4,7 +4,12 @@ import { AlertCircle } from 'lucide-react';
 import { cx } from '../lib/classnames';
 import { INTERACTION_DURATION } from '../lib/designTokens';
 
-const baseInputStyles = `block w-full rounded-lg border border-line focus:border-line-strong focus:ring-2 focus:ring-line/70 text-sm py-3 px-3 min-h-12 transition-all ${INTERACTION_DURATION} bg-surface-elevated placeholder:text-content-hint text-content`;
+const baseInputStyles = `block w-full rounded-lg border border-line focus:border-line-strong focus:ring-2 focus:ring-line/70 text-sm transition-all ${INTERACTION_DURATION} bg-surface-elevated placeholder:text-content-hint text-content`;
+
+const inputDensityStyles = {
+    default: 'min-h-12 px-3 py-3',
+    compact: 'min-h-11 px-3 py-2 [@media(pointer:fine)]:min-h-10'
+} as const;
 
 interface InputProps extends InputHTMLAttributes<HTMLInputElement | HTMLTextAreaElement> {
     label?: string;
@@ -14,6 +19,7 @@ interface InputProps extends InputHTMLAttributes<HTMLInputElement | HTMLTextArea
     rightIcon?: ReactNode;
     multiline?: boolean;
     rows?: number;
+    density?: keyof typeof inputDensityStyles;
 }
 
 const Input = forwardRef<HTMLInputElement | HTMLTextAreaElement, InputProps>(
@@ -26,6 +32,7 @@ const Input = forwardRef<HTMLInputElement | HTMLTextAreaElement, InputProps>(
             rightIcon,
             multiline = false,
             rows = 4,
+            density = 'default',
             className = '',
             id,
             required,
@@ -56,6 +63,7 @@ const Input = forwardRef<HTMLInputElement | HTMLTextAreaElement, InputProps>(
 
         const inputClasses = cx(
             baseInputStyles,
+            inputDensityStyles[density],
             readOnlyStyles,
             errorStyles,
             leftPadding,

--- a/backend/islands/packages/ui/src/components/Select.tsx
+++ b/backend/islands/packages/ui/src/components/Select.tsx
@@ -8,6 +8,17 @@ interface SelectItem {
     label: string;
 }
 
+const selectDensityStyles = {
+    default: {
+        trigger: 'px-4 py-3 rounded-xl',
+        item: 'px-4 py-2.5'
+    },
+    compact: {
+        trigger: 'min-h-11 px-3 py-2.5 rounded-lg [@media(pointer:fine)]:min-h-10 [@media(pointer:fine)]:py-2',
+        item: 'min-h-11 px-3 py-2 [@media(pointer:fine)]:min-h-10'
+    }
+} as const;
+
 interface SelectProps {
     value: string;
     onValueChange: (value: string) => void;
@@ -17,6 +28,7 @@ interface SelectProps {
     error?: string;
     className?: string;
     disabled?: boolean;
+    density?: keyof typeof selectDensityStyles;
 }
 
 const Select = ({
@@ -27,7 +39,8 @@ const Select = ({
     placeholder = '선택하세요',
     error,
     className = '',
-    disabled = false
+    disabled = false,
+    density = 'default'
 }: SelectProps) => {
     // Convert empty string to internal placeholder value
     const internalValue = value === '' ? EMPTY_VALUE : value;
@@ -54,13 +67,14 @@ const Select = ({
                     aria-label={ariaLabel}
                     aria-invalid={!!error}
                     className={`
-                        w-full flex items-center justify-between px-4 py-3
-                        bg-surface-elevated border border-line rounded-xl
+                        flex w-full items-center justify-between
+                        bg-surface-elevated border border-line
                         text-sm text-content
                         hover:border-line-strong focus:outline-none focus:ring-2 focus:ring-line/70 focus:border-line-strong
                         transition-colors cursor-pointer
                         disabled:cursor-not-allowed disabled:opacity-50
                         data-[placeholder]:text-content-hint
+                        ${selectDensityStyles[density].trigger}
                         ${errorStyles}
                         ${className}
                     `}>
@@ -82,12 +96,13 @@ const Select = ({
                                     key={item.value}
                                     value={item.value}
                                     className={`
-                                        relative flex items-center px-4 py-2.5 text-sm rounded-lg
+                                        relative flex items-center text-sm rounded-lg
                                         cursor-pointer select-none outline-none
                                         text-content-secondary
                                         data-[highlighted]:bg-surface-subtle data-[highlighted]:text-content
                                         data-[state=checked]:bg-line-light data-[state=checked]:text-content data-[state=checked]:font-medium
                                         transition-colors
+                                        ${selectDensityStyles[density].item}
                                     `}>
                                     <RadixSelect.ItemText>{item.label}</RadixSelect.ItemText>
                                     <RadixSelect.ItemIndicator className="absolute right-3">

--- a/backend/islands/packages/ui/src/components/Tabs/index.tsx
+++ b/backend/islands/packages/ui/src/components/Tabs/index.tsx
@@ -19,10 +19,12 @@ const Root = ({ children, className, ...props }: TabsRootProps) => (
 interface TabsListProps {
     children: ReactNode;
     className?: string;
+    ariaLabel?: string;
 }
 
-const List = ({ children, className }: TabsListProps) => (
+const List = ({ children, className, ariaLabel }: TabsListProps) => (
     <RadixTabs.List
+        aria-label={ariaLabel}
         className={cx(
             'flex border-b border-line',
             className
@@ -44,7 +46,7 @@ const Trigger = ({ value, children, className }: TabsTriggerProps) => (
             'px-4 py-2.5 text-sm font-medium text-content-secondary transition-colors',
             'hover:text-content',
             'data-[state=active]:text-content data-[state=active]:border-b-2 data-[state=active]:border-action data-[state=active]:-mb-px',
-            'focus:outline-none',
+            'focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-line-strong',
             className
         )}>
         {children}


### PR DESCRIPTION
## 🎯 Goal
- Make the settings experience easier to scan and operate without oversized desktop controls.
- Complete the post-management usability pass while preserving existing URLs, API behavior, permissions, and shared UI defaults.

## 🔧 Core Changes
- Normalize settings typography, navigation, action density, empty states, and header actions while preserving existing Card padding.
- Improve post status tabs, search, sorting, detailed filters, pagination, and tag/series inline editing.
- Preserve unsaved tag and series drafts across filters, pages, tabs, and reloads within the same browser tab.
- Add keyboard focus, current-value announcements, radio selection semantics, touch-safe targets, and consistent heading landmarks.
- Harden session draft restoration against malformed stored JSON.

## 🤔 Key Decisions
- Shared Button, Input, Select, and Dropdown defaults remain backward compatible; SettingsApp explicitly opts into compact density.
- Inline post editing remains limited to tags and series. Visibility stays in the menu, while title, body, URL, and publishing schedule stay in the editor.
- The duplicate settings-level new-post action remains removed because the global header already provides that entry point.
- Scheduled-post labels are contextualized, while the existing default ordering and all 12 supported sort URLs remain unchanged.
- No backend API, database model, permission, or public endpoint contract changes are included.

## 🧪 Verification Guide
### How to verify
1. Open account, profile, integrations, series, static page, banner, and post settings on desktop and a touch viewport.
2. In post settings, navigate tabs with Arrow, Home, and End keys; open sorting and detailed filters; edit tags or series and move between tabs before saving.
3. Open banner, static-page, and series editors and verify the top navigation, heading structure, previews, and touch targets.
4. Run:
   - npm run islands:lint
   - npm run islands:type-check
   - npm run islands:build
   - pnpm --dir backend/islands/apps/remotes run check:entry-budgets
   - git diff --check

### Expected result
- Desktop settings controls stay compact at 36–40px while touch targets remain at least 44px.
- Tabs and dropdowns expose keyboard focus, selected state, and current filter values.
- Each settings route exposes one main landmark and one page heading.
- Unsaved tag and series drafts restore safely without changing API payloads or persistence behavior.
- Existing sort query values and non-Settings shared component geometry remain compatible.
- Chromium desktop and touch checks complete without console or page errors.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (not required; no documented contract changed)