### PR TITLE
🐛 Harden admin-managed record handling

### DIFF
--- a/backend/src/board/admin/auth.py
+++ b/backend/src/board/admin/auth.py
@@ -1,32 +1,235 @@
-from django.contrib import admin
+from typing import Any
+
+from django.contrib import admin, messages
+from django.db import transaction
+from django.db.models import QuerySet
+from django.http import HttpRequest
 
 from board.constants.social_auth import SUPPORTED_SOCIAL_AUTH_PROVIDERS
 from board.models import TwoFactorAuth, SocialAuth, SocialAuthProvider
+from board.services.social_auth_connection_service import (
+    SocialAuthConnectionService,
+    SocialAuthDisconnectError,
+)
 from board.services.social_auth_provider_service import SocialAuthProviderService
+from board.services.two_factor_setup_service import (
+    TwoFactorSetupError,
+    TwoFactorSetupService,
+)
+
+from .action_confirmation import render_action_confirmation
+from .mixins import (
+    ConfirmedActionDeleteAdminMixin,
+    ReadOnlyRecordAdminMixin,
+)
+from .service import AdminDisplayService, AdminLinkService
 
 
 @admin.register(TwoFactorAuth)
-class TwoFactorAuthAdmin(admin.ModelAdmin):
-    list_display = ['user', 'created_date']
+class TwoFactorAuthAdmin(
+    ConfirmedActionDeleteAdminMixin,
+    ReadOnlyRecordAdminMixin,
+    admin.ModelAdmin,
+):
+    list_display = [
+        'user_link',
+        'credential_status',
+        'created_date',
+    ]
     search_fields = ['user__username']
     list_filter = [('created_date', admin.DateFieldListFilter)]
+    fields = ['user_link', 'credential_status', 'created_date']
+    readonly_fields = ['user_link', 'credential_status', 'created_date']
+    actions = ['disable_two_factor_auth']
     list_per_page = 30
 
-    def get_form(self, request, obj=None, **kwargs):
-        kwargs['exclude'] = ['user']
-        return super().get_form(request, obj, **kwargs)
+    def get_queryset(self, request):
+        return super().get_queryset(request).select_related('user').defer(
+            'recovery_key',
+            'totp_secret',
+        )
+
+    def user_link(self, obj: TwoFactorAuth):
+        return AdminLinkService.create_user_link(obj.user)
+    user_link.short_description = '사용자'
+    user_link.admin_order_field = 'user__username'
+
+    def credential_status(self, obj: TwoFactorAuth):
+        return AdminDisplayService.boolean_badge(
+            True,
+            true_text='활성화됨',
+        )
+    credential_status.short_description = '2FA 상태'
+
+    @admin.action(
+        description='선택한 사용자의 2FA 해제',
+        permissions=['delete'],
+    )
+    def disable_two_factor_auth(
+        self,
+        request: HttpRequest,
+        queryset: QuerySet[TwoFactorAuth],
+    ) -> Any:
+        if request.POST.get('confirm') != 'yes':
+            if not queryset.exists():
+                self.message_user(
+                    request,
+                    '해제할 2FA 설정이 없습니다.',
+                    level=messages.WARNING,
+                )
+                return None
+            return render_action_confirmation(
+                request,
+                self,
+                queryset,
+                action_name='disable_two_factor_auth',
+                title='2FA 해제 확인',
+                warning=(
+                    '선택한 사용자의 2FA 인증 정보가 삭제됩니다. 기존 '
+                    '24시간 해제 제한은 그대로 적용됩니다.'
+                ),
+                confirm_label='2FA 해제',
+            )
+
+        disabled = 0
+        failed = 0
+        for two_factor_auth in queryset.select_related('user'):
+            try:
+                with transaction.atomic():
+                    self.log_deletions(request, [two_factor_auth])
+                    TwoFactorSetupService.disable(two_factor_auth.user)
+            except TwoFactorSetupError:
+                failed += 1
+                continue
+            disabled += 1
+
+        self.message_user(
+            request,
+            f'{disabled}명의 2FA를 해제했습니다.',
+            level=messages.SUCCESS,
+        )
+        if failed:
+            self.message_user(
+                request,
+                f'{failed}명은 기존 해제 정책에 따라 처리하지 못했습니다.',
+                level=messages.WARNING,
+            )
+        return None
 
 
 @admin.register(SocialAuth)
-class SocialAuthAdmin(admin.ModelAdmin):
-    list_display = ['user', 'provider', 'created_date']
+class SocialAuthAdmin(
+    ConfirmedActionDeleteAdminMixin,
+    ReadOnlyRecordAdminMixin,
+    admin.ModelAdmin,
+):
+    list_display = [
+        'user_link',
+        'provider',
+        'identity_status',
+        'created_date',
+    ]
     search_fields = ['user__username', 'provider__key']
     list_filter = ['provider', ('created_date', admin.DateFieldListFilter)]
