### PR TITLE
🐛 Align admin post lifecycle with services

### DIFF
--- a/backend/src/board/admin/action_confirmation.py
+++ b/backend/src/board/admin/action_confirmation.py
@@ -1,0 +1,38 @@
+from django.contrib.admin import helpers
+from django.http import HttpRequest
+from django.template.response import TemplateResponse
+
+
+def render_action_confirmation(
+    request: HttpRequest,
+    model_admin,
+    queryset,
+    *,
+    action_name: str,
+    title: str,
+    warning: str,
+    confirm_label: str,
+) -> TemplateResponse:
+    """Render a reusable confirmation step for destructive Admin actions."""
+    object_count = queryset.count()
+    context = {
+        **model_admin.admin_site.each_context(request),
+        'title': title,
+        'warning': warning,
+        'confirm_label': confirm_label,
+        'object_count': object_count,
+        'object_preview': list(queryset[:20]),
+        'has_more_objects': object_count > 20,
+        'selected_ids': request.POST.getlist(
+            helpers.ACTION_CHECKBOX_NAME,
+        ),
+        'action_checkbox_name': helpers.ACTION_CHECKBOX_NAME,
+        'action_name': action_name,
+        'select_across': request.POST.get('select_across', '0'),
+        'opts': model_admin.model._meta,
+    }
+    return TemplateResponse(
+        request,
+        'admin/board/confirm_action.html',
+        context,
+    )

--- a/backend/src/board/admin/post.py
+++ b/backend/src/board/admin/post.py
@@ -1,16 +1,25 @@
 """
 Post Admin Configuration
 """
-from django.contrib import admin
+from typing import Any
+
+from django.contrib import admin, messages
+from django.core.exceptions import ObjectDoesNotExist
+from django.db import transaction
 from django.db.models import Count, QuerySet
 from django.http import HttpRequest
+from django.utils import timezone
 
+from board.services.post_revision_service import PostRevisionService
+from board.services.post_service import PostService, PostValidationError
 from board.services.post_status_service import PostStatusService
+from board.services.post_trash_service import PostTrashService
 from board.models import (
     EditHistory, EditRequest, Post, PinnedPost,
     PostConfig, PostContent,
 )
 
+from .action_confirmation import render_action_confirmation
 from .service import AdminDisplayService, AdminLinkService
 from .constants import (
     LIST_PER_PAGE_DEFAULT,
@@ -28,15 +37,21 @@ class PublishStatusFilter(admin.SimpleListFilter):
             ('draft', '임시글'),
             ('published', '발행됨'),
             ('scheduled', '예약됨'),
+            ('trashed', '휴지통'),
         ]
 
     def queryset(self, request, queryset):
+        if self.value() is None:
+            return queryset.filter(deleted_date__isnull=True)
         if self.value() == 'draft':
             return PostStatusService.filter_drafts(queryset)
         elif self.value() == 'published':
             return PostStatusService.filter_published(queryset)
         elif self.value() == 'scheduled':
             return PostStatusService.filter_scheduled(queryset)
+        elif self.value() == 'trashed':
+            return queryset.filter(deleted_date__isnull=False)
+        return queryset.filter(deleted_date__isnull=True)
 
 
 @admin.register(EditHistory)
@@ -87,7 +102,7 @@ class PostAdmin(admin.ModelAdmin):
     Post 관리 페이지
 
     - select_related/prefetch_related로 쿼리 최적화
