### PR TITLE
♻️ Improve related post relevance and stability

### DIFF
--- a/backend/islands/apps/remotes/package.json
+++ b/backend/islands/apps/remotes/package.json
@@ -9,7 +9,8 @@
         "build": "node scripts/watch-assets.js --once && vite build",
         "check:entry-budgets": "node scripts/check-entry-budgets.mjs",
         "e2e:smoke": "playwright test --config playwright.config.ts",
-        "lint": "eslint src",
+        "test": "node --test test/*.test.mjs",
+        "lint": "eslint src test",
         "type-check": "tsc --noEmit"
     },
     "dependencies": {

--- a/backend/islands/apps/remotes/src/components/remotes/RelatedPosts/RelatedPosts.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/RelatedPosts/RelatedPosts.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect } from 'react';
-import { logger } from '~/utils/logger';
+import { useQuery } from '@tanstack/react-query';
+import { selectVisibleRelatedPosts } from './selection';
 import { getRelatedPosts, type RelatedPost } from '~/lib/api/posts';
 
 interface RelatedPostsProps {
@@ -64,7 +64,7 @@ const PostCard = ({ relatedPost }: { relatedPost: RelatedPost }) => {
                 </h3>
 
                 <div className="text-xs text-content-secondary mb-3 flex items-center gap-3">
-                    <time dateTime={relatedPost.publishedDate}>
+                    <time dateTime={relatedPost.publishedAt}>
                         {relatedPost.publishedDate}
                     </time>
                     <span>{relatedPost.readTime}분</span>
@@ -101,27 +101,24 @@ const PostCard = ({ relatedPost }: { relatedPost: RelatedPost }) => {
 };
 
 const RelatedPosts = ({ postUrl, username }: RelatedPostsProps) => {
-    const [relatedPosts, setRelatedPosts] = useState<RelatedPost[]>([]);
-    const [isLoading, setIsLoading] = useState(true);
-
-    useEffect(() => {
-        const fetchRelatedPosts = async () => {
-            try {
-                const { data } = await getRelatedPosts(username, postUrl);
-                if (data.status === 'DONE') {
-                    const posts = data.body.posts || [];
-                    const count = posts.length >= 8 ? 8 : posts.length >= 4 ? 4 : posts.length;
-                    setRelatedPosts(posts.slice(0, count));
-                }
-            } catch (error) {
-                logger.error('Failed to fetch related posts:', error);
-            } finally {
-                setIsLoading(false);
+    const {
+        data: relatedPosts = [],
+        isLoading,
+        isError
+    } = useQuery({
+        queryKey: ['related-posts', username, postUrl],
+        queryFn: async () => {
+            const { data } = await getRelatedPosts(username, postUrl);
+            if (data.status === 'ERROR') {
+                throw new Error(data.errorMessage);
             }
-        };
 
-        fetchRelatedPosts();
-    }, [postUrl, username]);
+            return selectVisibleRelatedPosts(data.body.posts ?? []);
+        },
+        enabled: Boolean(username && postUrl),
+        staleTime: 5 * 60 * 1000,
+        retry: 1
+    });
 
     if (isLoading) {
         return (
@@ -138,6 +135,10 @@ const RelatedPosts = ({ postUrl, username }: RelatedPostsProps) => {
                 </div>
             </div>
         );
+    }
+
+    if (isError) {
+        return null;
     }
 
     if (relatedPosts.length === 0) {

--- a/backend/islands/apps/remotes/src/components/remotes/RelatedPosts/selection.ts
+++ b/backend/islands/apps/remotes/src/components/remotes/RelatedPosts/selection.ts
@@ -1,0 +1,5 @@
+export const MAX_RELATED_POSTS = 8;
+
+export const selectVisibleRelatedPosts = <T>(posts: readonly T[]): T[] => (
+    posts.slice(0, MAX_RELATED_POSTS)
+);

--- a/backend/islands/apps/remotes/src/lib/api/posts.ts
+++ b/backend/islands/apps/remotes/src/lib/api/posts.ts
@@ -96,6 +96,7 @@ export interface RelatedPost {
     metaDescription: string;
     image?: string;
     publishedDate: string;
+    publishedAt?: string;
     readTime: number;
 }
 

--- a/backend/islands/apps/remotes/test/relatedPosts.test.mjs
+++ b/backend/islands/apps/remotes/test/relatedPosts.test.mjs
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+    MAX_RELATED_POSTS,
+    selectVisibleRelatedPosts
+} from '../src/components/remotes/RelatedPosts/selection.ts';
+
+describe('selectVisibleRelatedPosts', () => {
+    test('keeps every related post when the API returns five to seven posts', () => {
+        for (const count of [5, 6, 7]) {
+            const posts = Array.from({ length: count }, (_, index) => index);
+
+            assert.deepEqual(selectVisibleRelatedPosts(posts), posts);
+        }
+    });
+
+    test('preserves ranking order and caps the result at eight posts', () => {
+        const posts = Array.from({ length: 10 }, (_, index) => index);
+
+        assert.deepEqual(
+            selectVisibleRelatedPosts(posts),
+            posts.slice(0, MAX_RELATED_POSTS)
+        );
+    });
+});

--- a/backend/islands/package.json
+++ b/backend/islands/package.json
@@ -6,7 +6,7 @@
         "build": "turbo run build",
         "check:entry-budgets": "pnpm --filter @blex/remotes run check:entry-budgets",
         "e2e:smoke": "pnpm --filter @blex/remotes run e2e:smoke",
-        "test": "pnpm --filter @blex/editor run test",
+        "test": "pnpm --filter @blex/editor --filter @blex/remotes run test",
         "lint": "turbo run lint",
         "type-check": "turbo run type-check"
     },

--- a/backend/src/board/services/post_service.py
+++ b/backend/src/board/services/post_service.py
@@ -5,7 +5,6 @@ Business logic for post operations.
 Extracted from views to improve testability and reusability.
 """
 
-import random
 from typing import Optional, Dict, Any, Tuple, List
 from datetime import datetime
 
@@ -568,10 +567,7 @@ class PostService:
 
     @staticmethod
     def get_related_posts(post: Post) -> List[Post]:
-        return RelatedPostService.get_related_posts(
-            post,
-            jitter=random.uniform,
-        )
+        return RelatedPostService.get_related_posts(post)
 
     @staticmethod
     @transaction.atomic

--- a/backend/src/board/services/related_post_service.py
+++ b/backend/src/board/services/related_post_service.py
@@ -2,13 +2,24 @@
 
 from __future__ import annotations
 
-import random
+from datetime import datetime, timedelta
+from typing import Callable, ClassVar
 
-from dataclasses import dataclass
-from datetime import datetime
-from typing import Callable, ClassVar, cast
-
-from django.db.models import Count, F, Q, QuerySet
+from django.db.models import (
+    Case,
+    Count,
+    Exists,
+    ExpressionWrapper,
+    F,
+    FloatField,
+    IntegerField,
+    OuterRef,
+    Q,
+    QuerySet,
+    Value,
+    When,
+)
+from django.db.models.functions import Cast, Least
 from django.utils import timezone
 
 from board.models import Post
@@ -18,17 +29,14 @@ from board.services.public_post_service import PublicPostService
 RelatedPostJitter = Callable[[float, float], float]
 
 
-@dataclass(frozen=True)
-class ScoredRelatedPost:
-    post: Post
-    score: float
-    tag_overlap: int
-
-
 class RelatedPostService:
-    """Return public related posts using the existing scoring algorithm."""
+    """Return deterministic public recommendations led by tag relevance."""
 
     MAX_RELATED_POSTS: ClassVar[int] = 8
+    TAG_OVERLAP_WEIGHT: ClassVar[int] = 3
+    MAX_TAG_SCORE: ClassVar[int] = 10
+    LIKE_WEIGHT: ClassVar[int] = 2
+    MAX_POPULARITY_SCORE: ClassVar[int] = 10
 
     @staticmethod
     def calculate_tag_score(
@@ -36,15 +44,20 @@ class RelatedPostService:
         current_tag_set: set[str],
     ) -> tuple[int, int]:
         tag_overlap = len(current_tag_set & candidate_tags)
-        return min(tag_overlap * 3, 10), tag_overlap
+        return min(
+            tag_overlap * RelatedPostService.TAG_OVERLAP_WEIGHT,
+            RelatedPostService.MAX_TAG_SCORE,
+        ), tag_overlap
 
     @staticmethod
     def calculate_popularity_score(
         likes_count: int,
         comments_count: int,
     ) -> int:
-        popularity = (likes_count * 2) + comments_count
-        return min(popularity, 10)
+        popularity = (
+            likes_count * RelatedPostService.LIKE_WEIGHT
+        ) + comments_count
+        return min(popularity, RelatedPostService.MAX_POPULARITY_SCORE)
 
     @staticmethod
     def calculate_recency_score(
@@ -60,14 +73,35 @@ class RelatedPostService:
             return 1
         return 0
 
-    @staticmethod
-    def get_candidates(post: Post, current_tags: list[str]) -> QuerySet[Post]:
-        return PublicPostService.filter_public_posts(
+    @classmethod
+    def get_candidates(
+        cls,
+        post: Post,
+        current_tags: list[str],
+        *,
+        now: datetime | None = None,
+    ) -> QuerySet[Post]:
+        ranking_time = now or timezone.now()
+        shared_tag_match = Post.tags.through.objects.filter(
+            post_id=OuterRef('pk'),
+            tag__value__in=current_tags,
+        )
+        tag_union_count = (
+            Value(len(current_tags))
+            + F('candidate_tag_count')
+            - F('candidate_tag_overlap')
+        )
+
+        candidates = PublicPostService.filter_public_posts(
             Post.objects.select_related(
                 'author', 'author__profile', 'config'
-            ).prefetch_related('tags')
+            )
         ).exclude(
             id=post.id
+        ).alias(
+            has_shared_tag=Exists(shared_tag_match),
+        ).filter(
+            has_shared_tag=True,
         ).annotate(
             author_username=F('author__username'),
             author_name=F('author__first_name'),
@@ -77,10 +111,63 @@ class RelatedPostService:
                 filter=Q(tags__value__in=current_tags),
                 distinct=True,
             ),
+            candidate_tag_count=Count('tags', distinct=True),
             likes_count=Count('likes', distinct=True),
             comments_count=Count('comments', distinct=True),
-        ).filter(
-            candidate_tag_overlap__gt=0,
+        )
+
+        candidates = candidates.annotate(
+            tag_score=Least(
+                F('candidate_tag_overlap') * Value(cls.TAG_OVERLAP_WEIGHT),
+                Value(cls.MAX_TAG_SCORE),
+                output_field=IntegerField(),
+            ),
+            tag_similarity=ExpressionWrapper(
+                Cast(F('candidate_tag_overlap'), FloatField())
+                / Cast(tag_union_count, FloatField()),
+                output_field=FloatField(),
+            ),
+            popularity_score=Least(
+                (
+                    F('likes_count') * Value(cls.LIKE_WEIGHT)
+                    + F('comments_count')
+                ),
+                Value(cls.MAX_POPULARITY_SCORE),
+                output_field=IntegerField(),
+            ),
+            recency_score=Case(
+                When(
+                    published_date__gt=ranking_time - timedelta(days=7),
+                    then=Value(5),
+                ),
+                When(
+                    published_date__gt=ranking_time - timedelta(days=30),
+                    then=Value(3),
+                ),
+                When(
+                    published_date__gt=ranking_time - timedelta(days=90),
+                    then=Value(1),
+                ),
+                default=Value(0),
+                output_field=IntegerField(),
+            ),
+            same_author_rank=Case(
+                When(author_id=post.author_id, then=Value(1)),
+                default=Value(0),
+                output_field=IntegerField(),
+            ),
+        ).annotate(
+            quality_score=F('popularity_score') + F('recency_score'),
+        )
+
+        return candidates.order_by(
+            '-tag_score',
+            '-candidate_tag_overlap',
+            '-tag_similarity',
+            'same_author_rank',
+            '-quality_score',
+            '-published_date',
+            '-pk',
         )
 
     @classmethod
@@ -90,50 +177,10 @@ class RelatedPostService:
         *,
         jitter: RelatedPostJitter | None = None,
     ) -> list[Post]:
+        """Return the top matches; ``jitter`` remains accepted for compatibility."""
         current_tags = [tag.value for tag in post.tags.all()]
         if not current_tags:
             return []
 
-        current_tag_set = set(current_tags)
         candidates = cls.get_candidates(post, current_tags)
-        scored_posts: list[ScoredRelatedPost] = []
-        now = timezone.now()
-        jitter_score = jitter if jitter is not None else random.uniform
-
-        for candidate in candidates:
-            candidate_tags = {
-                tag.value
-                for tag in candidate.tags.all()
-            }
-            tag_score, tag_overlap = cls.calculate_tag_score(
-                candidate_tags,
-                current_tag_set,
-            )
-            popularity_score = cls.calculate_popularity_score(
-                cast(int, candidate.likes_count),
-                cast(int, candidate.comments_count),
-            )
-            recency_score = cls.calculate_recency_score(
-                cast(datetime, candidate.published_date),
-                now,
-            )
-
-            score = tag_score + popularity_score + recency_score
-            if candidate.author.id == post.author.id:
-                score -= 5
-            score += jitter_score(-3, 3)
-
-            scored_posts.append(ScoredRelatedPost(
-                post=candidate,
-                score=score,
-                tag_overlap=tag_overlap,
-            ))
-
-        scored_posts.sort(
-            key=lambda item: (item.score, item.tag_overlap),
-            reverse=True,
-        )
-        return [
-            item.post
-            for item in scored_posts[:cls.MAX_RELATED_POSTS]
-        ]
+        return list(candidates[:cls.MAX_RELATED_POSTS])

--- a/backend/src/board/tests/api/test_post.py
+++ b/backend/src/board/tests/api/test_post.py
@@ -14,6 +14,7 @@ from django.test.utils import CaptureQueriesContext
 from board.models import (
     User, Config, Post, PostContent, PostConfig, Profile, Series, Tag
 )
+from board.modules.time import time_since
 
 
 class PostTestCase(TestCase):
@@ -917,6 +918,28 @@ class PostTestCase(TestCase):
         response = self.client.get('/v1/users/@author/posts/test-post-1/related')
 
         self.assertEqual(response.status_code, 404)
+
+    def test_related_posts_adds_iso_timestamp_without_replacing_display_date(self):
+        """관련 글 날짜 계약은 기존 표시값을 유지하고 ISO 시각을 추가한다."""
+        reference = Post.objects.get(url='test-post-1')
+        candidate = Post.objects.get(url='test-post-2')
+        tag = Tag.objects.create(value='related-api-contract')
+        reference.tags.add(tag)
+        candidate.tags.add(tag)
+
+        response = self.client.get('/v1/users/@author/posts/test-post-1/related')
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        related_post = content['body']['posts'][0]
+        self.assertEqual(
+            related_post['publishedDate'],
+            time_since(candidate.published_date),
+        )
+        self.assertEqual(
+            related_post['publishedAt'],
+            candidate.published_date.isoformat(),
+        )
 
     def test_related_posts_rejects_draft_post_for_non_owner(self):
         """관련 글 API는 임시저장 글을 비작성자에게 노출하지 않는다."""

--- a/backend/src/board/tests/services/test_related_post_service.py
+++ b/backend/src/board/tests/services/test_related_post_service.py
@@ -1,8 +1,9 @@
 from datetime import timedelta
-from unittest.mock import call, patch
 
 from django.contrib.auth.models import User
+from django.db import connection
 from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 
 from board.models import Post, PostConfig, PostLikes, Profile, Tag
@@ -101,54 +102,71 @@ class RelatedPostServiceTestCase(TestCase):
         post.tags.add(*tags)
         return post
 
-    @patch('board.services.post_service.random.uniform', side_effect=[0, 0, 0])
-    def test_facade_preserves_ranking_and_random_call_order(self, mock_uniform):
-        posts = PostService.get_related_posts(self.reference)
-
-        self.assertEqual(posts, [self.popular, self.overlap, self.same_author])
-        self.assertEqual(
-            mock_uniform.call_args_list,
-            [call(-3, 3), call(-3, 3), call(-3, 3)],
+    def test_facade_prioritizes_tag_relevance_deterministically(self):
+        first_result = PostService.get_related_posts(self.reference)
+        second_result = PostService.get_related_posts(self.reference)
+        legacy_keyword_result = RelatedPostService.get_related_posts(
+            self.reference,
+            jitter=lambda lower, upper: upper,
         )
 
-    @patch('board.services.related_post_service.random.uniform', side_effect=[0, 0, 0])
-    def test_typed_service_preserves_direct_ranking(self, mock_uniform):
-        posts = RelatedPostService.get_related_posts(self.reference)
+        expected = [self.overlap, self.same_author, self.popular]
+        self.assertEqual(first_result, expected)
+        self.assertEqual(second_result, expected)
+        self.assertEqual(legacy_keyword_result, expected)
 
-        self.assertEqual(posts, [self.popular, self.overlap, self.same_author])
-        self.assertEqual(
-            mock_uniform.call_args_list,
-            [call(-3, 3), call(-3, 3), call(-3, 3)],
-        )
-
-    @patch('board.services.post_service.random.uniform', return_value=0)
-    def test_facade_preserves_same_author_penalty(self, mock_uniform):
-        penalty_tag = Tag.objects.create(value='penalty-tag')
+    def test_equal_relevance_prefers_another_author(self):
+        diversity_tag = Tag.objects.create(value='diversity-tag')
+        published_date = timezone.now()
         reference = self.create_post(
-            'Penalty Reference',
+            'Diversity Reference',
             self.author,
-            timezone.now(),
-            (penalty_tag,),
+            published_date,
+            (diversity_tag,),
         )
         same_author = self.create_post(
-            'Penalty Same Author',
+            'Diversity Same Author',
             self.author,
-            timezone.now(),
-            (penalty_tag,),
+            published_date,
+            (diversity_tag,),
         )
         other_author = self.create_post(
-            'Penalty Other Author',
+            'Diversity Other Author',
             self.other_author,
-            timezone.now(),
-            (penalty_tag,),
+            published_date,
+            (diversity_tag,),
         )
 
         posts = PostService.get_related_posts(reference)
 
         self.assertEqual(posts, [other_author, same_author])
 
-    @patch('board.services.post_service.random.uniform', return_value=0)
-    def test_candidates_preserve_public_policy_and_api_annotations(self, mock_uniform):
+    def test_focused_tag_match_wins_when_overlap_is_equal(self):
+        published_date = timezone.now()
+        reference = self.create_post(
+            'Focused Reference',
+            self.author,
+            published_date,
+            (self.alpha, self.beta),
+        )
+        focused = self.create_post(
+            'Focused Candidate',
+            self.other_author,
+            published_date,
+            (self.alpha, self.beta),
+        )
+        broad = self.create_post(
+            'Broad Candidate',
+            self.other_author,
+            published_date,
+            (self.alpha, self.beta, self.gamma, self.delta),
+        )
+
+        posts = PostService.get_related_posts(reference)
+
+        self.assertLess(posts.index(focused), posts.index(broad))
+
+    def test_candidates_preserve_public_policy_and_api_annotations(self):
         posts = PostService.get_related_posts(self.reference)
 
         self.assertEqual({post.url for post in posts}, {
@@ -162,10 +180,11 @@ class RelatedPostServiceTestCase(TestCase):
         self.assertEqual(str(popular.author_image), '')
         self.assertEqual(popular.likes_count, 5)
         self.assertEqual(popular.comments_count, 0)
+        self.assertEqual(popular.candidate_tag_overlap, 1)
+        self.assertEqual(popular.tag_score, 3)
 
-    @patch('board.services.post_service.random.uniform', return_value=0)
-    def test_facade_query_count_does_not_regress(self, mock_uniform):
-        with self.assertNumQueries(3):
+    def test_facade_query_count_does_not_regress(self):
+        with self.assertNumQueries(2):
             posts = PostService.get_related_posts(self.reference)
 
         self.assertEqual(len(posts), 3)
@@ -183,8 +202,7 @@ class RelatedPostServiceTestCase(TestCase):
 
         self.assertEqual(posts, [])
 
-    @patch('board.services.post_service.random.uniform', return_value=0)
-    def test_related_posts_keep_maximum_of_eight(self, mock_uniform):
+    def test_related_posts_keep_maximum_of_eight(self):
         for index in range(8):
             self.create_post(
                 f'Additional {index}',
@@ -198,42 +216,60 @@ class RelatedPostServiceTestCase(TestCase):
         self.assertEqual(len(posts), 8)
         self.assertNotIn(self.reference, posts)
 
-    @patch('board.services.related_post_service.random.uniform', return_value=0)
-    def test_popular_tag_evaluates_all_candidates_with_constant_queries(self, mock_uniform):
-        candidate_count = 144
-        for index in range(candidate_count):
+    def test_popular_tag_limits_rows_in_the_database(self):
+        for index in range(144):
             self.create_post(
                 f'Popular Tag Candidate {index}',
                 self.other_author,
                 timezone.now(),
                 (self.alpha,),
             )
-        total_candidates = RelatedPostService.get_candidates(
-            self.reference,
-            [self.alpha.value],
-        ).count()
 
-        with self.assertNumQueries(3):
+        with CaptureQueriesContext(connection) as captured:
             posts = RelatedPostService.get_related_posts(self.reference)
 
+        self.assertEqual(len(captured), 2)
         self.assertEqual(len(posts), RelatedPostService.MAX_RELATED_POSTS)
-        self.assertEqual(
-            mock_uniform.call_count,
-            total_candidates,
+        self.assertIn(
+            f'LIMIT {RelatedPostService.MAX_RELATED_POSTS}',
+            captured[-1]['sql'].upper(),
         )
 
     def test_score_helper_boundaries_remain_stable(self):
         self.assertEqual(
-            PostService._calculate_tag_score({'a', 'b', 'c', 'd'}, {'a', 'b', 'c', 'd'}),
+            RelatedPostService.calculate_tag_score(
+                {'a', 'b', 'c', 'd'},
+                {'a', 'b', 'c', 'd'},
+            ),
             (10, 4),
         )
-        self.assertEqual(PostService._calculate_popularity_score(6, 3), 10)
+        self.assertEqual(RelatedPostService.calculate_popularity_score(6, 3), 10)
         now = timezone.now()
-        self.assertEqual(PostService._calculate_recency_score(now - timedelta(days=6), now), 5)
-        self.assertEqual(PostService._calculate_recency_score(now - timedelta(days=7), now), 3)
-        self.assertEqual(PostService._calculate_recency_score(now - timedelta(days=30), now), 1)
-        self.assertEqual(PostService._calculate_recency_score(now - timedelta(days=90), now), 0)
         self.assertEqual(
-            RelatedPostService.calculate_tag_score({'a', 'b'}, {'a', 'b'}),
-            (6, 2),
+            RelatedPostService.calculate_recency_score(
+                now - timedelta(days=6),
+                now,
+            ),
+            5,
+        )
+        self.assertEqual(
+            RelatedPostService.calculate_recency_score(
+                now - timedelta(days=7),
+                now,
+            ),
+            3,
+        )
+        self.assertEqual(
+            RelatedPostService.calculate_recency_score(
+                now - timedelta(days=30),
+                now,
+            ),
+            1,
+        )
+        self.assertEqual(
+            RelatedPostService.calculate_recency_score(
+                now - timedelta(days=90),
+                now,
+            ),
+            0,
         )

--- a/backend/src/board/views/api/v1/post.py
+++ b/backend/src/board/views/api/v1/post.py
@@ -249,8 +249,7 @@ def user_posts(request, username, url=None):
 
 def user_post_related(request, username, url):
     """
-    Get related posts for a specific post based on shared tags and popularity.
-    Uses a scoring system to rank relevance.
+    Get deterministic related posts led by shared-tag relevance.
     """
     if request.method == 'GET':
         post = get_object_or_404(Post.objects.select_related('config', 'author').prefetch_related('tags'),
@@ -269,6 +268,7 @@ def user_post_related(request, username, url):
                 'meta_description': related_post.meta_description,
                 'read_time': related_post.read_time,
                 'published_date': time_since(related_post.published_date),
+                'published_at': related_post.published_date.isoformat(),
                 'author_username': related_post.author_username,
                 'author_name': related_post.author_name,
                 'author_image': str(related_post.author_image) if related_post.author_image else None,


### PR DESCRIPTION
## 🎯 Goal
- Make related-post recommendations stable, relevant, and bounded for high-volume tags.
- Fix the client-side loss of valid 5–7 item responses without breaking the existing route or response fields.

## 🔧 Core Changes
- Rank public candidates deterministically in the database: tag overlap and similarity first, author diversity on equal relevance, then popularity and recency.
- Apply `LIMIT 8` in SQL instead of loading and randomly scoring every matching post in Python.
- Keep `publishedDate` unchanged and add optional `publishedAt` for a valid semantic `<time>` value.
- Fetch through React Query and display every ranked result up to eight; add focused Node unit coverage without adding browser E2E cases.

## 🤔 Key Decisions
- Tag relevance is the primary contract, so popularity or random jitter cannot move a weak match above a stronger match.
- Exact-relevance ties prefer another author before quality signals to retain discovery diversity without the previous arbitrary author penalty.
- The public URL, existing response fields, facade signature, and legacy `jitter` keyword acceptance remain compatible; the timestamp field is additive.
- Pure selection behavior is covered with unit tests because it does not require browser APIs. Existing required browser smoke remains in CI.

## 🧪 Verification Guide
### How to verify
1. Open a public post that shares tags with several public posts, including multiple posts with the same overlap.
2. Request `/v1/users/@{username}/posts/{postUrl}/related` repeatedly and compare the ordered results.
3. Confirm that responses with 5–8 posts render every card and that each card still displays the existing relative date.

### Expected result
- Results are stable across requests, stronger tag matches stay ahead of weaker matches, only public posts appear, and no more than eight rows are returned.
- Existing consumers continue receiving `publishedDate`; updated clients additionally use `publishedAt`.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed (1,213 backend tests plus islands unit tests)
- [x] Documentation updated (not needed; no public route or required usage documentation changed)