+    fields = [
+        'user_link',
+        'provider',
+        'identity_status',
+        'extra_data_status',
+        'created_date',
+    ]
+    readonly_fields = [
+        'user_link',
+        'provider',
+        'identity_status',
+        'extra_data_status',
+        'created_date',
+    ]
+    actions = ['disconnect_social_auth']
     list_per_page = 30
 
-    def get_form(self, request, obj=None, **kwargs):
-        kwargs['exclude'] = ['user', 'provider', 'uid']
-        return super().get_form(request, obj, **kwargs)
+    def get_queryset(self, request):
+        return super().get_queryset(request).select_related(
+            'user',
+            'provider',
+        ).defer(
+            'uid',
+            'extra_data',
+        )
+
+    def user_link(self, obj: SocialAuth):
+        return AdminLinkService.create_user_link(obj.user)
+    user_link.short_description = '사용자'
+    user_link.admin_order_field = 'user__username'
+
+    def identity_status(self, obj: SocialAuth):
+        return AdminDisplayService.boolean_badge(
+            True,
+            true_text='보호됨',
+        )
+    identity_status.short_description = '외부 식별자'
+
+    def extra_data_status(self, obj: SocialAuth):
+        return AdminDisplayService.boolean_badge(
+            True,
+            true_text='보호됨',
+        )
+    extra_data_status.short_description = '제공자 원본 데이터'
+
+    @admin.action(
+        description='선택한 소셜 로그인 연동 해제',
+        permissions=['delete'],
+    )
+    def disconnect_social_auth(
+        self,
+        request: HttpRequest,
+        queryset: QuerySet[SocialAuth],
+    ) -> Any:
+        if request.POST.get('confirm') != 'yes':
+            if not queryset.exists():
+                self.message_user(
+                    request,
+                    '해제할 소셜 로그인 연동이 없습니다.',
+                    level=messages.WARNING,
+                )
+                return None
+            return render_action_confirmation(
+                request,
+                self,
+                queryset,
+                action_name='disconnect_social_auth',
+                title='소셜 로그인 연동 해제 확인',
+                warning=(
+                    '선택한 외부 계정 연동이 삭제됩니다. 사용 가능한 '
+                    '비밀번호나 다른 연동이 없는 계정은 해제하지 않습니다.'
+                ),
+                confirm_label='연동 해제',
+            )
+
+        disconnected = 0
+        failed = 0
+        for social_auth in queryset.select_related('user', 'provider'):
+            try:
+                with transaction.atomic():
+                    self.log_deletions(request, [social_auth])
+                    SocialAuthConnectionService.disconnect(social_auth)
+            except SocialAuthDisconnectError:
+                failed += 1
+                continue
+            disconnected += 1
+
+        self.message_user(
+            request,
+            f'{disconnected}개의 소셜 로그인 연동을 해제했습니다.',
+            level=messages.SUCCESS,
+        )
+        if failed:
+            self.message_user(
+                request,
+                f'{failed}개는 로그인 수단을 보존하기 위해 해제하지 않았습니다.',
+                level=messages.WARNING,
+            )
+        return None
 
 
 @admin.register(SocialAuthProvider)

--- a/backend/src/board/admin/comment.py
+++ b/backend/src/board/admin/comment.py
@@ -1,3 +1,6 @@
+import re
+from html import unescape
+
 from django.contrib import admin
 from django.utils.html import strip_tags, format_html
 from django.utils.safestring import mark_safe
@@ -6,12 +9,13 @@ from django.db.models import Count
 
 from board.models import Comment
 
+from .mixins import ReadOnlyRecordAdminMixin
 from .service import AdminDisplayService, AdminLinkService
 from .constants import COLOR_MUTED, COLOR_DARKENED_BG, COLOR_WARNING, COLOR_DANGER, COLOR_TEXT, COLOR_BG, COLOR_BORDER
 
 
 @admin.register(Comment)
-class CommentAdmin(admin.ModelAdmin):
+class CommentAdmin(ReadOnlyRecordAdminMixin, admin.ModelAdmin):
     autocomplete_fields = ['post']
     search_fields = ['text_md', 'author__username', 'post__title']
 
@@ -25,7 +29,7 @@ class CommentAdmin(admin.ModelAdmin):
 
     fieldsets = (
         ('기본 정보', {
-            'fields': ('author', 'post', 'author_info')
+            'fields': ('author', 'post', 'parent', 'author_info')
         }),
         ('내용', {
             'fields': ('text_md', 'text_html', 'edited', 'heart')
@@ -38,15 +42,38 @@ class CommentAdmin(admin.ModelAdmin):
             'classes': ('collapse',),
         }),
     )
-    readonly_fields = ['author', 'post', 'author_info', 'text_html_preview', 'likes_count', 'created_at']
+    readonly_fields = [
+        'author',
+        'post',
+        'parent',
+        'author_info',
+        'text_md',
+        'text_html',
+        'edited',
+        'heart',
+        'text_html_preview',
+        'likes_count',
+        'created_at',
+    ]
 
     def text_html_preview(self, obj):
