### PR TITLE
🧪 Keep browser tests focused on essential coverage

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -91,6 +91,10 @@ jobs:
       run: pnpm type-check
       working-directory: backend/islands
 
+    - name: Unit test Islands
+      run: pnpm test
+      working-directory: backend/islands
+
     - name: Build Islands
       run: pnpm run build
       working-directory: backend/islands
@@ -120,8 +124,11 @@ jobs:
       run: pnpm --filter @blex/remotes exec playwright install --with-deps chromium
       working-directory: backend/islands
 
-    - name: Run island browser smoke
-      run: pnpm run e2e:smoke
+    - name: Run editor browser regression tests
+      run: >-
+        pnpm --filter @blex/remotes exec playwright test
+        --config playwright.config.ts
+        e2e/editor-media-upload.spec.ts
       working-directory: backend/islands
       env:
         BLEX_E2E_ENV_FILE: ${{ github.workspace }}/samples/.env
@@ -242,7 +249,9 @@ jobs:
           E2E_SKIP_WEB_SERVER=1 \
           E2E_EXPECT_PRODUCTION=1 \
           pnpm --dir backend/islands/apps/remotes exec \
-          playwright test --config playwright.config.ts
+          playwright test \
+          --config playwright.config.ts \
+          e2e/island-smoke.spec.ts
 
         docker restart blex-ci
         for attempt in $(seq 1 60); do

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ AI Agents must read `docs/DEV_CONVENTION.md` before starting any development.
 - Install dependencies: `npm i`
 - Start local development: `npm run dev`
 - Run backend tests: `npm run server:test`
+- Run island unit tests: `npm run islands:test`
 - Run island lint: `npm run islands:lint`
 - Run island type checks: `npm run islands:type-check`
 

--- a/backend/islands/apps/remotes/e2e/editor-media-upload.spec.ts
+++ b/backend/islands/apps/remotes/e2e/editor-media-upload.spec.ts
@@ -93,32 +93,6 @@ const dispatchFileDrop = async (
     }, { point, file });
 };
 
