### PR TITLE
✨ Add post revision deletion and improve history panel

### DIFF
--- a/backend/islands/apps/remotes/src/components/remotes/PostEditor/components/PostRevisionDialog.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/PostEditor/components/PostRevisionDialog.tsx
@@ -4,15 +4,22 @@ import { Dialog } from '@blex/ui/dialog';
 import { IconButton } from '@blex/ui/icon-button';
 import {
     AlertTriangle,
+    ArrowLeft,
+    ChevronRight,
     Clock,
     History,
     Loader2,
     RotateCcw,
+    Trash2,
     X
 } from '@blex/ui/icons';
-import { DIM_OVERLAY_DEFAULT } from '@blex/ui/design-tokens';
+import {
+    DIM_OVERLAY_DEFAULT,
+    ENTRANCE_DURATION
+} from '@blex/ui/design-tokens';
 import { cx } from '~/lib/classnames';
 import {
+    deletePostRevision,
     getPostRevision,
     getPostRevisions,
     restorePostRevision,
@@ -60,14 +67,27 @@ const PostRevisionDialog = ({
     const [selectedRevision, setSelectedRevision] = useState<PostRevisionDetail | null>(null);
     const [currentPage, setCurrentPage] = useState(1);
     const [lastPage, setLastPage] = useState(1);
+    const [totalCount, setTotalCount] = useState(0);
     const [serverUpdatedDate, setServerUpdatedDate] = useState('');
     const [isLoading, setIsLoading] = useState(false);
     const [isLoadingMore, setIsLoadingMore] = useState(false);
     const [isLoadingDetail, setIsLoadingDetail] = useState(false);
     const [isRestoring, setIsRestoring] = useState(false);
+    const [isDeleting, setIsDeleting] = useState(false);
     const [isConfirmingRestore, setIsConfirmingRestore] = useState(false);
+    const [isConfirmingDelete, setIsConfirmingDelete] = useState(false);
     const [errorMessage, setErrorMessage] = useState('');
     const detailRequestIdRef = useRef(0);
+    const isDetailView = selectedRevisionId !== null;
+
+    const handleBackToList = useCallback(() => {
+        detailRequestIdRef.current += 1;
+        setSelectedRevisionId(null);
+        setSelectedRevision(null);
+        setIsLoadingDetail(false);
+        setIsConfirmingRestore(false);
+        setIsConfirmingDelete(false);
+    }, []);
 
     const loadDetail = useCallback(async (revisionId: number) => {
         const requestId = detailRequestIdRef.current + 1;
@@ -75,6 +95,7 @@ const PostRevisionDialog = ({
         setSelectedRevisionId(revisionId);
         setSelectedRevision(null);
         setIsConfirmingRestore(false);
+        setIsConfirmingDelete(false);
         setIsLoadingDetail(true);
 
         try {
@@ -82,31 +103,31 @@ const PostRevisionDialog = ({
             if (detailRequestIdRef.current !== requestId) return;
             if (data.status === 'ERROR') {
                 toast.error(data.errorMessage || '수정본을 불러오지 못했습니다.');
+                handleBackToList();
                 return;
             }
             setSelectedRevision(data.body.revision);
         } catch {
             if (detailRequestIdRef.current === requestId) {
                 toast.error('수정본을 불러오지 못했습니다.');
+                handleBackToList();
             }
         } finally {
             if (detailRequestIdRef.current === requestId) {
                 setIsLoadingDetail(false);
             }
         }
-    }, [username, postUrl]);
+    }, [username, postUrl, handleBackToList]);
 
     const loadFirstPage = useCallback(async () => {
         setIsLoading(true);
         setErrorMessage('');
         setRevisions([]);
-        setSelectedRevisionId(null);
-        setSelectedRevision(null);
         setCurrentPage(1);
         setLastPage(1);
+        setTotalCount(0);
         setServerUpdatedDate('');
-        setIsConfirmingRestore(false);
-        detailRequestIdRef.current += 1;
+        handleBackToList();
 
         try {
             const { data } = await getPostRevisions(username, postUrl);
@@ -118,22 +139,20 @@ const PostRevisionDialog = ({
             setRevisions(data.body.revisions);
             setCurrentPage(data.body.pagination.page);
             setLastPage(data.body.pagination.lastPage);
+            setTotalCount(data.body.pagination.totalCount);
             setServerUpdatedDate(data.body.currentUpdatedDate);
-            const firstRevision = data.body.revisions[0];
-            if (firstRevision) {
-                void loadDetail(firstRevision.id);
-            }
         } catch {
             setErrorMessage('수정 이력을 불러오지 못했습니다.');
         } finally {
             setIsLoading(false);
         }
-    }, [username, postUrl, loadDetail]);
+    }, [username, postUrl, handleBackToList]);
 
     useEffect(() => {
         if (!isOpen) {
             detailRequestIdRef.current += 1;
             setIsConfirmingRestore(false);
+            setIsConfirmingDelete(false);
             return;
         }
         void loadFirstPage();
@@ -151,6 +170,7 @@ const PostRevisionDialog = ({
             setRevisions(current => [...current, ...data.body.revisions]);
             setCurrentPage(data.body.pagination.page);
             setLastPage(data.body.pagination.lastPage);
+            setTotalCount(data.body.pagination.totalCount);
             setServerUpdatedDate(data.body.currentUpdatedDate);
         } catch {
             toast.error('다음 수정 이력을 불러오지 못했습니다.');
@@ -164,6 +184,30 @@ const PostRevisionDialog = ({
         && expectedUpdatedDate
         && serverUpdatedDate !== expectedUpdatedDate
     );
+
+    const handleDelete = async () => {
+        if (!selectedRevision || isDeleting) return;
+
+        setIsDeleting(true);
+        try {
+            const { data } = await deletePostRevision(
+                username,
+                postUrl,
+                selectedRevision.id
+            );
+            if (data.status === 'ERROR') {
+                toast.error(data.errorMessage || '수정 이력을 삭제하지 못했습니다.');
+                return;
+            }
+
+            toast.success('수정 이력을 삭제했습니다.');
+            await loadFirstPage();
+        } catch {
+            toast.error('수정 이력을 삭제하지 못했습니다.');
+        } finally {
+            setIsDeleting(false);
+        }
+    };
 
     const handleRestore = async () => {
         if (!selectedRevision?.canRestore || hasVersionConflict || isRestoring) return;
@@ -199,7 +243,7 @@ const PostRevisionDialog = ({
         <Dialog.Root open={isOpen} onOpenChange={(open) => !open && onClose()}>
             <Dialog.Portal>
                 <Dialog.Overlay
-                    className={`fixed inset-0 ${DIM_OVERLAY_DEFAULT} z-[70]`}
+                    className={`fixed inset-0 ${DIM_OVERLAY_DEFAULT} z-[70] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0`}
                 />
                 <Dialog.Content
                     onEscapeKeyDown={(event) => {
@@ -212,20 +256,37 @@ const PostRevisionDialog = ({
                         returnFocusTo.focus({ preventScroll: true });
                     }}
                     className={cx(
-                        'fixed inset-0 z-[80] flex flex-col overflow-hidden bg-surface shadow-2xl focus:outline-none',
-                        'sm:inset-x-6 sm:inset-y-8 sm:mx-auto sm:max-w-5xl sm:rounded-2xl sm:border sm:border-line'
+                        'fixed inset-y-0 left-0 z-[80] flex w-full flex-col bg-surface shadow-2xl focus:outline-none sm:w-[520px]',
+                        'data-[state=open]:animate-in data-[state=closed]:animate-out',
+                        'data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left',
+                        `${ENTRANCE_DURATION} ease-in-out`
                     )}>
-                    <header className="flex items-start justify-between gap-3 border-b border-line bg-surface-elevated px-4 py-4 sm:px-5">
-                        <div className="min-w-0">
-                            <div className="flex items-center gap-2">
-                                <History aria-hidden="true" className="h-5 w-5 shrink-0 text-content-hint" />
-                                <Dialog.Title className="text-base font-semibold text-content sm:text-lg">
-                                    수정 이력
-                                </Dialog.Title>
+                    <header className="flex items-start justify-between gap-3 border-b border-line bg-surface-elevated p-5">
+                        <div className="flex min-w-0 items-start gap-2">
+                            {isDetailView && (
+                                <IconButton
+                                    size="sm"
+                                    aria-label="수정 이력 목록으로"
+                                    title="수정 이력 목록으로"
+                                    onClick={handleBackToList}>
+                                    <ArrowLeft className="h-5 w-5" />
+                                </IconButton>
+                            )}
+                            <div className="min-w-0 pt-1.5">
+                                <div className="flex items-center gap-2">
+                                    {!isDetailView && (
+                                        <History aria-hidden="true" className="h-5 w-5 shrink-0 text-content-hint" />
+                                    )}
+                                    <Dialog.Title className="truncate text-lg font-semibold text-content">
+                                        {isDetailView ? '수정본 상세' : '수정 이력'}
+                                    </Dialog.Title>
+                                </div>
+                                <Dialog.Description className="mt-1 text-xs leading-relaxed text-content-secondary">
+                                    {isDetailView
+                                        ? '저장된 내용을 확인하고 복원하거나 삭제할 수 있습니다'
+                                        : '내용 수정 직전 저장본을 확인할 수 있습니다'}
+                                </Dialog.Description>
                             </div>
-                            <Dialog.Description className="mt-1 text-xs leading-relaxed text-content-secondary sm:text-sm">
-                                내용 수정 직전 저장본을 확인하고 복원할 수 있습니다
-                            </Dialog.Description>
                         </div>
                         <IconButton
                             size="sm"
@@ -236,186 +297,230 @@ const PostRevisionDialog = ({
                         </IconButton>
                     </header>
 
-                    <div className="grid min-h-0 flex-1 grid-rows-[minmax(11rem,38vh)_minmax(0,1fr)] md:grid-cols-[20rem_minmax(0,1fr)] md:grid-rows-1">
-                        <aside className="min-h-0 overflow-y-auto border-b border-line bg-surface-subtle md:border-b-0 md:border-r">
-                            {isLoading ? (
-                                <div className="flex h-full min-h-44 items-center justify-center" role="status">
-                                    <Loader2 className="h-5 w-5 animate-spin text-content-hint" />
-                                    <span className="sr-only">수정 이력 불러오는 중</span>
-                                </div>
-                            ) : errorMessage ? (
-                                <div className="flex h-full min-h-44 flex-col items-center justify-center gap-3 p-5 text-center">
-                                    <AlertTriangle className="h-5 w-5 text-danger" aria-hidden="true" />
-                                    <p className="text-sm text-content-secondary">{errorMessage}</p>
-                                    <Button variant="secondary" onClick={() => void loadFirstPage()}>
-                                        다시 시도
-                                    </Button>
-                                </div>
-                            ) : revisions.length === 0 ? (
-                                <div className="flex h-full min-h-44 flex-col items-center justify-center gap-2 p-5 text-center">
-                                    <History className="h-6 w-6 text-content-hint" aria-hidden="true" />
-                                    <p className="text-sm font-medium text-content">아직 수정 이력이 없습니다</p>
-                                    <p className="text-xs leading-relaxed text-content-secondary">
-                                        발행된 글의 내용을 수정하면 직전 저장본이 여기에 남습니다.
-                                    </p>
-                                </div>
-                            ) : (
-                                <div className="p-2" aria-label="수정본 목록">
-                                    {revisions.map(revision => {
-                                        const isSelected = revision.id === selectedRevisionId;
-                                        return (
-                                            <button
-                                                key={revision.id}
-                                                type="button"
-                                                aria-current={isSelected ? 'true' : undefined}
-                                                onClick={() => void loadDetail(revision.id)}
-                                                className={cx(
-                                                    'mb-1 w-full rounded-xl border px-3 py-3 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-action/30',
-                                                    isSelected
-                                                        ? 'border-action/40 bg-surface-elevated shadow-sm'
-                                                        : 'border-transparent hover:border-line hover:bg-surface-elevated'
-                                                )}>
-                                                <div className="flex items-center justify-between gap-2">
-                                                    <span className="min-w-0 truncate text-sm font-semibold text-content">
-                                                        {revision.title || '제목 없음'}
-                                                    </span>
-                                                    <span className="shrink-0 rounded-full bg-line-light px-2 py-0.5 text-[11px] font-medium text-content-secondary">
-                                                        {changeTypeLabels[revision.changeType]}
-                                                    </span>
-                                                </div>
-                                                <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-content-secondary">
-                                                    {revision.contentExcerpt || '본문 미리보기 없음'}
-                                                </p>
-                                                <span className="mt-2 flex items-center gap-1 text-[11px] text-content-hint">
-                                                    <Clock className="h-3 w-3" aria-hidden="true" />
-                                                    {formatDateTime(revision.createdDate)}
-                                                </span>
-                                            </button>
-                                        );
-                                    })}
-                                    {currentPage < lastPage && (
-                                        <Button
-                                            variant="ghost"
-                                            fullWidth
-                                            isLoading={isLoadingMore}
-                                            onClick={() => void handleLoadMore()}>
-                                            더 보기
-                                        </Button>
-                                    )}
-                                </div>
-                            )}
-                        </aside>
-
-                        <main className="min-h-0 overflow-y-auto bg-surface p-4 sm:p-5">
-                            {isLoadingDetail ? (
-                                <div className="flex min-h-48 items-center justify-center" role="status">
-                                    <Loader2 className="h-5 w-5 animate-spin text-content-hint" />
-                                    <span className="sr-only">수정본 내용 불러오는 중</span>
-                                </div>
-                            ) : selectedRevision ? (
-                                <article className="mx-auto max-w-2xl">
-                                    <div className="border-b border-line pb-4">
-                                        <p className="text-xs text-content-hint">
-                                            {formatDateTime(selectedRevision.createdDate)} · {changeTypeLabels[selectedRevision.changeType]}
-                                        </p>
-                                        <h3 className="mt-2 break-words text-xl font-bold text-content sm:text-2xl">
-                                            {selectedRevision.title || '제목 없음'}
-                                        </h3>
-                                        {selectedRevision.subtitle && (
-                                            <p className="mt-2 break-words text-sm text-content-secondary">
-                                                {selectedRevision.subtitle}
-                                            </p>
-                                        )}
-                                        {selectedRevision.tags.length > 0 && (
-                                            <div className="mt-3 flex flex-wrap gap-1.5" aria-label="수정본 태그">
-                                                {selectedRevision.tags.map(tag => (
-                                                    <span
-                                                        key={tag}
-                                                        className="rounded-full bg-surface-subtle px-2.5 py-1 text-xs text-content-secondary">
-                                                        #{tag}
-                                                    </span>
-                                                ))}
-                                            </div>
-                                        )}
+                    {!isDetailView ? (
+                        <>
+                            <div className="min-h-0 flex-1 overflow-y-auto">
+                                {isLoading ? (
+                                    <div className="flex h-full min-h-52 items-center justify-center" role="status">
+                                        <Loader2 className="h-5 w-5 animate-spin text-content-hint" />
+                                        <span className="sr-only">수정 이력 불러오는 중</span>
                                     </div>
+                                ) : errorMessage ? (
+                                    <div className="flex h-full min-h-52 flex-col items-center justify-center gap-3 px-6 text-center">
+                                        <AlertTriangle className="h-8 w-8 text-danger" aria-hidden="true" />
+                                        <p className="text-sm text-content-secondary">{errorMessage}</p>
+                                        <Button size="sm" variant="secondary" onClick={() => void loadFirstPage()}>
+                                            다시 시도
+                                        </Button>
+                                    </div>
+                                ) : revisions.length === 0 ? (
+                                    <div className="flex h-full min-h-52 flex-col items-center justify-center gap-2 px-6 text-center">
+                                        <History className="h-8 w-8 text-content-hint" aria-hidden="true" />
+                                        <p className="text-sm font-medium text-content">아직 수정 이력이 없습니다</p>
+                                        <p className="text-xs leading-relaxed text-content-secondary">
+                                            발행된 글의 내용을 수정하면 직전 저장본이 여기에 남습니다.
+                                        </p>
+                                    </div>
+                                ) : (
+                                    <ul className="divide-y divide-line-light" aria-label="수정본 목록">
+                                        {revisions.map(revision => (
+                                            <li key={revision.id}>
+                                                <button
+                                                    type="button"
+                                                    onClick={() => void loadDetail(revision.id)}
+                                                    className="flex min-h-24 w-full items-center gap-3 px-4 py-4 text-left transition-colors hover:bg-surface-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-action/30">
+                                                    <div className="min-w-0 flex-1">
+                                                        <div className="flex items-center gap-2">
+                                                            <span className="min-w-0 truncate text-sm font-semibold text-content">
+                                                                {revision.title || '제목 없음'}
+                                                            </span>
+                                                            <span className="shrink-0 rounded-full bg-line-light px-2 py-0.5 text-[11px] font-medium text-content-secondary">
+                                                                {changeTypeLabels[revision.changeType]}
+                                                            </span>
+                                                        </div>
+                                                        <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-content-secondary">
+                                                            {revision.contentExcerpt || '본문 미리보기 없음'}
+                                                        </p>
+                                                        <span className="mt-2 flex items-center gap-1 text-[11px] text-content-hint">
+                                                            <Clock className="h-3 w-3" aria-hidden="true" />
+                                                            {formatDateTime(revision.createdDate)}
+                                                        </span>
+                                                    </div>
+                                                    <ChevronRight aria-hidden="true" className="h-4 w-4 shrink-0 text-content-hint" />
+                                                </button>
+                                            </li>
+                                        ))}
+                                    </ul>
+                                )}
+                            </div>
 
-                                    {selectedRevision.description && (
-                                        <section className="border-b border-line py-4">
-                                            <h4 className="text-xs font-semibold uppercase tracking-wide text-content-hint">설명</h4>
-                                            <p className="mt-2 whitespace-pre-wrap break-words text-sm leading-relaxed text-content-secondary">
-                                                {selectedRevision.description}
+                            <footer className="border-t border-line bg-surface-subtle p-4">
+                                {currentPage < lastPage && (
+                                    <Button
+                                        size="sm"
+                                        variant="ghost"
+                                        fullWidth
+                                        isLoading={isLoadingMore}
+                                        onClick={() => void handleLoadMore()}>
+                                        더 보기
+                                    </Button>
+                                )}
+                                <p
+                                    className={cx(
+                                        'text-center text-xs text-content-secondary',
+                                        currentPage < lastPage && 'mt-2'
+                                    )}>
+                                    총 {totalCount}개의 수정 이력
+                                </p>
+                            </footer>
+                        </>
+                    ) : (
+                        <>
+                            <div className="min-h-0 flex-1 overflow-y-auto bg-surface p-5">
+                                {isLoadingDetail ? (
+                                    <div className="flex min-h-52 items-center justify-center" role="status">
+                                        <Loader2 className="h-5 w-5 animate-spin text-content-hint" />
+                                        <span className="sr-only">수정본 내용 불러오는 중</span>
+                                    </div>
+                                ) : selectedRevision ? (
+                                    <article>
+                                        <div className="border-b border-line pb-4">
+                                            <p className="text-xs text-content-hint">
+                                                {formatDateTime(selectedRevision.createdDate)} · {changeTypeLabels[selectedRevision.changeType]}
+                                            </p>
+                                            <h3 className="mt-2 break-words text-xl font-bold text-content">
+                                                {selectedRevision.title || '제목 없음'}
+                                            </h3>
+                                            {selectedRevision.subtitle && (
+                                                <p className="mt-2 break-words text-sm text-content-secondary">
+                                                    {selectedRevision.subtitle}
+                                                </p>
+                                            )}
+                                            {selectedRevision.tags.length > 0 && (
+                                                <div className="mt-3 flex flex-wrap gap-1.5" aria-label="수정본 태그">
+                                                    {selectedRevision.tags.map(tag => (
+                                                        <span
+                                                            key={tag}
+                                                            className="rounded-full bg-surface-subtle px-2.5 py-1 text-xs text-content-secondary">
+                                                            #{tag}
+                                                        </span>
+                                                    ))}
+                                                </div>
+                                            )}
+                                        </div>
+
+                                        {selectedRevision.description && (
+                                            <section className="border-b border-line py-4">
+                                                <h4 className="text-xs font-semibold uppercase tracking-wide text-content-hint">설명</h4>
+                                                <p className="mt-2 whitespace-pre-wrap break-words text-sm leading-relaxed text-content-secondary">
+                                                    {selectedRevision.description}
+                                                </p>
+                                            </section>
+                                        )}
+
+                                        <section className="py-4">
+                                            <h4 className="text-xs font-semibold uppercase tracking-wide text-content-hint">본문</h4>
+                                            <p className="mt-3 whitespace-pre-wrap break-words text-sm leading-7 text-content">
+                                                {selectedRevision.contentText || '본문 내용이 없습니다.'}
                                             </p>
                                         </section>
-                                    )}
 
-                                    <section className="py-4">
-                                        <h4 className="text-xs font-semibold uppercase tracking-wide text-content-hint">본문</h4>
-                                        <p className="mt-3 whitespace-pre-wrap break-words text-sm leading-7 text-content">
-                                            {selectedRevision.contentText || '본문 내용이 없습니다.'}
-                                        </p>
-                                    </section>
+                                        {!selectedRevision.canRestore && (
+                                            <div className="flex gap-2 rounded-xl border border-line bg-surface-subtle p-3 text-sm text-content-secondary">
+                                                <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+                                                <p>이전 형식으로 저장된 이력은 원문 형식을 확정할 수 없어 조회만 지원합니다.</p>
+                                            </div>
+                                        )}
+                                    </article>
+                                ) : null}
+                            </div>
 
-                                    {!selectedRevision.canRestore && (
-                                        <div className="flex gap-2 rounded-xl border border-line bg-surface-subtle p-3 text-sm text-content-secondary">
+                            {selectedRevision && (
+                                <footer className="border-t border-line bg-surface-elevated p-4">
+                                    {hasVersionConflict && (
+                                        <div className="mb-3 flex gap-2 rounded-xl border border-danger/30 bg-danger-surface p-3 text-sm text-danger" role="alert">
                                             <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
-                                            <p>이전 형식으로 저장된 이력은 원문 형식을 확정할 수 없어 조회만 지원합니다.</p>
+                                            <p>이 페이지를 연 뒤 포스트가 변경되었습니다. 새로고침한 뒤 복원해주세요.</p>
                                         </div>
                                     )}
-                                </article>
-                            ) : revisions.length > 0 ? (
-                                <div className="flex min-h-48 items-center justify-center text-sm text-content-secondary">
-                                    확인할 수정본을 선택해주세요.
-                                </div>
-                            ) : null}
-                        </main>
-                    </div>
-
-                    <footer className="border-t border-line bg-surface-elevated px-4 py-3 sm:px-5">
-                        {hasVersionConflict && (
-                            <div className="mb-3 flex gap-2 rounded-xl border border-danger/30 bg-danger-surface p-3 text-sm text-danger" role="alert">
-                                <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
-                                <p>이 페이지를 연 뒤 포스트가 변경되었습니다. 새로고침한 뒤 수정 이력을 다시 확인해주세요.</p>
-                            </div>
-                        )}
-                        {isConfirmingRestore && selectedRevision && (
-                            <div className="mb-3 rounded-xl border border-line bg-surface-subtle p-3 text-sm leading-relaxed text-content-secondary">
-                                <strong className="text-content">‘{selectedRevision.title || '제목 없음'}’ 수정본으로 복원할까요?</strong>
-                                <p className="mt-1">현재 내용은 복원 직전 수정본으로 남습니다. URL과 발행·공개·댓글 설정은 바뀌지 않습니다.</p>
-                            </div>
-                        )}
-                        <div className="flex items-center justify-end gap-2">
-                            {isConfirmingRestore ? (
-                                <>
-                                    <Button
-                                        variant="secondary"
-                                        size="lg"
-                                        disabled={isRestoring}
-                                        onClick={() => setIsConfirmingRestore(false)}>
-                                        취소
-                                    </Button>
-                                    <Button
-                                        size="lg"
-                                        isLoading={isRestoring}
-                                        disabled={!selectedRevision?.canRestore || hasVersionConflict}
-                                        leftIcon={<RotateCcw className="h-4 w-4" />}
-                                        onClick={() => void handleRestore()}>
-                                        복원
-                                    </Button>
-                                </>
-                            ) : (
-                                <>
-                                    <Button variant="secondary" size="lg" onClick={onClose}>닫기</Button>
-                                    <Button
-                                        size="lg"
-                                        disabled={!selectedRevision?.canRestore || hasVersionConflict}
-                                        leftIcon={<RotateCcw className="h-4 w-4" />}
-                                        onClick={() => setIsConfirmingRestore(true)}>
-                                        이 수정본으로 복원
-                                    </Button>
-                                </>
+                                    {isConfirmingDelete && (
+                                        <div className="mb-3 rounded-xl border border-danger/30 bg-danger-surface p-3 text-sm leading-relaxed text-danger">
+                                            <strong>‘{selectedRevision.title || '제목 없음'}’ 수정 이력을 삭제할까요?</strong>
+                                            <p className="mt-1">삭제한 수정 이력은 복구할 수 없습니다. 현재 포스트 내용은 바뀌지 않습니다.</p>
+                                        </div>
+                                    )}
+                                    {isConfirmingRestore && (
+                                        <div className="mb-3 rounded-xl border border-line bg-surface-subtle p-3 text-sm leading-relaxed text-content-secondary">
+                                            <strong className="text-content">‘{selectedRevision.title || '제목 없음'}’ 수정본으로 복원할까요?</strong>
+                                            <p className="mt-1">현재 내용은 복원 직전 수정본으로 남습니다. URL과 발행·공개·댓글 설정은 바뀌지 않습니다.</p>
+                                        </div>
+                                    )}
+                                    <div className="flex items-center justify-end gap-2">
+                                        {isConfirmingDelete ? (
+                                            <>
+                                                <Button
+                                                    variant="secondary"
+                                                    size="md"
+                                                    disabled={isDeleting}
+                                                    onClick={() => setIsConfirmingDelete(false)}>
+                                                    취소
+                                                </Button>
+                                                <Button
+                                                    variant="danger-solid"
+                                                    size="md"
+                                                    isLoading={isDeleting}
+                                                    leftIcon={<Trash2 className="h-4 w-4" />}
+                                                    onClick={() => void handleDelete()}>
+                                                    삭제
+                                                </Button>
+                                            </>
+                                        ) : isConfirmingRestore ? (
+                                            <>
+                                                <Button
+                                                    variant="secondary"
+                                                    size="md"
+                                                    disabled={isRestoring}
+                                                    onClick={() => setIsConfirmingRestore(false)}>
+                                                    취소
+                                                </Button>
+                                                <Button
+                                                    size="md"
+                                                    isLoading={isRestoring}
+                                                    disabled={!selectedRevision.canRestore || hasVersionConflict}
+                                                    leftIcon={<RotateCcw className="h-4 w-4" />}
+                                                    onClick={() => void handleRestore()}>
+                                                    복원
+                                                </Button>
+                                            </>
+                                        ) : (
+                                            <>
+                                                <Button
+                                                    variant="danger"
+                                                    size="md"
+                                                    leftIcon={<Trash2 className="h-4 w-4" />}
+                                                    onClick={() => {
+                                                        setIsConfirmingRestore(false);
+                                                        setIsConfirmingDelete(true);
+                                                    }}>
+                                                    삭제
+                                                </Button>
+                                                <Button
+                                                    size="md"
+                                                    disabled={!selectedRevision.canRestore || hasVersionConflict}
+                                                    leftIcon={<RotateCcw className="h-4 w-4" />}
+                                                    onClick={() => {
+                                                        setIsConfirmingDelete(false);
+                                                        setIsConfirmingRestore(true);
+                                                    }}>
+                                                    이 수정본으로 복원
+                                                </Button>
+                                            </>
+                                        )}
+                                    </div>
+                                </footer>
                             )}
-                        </div>
-                    </footer>
+                        </>
+                    )}
                 </Dialog.Content>
             </Dialog.Portal>
         </Dialog.Root>

--- a/backend/islands/apps/remotes/src/lib/api/posts.ts
+++ b/backend/islands/apps/remotes/src/lib/api/posts.ts
@@ -333,6 +333,19 @@ export const getPostRevision = async (
     );
 };
 
+export const deletePostRevision = async (
+    username: string,
+    postUrl: string,
+    revisionId: number
+) => {
+    return http.delete<Response<{
+        revisionId: number;
+        deleted: boolean;
+    }>>(
+        `v1/users/@${username}/posts/${postUrl}/revisions/${revisionId}`
+    );
+};
+
 export const restorePostRevision = async (
     username: string,
     postUrl: string,

--- a/backend/src/board/services/post_revision_service.py
+++ b/backend/src/board/services/post_revision_service.py
@@ -135,6 +135,17 @@ class PostRevisionService:
 
     @staticmethod
     @transaction.atomic
+    def delete_revision(post: Post, history: EditHistory) -> int:
+        history = EditHistory.objects.select_for_update().get(
+            pk=history.pk,
+            post=post,
+        )
+        revision_id = history.pk
+        history.delete()
+        return revision_id
+
+    @staticmethod
+    @transaction.atomic
     def restore_revision(
         post: Post,
         history: EditHistory,

--- a/backend/src/board/tests/api/test_post_revision.py
+++ b/backend/src/board/tests/api/test_post_revision.py
@@ -193,11 +193,47 @@ class PostRevisionTestCase(TestCase):
         self.assertEqual(detail['contentText'], 'Previous body')
         self.assertEqual(detail['tags'], ['old-a', 'old-b'])
 
+    def test_owner_can_delete_one_revision_without_changing_post(self):
+        deleted_revision = self.create_revision(title='Delete revision')
+        retained_revision = self.create_revision(title='Keep revision')
+        original_updated_date = self.post.updated_date
+        self.client.force_login(self.author)
+
+        response = self.client.delete(
+            self.revision_url(f'/{deleted_revision.id}'),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['body'], {
+            'revisionId': deleted_revision.id,
+            'deleted': True,
+        })
+        self.assertFalse(
+            EditHistory.objects.filter(pk=deleted_revision.id).exists(),
+        )
+        self.assertTrue(
+            EditHistory.objects.filter(pk=retained_revision.id).exists(),
+        )
+        self.post.refresh_from_db()
+        self.assertEqual(self.post.updated_date, original_updated_date)
+
+    def test_delete_revision_requires_detail_url(self):
+        self.create_revision()
+        self.client.force_login(self.author)
+
+        response = self.client.delete(self.revision_url())
+
+        self.assertEqual(response.status_code, 404)
+
     def test_revision_access_is_limited_to_current_owner_editor(self):
         revision = self.create_revision()
 
         anonymous = self.client.get(self.revision_url())
         self.assertEqual(anonymous.json()['errorCode'], 'error:NL')
+        anonymous_delete = self.client.delete(
+            self.revision_url(f'/{revision.id}'),
+        )
+        self.assertEqual(anonymous_delete.json()['errorCode'], 'error:NL')
 
         self.client.force_login(self.other_editor)
         self.assertEqual(self.client.get(self.revision_url()).status_code, 404)
@@ -210,6 +246,12 @@ class PostRevisionTestCase(TestCase):
                 self.revision_url(f'/{revision.id}/restore'),
                 json.dumps({'expectedUpdatedDate': self.post.updated_date.isoformat()}),
                 content_type='application/json',
+            ).status_code,
+            404,
+        )
+        self.assertEqual(
+            self.client.delete(
+                self.revision_url(f'/{revision.id}'),
             ).status_code,
             404,
         )

--- a/backend/src/board/views/api/v1/post_revision.py
+++ b/backend/src/board/views/api/v1/post_revision.py
@@ -41,14 +41,14 @@ def _positive_integer(value: str | None, default: int) -> int | None:
     return parsed if parsed > 0 else None
 
 
-@api_editor_required_methods(['GET'])
+@api_editor_required_methods(['GET', 'DELETE'])
 def post_revisions(
     request: HttpRequest,
     username: str,
     url: str,
     revision_id: int | None = None,
 ) -> HttpResponse:
-    if request.method != 'GET':
+    if request.method not in {'GET', 'DELETE'}:
         raise Http404
 
     post = _get_editable_revision_post(request, username, url)
@@ -60,9 +60,24 @@ def post_revisions(
 
     if revision_id is not None:
         revision = get_object_or_404(revisions, pk=revision_id)
+        if request.method == 'DELETE':
+            try:
+                deleted_revision_id = PostRevisionService.delete_revision(
+                    post,
+                    revision,
+                )
+            except EditHistory.DoesNotExist as error:
+                raise Http404 from error
+            return StatusDone({
+                'revision_id': deleted_revision_id,
+                'deleted': True,
+            })
         return StatusDone({
             'revision': PostRevisionService.serialize_detail(revision),
         })
+
+    if request.method == 'DELETE':
+        raise Http404
 
     page = _positive_integer(request.GET.get('page'), 1)
     limit = _positive_integer(


### PR DESCRIPTION
## 🎯 Goal
- Let post owners remove obsolete revision snapshots without changing the current post.
- Make revision history easier to browse with a focused list-to-detail panel flow.

## 🔧 Core Changes
- Add an owner-only API and service flow for deleting an individual post revision.
- Add deletion controls with explicit confirmation and refresh the history after deletion.
- Redesign the revision dialog as a sliding panel with separate list and detail views.
- Cover deletion, authorization, and post immutability behavior with backend tests.

## 🤔 Key Decisions
- Delete only the selected revision record and leave the current post content and update timestamp untouched.
- Reuse the existing revision ownership checks so unauthorized users receive the same protected behavior as list, detail, and restore requests.
- Require confirmation in the revision detail view because deletion cannot be undone.

## 🧪 Verification Guide
### How to verify
1. Open a published post with revision history and open the revision panel.
2. Select a revision, delete it after confirming, and verify it disappears while the current post remains unchanged.
3. Select another revision and verify restore behavior still works.

### Expected result
- Owners can delete exactly one selected revision, unauthorized users cannot access the operation, and revision browsing/restoration remains functional.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)
