### PR TITLE
🐛 Harden admin revision snapshot handling

### DIFF
--- a/backend/src/board/admin/__init__.py
+++ b/backend/src/board/admin/__init__.py
@@ -6,6 +6,7 @@ from .webhook import *
 from .form import *
 from .image import *
 from .notify import *
+from .revision import *
 from .series import *
 from .post import *
 from .tag import *

--- a/backend/src/board/admin/post.py
+++ b/backend/src/board/admin/post.py
@@ -15,7 +15,7 @@ from board.services.post_service import PostService, PostValidationError
 from board.services.post_status_service import PostStatusService
 from board.services.post_trash_service import PostTrashService
 from board.models import (
-    EditHistory, EditRequest, Post, PinnedPost,
+    EditRequest, Post, PinnedPost,
     PostConfig, PostContent,
 )
 
@@ -52,14 +52,6 @@ class PublishStatusFilter(admin.SimpleListFilter):
         elif self.value() == 'trashed':
             return queryset.filter(deleted_date__isnull=False)
         return queryset.filter(deleted_date__isnull=True)
-
-
-@admin.register(EditHistory)
-class EditHistoryAdmin(admin.ModelAdmin):
-    list_display = ['id', 'post', 'created_date']
-    list_per_page = LIST_PER_PAGE_DEFAULT
-    search_fields = ['post__title']
-    readonly_fields = ['post', 'created_date']
 
 
 @admin.register(EditRequest)