-    - 대량 작업 시 bulk operation 사용
+    - 상태 변경은 포스트 도메인 서비스와 감사 로그를 사용
     """
 
     search_fields = ['title', 'content__content_html', 'author__username', 'series__name', 'tags__value']
@@ -122,14 +137,25 @@ class PostAdmin(admin.ModelAdmin):
     list_per_page = LIST_PER_PAGE_DEFAULT
     save_on_top = True
     date_hierarchy = 'created_date'
-    actions = ['make_hidden', 'make_visible', 'publish_drafts']
+    actions = [
+        'make_hidden',
+        'make_visible',
+        'publish_drafts',
+        'move_to_trash',
+        'restore_from_trash',
+        'permanently_delete_trashed',
+    ]
 
     fieldsets = (
         ('기본 정보', {
             'fields': ('author', 'title', 'url', 'series')
         }),
         ('발행', {
-            'fields': ('published_date', 'publish_status_display'),
+            'fields': (
+                'published_date',
+                'publish_status_display',
+                'deleted_at',
+            ),
         }),
         ('이미지', {
             'fields': ('image', 'image_preview'),
@@ -144,15 +170,107 @@ class PostAdmin(admin.ModelAdmin):
         }),
     )
 
-    readonly_fields = ['image_preview', 'publish_status_display', 'total_likes', 'total_comments', 'created_at', 'updated_at']
+    readonly_fields = [
+        'image_preview',
+        'publish_status_display',
+        'deleted_at',
+        'total_likes',
+        'total_comments',
+        'created_at',
+        'updated_at',
+    ]
 
     def get_queryset(self, request):
-        return super().get_queryset(request).select_related(
+        queryset = Post.all_objects.all()
+        ordering = self.get_ordering(request)
+        if ordering:
+            queryset = queryset.order_by(*ordering)
+
+        if (
+            getattr(request, 'resolver_match', None)
+            and request.resolver_match.url_name == 'autocomplete'
+        ):
+            queryset = queryset.filter(deleted_date__isnull=True)
+
+        return queryset.select_related(
             'author', 'content', 'config', 'series'
         ).prefetch_related('tags', 'likes', 'comments').annotate(
             likes_count=Count('likes', distinct=True),
             comments_count=Count('comments', distinct=True)
         )
+
+    def get_actions(self, request):
+        actions = super().get_actions(request)
+        actions.pop('delete_selected', None)
+        return actions
+
+    def has_change_permission(self, request, obj=None):
+        if obj is not None and obj.deleted_date is not None:
+            return False
+        return super().has_change_permission(request, obj)
+
+    def has_delete_permission(self, request, obj=None):
+        if obj is not None:
+            return False
+        return super().has_delete_permission(request, obj)
+
+    def save_model(self, request, obj, form, change):
+        if change and obj.pk:
+            persisted = Post.all_objects.select_for_update().get(pk=obj.pk)
+            obj._admin_previous_snapshot = (
+                PostRevisionService.capture_snapshot(persisted)
+            )
+            obj._admin_previous_updated_date = persisted.updated_date
+            obj._admin_was_published = persisted.published_date is not None
+            obj._admin_model_changed = form.has_changed()
+
+        super().save_model(request, obj, form, change)
+
+    def save_related(self, request, form, formsets, change):
+        super().save_related(request, form, formsets, change)
+        post = form.instance
+        previous_snapshot = getattr(
+            post,
+            '_admin_previous_snapshot',
+            None,
+        )
+        if previous_snapshot is None:
+            return
+
+        related_changed = any(
+            formset.has_changed() for formset in formsets
+        )
+        should_update_date = (
+            getattr(post, '_admin_model_changed', False)
+            or related_changed
+        )
+
+        if should_update_date:
+            post.updated_date = timezone.now()
+            Post.all_objects.filter(pk=post.pk).update(
+                updated_date=post.updated_date,
+            )
+
+        if getattr(post, '_admin_was_published', False):
+            PostRevisionService.record_previous_snapshot_if_changed(
+                post,
+                previous_snapshot,
+                source_updated_date=getattr(
+                    post,
+                    '_admin_previous_updated_date',
+                    None,
+                ),
+                actor=request.user,
+            )
+
+        for attribute_name in (
+            '_admin_previous_snapshot',
+            '_admin_previous_updated_date',
+            '_admin_was_published',
+            '_admin_model_changed',
+        ):
+            if hasattr(post, attribute_name):
+                delattr(post, attribute_name)
 
     def thumbnail_preview(self, obj: Post) -> str:
         width, height = THUMBNAIL_SIZE
@@ -229,23 +347,201 @@ class PostAdmin(admin.ModelAdmin):
         return AdminDisplayService.date_display(obj.updated_date, DATETIME_FORMAT_FULL)
     updated_at.short_description = '수정일시'
 
-    # Bulk operations for better performance
+    def deleted_at(self, obj: Post) -> str:
+        return AdminDisplayService.date_display(
+            obj.deleted_date,
+            DATETIME_FORMAT_FULL,
+        )
+    deleted_at.short_description = '휴지통 이동일시'
+
+    @staticmethod
+    def _active_posts(queryset: QuerySet[Post]) -> QuerySet[Post]:
+        return queryset.filter(deleted_date__isnull=True)
+
+    @admin.action(description='선택한 포스트 숨김 처리')
     def make_hidden(self, request: HttpRequest, queryset: QuerySet[Post]) -> None:
-        """선택한 포스트 숨김 처리 (bulk update)"""
-        post_ids = list(queryset.values_list('id', flat=True))
-        count = PostConfig.objects.filter(post_id__in=post_ids).update(hide=True)
+        """Route visibility changes through the post domain service."""
+        count = 0
+        failed = 0
+        for post in self._active_posts(queryset).select_related('config'):
+            try:
+                with transaction.atomic():
+                    updated_post = PostService.update_post(post, is_hide=True)
+                    self.log_change(
+                        request,
+                        updated_post,
+                        'Admin에서 숨김 처리',
+                    )
+            except (PostValidationError, ObjectDoesNotExist):
+                failed += 1
+                continue
+            count += 1
         self.message_user(request, f'{count}개의 포스트를 숨김 처리했습니다.')
-    make_hidden.short_description = '선택한 포스트 숨김 처리'
+        if failed:
+            self.message_user(
+                request,
+                f'{failed}개는 필수 설정이 없어 처리하지 못했습니다.',
+                level=messages.WARNING,
+            )
 
+    @admin.action(description='선택한 포스트 공개 처리')
     def make_visible(self, request: HttpRequest, queryset: QuerySet[Post]) -> None:
-        """선택한 포스트 공개 처리 (bulk update)"""
-        post_ids = list(queryset.values_list('id', flat=True))
-        count = PostConfig.objects.filter(post_id__in=post_ids).update(hide=False)
+        """Route visibility changes through the post domain service."""
+        count = 0
+        failed = 0
+        for post in self._active_posts(queryset).select_related('config'):
+            try:
+                with transaction.atomic():
+                    updated_post = PostService.update_post(post, is_hide=False)
+                    self.log_change(
+                        request,
+                        updated_post,
+                        'Admin에서 공개 처리',
+                    )
+            except (PostValidationError, ObjectDoesNotExist):
+                failed += 1
+                continue
+            count += 1
         self.message_user(request, f'{count}개의 포스트를 공개 처리했습니다.')
-    make_visible.short_description = '선택한 포스트 공개 처리'
+        if failed:
+            self.message_user(
+                request,
+                f'{failed}개는 필수 설정이 없어 처리하지 못했습니다.',
+                level=messages.WARNING,
+            )
 
+    @admin.action(description='선택한 임시글 즉시 발행')
     def publish_drafts(self, request: HttpRequest, queryset: QuerySet[Post]) -> None:
-        """선택한 임시글을 즉시 발행 (bulk update)"""
-        count = queryset.filter(published_date__isnull=True).update(published_date=timezone.now())
+        """Publish drafts with validation, timestamps, and notifications."""
+        drafts = PostStatusService.filter_drafts(queryset).select_related(
+            'content',
+            'config',
+        )
+        count = 0
+        failed = 0
+        for post in drafts:
+            try:
+                with transaction.atomic():
+                    published_post = PostService.publish_draft_now(post)
+                    self.log_change(
+                        request,
+                        published_post,
+                        'Admin에서 즉시 발행',
+                    )
+            except (PostValidationError, ObjectDoesNotExist):
+                failed += 1
+                continue
+            count += 1
         self.message_user(request, f'{count}개의 임시글을 발행했습니다.')
-    publish_drafts.short_description = '선택한 임시글 즉시 발행'
+        if failed:
+            self.message_user(
+                request,
+                f'{failed}개는 발행 조건을 충족하지 못해 건너뛰었습니다.',
+                level=messages.WARNING,
+            )
+
+    @admin.action(description='선택한 포스트를 휴지통으로 이동')
+    def move_to_trash(
+        self,
+        request: HttpRequest,
+        queryset: QuerySet[Post],
+    ) -> None:
+        posts = list(self._active_posts(queryset))
+        with transaction.atomic():
+            for post in posts:
+                trashed_post = PostTrashService.trash_post(post)
+                self.log_change(
+                    request,
+                    trashed_post,
+                    'Admin에서 휴지통으로 이동',
+                )
+
+        self.message_user(
+            request,
+            f'{len(posts)}개의 포스트를 휴지통으로 이동했습니다.',
+            level=messages.SUCCESS,
+        )
+
+    @admin.action(description='선택한 휴지통 포스트 복원')
+    def restore_from_trash(
+        self,
+        request: HttpRequest,
+        queryset: QuerySet[Post],
+    ) -> None:
+        posts = list(queryset.filter(deleted_date__isnull=False))
+        with transaction.atomic():
+            for post in posts:
+                restored_post = PostTrashService.restore_post(
+                    post,
+                    expected_deleted_date=post.deleted_date.isoformat(),
+                )
+                self.log_change(
+                    request,
+                    restored_post,
+                    'Admin에서 휴지통 복원',
+                )
+
+        self.message_user(
+            request,
+            f'{len(posts)}개의 포스트를 복원했습니다.',
+            level=messages.SUCCESS,
+        )
+
+    @admin.action(
+        description='선택한 휴지통 포스트 영구 삭제',
+        permissions=['delete'],
+    )
+    def permanently_delete_trashed(
+        self,
+        request: HttpRequest,
+        queryset: QuerySet[Post],
+    ) -> Any:
+        trashed_queryset = queryset.filter(deleted_date__isnull=False)
+        if request.POST.get('confirm') != 'yes':
+            if not trashed_queryset.exists():
+                self.message_user(
+                    request,
+                    '영구 삭제할 휴지통 포스트가 없습니다.',
+                    level=messages.WARNING,
+                )
+                return None
+            return render_action_confirmation(
+                request,
+                self,
+                trashed_queryset,
+                action_name='permanently_delete_trashed',
+                title='휴지통 포스트 영구 삭제 확인',
+                warning=(
+                    '포스트와 연결된 댓글, 수정 이력 및 설정이 함께 삭제되며 '
+                    '이 작업은 되돌릴 수 없습니다.'
+                ),
+                confirm_label='영구 삭제',
+            )
+
+        posts = list(trashed_queryset)
+        if not posts:
+            self.message_user(
+                request,
+                '영구 삭제할 휴지통 포스트가 없습니다.',
+                level=messages.WARNING,
+            )
+            return None
+
+        post_ids = [post.pk for post in posts]
+        with transaction.atomic():
+            self.log_deletions(
+                request,
+                Post.all_objects.filter(pk__in=post_ids),
+            )
+            for post in posts:
+                PostTrashService.purge_post(
+                    post,
+                    expected_deleted_date=post.deleted_date.isoformat(),
+                )
+
+        self.message_user(
+            request,
+            f'{len(posts)}개의 휴지통 포스트를 영구 삭제했습니다.',
+            level=messages.SUCCESS,
+        )
+        return None

--- a/backend/src/board/admin/service.py
+++ b/backend/src/board/admin/service.py
@@ -268,9 +268,15 @@ class AdminDisplayService:
 
     @staticmethod
     def publish_status_badge(post: Any) -> SafeString:
-        """발행 상태 뱃지 생성 (임시글/발행됨/예약됨)"""
+        """발행 상태 뱃지 생성 (휴지통/임시글/발행됨/예약됨)"""
         from django.utils import timezone
 
+        if getattr(post, 'deleted_date', None) is not None:
+            return format_html(
+                '<span style="background: {}; color: {}; padding: 3px 8px; '
+                'border-radius: 4px; font-size: 11px; font-weight: 600;">휴지통</span>',
+                COLOR_DANGER, COLOR_BG
+            )
         if post.published_date is None:
             return format_html(
                 '<span style="background: {}; color: {}; padding: 3px 8px; '

--- a/backend/src/board/services/post_revision_service.py
+++ b/backend/src/board/services/post_revision_service.py
@@ -99,6 +99,7 @@ class PostRevisionService:
         previous_snapshot: PostRevisionSnapshot,
         *,
         source_updated_date: datetime | None,
+        actor: User | None = None,
     ) -> EditHistory | None:
         if PostRevisionService.capture_snapshot(post) == previous_snapshot:
             return None
@@ -108,7 +109,7 @@ class PostRevisionService:
             previous_snapshot,
             change_type=EditHistory.ChangeType.EDIT,
             source_updated_date=source_updated_date,
-            actor=post.author,
+            actor=actor if actor is not None else post.author,
         )
 
     @staticmethod

--- a/backend/src/board/services/post_service.py
+++ b/backend/src/board/services/post_service.py
@@ -1122,6 +1122,13 @@ class PostService:
         return post
 
     @staticmethod
+    @transaction.atomic
+    def publish_draft_now(post: Post) -> Post:
+        """Publish immediately without applying a saved draft reservation."""
+        PostService.set_draft_reserved_date(post, '')
+        return PostService.publish_draft(post, reserved_date_str='')
+
+    @staticmethod
     def get_user_drafts(user: User):
         """Get all draft posts for a user."""
         return Post.objects.filter(

--- a/backend/src/board/templates/admin/board/confirm_action.html
+++ b/backend/src/board/templates/admin/board/confirm_action.html
@@ -1,0 +1,40 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+  <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
+  &rsaquo; <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>
+  &rsaquo; {{ title }}
+</div>
+{% endblock %}
+
+{% block content %}
+<div id="content-main">
+  <p>{{ warning }}</p>
+  <p><strong>대상 {{ object_count }}개</strong></p>
+
+  <ul>
+    {% for object in object_preview %}
+      <li>{{ object }}</li>
+    {% endfor %}
+    {% if has_more_objects %}
+      <li>외 {{ object_count|add:"-20" }}개</li>
+    {% endif %}
+  </ul>
+
+  <form method="post">
+    {% csrf_token %}
+    {% for selected_id in selected_ids %}
+      <input type="hidden" name="{{ action_checkbox_name }}" value="{{ selected_id }}">
+    {% endfor %}
+    <input type="hidden" name="action" value="{{ action_name }}">
+    <input type="hidden" name="select_across" value="{{ select_across }}">
+    <input type="hidden" name="confirm" value="yes">
+    <div class="submit-row">
+      <input type="submit" value="{{ confirm_label }}" class="deletelink">
+      <a href="{% url opts|admin_urlname:'changelist' %}" class="button cancel-link">취소</a>
+    </div>
+  </form>
+</div>
+{% endblock %}

--- a/backend/src/board/tests/admin/test_post_admin.py
+++ b/backend/src/board/tests/admin/test_post_admin.py
@@ -1,15 +1,453 @@
-from django.contrib.admin.sites import AdminSite
+from datetime import timedelta
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from django.contrib import admin
+from django.contrib.admin import helpers
+from django.contrib.admin.models import CHANGE, DELETION, LogEntry
+from django.contrib.auth.models import User
+from django.contrib.messages.storage.fallback import FallbackStorage
+from django.template.response import TemplateResponse
 from django.test import RequestFactory, TestCase
+from django.urls import reverse
+from django.utils import timezone
 
 from board.admin.post import PostAdmin
-from board.models import Post
+from board.models import (
+    EditHistory,
+    Post,
+    PostConfig,
+    PostConfigMeta,
+    PostContent,
+    Tag,
+)
+from board.services.post_service import PostService
 
 
-class PostAdminTestCase(TestCase):
+class DummyAdminForm:
+    def __init__(self, instance: Post, *, changed: bool):
+        self.instance = instance
+        self._changed = changed
+
+    def has_changed(self):
+        return self._changed
+
+    def save_m2m(self):
+        return None
+
+
+class DummyInlineFormSet:
+    def __init__(self, *, changed: bool, save_callback=None):
+        self._changed = changed
+        self._save_callback = save_callback
+
+    def has_changed(self):
+        return self._changed
+
+    def save(self):
+        if self._save_callback:
+            self._save_callback()
+        return []
+
+
+class AdminRequestMixin:
+    @classmethod
+    def setUpTestData(cls):
+        cls.admin_user = User.objects.create_superuser(
+            username='admin-operator',
+            email='admin@example.com',
+            password='test',
+        )
+        cls.author = User.objects.create_user(
+            username='post-author',
+            password='test',
+        )
+
+    def admin_request(self, method='get', data=None, path='/admin/board/post/'):
+        factory_method = getattr(RequestFactory(), method)
+        request = factory_method(path, data=data or {})
+        request.user = self.admin_user
+        request.session = {}
+        request._messages = FallbackStorage(request)
+        return request
+
+    def create_post(self, *, published=True, title='Admin post'):
+        published_date = timezone.now() if published else None
+        post = Post.objects.create(
+            author=self.author,
+            title=title,
+            url=f'{title.lower().replace(" ", "-")}-{Post.all_objects.count()}',
+            published_date=published_date,
+            updated_date=timezone.now() - timedelta(days=1),
+        )
+        PostContent.objects.create(
+            post=post,
+            content_html='<p>Original body</p>',
+        )
+        PostConfig.objects.create(post=post)
+        return post
+
+
+class PostAdminTestCase(AdminRequestMixin, TestCase):
+    def setUp(self):
+        self.admin_instance = PostAdmin(Post, admin.site)
+
     def test_url_is_not_readonly_field(self):
-        admin_instance = PostAdmin(Post, AdminSite())
-        request = RequestFactory().get('/admin/board/post/')
+        request = self.admin_request()
 
-        readonly_fields = admin_instance.get_readonly_fields(request, obj=None)
+        readonly_fields = self.admin_instance.get_readonly_fields(
+            request,
+            obj=None,
+        )
 
         self.assertNotIn('url', readonly_fields)
+
+    def test_queryset_includes_trash_but_autocomplete_excludes_it(self):
+        active = self.create_post(title='Active post')
+        trashed = self.create_post(title='Trashed post')
+        Post.all_objects.filter(pk=trashed.pk).update(
+            deleted_date=timezone.now(),
+        )
+
+        regular_request = self.admin_request()
+        queryset = self.admin_instance.get_queryset(regular_request)
+        self.assertSetEqual(
+            set(queryset.values_list('pk', flat=True)),
+            {active.pk, trashed.pk},
+        )
+        trashed_from_admin = queryset.get(pk=trashed.pk)
+        self.assertIn(
+            '휴지통',
+            str(self.admin_instance.publish_status(trashed_from_admin)),
+        )
+
+        autocomplete_request = self.admin_request()
+        autocomplete_request.resolver_match = SimpleNamespace(
+            url_name='autocomplete',
+        )
+        autocomplete_queryset = self.admin_instance.get_queryset(
+            autocomplete_request,
+        )
+        self.assertSetEqual(
+            set(autocomplete_queryset.values_list('pk', flat=True)),
+            {active.pk},
+        )
+
+    def test_changelist_keeps_active_default_and_exposes_trash_filter(self):
+        active = self.create_post(title='Visible active row')
+        trashed = self.create_post(title='Visible trash row')
+        Post.all_objects.filter(pk=trashed.pk).update(
+            deleted_date=timezone.now(),
+        )
+        self.client.force_login(self.admin_user)
+        changelist_url = reverse('admin:board_post_changelist')
+
+        default_response = self.client.get(changelist_url)
+        self.assertEqual(default_response.status_code, 200)
+        self.assertContains(default_response, active.title)
+        self.assertNotContains(default_response, trashed.title)
+
+        trash_response = self.client.get(
+            changelist_url,
+            {'publish_status': 'trashed'},
+        )
+        self.assertEqual(trash_response.status_code, 200)
+        self.assertNotContains(trash_response, active.title)
+        self.assertContains(trash_response, trashed.title)
+
+        invalid_filter_response = self.client.get(
+            changelist_url,
+            {'publish_status': 'unknown'},
+        )
+        self.assertEqual(invalid_filter_response.status_code, 200)
+        self.assertContains(invalid_filter_response, active.title)
+        self.assertNotContains(invalid_filter_response, trashed.title)
+
+    def test_trashed_post_is_viewable_but_not_editable_or_directly_deletable(self):
+        post = self.create_post()
+        Post.all_objects.filter(pk=post.pk).update(
+            deleted_date=timezone.now(),
+        )
+        post = Post.all_objects.get(pk=post.pk)
+        request = self.admin_request()
+
+        self.assertFalse(
+            self.admin_instance.has_change_permission(request, post),
+        )
+        self.assertFalse(
+            self.admin_instance.has_delete_permission(request, post),
+        )
+        self.client.force_login(self.admin_user)
+        response = self.client.get(
+            reverse('admin:board_post_change', args=[post.pk]),
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, 'name="_save"')
+
+    def test_default_bulk_delete_is_replaced_with_lifecycle_actions(self):
+        actions = self.admin_instance.get_actions(self.admin_request())
+
+        self.assertNotIn('delete_selected', actions)
+        self.assertIn('move_to_trash', actions)
+        self.assertIn('restore_from_trash', actions)
+        self.assertIn('permanently_delete_trashed', actions)
+
+    def test_move_to_trash_and_restore_use_recoverable_state(self):
+        post = self.create_post()
+        original_updated_date = post.updated_date
+
+        self.admin_instance.move_to_trash(
+            self.admin_request('post'),
+            Post.all_objects.filter(pk=post.pk),
+        )
+
+        trashed = Post.all_objects.get(pk=post.pk)
+        self.assertIsNotNone(trashed.deleted_date)
+        self.assertEqual(trashed.updated_date, original_updated_date)
+        self.assertFalse(Post.objects.filter(pk=post.pk).exists())
+
+        self.admin_instance.restore_from_trash(
+            self.admin_request('post'),
+            Post.all_objects.filter(pk=post.pk),
+        )
+
+        restored = Post.objects.get(pk=post.pk)
+        self.assertIsNone(restored.deleted_date)
+        self.assertEqual(restored.updated_date, original_updated_date)
+        logs = LogEntry.objects.filter(
+            object_id=str(post.pk),
+            action_flag=CHANGE,
+        )
+        self.assertEqual(logs.count(), 2)
+        self.assertTrue(
+            logs.filter(change_message__contains='휴지통으로 이동').exists(),
+        )
+        self.assertTrue(
+            logs.filter(change_message__contains='휴지통 복원').exists(),
+        )
+
+    def test_permanent_delete_requires_confirmation_and_only_accepts_trash(self):
+        active = self.create_post(title='Keep active')
+        trashed = self.create_post(title='Purge trashed')
+        Post.all_objects.filter(pk=trashed.pk).update(
+            deleted_date=timezone.now(),
+        )
+        queryset = Post.all_objects.filter(pk__in=[active.pk, trashed.pk])
+        selection = {
+            helpers.ACTION_CHECKBOX_NAME: [str(active.pk), str(trashed.pk)],
+            'action': 'permanently_delete_trashed',
+            'select_across': '0',
+        }
+
+        confirmation = self.admin_instance.permanently_delete_trashed(
+            self.admin_request('post', selection),
+            queryset,
+        )
+
+        self.assertIsInstance(confirmation, TemplateResponse)
+        confirmation.render()
+        self.assertTrue(Post.all_objects.filter(pk=trashed.pk).exists())
+
+        confirmed_request = self.admin_request(
+            'post',
+            {**selection, 'confirm': 'yes'},
+        )
+        self.admin_instance.permanently_delete_trashed(
+            confirmed_request,
+            queryset,
+        )
+
+        self.assertTrue(Post.all_objects.filter(pk=active.pk).exists())
+        self.assertFalse(Post.all_objects.filter(pk=trashed.pk).exists())
+        self.assertTrue(
+            LogEntry.objects.filter(
+                object_id=str(trashed.pk),
+                action_flag=DELETION,
+            ).exists(),
+        )
+
+    def test_publish_drafts_uses_service_timestamp_contract(self):
+        draft = self.create_post(published=False, title='Publish draft')
+        previous_updated_date = draft.updated_date
+        saved_reservation = timezone.now() + timedelta(days=2)
+        PostConfigMeta.objects.create(
+            post=draft,
+            name=PostService.DRAFT_RESERVED_DATE_META,
+            value=saved_reservation.isoformat(),
+        )
+
+        self.admin_instance.publish_drafts(
+            self.admin_request('post'),
+            Post.all_objects.filter(pk=draft.pk),
+        )
+
+        published = Post.objects.get(pk=draft.pk)
+        self.assertIsNotNone(published.published_date)
+        self.assertLess(published.published_date, saved_reservation)
+        self.assertGreater(published.updated_date, previous_updated_date)
+        self.assertFalse(
+            PostConfigMeta.objects.filter(
+                post=draft,
+                name=PostService.DRAFT_RESERVED_DATE_META,
+            ).exists(),
+        )
+        self.assertTrue(
+            LogEntry.objects.filter(
+                object_id=str(draft.pk),
+                action_flag=CHANGE,
+                change_message__contains='즉시 발행',
+            ).exists(),
+        )
+
+    def test_failed_immediate_publish_restores_saved_reservation(self):
+        draft = self.create_post(published=False, title='Broken draft')
+        draft.config.delete()
+        saved_reservation = timezone.now() + timedelta(days=2)
+        PostConfigMeta.objects.create(
+            post=draft,
+            name=PostService.DRAFT_RESERVED_DATE_META,
+            value=saved_reservation.isoformat(),
+        )
+
+        self.admin_instance.publish_drafts(
+            self.admin_request('post'),
+            Post.all_objects.filter(pk=draft.pk),
+        )
+
+        draft.refresh_from_db()
+        self.assertIsNone(draft.published_date)
+        self.assertEqual(
+            PostConfigMeta.objects.get(
+                post=draft,
+                name=PostService.DRAFT_RESERVED_DATE_META,
+            ).value,
+            saved_reservation.isoformat(),
+        )
+
+    def test_visibility_actions_use_service_and_skip_trash(self):
+        active = self.create_post(title='Visibility active')
+        trashed = self.create_post(title='Visibility trashed')
+        Post.all_objects.filter(pk=trashed.pk).update(
+            deleted_date=timezone.now(),
+        )
+        previous_updated_date = active.updated_date
+
+        self.admin_instance.make_hidden(
+            self.admin_request('post'),
+            Post.all_objects.filter(pk__in=[active.pk, trashed.pk]),
+        )
+
+        active.refresh_from_db()
+        trashed.config.refresh_from_db()
+        self.assertTrue(active.config.hide)
+        self.assertFalse(trashed.config.hide)
+        self.assertGreater(active.updated_date, previous_updated_date)
+        self.assertTrue(
+            LogEntry.objects.filter(
+                object_id=str(active.pk),
+                action_flag=CHANGE,
+                change_message__contains='숨김 처리',
+            ).exists(),
+        )
+
+    def test_visibility_change_rolls_back_when_audit_log_fails(self):
+        post = self.create_post(title='Audit rollback')
+
+        with patch.object(
+            self.admin_instance,
+            'log_change',
+            side_effect=RuntimeError('audit unavailable'),
+        ):
+            with self.assertRaisesRegex(RuntimeError, 'audit unavailable'):
+                self.admin_instance.make_hidden(
+                    self.admin_request('post'),
+                    Post.all_objects.filter(pk=post.pk),
+                )
+
+        post.config.refresh_from_db()
+        self.assertFalse(post.config.hide)
+
+    def test_admin_edit_records_operator_revision_and_updates_timestamp(self):
+        post = self.create_post(title='Original title')
+        tag = Tag.objects.create(value='original-tag')
+        post.tags.add(tag)
+        previous_updated_date = post.updated_date
+        post.title = 'Changed in Admin'
+        form = DummyAdminForm(post, changed=True)
+        request = self.admin_request('post')
+
+        self.admin_instance.save_model(request, post, form, change=True)
+        self.admin_instance.save_related(
+            request,
+            form,
+            [],
+            change=True,
+        )
+
+        post.refresh_from_db()
+        revision = EditHistory.objects.get(post=post)
+        self.assertEqual(revision.title, 'Original title')
+        self.assertEqual(revision.content, '<p>Original body</p>')
+        self.assertEqual(revision.tags, ['original-tag'])
+        self.assertEqual(revision.actor, self.admin_user)
+        self.assertEqual(
+            revision.source_updated_date,
+            previous_updated_date,
+        )
+        self.assertGreater(post.updated_date, previous_updated_date)
+
+    def test_admin_inline_edit_records_revision_but_draft_edit_does_not(self):
+        published = self.create_post(title='Published inline')
+        published_previous_date = published.updated_date
+        published_form = DummyAdminForm(published, changed=False)
+        published_formset = DummyInlineFormSet(
+            changed=True,
+            save_callback=lambda: PostContent.objects.filter(
+                post=published,
+            ).update(content_html='<p>Changed inline body</p>'),
+        )
+        request = self.admin_request('post')
+
+        self.admin_instance.save_model(
+            request,
+            published,
+            published_form,
+            change=True,
+        )
+        self.admin_instance.save_related(
+            request,
+            published_form,
+            [published_formset],
+            change=True,
+        )
+
+        published.refresh_from_db()
+        self.assertEqual(
+            EditHistory.objects.get(post=published).content,
+            '<p>Original body</p>',
+        )
+        self.assertGreater(
+            published.updated_date,
+            published_previous_date,
+        )
+
+        draft = self.create_post(published=False, title='Draft inline')
+        draft_previous_date = draft.updated_date
+        draft.title = 'Changed draft title'
+        draft_form = DummyAdminForm(draft, changed=True)
+        self.admin_instance.save_model(
+            request,
+            draft,
+            draft_form,
+            change=True,
+        )
+        self.admin_instance.save_related(
+            request,
+            draft_form,
+            [],
+            change=True,
+        )
+
+        draft.refresh_from_db()
+        self.assertFalse(EditHistory.objects.filter(post=draft).exists())
+        self.assertGreater(draft.updated_date, draft_previous_date)


### PR DESCRIPTION
## 🎯 Goal
- Django Admin의 포스트 작업이 휴지통, 발행, 수정 이력 도메인 계약을 우회하지 않게 합니다.
- 기존 공개 URL, API, DB 스키마와 기본 활성 포스트 목록 동작은 그대로 유지합니다.

## 🔧 Core Changes
- 기본 목록은 활성 포스트만 유지하면서 휴지통 필터, 복원, 확인 후 영구 삭제를 추가했습니다.
- 일괄 공개·숨김·즉시 발행을 도메인 서비스와 트랜잭션, 감사 로그 기반으로 전환했습니다.
- 관리자 수정도 updated_date와 발행 포스트의 이전 스냅샷·작업자 기록을 남기도록 했습니다.
- 위험 액션 공통 확인 화면과 장기 회귀 테스트를 추가했습니다.

## 🤔 Key Decisions
- 기존 delete_selected와 객체 직접 삭제는 제거하고, 영구 삭제는 휴지통 포스트에만 허용했습니다.
- 임시글 수정은 기존 제품 계약대로 수정 이력을 만들지 않고 수정 시각만 갱신합니다.
- 기존 publish_draft 시그니처는 보존하고 즉시 발행용 호환 메서드를 추가했습니다.
- 공개 API·모델·마이그레이션은 변경하지 않았습니다.

## 🧪 Verification Guide
### How to verify
1. 포스트 Admin 기본 목록과 휴지통 필터를 확인합니다.
2. 숨김·공개·즉시 발행·휴지통 이동·복원·영구 삭제 액션을 확인합니다.
3. 발행된 포스트를 Admin에서 수정한 뒤 수정 이력과 작업자, 감사 로그를 확인합니다.

### Expected result
- 활성 포스트 기본 목록은 유지되고 위험 작업은 서비스 검증과 명시적 확인을 거칩니다.
- 휴지통 포스트는 직접 수정·삭제할 수 없으며 복원 또는 확인된 영구 삭제만 가능합니다.
- 전체 백엔드 테스트 1,229개와 정적 검사가 통과합니다.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (not needed: public contract and schema unchanged)