-const dispatchHtmlDrop = async (
-    page: Page,
-    point: { x: number; y: number },
-    html: string
-) => {
-    await page.evaluate(({ point, html }) => {
-        const target = document.elementFromPoint(point.x, point.y);
-        if (!target) {
-            throw new Error('No element at drop point');
-        }
-
-        const dataTransfer = new DataTransfer();
-        dataTransfer.setData('text/html', html);
-
-        for (const eventName of ['dragenter', 'dragover', 'drop']) {
-            target.dispatchEvent(new DragEvent(eventName, {
-                bubbles: true,
-                cancelable: true,
-                clientX: point.x,
-                clientY: point.y,
-                dataTransfer
-            }));
-        }
-    }, { point, html });
-};
-
 test.describe('PostEditor media drag and drop', () => {
     test('drops an image at the visual drop position instead of the stale cursor', async ({ page }) => {
         const errors = collectRuntimeSignals(page);
@@ -203,44 +177,6 @@ test.describe('PostEditor media drag and drop', () => {
         const html = await page.locator('input[name="content_html"]').inputValue();
         expect(html).toContain(uploadedVideoUrl);
         expect(html).not.toContain('media-upload-placeholder');
-        expectNoRuntimeErrors(errors);
-    });
-
-    test('blocks dragged remote media html instead of silently copying it into the document', async ({ page }) => {
-        const errors = collectRuntimeSignals(page);
-        await mountPostEditor(page);
-
-        const editor = page.locator('.ProseMirror');
-        const dropPoint = await getVisibleDropPoint(editor);
-
-        await dispatchHtmlDrop(
-            page,
-            dropPoint,
-            '<img src="https://example.com/remote-image.png" alt="Remote">'
-        );
-
-        await expect(page.locator('text=이미지나 비디오는 파일로 내려놓아 주세요.')).toBeVisible();
-        await expect(editor.locator('figure')).toHaveCount(0);
-
-        const html = await page.locator('input[name="content_html"]').inputValue();
-        expect(html).not.toContain('remote-image.png');
-        expectNoRuntimeErrors(errors);
-    });
-
-    test('does not treat ProseMirror media node moves as external media drops', async ({ page }) => {
-        const errors = collectRuntimeSignals(page);
-        await mountPostEditor(page);
-
-        const editor = page.locator('.ProseMirror');
-        const dropPoint = await getVisibleDropPoint(editor);
-
-        await dispatchHtmlDrop(
-            page,
-            dropPoint,
-            '<div data-pm-slice="0 0 []"><figure><img src="https://example.com/internal-image.png" alt="Internal"></figure></div>'
-        );
-
-        await expect(page.locator('text=이미지나 비디오는 파일로 내려놓아 주세요.')).toHaveCount(0);
         expectNoRuntimeErrors(errors);
     });
 

--- a/backend/islands/package.json
+++ b/backend/islands/package.json
@@ -6,6 +6,7 @@
         "build": "turbo run build",
         "check:entry-budgets": "pnpm --filter @blex/remotes run check:entry-budgets",
         "e2e:smoke": "pnpm --filter @blex/remotes run e2e:smoke",
+        "test": "pnpm --filter @blex/editor run test",
         "lint": "turbo run lint",
         "type-check": "turbo run type-check"
     },

--- a/backend/islands/packages/editor/package.json
+++ b/backend/islands/packages/editor/package.json
@@ -20,10 +20,11 @@
         }
     },
     "scripts": {
+        "test": "node --test test/*.test.mjs",
         "type-check": "tsc --noEmit",
         "build": "tsup",
         "dev": "tsup --watch",
-        "lint": "eslint src"
+        "lint": "eslint src test"
     },
     "dependencies": {
         "@blex/ui": "workspace:^",

--- a/backend/islands/packages/editor/src/TiptapEditor/TiptapEditor.tsx
+++ b/backend/islands/packages/editor/src/TiptapEditor/TiptapEditor.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useEditor, EditorContent } from '@tiptap/react';
 import MenuBar from './components/menus/MenuBar';
 import { getEditorExtensions } from './config/editorConfig';
-import { hasProseMirrorSliceData } from './config/mediaUpload';
+import { classifyTextMediaDrop } from './config/mediaUpload';
 import { useImageUpload } from './hooks/useImageUpload';
 import { normalizeMediaUrlsInHtml } from './utils/mediaUrls';
 
@@ -29,13 +29,6 @@ interface HandlersRef {
 
 const removeUploadPlaceholders = (html: string) => {
     return html.replace(/<div[^>]*data-upload-placeholder="true"[^>]*>[\s\S]*?<\/div>/g, '');
-};
-
-const mayContainExternalMediaReference = (dataTransfer: DataTransfer) => {
-    const types = Array.from(dataTransfer.types ?? []);
-    return types.includes('text/html')
-        || types.includes('text/uri-list')
-        || types.includes('text/plain');
 };
 
 const TiptapEditor = ({
@@ -74,8 +67,7 @@ const TiptapEditor = ({
                         !dataTransfer
                         || dataTransfer.files.length > 0
                         || view.dragging
-                        || hasProseMirrorSliceData(dataTransfer)
-                        || !mayContainExternalMediaReference(dataTransfer)
+                        || classifyTextMediaDrop(dataTransfer) !== 'external-media'
                     ) {
                         return false;
                     }
@@ -191,8 +183,7 @@ const TiptapEditor = ({
                 !dataTransfer
                 || dataTransfer.files.length > 0
                 || editor.view.dragging
-                || hasProseMirrorSliceData(dataTransfer)
-                || !mayContainExternalMediaReference(dataTransfer)
+                || classifyTextMediaDrop(dataTransfer) !== 'external-media'
             ) {
                 return;
             }

--- a/backend/islands/packages/editor/src/TiptapEditor/config/mediaUpload.ts
+++ b/backend/islands/packages/editor/src/TiptapEditor/config/mediaUpload.ts
@@ -13,7 +13,25 @@ export const ACCEPTED_VIDEO_INPUT_TYPES = [
     ...ACCEPTED_VIDEO_EXTENSIONS.map(extension => `.${extension}`)
 ].join(',');
 
-export const hasProseMirrorSliceData = (dataTransfer: DataTransfer) => {
+type TextDataTransfer = Pick<DataTransfer, 'types' | 'getData'>;
+
+type TextMediaDropKind = 'prosemirror' | 'external-media' | 'none';
+
+const hasProseMirrorSliceData = (dataTransfer: TextDataTransfer) => {
     return Array.from(dataTransfer.types).includes('application/x-prosemirror-slice')
         || dataTransfer.getData('text/html').includes('data-pm-slice');
+};
+
+const hasExternalMediaContent = (dataTransfer: TextDataTransfer) => {
+    const html = dataTransfer.getData('text/html');
+    if (/<(?:img|video|source)\b/i.test(html)) return true;
+
+    const uri = dataTransfer.getData('text/uri-list') || dataTransfer.getData('text/plain');
+    return /\.(?:jpe?g|png|gif|webp|avif|mp4|webm)(?:[?#].*)?$/i.test(uri.trim());
+};
+
+export const classifyTextMediaDrop = (dataTransfer: TextDataTransfer): TextMediaDropKind => {
+    if (hasProseMirrorSliceData(dataTransfer)) return 'prosemirror';
+    if (hasExternalMediaContent(dataTransfer)) return 'external-media';
+    return 'none';
 };

--- a/backend/islands/packages/editor/src/TiptapEditor/hooks/useImageUpload.tsx
+++ b/backend/islands/packages/editor/src/TiptapEditor/hooks/useImageUpload.tsx
@@ -9,7 +9,7 @@ import {
     ACCEPTED_IMAGE_TYPES,
     ACCEPTED_VIDEO_EXTENSIONS,
     ACCEPTED_VIDEO_TYPES,
-    hasProseMirrorSliceData
+    classifyTextMediaDrop
 } from '../config/mediaUpload';
 import { normalizeMediaUrlForStorage } from '../utils/mediaUrls';
 
@@ -374,14 +374,6 @@ export const useImageUpload = ({ editor, onImageUpload, onImageUploadError }: Us
         };
     };
 
-    const hasExternalMediaContent = (dataTransfer: DataTransfer) => {
-        const html = dataTransfer.getData('text/html');
-        if (/<(?:img|video|source)\b/i.test(html)) return true;
-
-        const uri = dataTransfer.getData('text/uri-list') || dataTransfer.getData('text/plain');
-        return /\.(?:jpe?g|png|gif|webp|avif|mp4|webm)(?:[?#].*)?$/i.test(uri.trim());
-    };
-
     const handlePaste = async (event: ClipboardEvent) => {
         if (!editor) return;
 
@@ -436,10 +428,11 @@ export const useImageUpload = ({ editor, onImageUpload, onImageUploadError }: Us
 
         const dataTransfer = event.dataTransfer;
         if (!dataTransfer) return false;
-        if (hasProseMirrorSliceData(dataTransfer)) return false;
+        const textMediaDropKind = classifyTextMediaDrop(dataTransfer);
+        if (textMediaDropKind === 'prosemirror') return false;
 
         const { mediaFiles, rejectedFiles } = getMediaFiles(dataTransfer.files);
-        const hasExternalMedia = hasExternalMediaContent(dataTransfer);
+        const hasExternalMedia = textMediaDropKind === 'external-media';
         const hasHandledMediaPayload = mediaFiles.length > 0 || rejectedFiles.length > 0 || hasExternalMedia;
 
         if (options?.invalidPositionMessage && hasHandledMediaPayload) {

--- a/backend/islands/packages/editor/test/mediaUpload.test.mjs
+++ b/backend/islands/packages/editor/test/mediaUpload.test.mjs
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { classifyTextMediaDrop } from '../src/TiptapEditor/config/mediaUpload.ts';
+
+const createDataTransfer = (data = {}, types = Object.keys(data)) => ({
+    types,
+    getData: format => data[format] ?? ''
+});
+
+describe('classifyTextMediaDrop', () => {
+    test('classifies remote media HTML and URLs as external media', () => {
+        const imageHtml = '<img src="https://example.com/image.png" alt="Remote">';
+        assert.equal(classifyTextMediaDrop(
+            createDataTransfer({ 'text/html': imageHtml })
+        ), 'external-media');
+        assert.equal(classifyTextMediaDrop(
+            createDataTransfer({ 'text/uri-list': 'https://example.com/video.mp4?download=1' })
+        ), 'external-media');
+    });
+
+    test('gives ProseMirror slices precedence over embedded media', () => {
+        const sliceHtml = '<div data-pm-slice="0 0 []"><img src="https://example.com/internal.png"></div>';
+        assert.equal(classifyTextMediaDrop(
+            createDataTransfer({ 'text/html': sliceHtml })
+        ), 'prosemirror');
+        assert.equal(classifyTextMediaDrop(createDataTransfer(
+            { 'text/html': '<img src="https://example.com/internal.png">' },
+            ['application/x-prosemirror-slice', 'text/html']
+        )), 'prosemirror');
+    });
+
+    test('ignores unrelated text drops', () => {
+        assert.equal(classifyTextMediaDrop(
+            createDataTransfer({ 'text/plain': 'ordinary text' })
+        ), 'none');
+    });
+});

--- a/docs/DEV_CONVENTION.md
+++ b/docs/DEV_CONVENTION.md
@@ -60,6 +60,7 @@
 
 ## Frontend Guidelines
 - **Always read `docs/FRONTEND_GUIDE.md` first.**
+- Prefer `npm run islands:test` for pure logic. Reserve Playwright E2E tests for behavior that requires browser APIs, built assets, or production runtime integration.
 - **IMPORTANT**: Lint and type checks are **ONLY** for Islands (React) work, **NOT** for template work.
   - After development, run lint and type checks:
     - `npm run islands:lint` for linting

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
         "islands:build": "pnpm --dir backend/islands run build",
         "islands:check-entry-budgets": "pnpm --dir backend/islands run check:entry-budgets",
         "islands:e2e:smoke": "pnpm --dir backend/islands run e2e:smoke",
+        "islands:test": "pnpm --dir backend/islands run test",
         "islands:type-check": "pnpm --dir backend/islands run type-check",
         "dev": "concurrently \"npm run server:dev\" \"npm run islands:dev\""
     },


### PR DESCRIPTION
## 🎯 Goal
- Reduce browser-test cost without weakening production asset and editor interaction coverage.
- Cover pure media-drop classification with fast unit tests instead of Playwright.

## 🔧 Core Changes
- Add npm run islands:test backed by the Node test runner, with no new dependency.
- Move remote-media and ProseMirror-slice classification coverage from E2E to unit tests.
- Keep only three real editor interaction tests and five production Island/runtime tests in Playwright.
- Split CI ownership so editor E2E runs in islands_ci and production Island smoke runs in container_ci, eliminating duplicate execution.
- Document the unit-first, browser-only-when-required testing rule.

## 🤔 Key Decisions
- Use the built-in Node 22 test runner instead of adding Vitest for three small pure-logic tests.
- Retain container browser smoke because malformed production static URLs cannot be covered by unit tests.
- Retain visual drop positioning, media node insertion, and real node dragging in Playwright because they depend on browser and ProseMirror behavior.

## 🧪 Verification Guide
### How to verify
1. Run npm run islands:test.
2. Run npm run islands:lint and npm run islands:type-check.
3. Run npm run islands:build and npm run islands:check-entry-budgets.
4. Run PORT=18081 npm run islands:e2e:smoke.

### Expected result
- Three unit tests and eight non-duplicated browser tests pass.
- Built static asset requests return successfully without malformed paths.
- CI executes 3 editor E2E tests in islands_ci and 5 production smoke tests in container_ci.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)