--- a/backend/src/board/admin/revision.py
+++ b/backend/src/board/admin/revision.py
@@ -1,0 +1,235 @@
+"""Django Admin configuration for immutable post revision snapshots."""
+
+from typing import Any
+
+from django.contrib import admin, messages
+from django.db import transaction
+from django.db.models import QuerySet
+from django.http import HttpRequest
+from django.utils.html import format_html
+
+from board.models import EditHistory
+from board.services.post_revision_service import PostRevisionService
+
+from .action_confirmation import render_action_confirmation
+from .constants import LIST_PER_PAGE_DEFAULT
+from .service import AdminDisplayService, AdminLinkService
+
+
+class RevisionPostStatusFilter(admin.SimpleListFilter):
+    """Filter revision snapshots by the current lifecycle of their post."""
+
+    title = '포스트 상태'
+    parameter_name = 'post_status'
+
+    def lookups(self, request, model_admin):
+        return [
+            ('active', '활성'),
+            ('trashed', '휴지통'),
+        ]
+
+    def queryset(self, request, queryset):
+        if self.value() == 'active':
+            return queryset.filter(post__deleted_date__isnull=True)
+        if self.value() == 'trashed':
+            return queryset.filter(post__deleted_date__isnull=False)
+        return queryset
+
+
+@admin.register(EditHistory)
+class EditHistoryAdmin(admin.ModelAdmin):
+    """Expose revision snapshots without allowing their content to be edited."""
+
+    list_display = [
+        'id',
+        'post_link',
+        'post_status',
+        'change_type_label',
+        'actor_link',
+        'snapshot_summary',
+        'source_updated_date',
+        'created_date',
+    ]
+    list_display_links = ['id']
+    list_filter = [
+        RevisionPostStatusFilter,
+        'change_type',
+        ('created_date', admin.DateFieldListFilter),
+    ]
+    search_fields = [
+        'post__title',
+        'post__url',
+        'post__author__username',
+        'actor__username',
+        'title',
+        'content_excerpt',
+    ]
+    readonly_fields = [
+        'post',
+        'actor',
+        'restored_from',
+        'change_type',
+        'title',
+        'subtitle',
+        'content',
+        'content_excerpt',
+        'description',
+        'tags',
+        'source_updated_date',
+        'created_date',
+    ]
+    fieldsets = (
+        ('이력 정보', {
+            'fields': (
+                'post',
+                'actor',
+                'change_type',
+                'restored_from',
+            ),
+        }),
+        ('이전 스냅샷', {
+            'fields': (
+                'title',
+                'subtitle',
+                'content',
+                'description',
+                'tags',
+            ),
+        }),
+        ('기록 시점', {
+            'fields': (
+                'content_excerpt',
+                'source_updated_date',
+                'created_date',
+            ),
+            'classes': ('collapse',),
+        }),
+    )
+    actions = ['delete_revisions']
+    ordering = ['-created_date', '-id']
+    date_hierarchy = 'created_date'
+    list_per_page = LIST_PER_PAGE_DEFAULT
+
+    def get_queryset(self, request):
+        queryset = super().get_queryset(request).select_related(
+            'post',
+            'post__author',
+            'actor',
+            'restored_from',
+        )
+        if (
+            getattr(request, 'resolver_match', None)
+            and request.resolver_match.url_name
+            == 'board_edithistory_changelist'
+        ):
+            return queryset.defer(
+                'content',
+                'description',
+                'tags',
+                'subtitle',
+            )
+        return queryset
+
+    def get_actions(self, request):
+        actions = super().get_actions(request)
+        actions.pop('delete_selected', None)
+        return actions
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        if obj is not None:
+            return False
+        return super().has_change_permission(request, obj)
+
+    def post_link(self, obj: EditHistory):
+        return AdminLinkService.create_post_link(obj.post)
+    post_link.short_description = '포스트'
+    post_link.admin_order_field = 'post__title'
+
+    def post_status(self, obj: EditHistory):
+        return AdminDisplayService.publish_status_badge(obj.post)
+    post_status.short_description = '현재 상태'
+    post_status.admin_order_field = 'post__deleted_date'
+
+    def change_type_label(self, obj: EditHistory) -> str:
+        return obj.get_change_type_display()
+    change_type_label.short_description = '변경 유형'
+    change_type_label.admin_order_field = 'change_type'
+
+    def actor_link(self, obj: EditHistory):
+        return AdminLinkService.create_user_link(obj.actor)
+    actor_link.short_description = '작업자'
+    actor_link.admin_order_field = 'actor__username'
+
+    def snapshot_summary(self, obj: EditHistory):
+        excerpt = obj.content_excerpt or '본문 요약 없음'
+        return format_html(
+            '<strong>{}</strong><br><span>{}</span>',
+            obj.title,
+            excerpt,
+        )
+    snapshot_summary.short_description = '이전 내용'
+    snapshot_summary.admin_order_field = 'title'
+
+    def delete_model(self, request, obj: EditHistory) -> None:
+        PostRevisionService.delete_revision(obj.post, obj)
+
+    @admin.action(
+        description='선택한 수정 이력 삭제',
+        permissions=['delete'],
+    )
+    def delete_revisions(
+        self,
+        request: HttpRequest,
+        queryset: QuerySet[EditHistory],
+    ) -> Any:
+        if request.POST.get('confirm') != 'yes':
+            if not queryset.exists():
+                self.message_user(
+                    request,
+                    '삭제할 수정 이력이 없습니다.',
+                    level=messages.WARNING,
+                )
+                return None
+            return render_action_confirmation(
+                request,
+                self,
+                queryset,
+                action_name='delete_revisions',
+                title='수정 이력 삭제 확인',
+                warning=(
+                    '선택한 이전 스냅샷만 삭제됩니다. 현재 포스트 내용은 '
+                    '바뀌지 않지만 삭제한 이력은 복구할 수 없습니다.'
+                ),
+                confirm_label='수정 이력 삭제',
+            )
+
+        revisions = list(queryset.select_related('post'))
+        if not revisions:
+            self.message_user(
+                request,
+                '삭제할 수정 이력이 없습니다.',
+                level=messages.WARNING,
+            )
+            return None
+
+        revision_ids = [revision.pk for revision in revisions]
+        with transaction.atomic():
+            self.log_deletions(
+                request,
+                EditHistory.objects.filter(pk__in=revision_ids),
+            )
+            for revision in revisions:
+                PostRevisionService.delete_revision(
+                    revision.post,
+                    revision,
+                )
+
+        self.message_user(
+            request,
+            f'{len(revisions)}개의 수정 이력을 삭제했습니다.',
+            level=messages.SUCCESS,
+        )
+        return None