-        return AdminDisplayService.html(
+        content_with_breaks = re.sub(
+            r'<\s*br\s*/?\s*>',
+            '\n',
             obj.text_html,
-            use_folding=True,
-            remove_lazy_load=True,
+            flags=re.IGNORECASE,
         )
-    text_html_preview.short_description = 'HTML 미리보기'
+        content_with_breaks = re.sub(
+            r'</\s*(?:p|div|li)\s*>',
+            '\n',
+            content_with_breaks,
+            flags=re.IGNORECASE,
+        )
+        return format_html(
+            '<div style="white-space: pre-wrap;">{}</div>',
+            unescape(strip_tags(content_with_breaks)).strip(),
+        )
+    text_html_preview.short_description = '텍스트 미리보기'
 
     list_display = ['id', 'content_preview', 'post_link', 'author_link', 'likes_display', 'status_badges', 'created_date']
     list_display_links = ['content_preview']

--- a/backend/src/board/admin/form.py
+++ b/backend/src/board/admin/form.py
@@ -1,26 +1,46 @@
 from django.contrib import admin
-from django.urls import reverse
-from django.utils.safestring import mark_safe
 
 from board.models import Form
 
+from .mixins import ReadOnlyRecordAdminMixin
 from .service import AdminLinkService
 
 
 @admin.register(Form)
-class FormAdmin(admin.ModelAdmin):
-    list_display = ['id', 'user_link', 'title', 'is_public', 'created_date']
+class FormAdmin(ReadOnlyRecordAdminMixin, admin.ModelAdmin):
+    list_display = [
+        'id',
+        'user_link',
+        'title',
+        'is_public',
+        'created_date',
+        'updated_date',
+    ]
     list_per_page = 30
     search_fields = ['title', 'user__username']
     list_filter = ['is_public', ('created_date', admin.DateFieldListFilter)]
+    fields = [
+        'user_link',
+        'title',
+        'content',
+        'is_public',
+        'created_date',
+        'updated_date',
+    ]
+    readonly_fields = fields
 
     def get_queryset(self, request):
-        return super().get_queryset(request).select_related('user')
+        queryset = super().get_queryset(request).select_related('user')
+        if (
+            getattr(request, 'resolver_match', None)
+            and request.resolver_match.url_name == 'board_form_changelist'
+        ):
+            return queryset.defer('content')
+        return queryset
+
+    def has_delete_permission(self, request, obj=None):
+        return False
 
     def user_link(self, obj):
         return AdminLinkService.create_user_link(obj.user)
     user_link.short_description = '사용자'
-
-    def get_form(self, request, obj=None, **kwargs):
-        kwargs['exclude'] = ['user']
-        return super().get_form(request, obj, **kwargs)

--- a/backend/src/board/admin/mixins.py
+++ b/backend/src/board/admin/mixins.py
@@ -1,0 +1,24 @@
+class ReadOnlyRecordAdminMixin:
+    """Inspect externally owned or system-managed rows without editing them."""
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        if obj is not None:
+            return False
+        return super().has_change_permission(request, obj)
+
+
+class ConfirmedActionDeleteAdminMixin:
+    """Disable Django deletes while retaining delete permission for actions."""
+
+    def get_actions(self, request):
+        actions = super().get_actions(request)
+        actions.pop('delete_selected', None)
+        return actions
+
+    def has_delete_permission(self, request, obj=None):
+        if obj is not None:
+            return False
+        return super().has_delete_permission(request, obj)

--- a/backend/src/board/admin/user.py
+++ b/backend/src/board/admin/user.py
@@ -3,10 +3,11 @@ User & Profile Admin Configuration
 """
 from typing import Any, Optional
 from django import forms
-from django.contrib import admin
+from django.contrib import admin, messages
 from django.contrib.auth.models import User
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
 from django.http import HttpRequest
+from django.db import transaction
 from django.db.models import Count, QuerySet
 from django.urls import reverse
 from django.utils.html import format_html, format_html_join
@@ -16,27 +17,137 @@ from board.models import (
     EmailChange, Profile
 )
 from board.constants.config_meta import CONFIG_TYPES
+from board.services.email_change_service import (
+    EmailChangeCancellationError,
+    EmailChangeService,
+)
 from board.services.user_role_service import UserRoleService
 
+from .action_confirmation import render_action_confirmation
+from .mixins import (
+    ConfirmedActionDeleteAdminMixin,
+    ReadOnlyRecordAdminMixin,
+)
 from .service import AdminDisplayService, AdminLinkService
 from .constants import COLOR_MUTED, COLOR_INFO, COLOR_BG, COLOR_TEXT
 from .constants import LIST_PER_PAGE_DEFAULT
 
 
 @admin.register(EmailChange)
-class EmailChangeAdmin(admin.ModelAdmin):
-    list_display = ['id', 'user', 'email', 'created_date']
+class EmailChangeAdmin(
+    ConfirmedActionDeleteAdminMixin,
+    ReadOnlyRecordAdminMixin,
+    admin.ModelAdmin,
+):
+    list_display = [
+        'id',
+        'user_link',
+        'email',
+        'token_status',
+        'created_date',
+    ]
     list_per_page = LIST_PER_PAGE_DEFAULT
     search_fields = ['user__username', 'email']
-    readonly_fields = ['user', 'email', 'created_date']
+    fields = ['user_link', 'email', 'token_status', 'created_date']
+    readonly_fields = [
+        'user_link',
+        'email',
+        'token_status',
+        'created_date',
+    ]
+    actions = ['cancel_email_changes']
+
+    def get_queryset(self, request):
+        return super().get_queryset(request).select_related('user').defer(
+            'auth_token',
+        )
+
+    def user_link(self, obj: EmailChange):
+        return AdminLinkService.create_user_link(obj.user)
+    user_link.short_description = '사용자'
+    user_link.admin_order_field = 'user__username'
+
+    def token_status(self, obj: EmailChange):
+        return AdminDisplayService.boolean_badge(
+            True,
+            true_text='비공개',
+        )
+    token_status.short_description = '인증 토큰'
+
+    @admin.action(
+        description='선택한 이메일 변경 요청 취소',
+        permissions=['delete'],
+    )
+    def cancel_email_changes(
+        self,
+        request: HttpRequest,
+        queryset: QuerySet[EmailChange],
+    ) -> Any:
+        if request.POST.get('confirm') != 'yes':
+            if not queryset.exists():
+                self.message_user(
+                    request,
+                    '취소할 이메일 변경 요청이 없습니다.',
+                    level=messages.WARNING,
+                )
+                return None
+            return render_action_confirmation(
+                request,
+                self,
+                queryset,
+                action_name='cancel_email_changes',
+                title='이메일 변경 요청 취소 확인',
+                warning=(
+                    '선택한 대기 요청과 인증 토큰만 삭제됩니다. 사용자의 '
+                    '현재 이메일은 바뀌지 않습니다.'
+                ),
+                confirm_label='변경 요청 취소',
+            )
+
+        cancelled = 0
+        failed = 0
+        for email_change in queryset.select_related('user'):
+            try:
+                with transaction.atomic():
+                    self.log_deletions(request, [email_change])
+                    EmailChangeService.cancel_pending_change(email_change)
+            except EmailChangeCancellationError:
+                failed += 1
+                continue
+            cancelled += 1
+
+        self.message_user(
+            request,
+            f'{cancelled}개의 이메일 변경 요청을 취소했습니다.',
+            level=messages.SUCCESS,
+        )
+        if failed:
+            self.message_user(
+                request,
+                f'{failed}개는 이미 처리되어 취소하지 못했습니다.',
+                level=messages.WARNING,
+            )
+        return None
 
 
 @admin.register(UsernameChangeLog)
-class UsernameChangeLogAdmin(admin.ModelAdmin):
-    list_display = ['id', 'user', 'username', 'created_date']
+class UsernameChangeLogAdmin(ReadOnlyRecordAdminMixin, admin.ModelAdmin):
+    list_display = ['id', 'user_link', 'username', 'created_date']
     list_per_page = LIST_PER_PAGE_DEFAULT
     search_fields = ['user__username', 'username']
-    readonly_fields = ['user', 'username', 'created_date']
+    fields = ['user_link', 'username', 'created_date']
+    readonly_fields = fields
+
+    def get_queryset(self, request):
+        return super().get_queryset(request).select_related('user')
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+    def user_link(self, obj: UsernameChangeLog):
+        return AdminLinkService.create_user_link(obj.user)
+    user_link.short_description = '현재 사용자'
+    user_link.admin_order_field = 'user__username'
 
 
 class UserLinkMetaInline(admin.TabularInline):

--- a/backend/src/board/services/email_change_service.py
+++ b/backend/src/board/services/email_change_service.py
@@ -1,0 +1,29 @@
+from django.db import transaction
+
+from board.models import EmailChange
+
+
+class EmailChangeCancellationError(Exception):
+    pass
+
+
+class EmailChangeService:
+    """Manage pending email changes without mutating the user account."""
+
+    @staticmethod
+    @transaction.atomic
+    def cancel_pending_change(email_change: EmailChange) -> int:
+        try:
+            pending_change = (
+                EmailChange.objects.select_for_update()
+                .only('id')
+                .get(pk=email_change.pk)
+            )
+        except EmailChange.DoesNotExist as error:
+            raise EmailChangeCancellationError(
+                '취소할 이메일 변경 요청을 찾을 수 없습니다.',
+            ) from error
+
+        pending_change_id = pending_change.pk
+        pending_change.delete()
+        return pending_change_id

--- a/backend/src/board/services/social_auth_connection_service.py
+++ b/backend/src/board/services/social_auth_connection_service.py
@@ -1,0 +1,40 @@
+from django.contrib.auth.models import User
+from django.db import transaction
+
+from board.models import SocialAuth
+
+
+class SocialAuthDisconnectError(Exception):
+    pass
+
+
+class SocialAuthConnectionService:
+    """Disconnect social identities while preserving an account login path."""
+
+    @staticmethod
+    @transaction.atomic
+    def disconnect(social_auth: SocialAuth) -> int:
+        try:
+            connection = (
+                SocialAuth.objects.select_for_update()
+                .only('id', 'user_id')
+                .get(pk=social_auth.pk)
+            )
+        except SocialAuth.DoesNotExist as error:
+            raise SocialAuthDisconnectError(
+                '해제할 소셜 로그인 연동을 찾을 수 없습니다.',
+            ) from error
+
+        user = User.objects.select_for_update().get(pk=connection.user_id)
+        has_another_connection = SocialAuth.objects.select_for_update().filter(
+            user_id=user.pk,
+        ).exclude(pk=connection.pk).exists()
+        if not user.has_usable_password() and not has_another_connection:
+            raise SocialAuthDisconnectError(
+                '사용 가능한 비밀번호나 다른 소셜 로그인이 없어 연동을 '
+                '해제할 수 없습니다.',
+            )
+
+        connection_id = connection.pk
+        connection.delete()
+        return connection_id

--- a/backend/src/board/services/two_factor_setup_service.py
+++ b/backend/src/board/services/two_factor_setup_service.py
@@ -142,16 +142,22 @@ class TwoFactorSetupService:
 
     @staticmethod
     def disable(user: User) -> None:
-        if not hasattr(user, 'twofactorauth'):
+        try:
+            two_factor_auth = TwoFactorAuth.objects.only(
+                'id',
+                'user_id',
+                'created_date',
+            ).get(user=user)
+        except TwoFactorAuth.DoesNotExist:
             raise TwoFactorSetupError(ErrorCode.ALREADY_DISCONNECTED)
 
-        if not user.twofactorauth.has_been_a_day():
+        if not two_factor_auth.has_been_a_day():
             raise TwoFactorSetupError(
                 ErrorCode.REJECT,
                 '24시간 동안 해제할 수 없습니다.',
             )
 
-        user.twofactorauth.delete()
+        two_factor_auth.delete()
 
     @classmethod
     @transaction.atomic

--- a/backend/src/board/tests/admin/test_system_record_admin.py
+++ b/backend/src/board/tests/admin/test_system_record_admin.py
@@ -1,0 +1,448 @@
+from datetime import timedelta
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from django.contrib import admin
+from django.contrib.admin import helpers
+from django.contrib.admin.models import DELETION, LogEntry
+from django.contrib.auth.models import User
+from django.contrib.messages.storage.fallback import FallbackStorage
+from django.template.response import TemplateResponse
+from django.test import RequestFactory, TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from board.admin.auth import SocialAuthAdmin, TwoFactorAuthAdmin
+from board.admin.comment import CommentAdmin
+from board.admin.form import FormAdmin
+from board.admin.user import EmailChangeAdmin, UsernameChangeLogAdmin
+from board.models import (
+    Comment,
+    EmailChange,
+    Form,
+    Post,
+    SocialAuth,
+    SocialAuthProvider,
+    TwoFactorAuth,
+    UsernameChangeLog,
+)
+from board.services.email_change_service import EmailChangeService
+from board.services.social_auth_connection_service import (
+    SocialAuthConnectionService,
+)
+from board.services.two_factor_setup_service import TwoFactorSetupService
+
+
+class SystemRecordAdminTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.admin_user = User.objects.create_superuser(
+            username='system-admin',
+            email='system-admin@example.com',
+            password='test',
+        )
+        cls.user = User.objects.create_user(
+            username='account-owner',
+            email='current@example.com',
+            password='usable-password',
+        )
+        cls.passwordless_user = User.objects.create_user(
+            username='social-only',
+            email='social-only@example.com',
+            password=None,
+        )
+        cls.provider = SocialAuthProvider.objects.get(key='github')
+
+    def setUp(self):
+        self.email_admin = EmailChangeAdmin(EmailChange, admin.site)
+        self.username_admin = UsernameChangeLogAdmin(
+            UsernameChangeLog,
+            admin.site,
+        )
+        self.two_factor_admin = TwoFactorAuthAdmin(
+            TwoFactorAuth,
+            admin.site,
+        )
+        self.social_admin = SocialAuthAdmin(SocialAuth, admin.site)
+        self.form_admin = FormAdmin(Form, admin.site)
+        self.comment_admin = CommentAdmin(Comment, admin.site)
+
+    def admin_request(self, method='get', data=None, path='/admin/'):
+        factory_method = getattr(RequestFactory(), method)
+        request = factory_method(path, data=data or {})
+        request.user = self.admin_user
+        request.session = {}
+        request._messages = FallbackStorage(request)
+        return request
+
+    @staticmethod
+    def action_selection(action: str, object_id: int) -> dict[str, object]:
+        return {
+            helpers.ACTION_CHECKBOX_NAME: [str(object_id)],
+            'action': action,
+            'select_across': '0',
+        }
+
+    def create_two_factor_auth(self, *, old_enough=True) -> TwoFactorAuth:
+        created_date = timezone.now()
+        if old_enough:
+            created_date -= timedelta(days=2)
+        return TwoFactorAuth.objects.create(
+            user=self.user,
+            recovery_key='recovery-key-secret',
+            totp_secret='totp-secret-value',
+            created_date=created_date,
+        )
+
+    def create_social_auth(self, *, passwordless=False) -> SocialAuth:
+        user = self.passwordless_user if passwordless else self.user
+        return SocialAuth.objects.create(
+            user=user,
+            provider=self.provider,
+            uid=f'external-identity-secret-{user.pk}',
+            extra_data='{"access_token":"provider-token-secret"}',
+        )
+
+    def create_comment(self) -> Comment:
+        post = Post.objects.create(
+            author=self.user,
+            title='Comment admin post',
+            url='comment-admin-post',
+            published_date=timezone.now(),
+        )
+        return Comment.objects.create(
+            author=self.user,
+            post=post,
+            text_md='Legacy comment',
+            text_html=(
+                '<p>First line<br>Second line</p>'
+                '<script>alert("admin-xss")</script>'
+            ),
+        )
+
+    def test_system_owned_records_have_no_add_or_edit_surface(self):
+        email_change = EmailChange.objects.create(
+            user=self.user,
+            email='next@example.com',
+            auth_token='12345678',
+        )
+        username_log = UsernameChangeLog.objects.create(
+            user=self.user,
+            username='old-username',
+        )
+        two_factor_auth = self.create_two_factor_auth()
+        social_auth = self.create_social_auth()
+        form = Form.objects.create(
+            user=self.user,
+            title='User form',
+            content='<p>User-owned content</p>',
+        )
+        comment = self.create_comment()
+        request = self.admin_request()
+
+        records = [
+            (self.email_admin, email_change),
+            (self.username_admin, username_log),
+            (self.two_factor_admin, two_factor_auth),
+            (self.social_admin, social_auth),
+            (self.form_admin, form),
+            (self.comment_admin, comment),
+        ]
+        for model_admin, record in records:
+            with self.subTest(model=type(record).__name__):
+                self.assertFalse(model_admin.has_add_permission(request))
+                self.assertFalse(
+                    model_admin.has_change_permission(request, record),
+                )
+
+        self.assertFalse(
+            self.username_admin.has_delete_permission(request, username_log),
+        )
+        self.assertFalse(self.form_admin.has_delete_permission(request, form))
+        self.assertFalse(
+            self.email_admin.has_delete_permission(request, email_change),
+        )
+        self.assertFalse(
+            self.two_factor_admin.has_delete_permission(
+                request,
+                two_factor_auth,
+            ),
+        )
+        self.assertFalse(
+            self.social_admin.has_delete_permission(request, social_auth),
+        )
+
+        self.assertNotIn(
+            'delete_selected',
+            self.email_admin.get_actions(request),
+        )
+        self.assertNotIn(
+            'delete_selected',
+            self.two_factor_admin.get_actions(request),
+        )
+        self.assertNotIn(
+            'delete_selected',
+            self.social_admin.get_actions(request),
+        )
+
+    def test_sensitive_auth_values_are_not_loaded_or_rendered(self):
+        email_change = EmailChange.objects.create(
+            user=self.user,
+            email='next@example.com',
+            auth_token='87654321',
+        )
+        two_factor_auth = self.create_two_factor_auth()
+        social_auth = self.create_social_auth()
+        two_factor_auth.refresh_from_db()
+        stored_recovery_key = two_factor_auth.recovery_key
+        stored_totp_secret = two_factor_auth.totp_secret
+
+        email_request = self.admin_request()
+        email_request.resolver_match = SimpleNamespace(
+            url_name='board_emailchange_changelist',
+        )
+        loaded_email = self.email_admin.get_queryset(email_request).get(
+            pk=email_change.pk,
+        )
+        self.assertIn('auth_token', loaded_email.get_deferred_fields())
+
+        two_factor_request = self.admin_request()
+        loaded_two_factor = self.two_factor_admin.get_queryset(
+            two_factor_request,
+        ).get(pk=two_factor_auth.pk)
+        self.assertTrue(
+            {'recovery_key', 'totp_secret'}.issubset(
+                loaded_two_factor.get_deferred_fields(),
+            ),
+        )
+
+        social_request = self.admin_request()
+        loaded_social = self.social_admin.get_queryset(social_request).get(
+            pk=social_auth.pk,
+        )
+        self.assertTrue(
+            {'uid', 'extra_data'}.issubset(
+                loaded_social.get_deferred_fields(),
+            ),
+        )
+
+        self.client.force_login(self.admin_user)
+        responses = [
+            self.client.get(
+                reverse(
+                    'admin:board_emailchange_change',
+                    args=[email_change.pk],
+                ),
+            ),
+            self.client.get(
+                reverse(
+                    'admin:board_twofactorauth_change',
+                    args=[two_factor_auth.pk],
+                ),
+            ),
+            self.client.get(
+                reverse(
+                    'admin:board_socialauth_change',
+                    args=[social_auth.pk],
+                ),
+            ),
+        ]
+        for response in responses:
+            self.assertEqual(response.status_code, 200)
+            self.assertNotContains(response, 'name="_save"')
+
+        rendered = b''.join(response.content for response in responses)
+        for secret in (
+            b'87654321',
+            stored_recovery_key.encode(),
+            stored_totp_secret.encode(),
+            f'external-identity-secret-{self.user.pk}'.encode(),
+            b'provider-token-secret',
+        ):
+            self.assertNotIn(secret, rendered)
+
+    def test_email_change_cancel_requires_confirmation_and_keeps_user_email(self):
+        pending_change = EmailChange.objects.create(
+            user=self.user,
+            email='next@example.com',
+            auth_token='12345678',
+        )
+        action = 'cancel_email_changes'
+        selection = self.action_selection(action, pending_change.pk)
+        queryset = EmailChange.objects.filter(pk=pending_change.pk)
+
+        confirmation = self.email_admin.cancel_email_changes(
+            self.admin_request('post', selection),
+            queryset,
+        )
+        self.assertIsInstance(confirmation, TemplateResponse)
+        confirmation.render()
+        self.assertTrue(queryset.exists())
+
+        with patch.object(
+            EmailChangeService,
+            'cancel_pending_change',
+            wraps=EmailChangeService.cancel_pending_change,
+        ) as cancel_pending_change:
+            self.email_admin.cancel_email_changes(
+                self.admin_request(
+                    'post',
+                    {**selection, 'confirm': 'yes'},
+                ),
+                queryset,
+            )
+
+        cancel_pending_change.assert_called_once()
+        self.assertFalse(EmailChange.objects.filter(pk=pending_change.pk).exists())
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.email, 'current@example.com')
+        self.assertTrue(
+            LogEntry.objects.filter(
+                object_id=str(pending_change.pk),
+                action_flag=DELETION,
+            ).exists(),
+        )
+
+    def test_two_factor_disable_uses_existing_policy_and_audit_log(self):
+        two_factor_auth = self.create_two_factor_auth()
+        action = 'disable_two_factor_auth'
+        selection = self.action_selection(action, two_factor_auth.pk)
+        queryset = TwoFactorAuth.objects.filter(pk=two_factor_auth.pk)
+
+        confirmation = self.two_factor_admin.disable_two_factor_auth(
+            self.admin_request('post', selection),
+            queryset,
+        )
+        self.assertIsInstance(confirmation, TemplateResponse)
+        confirmation.render()
+
+        with patch.object(
+            TwoFactorSetupService,
+            'disable',
+            wraps=TwoFactorSetupService.disable,
+        ) as disable:
+            self.two_factor_admin.disable_two_factor_auth(
+                self.admin_request(
+                    'post',
+                    {**selection, 'confirm': 'yes'},
+                ),
+                queryset,
+            )
+
+        disable.assert_called_once()
+        self.assertFalse(
+            TwoFactorAuth.objects.filter(pk=two_factor_auth.pk).exists(),
+        )
+        self.assertTrue(User.objects.filter(pk=self.user.pk).exists())
+        self.assertTrue(
+            LogEntry.objects.filter(
+                object_id=str(two_factor_auth.pk),
+                action_flag=DELETION,
+            ).exists(),
+        )
+
+    def test_two_factor_disable_keeps_recent_setup(self):
+        two_factor_auth = self.create_two_factor_auth(old_enough=False)
+        selection = self.action_selection(
+            'disable_two_factor_auth',
+            two_factor_auth.pk,
+        )
+
+        self.two_factor_admin.disable_two_factor_auth(
+            self.admin_request(
+                'post',
+                {**selection, 'confirm': 'yes'},
+            ),
+            TwoFactorAuth.objects.filter(pk=two_factor_auth.pk),
+        )
+
+        self.assertTrue(
+            TwoFactorAuth.objects.filter(pk=two_factor_auth.pk).exists(),
+        )
+        self.assertFalse(
+            LogEntry.objects.filter(
+                object_id=str(two_factor_auth.pk),
+                action_flag=DELETION,
+            ).exists(),
+        )
+
+    def test_social_disconnect_preserves_at_least_one_login_method(self):
+        safe_connection = self.create_social_auth()
+        locked_connection = self.create_social_auth(passwordless=True)
+
+        for connection, should_disconnect in (
+            (safe_connection, True),
+            (locked_connection, False),
+        ):
+            selection = self.action_selection(
+                'disconnect_social_auth',
+                connection.pk,
+            )
+            queryset = SocialAuth.objects.filter(pk=connection.pk)
+            with patch.object(
+                SocialAuthConnectionService,
+                'disconnect',
+                wraps=SocialAuthConnectionService.disconnect,
+            ) as disconnect:
+                self.social_admin.disconnect_social_auth(
+                    self.admin_request(
+                        'post',
+                        {**selection, 'confirm': 'yes'},
+                    ),
+                    queryset,
+                )
+
+            disconnect.assert_called_once()
+            self.assertEqual(
+                SocialAuth.objects.filter(pk=connection.pk).exists(),
+                not should_disconnect,
+            )
+            self.assertEqual(
+                LogEntry.objects.filter(
+                    object_id=str(connection.pk),
+                    action_flag=DELETION,
+                ).exists(),
+                should_disconnect,
+            )
+
+        self.assertTrue(
+            User.objects.filter(pk=self.passwordless_user.pk).exists(),
+        )
+
+    def test_social_disconnect_allows_another_social_login_to_remain(self):
+        selected_connection = self.create_social_auth(passwordless=True)
+        other_provider = SocialAuthProvider.objects.get(key='google')
+        retained_connection = SocialAuth.objects.create(
+            user=self.passwordless_user,
+            provider=other_provider,
+            uid='retained-google-identity',
+            extra_data='{}',
+        )
+        selection = self.action_selection(
+            'disconnect_social_auth',
+            selected_connection.pk,
+        )
+
+        self.social_admin.disconnect_social_auth(
+            self.admin_request(
+                'post',
+                {**selection, 'confirm': 'yes'},
+            ),
+            SocialAuth.objects.filter(pk=selected_connection.pk),
+        )
+
+        self.assertFalse(
+            SocialAuth.objects.filter(pk=selected_connection.pk).exists(),
+        )
+        self.assertTrue(
+            SocialAuth.objects.filter(pk=retained_connection.pk).exists(),
+        )
+
+    def test_comment_preview_is_plain_text_and_preserves_line_breaks(self):
+        comment = self.create_comment()
+        preview = str(self.comment_admin.text_html_preview(comment))
+
+        self.assertNotIn('<script>', preview)
+        self.assertNotIn('<br>', preview)
+        self.assertIn('First line\nSecond line', preview)
+        self.assertIn('alert(&quot;admin-xss&quot;)', preview)


### PR DESCRIPTION
## 🎯 Goal
- 사용자 또는 시스템이 소유하는 레코드를 Django Admin에서 임의 생성·편집해 인증·감사·콘텐츠 계약을 우회하지 않게 합니다.
- 인증 토큰, 2FA secret, 복구 키, 외부 계정 식별자와 제공자 원본 데이터를 Admin 쿼리와 화면에서 제외합니다.

## 🔧 Core Changes
- EmailChange, UsernameChangeLog, TwoFactorAuth, SocialAuth, Form, Comment의 잘못된 Add·편집 표면을 읽기 전용으로 전환했습니다.
- 이메일 변경 요청 취소, 2FA 해제, 소셜 로그인 연동 해제를 확인·서비스·트랜잭션·감사 로그 기반 액션으로 제공했습니다.
- 비밀번호 없는 계정의 마지막 소셜 로그인 수단은 해제할 수 없게 했습니다.
- 2FA 해제는 기존 24시간 제한과 공개 API 응답 계약을 그대로 사용합니다.
- 댓글 HTML 미리보기는 실행하지 않고 기존 줄바꿈을 보존한 일반 텍스트로 표시합니다.
- 폼 대용량 본문과 인증 비밀 필드는 목록 쿼리에서 제외합니다.

## 🤔 Key Decisions
- UsernameChangeLog는 이전 사용자명 리디렉션 계약을 보존하기 위해 Admin 삭제도 금지했습니다.
- Form은 제품 화면을 정본으로 두고 Admin에서는 조회만 허용했습니다.
- Comment의 하트·삭제 운영 액션 개선은 별도 파괴적 액션 PR 범위로 유지했습니다.
- 공개 URL, API, 모델, DB 스키마와 서비스 시그니처는 변경하지 않았습니다.

## 🧪 Verification Guide
### How to verify
1. 대상 Admin 상세에서 추가·저장·직접 삭제 버튼이 노출되지 않는지 확인합니다.
2. 인증 레코드 목록과 상세 HTML에 비밀값이 포함되지 않는지 확인합니다.
3. 이메일 요청 취소, 2FA 해제, 소셜 연동 해제가 확인 화면과 감사 로그를 거치는지 확인합니다.
4. 비밀번호 없는 마지막 소셜 연동과 생성 24시간 이내 2FA가 보존되는지 확인합니다.

### Expected result
- 시스템 레코드는 읽기 전용이며 필요한 지원 작업만 안전한 명시적 액션으로 수행됩니다.
- 기존 사용자 인증·폼·댓글 API 동작에는 변화가 없습니다.
- 전체 백엔드 테스트 1,242개와 정적 검사가 통과합니다.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (not needed: public contract and schema unchanged)