### PR TITLE
🐛 Treat comment content as plain text safely

### DIFF
--- a/backend/islands/apps/remotes/src/components/remotes/Comments/components/CommentForm.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/Comments/components/CommentForm.tsx
@@ -49,7 +49,6 @@ export const CommentForm = ({
         : mentionableUsers;
 
     // 텍스트 변경 감지 및 멘션 자동완성 트리거
-    // 텍스트 변경 감지 및 멘션 자동완성 트리거
     const handleTextChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
         const newText = e.target.value;
         const cursorPos = e.target.selectionStart;
@@ -80,20 +79,19 @@ export const CommentForm = ({
     const selectUser = (username: string) => {
         const before = commentText.substring(0, mentionStartPos);
         const after = commentText.substring(textareaRef.current?.selectionStart || commentText.length);
-        const newText = `${before}\`@${username}\` ${after}`;
+        const newText = `${before}@${username} ${after}`;
 
         onCommentTextChange(newText);
         setShowMentionAutocomplete(false);
 
         // 커서 위치 조정
         setTimeout(() => {
-            const newCursorPos = before.length + username.length + 4; // ` + @ + username + ` + space
+            const newCursorPos = before.length + username.length + 2; // @ + username + space
             textareaRef.current?.setSelectionRange(newCursorPos, newCursorPos);
             textareaRef.current?.focus();
         }, 0);
     };
 
-    // 키보드 이벤트 처리
     // 키보드 이벤트 처리
     const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
         if (!showMentionAutocomplete || filteredUsers.length === 0) return;

--- a/backend/islands/apps/remotes/src/components/remotes/Comments/components/CommentForm.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/Comments/components/CommentForm.tsx
@@ -1,6 +1,7 @@
 import { useRef, useEffect, useState } from 'react';
 import { Loader2, Lock } from '@blex/ui/icons';
 import { MentionAutocomplete } from './MentionAutocomplete';
+import { isMentionQuery, isMentionStart } from '../utils/mentionText';
 
 interface CommentFormProps {
     isLoggedIn: boolean;
@@ -62,7 +63,7 @@ export const CommentForm = ({
         if (lastAtIndex !== -1) {
             const textAfterAt = textBeforeCursor.substring(lastAtIndex + 1);
             // @ 뒤에 공백이 없고, 알파벳/숫자/점만 있으면 자동완성 표시
-            if (/^[a-zA-Z0-9.]*$/.test(textAfterAt)) {
+            if (isMentionStart(textBeforeCursor, lastAtIndex) && isMentionQuery(textAfterAt)) {
                 setMentionQuery(textAfterAt);
                 setMentionStartPos(lastAtIndex);
                 setShowMentionAutocomplete(true);

--- a/backend/islands/apps/remotes/src/components/remotes/Comments/hooks/useCommentsController.ts
+++ b/backend/islands/apps/remotes/src/components/remotes/Comments/hooks/useCommentsController.ts
@@ -20,6 +20,7 @@ import {
     mergeCommentInTree,
     updateCommentInTree
 } from '../utils/commentTree';
+import { buildReplySubmissionText } from '../utils/replyText';
 
 interface CommentsData {
     comments: Comment[];
@@ -266,18 +267,7 @@ export const useCommentsController = ({
     };
 
     const getReplySubmissionText = () => {
-        const content = replyText.trim();
-
-        if (!replyTargetAuthor) {
-            return content;
-        }
-
-        const mentionPrefix = `\`@${replyTargetAuthor}\``;
-        if (content.startsWith(mentionPrefix)) {
-            return content;
-        }
-
-        return `${mentionPrefix} ${content}`;
+        return buildReplySubmissionText(replyText, replyTargetAuthor);
     };
 
     const handleReply = async () => {

--- a/backend/islands/apps/remotes/src/components/remotes/Comments/utils/mentionText.ts
+++ b/backend/islands/apps/remotes/src/components/remotes/Comments/utils/mentionText.ts
@@ -1,0 +1,11 @@
+const MENTION_START_BLOCKERS = /[\p{L}\p{N}_@.+\-`*~]/u;
+
+export const isMentionStart = (text: string, atIndex: number): boolean => {
+    const previousCharacter = text[atIndex - 1];
+
+    return previousCharacter === undefined || !MENTION_START_BLOCKERS.test(previousCharacter);
+};
+
+export const isMentionQuery = (query: string): boolean => {
+    return /^[a-z0-9]*$/i.test(query);
+};

--- a/backend/islands/apps/remotes/src/components/remotes/Comments/utils/replyText.ts
+++ b/backend/islands/apps/remotes/src/components/remotes/Comments/utils/replyText.ts
@@ -1,0 +1,39 @@
+const REPLY_MENTION_SEPARATOR = /[\s,!?;:()[\]{}]/;
+
+const isMentionBoundary = (text: string, index: number): boolean => {
+    const nextCharacter = text[index];
+
+    if (nextCharacter === undefined) {
+        return true;
+    }
+
+    if (nextCharacter === '.') {
+        const characterAfterDot = text[index + 1];
+        return characterAfterDot === undefined || !/[a-z0-9]/i.test(characterAfterDot);
+    }
+
+    return REPLY_MENTION_SEPARATOR.test(nextCharacter);
+};
+
+export const buildReplySubmissionText = (
+    replyText: string,
+    replyTargetAuthor: string | null
+): string => {
+    const content = replyText.trim();
+
+    if (!replyTargetAuthor) {
+        return content;
+    }
+
+    const mentionPrefix = `@${replyTargetAuthor}`;
+    const alreadyMentionsTarget = content === mentionPrefix || (
+        content.startsWith(mentionPrefix)
+        && isMentionBoundary(content, mentionPrefix.length)
+    );
+
+    if (alreadyMentionsTarget) {
+        return content;
+    }
+
+    return content ? `${mentionPrefix} ${content}` : mentionPrefix;
+};

--- a/backend/islands/apps/remotes/src/lib/api/comments.ts
+++ b/backend/islands/apps/remotes/src/lib/api/comments.ts
@@ -55,9 +55,9 @@ export const getComments = async (postUrl: string) => {
     return http.get<CommentsResponse>(`v1/posts/${postUrl}/comments`);
 };
 
-export const createComment = async (postUrl: string, commentMarkdown: string, parentId?: number) => {
+export const createComment = async (postUrl: string, commentText: string, parentId?: number) => {
     const formData = new URLSearchParams();
-    formData.append('comment_md', commentMarkdown);
+    formData.append('comment_md', commentText);
     if (parentId) {
         formData.append('parent_id', parentId.toString());
     }
@@ -69,10 +69,10 @@ export const getComment = async (commentId: number) => {
     return http.get<CommentResponse>(`v1/comments/${commentId}`);
 };
 
-export const updateComment = async (commentId: number, commentMarkdown: string) => {
+export const updateComment = async (commentId: number, commentText: string) => {
     const formData = new URLSearchParams();
     formData.append('comment', 'true');
-    formData.append('comment_md', commentMarkdown);
+    formData.append('comment_md', commentText);
 
     return http.put<UpdateCommentResponse>(`v1/comments/${commentId}`, formData, { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } });
 };

--- a/backend/islands/apps/remotes/test/comments.test.mjs
+++ b/backend/islands/apps/remotes/test/comments.test.mjs
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import { isMentionQuery, isMentionStart } from '../src/components/remotes/Comments/utils/mentionText.ts';
+import { buildReplySubmissionText } from '../src/components/remotes/Comments/utils/replyText.ts';
+
+describe('mention text boundaries', () => {
+    test('does not start autocomplete inside email or code-like text', () => {
+        assert.equal(isMentionStart('contact@', 7), false);
+        assert.equal(isMentionStart('`@', 1), false);
+        assert.equal(isMentionStart('**@', 2), false);
+        assert.equal(isMentionStart('@@', 1), false);
+    });
+
+    test('allows mentions at the beginning or after normal punctuation', () => {
+        assert.equal(isMentionStart('@', 0), true);
+        assert.equal(isMentionStart('(@', 1), true);
+        assert.equal(isMentionStart('hello @', 6), true);
+    });
+
+    test('accepts only valid username characters while searching', () => {
+        assert.equal(isMentionQuery('viewer'), true);
+        assert.equal(isMentionQuery('viewer.'), false);
+        assert.equal(isMentionQuery('viewer-name'), false);
+    });
+});
+
+describe('buildReplySubmissionText', () => {
+    test('adds a plain-text mention when replying to a comment', () => {
+        assert.equal(
+            buildReplySubmissionText('답글 내용', 'viewer'),
+            '@viewer 답글 내용'
+        );
+    });
+
+    test('does not duplicate an existing target mention', () => {
+        assert.equal(
+            buildReplySubmissionText('@viewer 답글 내용', 'viewer'),
+            '@viewer 답글 내용'
+        );
+    });
+
+    test('does not treat a username prefix as the target mention', () => {
+        assert.equal(
+            buildReplySubmissionText('@viewers 답글 내용', 'viewer'),
+            '@viewer @viewers 답글 내용'
+        );
+    });
+
+    test('does not treat a domain-like prefix as the target mention', () => {
+        assert.equal(
+            buildReplySubmissionText('@viewer.com 답글 내용', 'viewer'),
+            '@viewer @viewer.com 답글 내용'
+        );
+    });
+});

--- a/backend/src/board/admin/comment.py
+++ b/backend/src/board/admin/comment.py
@@ -133,7 +133,7 @@ class CommentAdmin(
     post_link.short_description = '포스트'
 
     def content_preview(self, obj):
-        content = truncatewords(strip_tags(obj.text_html), 8)
+        content = truncatewords(strip_tags(obj.get_text_html()), 8)
         if not obj.author:
             return format_html('<span style="color: {}; font-style: italic;">[삭제됨] {}</span>', COLOR_MUTED, content)
         return content

--- a/backend/src/board/html_utils.py
+++ b/backend/src/board/html_utils.py
@@ -394,6 +394,219 @@ def sanitize_content_html(html_content: str) -> str:
     return HtmlSanitizer.sanitize_content(html_content)
 
 
+class CommentHtmlSanitizer(HtmlSanitizer):
+    """Sanitize stored comment HTML while preserving legacy rendering."""
+
+    ALLOWED_TAGS = [
+        'div', 'p', 'span', 'a', 'img', 'h1', 'h2', 'h3', 'h4', 'h5',
+        'h6', 'ul', 'ol', 'li', 'br', 'strong', 'em', 'b', 'i', 'u',
+        'blockquote', 'code', 'pre', 'hr', 'small', 'sub', 'sup', 'mark',
+        'del', 'ins', 's', 'figure', 'figcaption', 'table', 'thead',
+        'tbody', 'tfoot', 'tr', 'th', 'td', 'video', 'source', 'iframe',
+        'input',
+    ]
+
+    ALLOWED_ATTRIBUTES = {
+        'a': ['href', 'title', 'target', 'rel', 'class'],
+        'img': [
+            'src', 'data-src', 'alt', 'title', 'width', 'height', 'class',
+            'loading',
+        ],
+        'ul': ['class'],
+        'li': ['class'],
+        'code': ['class'],
+        'pre': ['class'],
+        'figure': ['class'],
+        'th': ['colspan', 'rowspan'],
+        'td': ['colspan', 'rowspan'],
+        'video': [
+            'class', 'autoplay', 'muted', 'loop', 'playsinline', 'controls',
+            'poster',
+        ],
+        'source': ['src', 'data-src', 'type'],
+        'iframe': [
+            'src', 'title', 'allow', 'allowfullscreen', 'frameborder',
+            'loading', 'referrerpolicy',
+        ],
+        'input': ['type', 'checked', 'disabled'],
+    }
+
+    DANGEROUS_TAGS = HtmlSanitizer.DANGEROUS_TAGS | {
+        'button', 'frame', 'frameset', 'link', 'math', 'plaintext', 'select',
+        'svg', 'textarea', 'xmp',
+    }
+
+    SAFE_CLASSES = {
+        'a': {'mention'},
+        'img': {'lazy'},
+        'video': {'lazy'},
+        'ul': {'task-list'},
+        'li': {'checkbox', 'checked', 'task-list-item'},
+        'figure': {'col-1', 'col-2', 'col-3'},
+        'pre': {'highlight', 'codehilite'},
+        'code': {'highlight', 'codehilite'},
+    }
+
+    SAFE_YOUTUBE_HOSTS = {
+        'youtube.com',
+        'www.youtube.com',
+        'youtube-nocookie.com',
+        'www.youtube-nocookie.com',
+    }
+    YOUTUBE_EMBED_PATH = re.compile(r'^/embed/[a-zA-Z0-9_-]{1,64}$')
+    LANGUAGE_CLASS = re.compile(r'^(?:lang|language)-[a-zA-Z0-9_+-]{1,50}$')
+    URL_ATTRIBUTES = {'href', 'src', 'data-src', 'poster'}
+
+    @classmethod
+    def remove_dangerous_tags(cls, soup):
+        for tag_name in cls.DANGEROUS_TAGS:
+            for tag in soup.find_all(tag_name):
+                tag.decompose()
+
+    @classmethod
+    def sanitize_tag(
+        cls,
+        tag,
+        *,
+        allowed_tags=None,
+        allowed_attributes=None,
+        allow_data_attributes=False,
+    ):
+        allowed_tags = allowed_tags or cls.ALLOWED_TAGS
+        allowed_attributes = allowed_attributes or cls.ALLOWED_ATTRIBUTES
+
+        if tag.name in {'html', 'body'}:
+            return
+
+        if tag.name not in allowed_tags:
+            if tag.name in cls.DANGEROUS_TAGS:
+                tag.decompose()
+            else:
+                tag.unwrap()
+            return
+
+        if tag.name == 'iframe' and not cls.is_safe_youtube_embed(tag.get('src')):
+            tag.decompose()
+            return
+
+        if tag.name == 'source' and getattr(tag.parent, 'name', None) != 'video':
+            tag.decompose()
+            return
+
+        if tag.name == 'input' and tag.get('type') != 'checkbox':
+            tag.decompose()
+            return
+
+        super().sanitize_tag(
+            tag,
+            allowed_tags=allowed_tags,
+            allowed_attributes=allowed_attributes,
+            allow_data_attributes=allow_data_attributes,
+        )
+        cls.normalize_url_attributes(tag)
+        cls.sanitize_classes(tag)
+        cls.sanitize_special_attributes(tag)
+
+    @staticmethod
+    def normalize_url(url) -> str:
+        if not isinstance(url, str):
+            return ''
+        return re.sub(r'[\x00-\x20\x7f]+', '', url)
+
+    @classmethod
+    def is_safe_youtube_embed(cls, url) -> bool:
+        normalized_url = cls.normalize_url(url)
+        if not HtmlSanitizer.is_safe_url(
+            normalized_url,
+            allowed_schemes={'https'},
+            allow_relative=False,
+        ):
+            return False
+
+        try:
+            parsed_url = urlsplit(normalized_url)
+            hostname = parsed_url.hostname
+            port = parsed_url.port
+        except ValueError:
+            return False
+
+        return (
+            parsed_url.scheme == 'https'
+            and hostname in cls.SAFE_YOUTUBE_HOSTS
+            and port in (None, 443)
+            and not parsed_url.username
+            and not parsed_url.password
+            and cls.YOUTUBE_EMBED_PATH.fullmatch(parsed_url.path) is not None
+        )
+
+    @classmethod
+    def normalize_url_attributes(cls, tag):
+        for attr in cls.URL_ATTRIBUTES:
+            if attr in tag.attrs:
+                tag.attrs[attr] = cls.normalize_url(tag.attrs[attr])
+
+    @classmethod
+    def sanitize_classes(cls, tag):
+        if 'class' not in tag.attrs:
+            return
+
+        classes = tag.get('class', [])
+        if isinstance(classes, str):
+            classes = classes.split()
+
+        allowed_classes = cls.SAFE_CLASSES.get(tag.name, set())
+        safe_classes = [
+            class_name
+            for class_name in classes
+            if class_name in allowed_classes
+            or (
+                tag.name in {'code', 'pre'}
+                and cls.LANGUAGE_CLASS.fullmatch(class_name)
+            )
+        ]
+
+        if safe_classes:
+            tag['class'] = safe_classes
+        else:
+            del tag.attrs['class']
+
+    @classmethod
+    def sanitize_special_attributes(cls, tag):
+        if tag.name == 'a':
+            if tag.get('target') == '_blank' and tag.get('href'):
+                tag['rel'] = ['noopener', 'noreferrer']
+            else:
+                tag.attrs.pop('target', None)
+                tag.attrs.pop('rel', None)
+
+        if tag.name in {'th', 'td'}:
+            for attr in ('colspan', 'rowspan'):
+                value = tag.get(attr)
+                if value and not re.fullmatch(r'[1-9][0-9]{0,2}', str(value)):
+                    del tag.attrs[attr]
+
+        if tag.name == 'input':
+            is_checked = 'checked' in tag.attrs
+            tag.attrs = {'type': 'checkbox', 'disabled': ''}
+            if is_checked:
+                tag['checked'] = ''
+
+        if tag.name == 'iframe':
+            tag['loading'] = 'lazy'
+            tag['referrerpolicy'] = 'strict-origin-when-cross-origin'
+            tag['frameborder'] = '0'
+            tag['allow'] = (
+                'accelerometer; autoplay; encrypted-media; gyroscope; '
+                'picture-in-picture'
+            )
+            tag['allowfullscreen'] = ''
+
+
+def sanitize_comment_html(html_content: str) -> str:
+    """Sanitize stored HTML before it is rendered as comment content."""
+    return CommentHtmlSanitizer.sanitize(html_content)
+
+
 class TableOfContentsExtractor:
     """
     Extracts headings from HTML content to generate a table of contents.

--- a/backend/src/board/models/posts.py
+++ b/backend/src/board/models/posts.py
@@ -9,6 +9,7 @@ from django.utils.text import slugify
 
 from modules.randomness import randstr
 
+from board.html_utils import sanitize_comment_html
 from board.modules.time import time_since, time_stamp
 from board.services.post_content_service import PostContentService
 from board.services.post_thumbnail_service import PostThumbnailService
@@ -44,7 +45,7 @@ class Comment(models.Model):
     def get_text_html(self):
         if not self.author:
             return '<p>삭제된 댓글입니다.</p>'
-        return self.text_html
+        return sanitize_comment_html(self.text_html)
 
     def get_thumbnail(self):
         if self.image:

--- a/backend/src/board/services/comment_service.py
+++ b/backend/src/board/services/comment_service.py
@@ -31,7 +31,9 @@ class CommentValidationError(Exception):
 
 class CommentService:
     """Service class for handling comment-related business logic"""
-    MENTION_PATTERN = re.compile(r'`@([a-zA-Z0-9\.\_\-\+]*)`\s?')
+    MENTION_PATTERN = re.compile(
+        r'(?<![a-zA-Z0-9])@([a-z0-9]{4,15})(?![a-zA-Z0-9])'
+    )
 
     @staticmethod
     def get_comment_queryset(user: User):
@@ -206,7 +208,7 @@ class CommentService:
         Extract mentioned usernames from comment text.
 
         Args:
-            text_md: Comment text in markdown
+            text_md: Plain comment text stored in the legacy text_md field
 
         Returns:
             Set of mentioned usernames
@@ -371,7 +373,7 @@ class CommentService:
         Args:
             user: Comment author
             post: Post to comment on
-            text_md: Comment text in markdown
+            text_md: Plain comment text stored in the legacy text_md field
             parent: Parent comment for nested replies (optional)
 
         Returns:
@@ -422,7 +424,7 @@ class CommentService:
 
         Args:
             comment: Comment instance
-            text_md: New comment text in markdown
+            text_md: New plain comment text stored in the legacy text_md field
 
         Returns:
             Updated Comment instance

--- a/backend/src/board/services/comment_service.py
+++ b/backend/src/board/services/comment_service.py
@@ -32,7 +32,9 @@ class CommentValidationError(Exception):
 class CommentService:
     """Service class for handling comment-related business logic"""
     MENTION_PATTERN = re.compile(
-        r'(?<![a-zA-Z0-9])@([a-z0-9]{4,15})(?![a-zA-Z0-9])'
+        r'(?<![\w@.+\-`*~])'
+        r'@([a-z0-9]{4,15})'
+        r'(?![\w+\-`*~]|(?:\.[a-zA-Z0-9]))'
     )
 
     @staticmethod

--- a/backend/src/board/tests/api/test_comment.py
+++ b/backend/src/board/tests/api/test_comment.py
@@ -497,6 +497,31 @@ class CommentTestCase(TestCase):
         last_notify = Notify.objects.filter(user=viewer).last()
         self.assertTrue('@author' in last_notify.content)
 
+    def test_does_not_notify_mention_inside_email_or_code_syntax(self):
+        """이메일 주소와 코드 표기 안의 사용자명은 멘션으로 처리하지 않는다."""
+        viewer = User.objects.get(username='viewer')
+        viewer.config.create_or_update_meta(CONFIG_TYPE.NOTIFY_MENTION, 'true')
+
+        self.client.login(username='author', password='test')
+        for text in (
+            'contact@viewer.com',
+            '@viewer.com',
+            '`@viewer`',
+            '**@viewer**',
+            'foo_@viewer',
+            '@@viewer',
+        ):
+            self.client.post('/v1/comments?url=test-post', {
+                'comment_md': text,
+            })
+
+        self.assertFalse(
+            Notify.objects.filter(
+                user=viewer,
+                content__contains='태그',
+            ).exists()
+        )
+
     def test_comment_treats_markdown_and_html_as_plain_text(self):
         """댓글의 Markdown 및 HTML 문법은 실행하지 않고 텍스트로 표시한다."""
         self.client.login(username='author', password='test')

--- a/backend/src/board/tests/api/test_comment.py
+++ b/backend/src/board/tests/api/test_comment.py
@@ -173,13 +173,19 @@ class CommentTestCase(TestCase):
         """댓글 생성 테스트"""
         self.client.login(username='viewer', password='test')
         data = {
-            'comment_md': '# New Comment',
+            'comment_md': 'New Comment\nnext line',
         }
         response = self.client.post('/v1/comments?url=test-post', data)
         content = json.loads(response.content)
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(Comment.objects.last().text_md, '# New Comment')
+        comment = Comment.objects.last()
+        self.assertEqual(comment.text_md, 'New Comment\nnext line')
+        self.assertEqual(comment.text_html, '<p>New Comment<br>next line</p>')
+        self.assertEqual(
+            content['body']['renderedContent'],
+            '<p>New Comment<br/>next line</p>',
+        )
         self.assertFalse(content['body']['isDeleted'])
         self.assertEqual(content['body']['permissions'], {
             'canEdit': True,
@@ -387,7 +393,7 @@ class CommentTestCase(TestCase):
 
         self.client.login(username='author', password='test')
         self.client.post('/v1/comments?url=test-post', {
-            'comment_md': '`@viewer` mentioned in reply',
+            'comment_md': '@viewer mentioned in reply',
             'parent_id': parent_comment.id,
         })
 
@@ -441,7 +447,7 @@ class CommentTestCase(TestCase):
         content = json.loads(response.content)
         self.assertEqual(content['status'], 'ERROR')
 
-    def test_comment_raw_markdown_only_visible_to_comment_author(self):
+    def test_comment_raw_text_only_visible_to_comment_author(self):
         """댓글 원문은 댓글 작성자에게만 노출된다."""
         comment = Comment.objects.get(text_md='Comment')
         self.client.login(username='author', password='test')
@@ -453,7 +459,7 @@ class CommentTestCase(TestCase):
         self.assertEqual(content['status'], 'ERROR')
         self.assertNotIn('textMd', content.get('body', {}))
 
-    def test_comment_raw_markdown_visible_to_comment_author(self):
+    def test_comment_raw_text_visible_to_comment_author(self):
         """댓글 작성자는 수정용 원문을 조회할 수 있다."""
         comment = Comment.objects.get(text_md='Comment')
         self.client.login(username='viewer', password='test')
@@ -465,7 +471,7 @@ class CommentTestCase(TestCase):
         self.assertEqual(content['status'], 'DONE')
         self.assertEqual(content['body']['textMd'], 'Comment')
 
-    def test_comment_raw_markdown_hidden_when_parent_post_is_not_public(self):
+    def test_comment_raw_text_hidden_when_parent_post_is_not_public(self):
         """비공개 글의 댓글 원문은 댓글 작성자에게도 공개 API에서 노출하지 않는다."""
         post = Post.objects.get(url='test-post')
         post.config.hide = True
@@ -484,23 +490,71 @@ class CommentTestCase(TestCase):
 
         self.client.login(username='author', password='test')
         data = {
-            'comment_md': '`@viewer` reply comment',
+            'comment_md': '@viewer reply comment',
         }
         self.client.post('/v1/comments?url=test-post', data)
 
         last_notify = Notify.objects.filter(user=viewer).last()
         self.assertTrue('@author' in last_notify.content)
 
-    def test_comment_markdown_renders_mentions_as_links(self):
-        """댓글 마크다운에서는 멘션이 링크로 변환되어야 함"""
+    def test_comment_treats_markdown_and_html_as_plain_text(self):
+        """댓글의 Markdown 및 HTML 문법은 실행하지 않고 텍스트로 표시한다."""
         self.client.login(username='author', password='test')
         self.client.post('/v1/comments?url=test-post', {
-            'comment_md': '`@viewer` mention',
+            'comment_md': '# title\n**bold** <img src=x onerror=alert(1)>',
         })
 
         comment = Comment.objects.last()
-        self.assertIn('class="mention"', comment.text_html)
-        self.assertIn('href="/@viewer"', comment.text_html)
+        self.assertEqual(
+            comment.text_html,
+            '<p># title<br>**bold** '
+            '&lt;img src=x onerror=alert(1)&gt;</p>',
+        )
+        self.assertNotIn('<h1', comment.text_html)
+        self.assertNotIn('<strong', comment.text_html)
+        self.assertNotIn('<img', comment.text_html)
+
+    def test_comment_list_sanitizes_legacy_html(self):
+        """기존 댓글 HTML은 안전한 서식을 보존하며 위험 요소를 제거한다."""
+        comment = Comment.objects.get(text_md='Comment')
+        comment.text_html = (
+            '<p onclick="alert(1)">Legacy <strong>bold</strong> '
+            '<a class="mention evil" href="javascript:alert(1)" '
+            'target="_blank">@viewer</a></p>'
+            '<script>alert(2)</script>'
+            '<iframe src="https://www.youtube.com/embed/abc123" '
+            'onload="alert(3)"></iframe>'
+            '<iframe src="https://attacker.example/embed/abc123"></iframe>'
+            '<iframe src="https://www.youtube.com:invalid/embed/abc123"></iframe>'
+        )
+        comment.save(update_fields=['text_html'])
+
+        response = self.client.get('/v1/posts/test-post/comments')
+
+        rendered_content = (
+            response.json()['body']['comments'][0]['renderedContent']
+        )
+        self.assertIn('<strong>bold</strong>', rendered_content)
+        self.assertIn('class="mention"', rendered_content)
+        self.assertIn('https://www.youtube.com/embed/abc123', rendered_content)
+        self.assertNotIn('attacker.example', rendered_content)
+        self.assertNotIn('javascript:', rendered_content)
+        self.assertNotIn('onclick', rendered_content)
+        self.assertNotIn('onload', rendered_content)
+        self.assertNotIn('<script', rendered_content)
+
+    def test_user_comment_list_sanitizes_legacy_html(self):
+        """내 댓글 목록도 저장된 기존 HTML을 정제해서 응답한다."""
+        comment = Comment.objects.get(text_md='Comment')
+        comment.text_html = '<img src="x" onerror="alert(1)"><p>Comment</p>'
+        comment.save(update_fields=['text_html'])
+        self.client.login(username='viewer', password='test')
+
+        response = self.client.get('/v1/comments/user')
+
+        rendered_content = response.json()['body']['comments'][0]['content']
+        self.assertIn('<p>Comment</p>', rendered_content)
+        self.assertNotIn('onerror', rendered_content)
 
     def test_not_notify_user_tag_on_comment_when_user_disagree_notify(self):
         """사용자가 멘션 알림 거부 시 태그 알림 미발송 테스트"""
@@ -514,7 +568,7 @@ class CommentTestCase(TestCase):
 
         self.client.login(username='author', password='test')
         self.client.post('/v1/comments?url=test-post', {
-            'comment_md': '`@viewer` reply comment',
+            'comment_md': '@viewer reply comment',
         })
 
         last_notify = Notify.objects.filter(user=viewer).last()
@@ -616,6 +670,23 @@ class CommentTestCase(TestCase):
         comment.refresh_from_db()
         self.assertEqual(comment.text_md, 'Edited comment')
         self.assertTrue(comment.edited)
+
+    def test_edit_comment_treats_content_as_plain_text(self):
+        """수정한 댓글도 일반 텍스트로 이스케이프하고 줄바꿈만 반영한다."""
+        comment = Comment.objects.last()
+        self.client.login(username='viewer', password='test')
+
+        response = self.client.put(
+            f'/v1/comments/{comment.id}',
+            'comment=comment&comment_md=first%0A%3Cscript%3Ealert(1)%3C%2Fscript%3E'
+        )
+
+        self.assertEqual(response.status_code, 200)
+        comment.refresh_from_db()
+        self.assertEqual(
+            comment.text_html,
+            '<p>first<br>&lt;script&gt;alert(1)&lt;/script&gt;</p>',
+        )
 
     def test_edit_comment_non_object_json_returns_not_found_instead_of_server_error(self):
         """댓글 수정 API는 JSON 객체가 아닌 body에서도 500을 내지 않는다."""

--- a/backend/src/board/tests/test_markdown.py
+++ b/backend/src/board/tests/test_markdown.py
@@ -135,12 +135,15 @@ class ParseToHtmlTest(TestCase):
         self.assertNotIn('class="mention"', result)
         self.assertIn('<code>@author</code>', result)
 
-    def test_comment_markdown_renders_mentions(self):
-        """Comment markdown should convert mention syntax to links."""
-        md = '`@author`'
-        result = parse_comment_to_html(md)
-        self.assertIn('class="mention"', result)
-        self.assertIn('href="/@author"', result)
+    def test_comment_text_is_escaped_and_preserves_line_breaks(self):
+        """Comment content should be plain text with HTML line breaks."""
+        text = '# Title\n**bold**\n\n<script>alert(1)</script>'
+        result = parse_comment_to_html(text)
+        self.assertEqual(
+            result,
+            '<p># Title<br>**bold**</p>\n\n'
+            '<p>&lt;script&gt;alert(1)&lt;/script&gt;</p>',
+        )
 
     def test_markdown_removes_unsafe_link_protocols(self):
         result = parse_post_to_html('[unsafe](javascript:alert(1))')
@@ -151,9 +154,10 @@ class ParseToHtmlTest(TestCase):
     def test_markdown_removes_unsafe_image_protocols(self):
         result = parse_comment_to_html('![unsafe](javascript:alert(1))')
 
-        self.assertNotIn('javascript:', result)
         self.assertNotIn('src=', result)
         self.assertNotIn('data-src=', result)
+        self.assertNotIn('<img', result)
+        self.assertIn('javascript:alert(1)', result)
 
     def test_youtube_markup_rejects_attribute_injection(self):
         result = parse_post_to_html('@youtube[abc" onload=alert(1)]')

--- a/backend/src/board/views/api/v1/comment.py
+++ b/backend/src/board/views/api/v1/comment.py
@@ -3,7 +3,6 @@ from django.http import Http404
 from django.shortcuts import get_object_or_404
 
 from board.models import Comment, Post
-from board.html_utils import sanitize_content_html
 from board.modules.response import StatusDone, StatusError
 from board.modules.paginator import Paginator
 from board.services.api_request_body_service import ApiRequestBodyService
@@ -123,7 +122,7 @@ def user_comment(request):
                     'title': comment.post_title,
                     'url': comment.post_url,
                 },
-                'content': sanitize_content_html(comment.text_html),
+                'content': comment.get_text_html(),
                 'created_date': comment.time_since(),
             }, comments)),
             'last_page': comments.paginator.num_pages,

--- a/backend/src/modules/markdown.py
+++ b/backend/src/modules/markdown.py
@@ -3,6 +3,7 @@ from html import escape
 from urllib.parse import urlsplit
 
 import markdown
+from django.utils.html import linebreaks
 from markdown.extensions import Extension
 from markdown.treeprocessors import Treeprocessor
 from markdown.preprocessors import Preprocessor
@@ -221,8 +222,10 @@ def parse_post_to_html(text):
 
 
 def parse_comment_to_html(text):
-    """Parse comment markdown to HTML (mentions enabled)."""
-    return _parse_to_html(text, enable_mentions=True)
+    """Render comment text as escaped HTML with line breaks."""
+    if not text:
+        return ''
+    return str(linebreaks(text, autoescape=True))
 
 
 # For backward compatibility


### PR DESCRIPTION
## 🎯 Goal
- Prevent comment input from being interpreted as Markdown or executable HTML.
- Preserve rendered HTML compatibility for existing comments without exposing legacy XSS payloads.

## 🔧 Core Changes
- Render new and edited comments as escaped plain text with paragraph and line-break HTML.
- Sanitize stored legacy comment HTML on every response and admin preview while keeping safe formatting and YouTube embeds.
- Use plain `@username` mention insertion and detection while preserving legacy API and database field names.

## 🤔 Key Decisions
- Kept `comment_md`, `text_md`, `text_html`, and rendered response fields unchanged for backward compatibility.
- Kept server-sanitized HTML rendering because existing comments are HTML-based and replacing it would break existing formatting.
- Added focused API and unit coverage instead of browser E2E because this is deterministic server behavior.

## 🧪 Verification Guide
### How to verify
1. Create or edit a comment containing Markdown, HTML, and multiple lines.
2. View an existing formatted comment and confirm safe legacy formatting remains.
3. Select a mention from autocomplete and verify the mention notification.

### Expected result
- Markdown and HTML syntax appear literally in new comments, line breaks render correctly, safe legacy formatting remains, unsafe markup is stripped, and plain `@username` mentions notify.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (not needed: no public contract change)