--- a/backend/src/board/tests/admin/test_revision_admin.py
+++ b/backend/src/board/tests/admin/test_revision_admin.py
@@ -1,0 +1,281 @@
+from unittest.mock import patch
+
+from django.contrib import admin
+from django.contrib.admin import helpers
+from django.contrib.admin.models import DELETION, LogEntry
+from django.contrib.auth.models import User
+from django.contrib.messages.storage.fallback import FallbackStorage
+from django.template.response import TemplateResponse
+from django.test import RequestFactory, TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from board.admin.revision import EditHistoryAdmin
+from board.models import EditHistory, Post
+from board.services.post_revision_service import PostRevisionService
+
+
+class EditHistoryAdminTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.admin_user = User.objects.create_superuser(
+            username='revision-admin',
+            email='revision-admin@example.com',
+            password='test',
+        )
+        cls.author = User.objects.create_user(
+            username='revision-author',
+            password='test',
+        )
+
+    def setUp(self):
+        self.admin_instance = EditHistoryAdmin(EditHistory, admin.site)
+
+    def admin_request(self, method='get', data=None):
+        factory_method = getattr(RequestFactory(), method)
+        request = factory_method(
+            '/admin/board/edithistory/',
+            data=data or {},
+        )
+        request.user = self.admin_user
+        request.session = {}
+        request._messages = FallbackStorage(request)
+        return request
+
+    def create_post(self, title: str, *, trashed: bool = False) -> Post:
+        post = Post.objects.create(
+            author=self.author,
+            title=title,
+            url=title.lower().replace(' ', '-'),
+            published_date=timezone.now(),
+        )
+        if trashed:
+            Post.all_objects.filter(pk=post.pk).update(
+                deleted_date=timezone.now(),
+            )
+            return Post.all_objects.get(pk=post.pk)
+        return post
+
+    def create_revision(
+        self,
+        post: Post,
+        *,
+        title='Previous title',
+        excerpt='Previous body',
+        actor=None,
+    ) -> EditHistory:
+        return EditHistory.objects.create(
+            post=post,
+            actor=actor if actor is not None else self.author,
+            title=title,
+            content='<p>Previous body</p>',
+            content_excerpt=excerpt,
+            change_type=EditHistory.ChangeType.EDIT,
+            source_updated_date=timezone.now(),
+        )
+
+    def test_snapshots_cannot_be_added_or_edited_in_admin(self):
+        post = self.create_post('Immutable revision')
+        revision = self.create_revision(post)
+        request = self.admin_request()
+
+        self.assertFalse(self.admin_instance.has_add_permission(request))
+        self.assertFalse(
+            self.admin_instance.has_change_permission(request, revision),
+        )
+        self.assertSetEqual(
+            set(self.admin_instance.get_readonly_fields(request, revision)),
+            {
+                field.name
+                for field in EditHistory._meta.fields
+                if not field.primary_key
+            },
+        )
+
+        actions = self.admin_instance.get_actions(request)
+        self.assertNotIn('delete_selected', actions)
+        self.assertIn('delete_revisions', actions)
+
+        self.client.force_login(self.admin_user)
+        change_response = self.client.get(
+            reverse('admin:board_edithistory_change', args=[revision.pk]),
+        )
+        self.assertEqual(change_response.status_code, 200)
+        self.assertNotContains(change_response, 'name="_save"')
+
+        with self.assertLogs('django.request', level='WARNING'):
+            add_response = self.client.get(
+                reverse('admin:board_edithistory_add'),
+            )
+        self.assertEqual(add_response.status_code, 403)
+
+    def test_changelist_identifies_post_lifecycle_actor_and_change_type(self):
+        active_post = self.create_post('Active revision post')
+        trashed_post = self.create_post(
+            'Trashed revision post',
+            trashed=True,
+        )
+        active_revision = self.create_revision(
+            active_post,
+            actor=self.admin_user,
+        )
+        trashed_revision = self.create_revision(trashed_post)
+        self.client.force_login(self.admin_user)
+        changelist_url = reverse('admin:board_edithistory_changelist')
+
+        response = self.client.get(changelist_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertSetEqual(
+            {revision.pk for revision in response.context['cl'].result_list},
+            {active_revision.pk, trashed_revision.pk},
+        )
+        for revision in response.context['cl'].result_list:
+            self.assertTrue(
+                {'content', 'description', 'tags', 'subtitle'}.issubset(
+                    revision.get_deferred_fields(),
+                ),
+            )
+        self.assertContains(response, 'revision-admin')
+        self.assertContains(response, '수정 전')
+        self.assertContains(response, '휴지통')
+        self.assertContains(
+            response,
+            reverse('admin:board_post_change', args=[trashed_post.pk]),
+        )
+
+        trash_response = self.client.get(
+            changelist_url,
+            {'post_status': 'trashed'},
+        )
+        self.assertEqual(trash_response.status_code, 200)
+        self.assertEqual(
+            [revision.pk for revision in trash_response.context['cl'].result_list],
+            [trashed_revision.pk],
+        )
+
+        active_response = self.client.get(
+            changelist_url,
+            {'post_status': 'active'},
+        )
+        self.assertEqual(
+            [revision.pk for revision in active_response.context['cl'].result_list],
+            [active_revision.pk],
+        )
+
+    def test_snapshot_summary_escapes_stored_html(self):
+        post = self.create_post('Escaped revision post')
+        self.create_revision(
+            post,
+            title='<img src=x onerror=alert(1)>',
+            excerpt='<script>alert(1)</script>',
+        )
+        self.client.force_login(self.admin_user)
+
+        response = self.client.get(
+            reverse('admin:board_edithistory_changelist'),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, '<img src=x onerror=alert(1)>')
+        self.assertNotContains(response, '<script>alert(1)</script>')
+        self.assertContains(
+            response,
+            '&lt;img src=x onerror=alert(1)>',
+            html=False,
+        )
+        self.assertContains(
+            response,
+            '&lt;script>alert(1)&lt;/script>',
+            html=False,
+        )
+
+    def test_bulk_delete_requires_confirmation_and_preserves_post(self):
+        post = self.create_post('Revision deletion post')
+        deleted_revision = self.create_revision(
+            post,
+            title='Delete this revision',
+        )
+        retained_revision = self.create_revision(
+            post,
+            title='Keep this revision',
+        )
+        selection = {
+            helpers.ACTION_CHECKBOX_NAME: [str(deleted_revision.pk)],
+            'action': 'delete_revisions',
+            'select_across': '0',
+        }
+        queryset = EditHistory.objects.filter(pk=deleted_revision.pk)
+
+        confirmation = self.admin_instance.delete_revisions(
+            self.admin_request('post', selection),
+            queryset,
+        )
+
+        self.assertIsInstance(confirmation, TemplateResponse)
+        confirmation.render()
+        self.assertTrue(
+            EditHistory.objects.filter(pk=deleted_revision.pk).exists(),
+        )
+
+        with patch.object(
+            PostRevisionService,
+            'delete_revision',
+            wraps=PostRevisionService.delete_revision,
+        ) as delete_revision:
+            self.admin_instance.delete_revisions(
+                self.admin_request(
+                    'post',
+                    {**selection, 'confirm': 'yes'},
+                ),
+                queryset,
+            )
+
+        delete_revision.assert_called_once()
+        self.assertFalse(
+            EditHistory.objects.filter(pk=deleted_revision.pk).exists(),
+        )
+        self.assertTrue(
+            EditHistory.objects.filter(pk=retained_revision.pk).exists(),
+        )
+        self.assertTrue(Post.all_objects.filter(pk=post.pk).exists())
+        self.assertTrue(
+            LogEntry.objects.filter(
+                object_id=str(deleted_revision.pk),
+                action_flag=DELETION,
+            ).exists(),
+        )
+
+    def test_direct_delete_confirms_then_uses_service_and_preserves_post(self):
+        post = self.create_post('Direct revision deletion')
+        revision = self.create_revision(post)
+        delete_url = reverse(
+            'admin:board_edithistory_delete',
+            args=[revision.pk],
+        )
+        self.client.force_login(self.admin_user)
+
+        confirmation = self.client.get(delete_url)
+        self.assertEqual(confirmation.status_code, 200)
+        self.assertContains(confirmation, '삭제하시겠습니까?')
+        self.assertTrue(EditHistory.objects.filter(pk=revision.pk).exists())
+
+        with patch.object(
+            PostRevisionService,
+            'delete_revision',
+            wraps=PostRevisionService.delete_revision,
+        ) as delete_revision:
+            response = self.client.post(
+                delete_url,
+                {'post': 'yes'},
+            )
+
+        self.assertEqual(response.status_code, 302)
+        delete_revision.assert_called_once()
+        self.assertFalse(EditHistory.objects.filter(pk=revision.pk).exists())
+        self.assertTrue(Post.all_objects.filter(pk=post.pk).exists())
+        self.assertTrue(
+            LogEntry.objects.filter(
+                object_id=str(revision.pk),
+                action_flag=DELETION,
+            ).exists(),
+        )


### PR DESCRIPTION
## 🎯 Goal
- 수정 이력 스냅샷이 Django Admin에서 실수로 생성·편집되거나 무확인 일괄 삭제되지 않게 합니다.
- 운영자가 현재 포스트 상태, 작업자, 변경 유형과 이전 내용 요약을 빠르게 식별할 수 있게 합니다.

## 🔧 Core Changes
- EditHistory Admin을 별도 모듈로 분리하고 모든 스냅샷 필드를 읽기 전용으로 고정했습니다.
- 포스트·작업자 링크, 활성·휴지통 필터, 변경 유형, 본문 요약과 검색을 추가했습니다.
- 목록에서는 대용량 HTML 본문과 상세 스냅샷 필드를 조회하지 않습니다.
- 기본 일괄 삭제를 제거하고 명시적 확인 후 수정 이력 서비스와 감사 로그를 거치는 삭제 액션을 추가했습니다.
- 직접 삭제도 Django 확인 화면과 같은 수정 이력 서비스를 사용합니다.

## 🤔 Key Decisions
- 수정 이력 내용은 불변으로 유지하되 기존 제품의 개별 이력 삭제 기능과 호환되도록 삭제 자체는 허용했습니다.
- 현재 포스트는 삭제하지 않고 선택한 이력만 서비스 경계를 통해 삭제합니다.
- 휴지통 포스트 이력도 포스트 Admin 읽기 화면으로 연결합니다.
- 공개 API, 모델, DB 스키마와 마이그레이션은 변경하지 않았습니다.

## 🧪 Verification Guide
### How to verify
1. 수정 이력 목록에서 활성·휴지통 필터, 작업자, 변경 유형과 요약을 확인합니다.
2. 수정 이력 상세에서 저장 버튼과 추가 화면이 노출되지 않는지 확인합니다.
3. 직접 삭제와 일괄 삭제가 확인 화면을 거치고 현재 포스트를 보존하는지 확인합니다.

### Expected result
- 수정 이력 스냅샷은 Admin에서 편집할 수 없고 삭제만 명시적으로 확인됩니다.
- 저장 HTML은 목록에서 escape되며 대용량 본문은 목록 쿼리에 포함되지 않습니다.
- 전체 백엔드 테스트 1,234개와 정적 검사가 통과합니다.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (not needed: public contract and schema unchanged)