### PR TITLE
🐛 Harden admin notification settings rendering

### DIFF
--- a/backend/src/board/admin/user.py
+++ b/backend/src/board/admin/user.py
@@ -9,7 +9,7 @@ from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
 from django.http import HttpRequest
 from django.db.models import Count, QuerySet
 from django.urls import reverse
-from django.utils.html import format_html
+from django.utils.html import format_html, format_html_join
 
 from board.models import (
     UserConfigMeta, UserLinkMeta, Config, UsernameChangeLog,
@@ -120,16 +120,21 @@ class CustomUserAdmin(BaseUserAdmin):
 @admin.register(UserConfigMeta)
 class UserConfigMetaAdmin(admin.ModelAdmin):
     class UserConfigMetaForm(forms.ModelForm):
+        name = forms.ChoiceField(
+            choices=[
+                (config_type, config_type) for config_type in CONFIG_TYPES
+            ],
+        )
+        value = forms.ChoiceField(
+            choices=[
+                ('true', '활성'),
+                ('false', '비활성'),
+            ],
+        )
+
         class Meta:
             model = UserConfigMeta
             fields = '__all__'
-            widgets = {
-                'name': forms.Select(
-                    choices=[
-                        (config_type, config_type) for config_type in CONFIG_TYPES
-                    ],
-                ),
-            }
     form = UserConfigMetaForm
 
     autocomplete_fields = ['user']
@@ -192,18 +197,29 @@ class ConfigAdmin(admin.ModelAdmin):
         if not configs:
             return format_html('<p style="color: {};">설정 없음</p>', COLOR_MUTED)
 
-        config_items = "".join([
-            f'<li style="padding: 4px 0;"><a href="{reverse("admin:board_userconfigmeta_change", args=[config.id])}" style="text-decoration: none;">'
-            f'<span style="background: {COLOR_INFO}; color: {COLOR_BG}; padding: 2px 8px; border-radius: 4px; font-size: 12px; opacity: 0.8;">{config.name}</span> '
-            f'<span style="color: {COLOR_TEXT};">{config.value}</span></a></li>'
-            for config in configs
-        ])
-
-        return AdminDisplayService.html(f"""
-                <ul style="list-style: none; padding: 0;">
-                    {config_items}
-                </ul>
-            """
+        config_items = format_html_join(
+            '',
+            '<li style="padding: 4px 0;"><a href="{}" style="text-decoration: none;">'
+            '<span style="background: {}; color: {}; padding: 2px 8px; border-radius: 4px; font-size: 12px; opacity: 0.8;">{}</span> '
+            '<span style="color: {};">{}</span></a></li>',
+            (
+                (
+                    reverse(
+                        'admin:board_userconfigmeta_change',
+                        args=[config.id],
+                    ),
+                    COLOR_INFO,
+                    COLOR_BG,
+                    config.name,
+                    COLOR_TEXT,
+                    config.value,
+                )
+                for config in configs
+            ),
+        )
+        return format_html(
+            '<ul style="list-style: none; padding: 0;">{}</ul>',
+            config_items,
         )
 
     list_display = ['user_link', 'telegram_status', 'two_factor_status']

--- a/backend/src/board/services/user_notification_service.py
+++ b/backend/src/board/services/user_notification_service.py
@@ -1,4 +1,5 @@
 import datetime
+from collections.abc import Mapping
 
 from django.contrib.auth.models import User
 from django.db.models import Q, QuerySet
@@ -82,11 +83,18 @@ class UserNotificationService:
         return True
 
     @staticmethod
-    def update_settings_notify_config(user: User, put) -> None:
+    def update_settings_notify_config(
+        user: User,
+        put: Mapping[str, object],
+    ) -> None:
         for config in UserNotificationService.get_notify_configs_by_role(user):
             value = put.get(config.value)
             if value in (None, ''):
                 continue
-            if isinstance(value, bool):
-                value = 'true' if value else 'false'
-            user.config.create_or_update_meta(config, value)
+
+            normalized_value = (
+                'true'
+                if value is True or value == 'true'
+                else 'false'
+            )
+            user.config.create_or_update_meta(config, normalized_value)

--- a/backend/src/board/tests/admin/test_user_admin.py
+++ b/backend/src/board/tests/admin/test_user_admin.py
@@ -1,0 +1,43 @@
+from django.contrib.admin.sites import AdminSite
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from board.admin.user import ConfigAdmin, UserConfigMetaAdmin
+from board.constants.config_meta import CONFIG_TYPE
+from board.models import Config, UserConfigMeta
+
+
+class ConfigAdminTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user(
+            username='admin-config-user',
+            password='test',
+        )
+        cls.config = Config.objects.create(user=cls.user)
+
+    def test_configs_preview_escapes_stored_values(self):
+        UserConfigMeta.objects.create(
+            user=self.user,
+            name=CONFIG_TYPE.NOTIFY_MENTION.value,
+            value='<img src=x onerror=alert(1)>',
+        )
+        model_admin = ConfigAdmin(Config, AdminSite())
+
+        rendered = str(model_admin.configs_preview(self.config))
+
+        self.assertNotIn('<img src=x onerror=alert(1)>', rendered)
+        self.assertIn('&lt;img src=x onerror=alert(1)&gt;', rendered)
+
+
+class UserConfigMetaAdminFormTestCase(TestCase):
+    def test_form_rejects_non_boolean_value(self):
+        form_class = UserConfigMetaAdmin.UserConfigMetaForm
+
+        form = form_class(data={
+            'name': CONFIG_TYPE.NOTIFY_MENTION.value,
+            'value': '<img src=x onerror=alert(1)>',
+        })
+
+        self.assertFalse(form.is_valid())
+        self.assertIn('value', form.errors)

--- a/backend/src/board/tests/api/test_setting.py
+++ b/backend/src/board/tests/api/test_setting.py
@@ -14,7 +14,7 @@ from board.constants.config_meta import CONFIG_TYPE
 from board.models import (
     Comment, Config, Notify, Post, PostConfig, PostContent,
     PinnedPost, PostLikes, Profile, Series, Tag, User, UserLinkMeta,
-    UsernameChangeLog,
+    UserConfigMeta, UsernameChangeLog,
 )
 from board.services.setting_post_management_service import SettingPostManagementService
 
@@ -728,6 +728,27 @@ class SettingTestCase(TestCase):
         user = User.objects.get(username='test')
         self.assertEqual(user.config.get_meta(CONFIG_TYPE.NOTIFY_COMMENT_LIKE), True)
         self.assertEqual(user.config.get_meta(CONFIG_TYPE.NOTIFY_MENTION), False)
+
+    def test_update_notify_config_normalizes_invalid_legacy_value(self):
+        self.client.login(username='test', password='test')
+
+        response = self.client.put(
+            '/v1/setting/notify-config',
+            json.dumps({
+                CONFIG_TYPE.NOTIFY_MENTION.value:
+                    '<img src=x onerror=alert(1)>',
+            }),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'DONE')
+        meta = UserConfigMeta.objects.get(
+            user__username='test',
+            name=CONFIG_TYPE.NOTIFY_MENTION.value,
+        )
+        self.assertEqual(meta.value, 'false')
 
     def test_update_notify_config_with_posts(self):
         """포스트가 있는 사용자의 알림 설정 업데이트 테스트"""

--- a/backend/src/board/tests/services/test_user_notification_service.py
+++ b/backend/src/board/tests/services/test_user_notification_service.py
@@ -96,6 +96,23 @@ class UserNotificationServiceTestCase(TestCase):
         self.assertEqual(self.user.config.get_meta(CONFIG_TYPE.NOTIFY_POSTS_LIKE), True)
         self.assertIsNone(self.user.config.get_meta(CONFIG_TYPE.NOTIFY_POSTS_COMMENT))
 
+    def test_update_settings_notify_config_normalizes_non_boolean_value(self):
+        UserNotificationService.update_settings_notify_config(
+            self.user,
+            {
+                CONFIG_TYPE.NOTIFY_MENTION.value:
+                    '<img src=x onerror=alert(1)>',
+            },
+        )
+
+        meta = self.user.conf_meta.get(
+            name=CONFIG_TYPE.NOTIFY_MENTION.value,
+        )
+        self.assertEqual(meta.value, 'false')
+        self.assertFalse(
+            self.user.config.get_meta(CONFIG_TYPE.NOTIFY_MENTION),
+        )
+
     def test_mark_notification_as_read_returns_false_when_missing(self):
         self.assertFalse(
             UserNotificationService.mark_notification_as_read(self.user, '999999')


### PR DESCRIPTION
## 🎯 Goal
- Prevent stored HTML in notification settings from becoming executable markup in Django Admin.
- Keep the existing notification-setting API response and boolean behavior backward compatible.

## 🔧 Core Changes
- Escape stored setting names and values in the Config Admin preview.
- Restrict UserConfigMeta Admin input to known setting names and canonical true or false values.
- Normalize non-boolean API payload values to false instead of persisting arbitrary text.
- Add Admin, service, and API regression tests for the persisted-XSS path.

## 🤔 Key Decisions
- Preserve the legacy 200 DONE response for malformed values because changing it could break existing clients.
- Normalize every value except boolean true or the string true to false, matching the prior observable BooleanType behavior.
- Avoid a schema migration so existing rows and public contracts remain intact.

## 🧪 Verification Guide
### How to verify
1. Open a Config record that contains a legacy HTML-like setting value and confirm the preview displays escaped text.
2. Submit an invalid notification-setting value and confirm the endpoint still returns 200 with DONE while storing false.
3. Run npm run server:test, npm run server:check-migrations, npm run islands:lint, and npm run islands:type-check.

### Expected result
- Stored setting content cannot execute as Admin HTML, valid toggles behave unchanged, and all 1,217 backend tests pass.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (not needed; no public contract changed)