### PR TITLE
🐛 Harden admin notification delivery actions

### DIFF
--- a/backend/src/board/admin/notify.py
+++ b/backend/src/board/admin/notify.py
@@ -1,21 +1,67 @@
 """
 Notification Admin Configuration
 """
-from typing import Any, Optional
-from django.contrib import admin
-from django.http import HttpRequest, HttpResponse
-from django.db.models import QuerySet
-from django.template.defaultfilters import truncatewords
-from django.shortcuts import render, redirect
-from django.urls import path
-from django.contrib.auth.models import User
+import logging
+from typing import Any
+
 from django import forms
+from django.contrib import admin, messages
+from django.contrib.admin.models import ADDITION, LogEntry
+from django.contrib.auth.models import User
+from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import PermissionDenied
+from django.db import transaction
+from django.db.models import QuerySet
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import redirect, render
+from django.template.defaultfilters import truncatewords
+from django.urls import path
+from django.utils import timezone
 
 from board.models import Notify
-from board.modules.notify import create_notify
+from board.services.bulk_notification_delivery_service import (
+    BulkNotificationDeliveryService,
+)
 
-from .service import AdminLinkService, AdminDisplayService
-from .constants import LIST_PER_PAGE_DEFAULT, CONTENT_PREVIEW_WORDS, DATETIME_FORMAT_FULL
+from .action_confirmation import render_action_confirmation
+from .constants import (
+    CONTENT_PREVIEW_WORDS,
+    DATETIME_FORMAT_FULL,
+    LIST_PER_PAGE_DEFAULT,
+)
+from .service import AdminDisplayService, AdminLinkService
+
+logger = logging.getLogger('board.notification')
+
+
+class NotifyAdminForm(forms.ModelForm):
+    """Validate notification identity before the Admin save lifecycle."""
+
+    class Meta:
+        model = Notify
+        fields = ['user', 'url', 'content', 'has_read']
+
+    def clean(self) -> dict[str, Any]:
+        cleaned_data = super().clean()
+        user = cleaned_data.get('user')
+        url = cleaned_data.get('url')
+        content = cleaned_data.get('content')
+        if user is None or url is None or content is None:
+            return cleaned_data
+
+        key = Notify.create_hash_key(
+            user=user,
+            url=url,
+            content=content,
+        )
+        duplicates = Notify.objects.filter(key=key)
+        if self.instance.pk is not None:
+            duplicates = duplicates.exclude(pk=self.instance.pk)
+        if duplicates.exists():
+            raise forms.ValidationError('이미 동일한 알림이 존재합니다.')
+
+        self.instance.key = key
+        return cleaned_data
 
 
 class BulkNotificationForm(forms.Form):
@@ -31,13 +77,14 @@ class BulkNotificationForm(forms.Form):
     content = forms.CharField(
         label='알림 내용',
         widget=forms.Textarea(attrs={'rows': 5, 'style': 'width: 100%;'}),
-        help_text='모든 사용자에게 전송될 알림 메시지'
+        help_text='모든 활성 사용자에게 전송될 알림 메시지'
     )
 
 
 @admin.register(Notify)
 class NotifyAdmin(admin.ModelAdmin):
     """알림 관리 페이지"""
+    form = NotifyAdminForm
     autocomplete_fields = ['user']
     search_fields = ['content', 'user__username', 'url']
 
@@ -47,9 +94,16 @@ class NotifyAdmin(admin.ModelAdmin):
         ('updated_date', admin.DateFieldListFilter),
     ]
 
-    actions = ['mark_as_read', 'mark_as_unread', 'send_notifications']
+    actions = ['mark_as_read', 'mark_as_unread', 'resend_notifications']
 
-    list_display = ['id', 'user_link', 'content_preview', 'read_status', 'url_link', 'created_date']
+    list_display = [
+        'id',
+        'user_link',
+        'content_preview',
+        'read_status',
+        'url_link',
+        'created_date',
+    ]
     list_display_links = ['content_preview']
     list_per_page = LIST_PER_PAGE_DEFAULT
     date_hierarchy = 'created_date'
@@ -96,89 +150,251 @@ class NotifyAdmin(admin.ModelAdmin):
         return AdminDisplayService.date_display(obj.updated_date, DATETIME_FORMAT_FULL)
     updated_at.short_description = '수정일시'
 
-    def mark_as_read(self, request: HttpRequest, queryset: QuerySet[Notify]) -> None:
-        count = queryset.update(has_read=True)
-        self.message_user(request, f'{count}개의 알림을 읽음으로 표시했습니다.')
-    mark_as_read.short_description = '선택한 알림을 읽음으로 표시'
+    def set_read_status(
+        self,
+        request: HttpRequest,
+        queryset: QuerySet[Notify],
+        *,
+        has_read: bool,
+    ) -> int:
+        updated_at = timezone.now()
+        with transaction.atomic():
+            notifications = list(queryset.select_for_update())
+            notification_ids = [notify.pk for notify in notifications]
+            count = Notify.objects.filter(pk__in=notification_ids).update(
+                has_read=has_read,
+                updated_date=updated_at,
+            )
+            status_label = '읽음' if has_read else '읽지 않음'
+            for notify in notifications:
+                notify.has_read = has_read
+                notify.updated_date = updated_at
+                self.log_change(
+                    request,
+                    notify,
+                    f'Admin에서 {status_label} 상태로 변경',
+                )
+        return count
 
-    def mark_as_unread(self, request: HttpRequest, queryset: QuerySet[Notify]) -> None:
-        count = queryset.update(has_read=False)
-        self.message_user(request, f'{count}개의 알림을 읽지 않음으로 표시했습니다.')
-    mark_as_unread.short_description = '선택한 알림을 읽지 않음으로 표시'
+    @admin.action(
+        description='선택한 알림을 읽음으로 표시',
+        permissions=['change'],
+    )
+    def mark_as_read(
+        self,
+        request: HttpRequest,
+        queryset: QuerySet[Notify],
+    ) -> None:
+        count = self.set_read_status(
+            request,
+            queryset,
+            has_read=True,
+        )
+        self.message_user(
+            request,
+            f'{count}개의 알림을 읽음으로 표시했습니다.',
+            level=messages.SUCCESS,
+        )
 
-    def send_notifications(self, request: HttpRequest, queryset: QuerySet[Notify]) -> None:
-        """텔레그램 알림 전송 (개별 처리 필요)"""
-        count = 0
-        for notify in queryset:
+    @admin.action(
+        description='선택한 알림을 읽지 않음으로 표시',
+        permissions=['change'],
+    )
+    def mark_as_unread(
+        self,
+        request: HttpRequest,
+        queryset: QuerySet[Notify],
+    ) -> None:
+        count = self.set_read_status(
+            request,
+            queryset,
+            has_read=False,
+        )
+        self.message_user(
+            request,
+            f'{count}개의 알림을 읽지 않음으로 표시했습니다.',
+            level=messages.SUCCESS,
+        )
+
+    @admin.action(
+        description='선택한 알림 외부 채널로 재발송',
+        permissions=['change'],
+    )
+    def resend_notifications(
+        self,
+        request: HttpRequest,
+        queryset: QuerySet[Notify],
+    ) -> Any:
+        if request.POST.get('confirm') != 'yes':
+            if not queryset.exists():
+                self.message_user(
+                    request,
+                    '재발송할 알림이 없습니다.',
+                    level=messages.WARNING,
+                )
+                return None
+            return render_action_confirmation(
+                request,
+                self,
+                queryset,
+                action_name='resend_notifications',
+                title='외부 알림 재발송 확인',
+                warning=(
+                    '선택한 알림을 연결된 외부 채널로 다시 전송합니다. '
+                    '수신자에게 중복 알림이 전달될 수 있습니다.'
+                ),
+                confirm_label='외부 알림 재발송',
+            )
+
+        sent_count = 0
+        failed_count = 0
+        for notify in queryset.select_related('user'):
             try:
+                with transaction.atomic():
+                    self.log_change(
+                        request,
+                        notify,
+                        'Admin에서 외부 알림 재발송 요청',
+                    )
                 notify.send_notify()
-                count += 1
-            except Exception as e:
-                self.message_user(request, f'알림 전송 실패: {str(e)}', level='ERROR')
-        self.message_user(request, f'{count}개의 알림을 전송했습니다.')
-    send_notifications.short_description = '선택한 알림 전송 (텔레그램)'
+            except Exception as error:
+                failed_count += 1
+                logger.error(
+                    'Admin notification resend failed notification_id=%s '
+                    'exception_type=%s',
+                    notify.pk,
+                    type(error).__name__,
+                )
+                continue
+            sent_count += 1
 
-    def save_model(self, request: HttpRequest, obj: Notify, form: Any, change: bool) -> None:
-        """중복 체크 후 저장"""
-        obj.key = Notify.create_hash_key(user=obj.user, url=obj.url, content=obj.content)
-        if Notify.objects.filter(key=obj.key).exists():
-            self.message_user(request, '이미 동일한 알림이 존재합니다.', level='WARNING')
+        self.message_user(
+            request,
+            f'{sent_count}개의 알림을 외부 채널로 재발송했습니다.',
+            level=messages.SUCCESS,
+        )
+        if failed_count:
+            self.message_user(
+                request,
+                f'{failed_count}개의 알림은 재발송하지 못했습니다.',
+                level=messages.ERROR,
+            )
+        return None
+
+    def save_model(
+        self,
+        request: HttpRequest,
+        obj: Notify,
+        form: Any,
+        change: bool,
+    ) -> None:
+        """Send newly created notifications without resending Admin edits."""
+        obj.key = Notify.create_hash_key(
+            user=obj.user,
+            url=obj.url,
+            content=obj.content,
+        )
+        super().save_model(request, obj, form, change)
+        if change:
             return
 
-        super().save_model(request, obj, form, change)
         try:
             obj.send_notify()
-        except Exception as e:
-            self.message_user(request, f'알림 전송 실패: {str(e)}', level='ERROR')
+        except Exception as error:
+            logger.error(
+                'Admin notification delivery failed notification_id=%s '
+                'exception_type=%s',
+                obj.pk,
+                type(error).__name__,
+            )
+            self.message_user(
+                request,
+                '알림은 저장했지만 외부 채널 전송을 예약하지 못했습니다.',
+                level=messages.ERROR,
+            )
 
     def get_urls(self):
         """Custom URL 추가"""
         urls = super().get_urls()
         custom_urls = [
-            path('bulk-send/', self.admin_site.admin_view(self.bulk_send_view), name='board_notify_bulk_send'),
+            path(
+                'bulk-send/',
+                self.admin_site.admin_view(self.bulk_send_view),
+                name='board_notify_bulk_send',
+            ),
         ]
         return custom_urls + urls
 
     def bulk_send_view(self, request: HttpRequest) -> HttpResponse:
         """일괄 알림 발송 페이지"""
+        if not self.has_add_permission(request):
+            raise PermissionDenied
+
+        confirmation = False
+        target_count = None
+        notification_url = None
+        notification_content = None
         if request.method == 'POST':
             form = BulkNotificationForm(request.POST)
             if form.is_valid():
                 url = form.cleaned_data['url'] or '/'
                 content = form.cleaned_data['content']
-
-                # 모든 활성 사용자에게 발송
-                users = User.objects.filter(is_active=True)
-                success_count = 0
-                fail_count = 0
-
-                for user in users:
-                    try:
-                        create_notify(user=user, url=url, content=content)
-                        success_count += 1
-                    except Exception as e:
-                        fail_count += 1
-                        print(f'Failed to send notification to {user.username}: {e}')
-
-                self.message_user(
-                    request,
-                    f'총 {success_count}명에게 알림을 발송했습니다. (실패: {fail_count}명)',
-                    level='SUCCESS'
+                user_ids = list(
+                    User.objects.filter(is_active=True).values_list(
+                        'pk',
+                        flat=True,
+                    )
                 )
-                return redirect('..')
+                target_count = len(user_ids)
+                notification_url = url
+                notification_content = content
+
+                if request.POST.get('confirm') != 'yes':
+                    confirmation = True
+                elif not user_ids:
+                    self.message_user(
+                        request,
+                        '발송할 활성 사용자가 없습니다.',
+                        level=messages.WARNING,
+                    )
+                    return redirect('..')
+                else:
+                    content_type = ContentType.objects.get_for_model(Notify)
+                    with transaction.atomic():
+                        LogEntry.objects.create(
+                            user=request.user,
+                            content_type=content_type,
+                            object_id=None,
+                            object_repr=f'전체 알림 발송 ({target_count}명)',
+                            action_flag=ADDITION,
+                            change_message=(
+                                'Admin 전체 알림 발송 예약: '
+                                f'대상 {target_count}명'
+                            ),
+                        )
+                    BulkNotificationDeliveryService.enqueue(
+                        user_ids=user_ids,
+                        url=url,
+                        content=content,
+                    )
+                    self.message_user(
+                        request,
+                        f'{target_count}명 대상 알림 발송 작업을 예약했습니다. '
+                        '동일한 알림은 건너뜁니다.',
+                        level=messages.SUCCESS,
+                    )
+                    return redirect('..')
         else:
             form = BulkNotificationForm()
 
         context = {
             **self.admin_site.each_context(request),
-            'title': '전체 사용자에게 알림 발송',
+            'title': '전체 활성 사용자에게 알림 발송',
             'form': form,
             'opts': self.model._meta,
+            'confirmation': confirmation,
+            'target_count': target_count,
+            'notification_url': notification_url,
+            'notification_content': notification_content,
         }
         return render(request, 'admin/board/notify/bulk_send.html', context)
-
-    def changelist_view(self, request, extra_context=None):
-        """알림 목록 페이지에 일괄 발송 버튼 추가"""
-        extra_context = extra_context or {}
-        extra_context['show_bulk_send_button'] = True
-        return super().changelist_view(request, extra_context=extra_context)

--- a/backend/src/board/modules/notify.py
+++ b/backend/src/board/modules/notify.py
@@ -1,15 +1,12 @@
-from board.models import Notify
+from board.services.notification_creation_service import (
+    NotificationCreationService,
+)
+
 
 def create_notify(user, url: str, content: str, hidden_key: str = None):
-    key = Notify.create_hash_key(user=user, url=url, content=content, hidden_key=hidden_key)
-
-    if Notify.objects.filter(key=key).exists():
-        return
-
-    new_notify = Notify.objects.create(
+    NotificationCreationService.create(
         user=user,
-        key=key,
         url=url,
         content=content,
+        hidden_key=hidden_key,
     )
-    new_notify.send_notify()

--- a/backend/src/board/services/bulk_notification_delivery_service.py
+++ b/backend/src/board/services/bulk_notification_delivery_service.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Sequence
+
+from django.contrib.auth.models import User
+
+from modules.sub_task import SubTaskProcessor
+
+from board.services.notification_creation_service import (
+    NotificationCreationService,
+)
+
+logger = logging.getLogger('board.notification')
+
+
+@dataclass(frozen=True)
+class BulkNotificationDeliveryStats:
+    requested_count: int
+    success_count: int
+    duplicate_count: int
+    failure_count: int
+
+
+class BulkNotificationDeliveryService:
+    """Process an Admin bulk-notification request outside its HTTP request."""
+
+    @staticmethod
+    def enqueue(user_ids: Sequence[int], url: str, content: str) -> None:
+        SubTaskProcessor.process(
+            BulkNotificationDeliveryService.deliver,
+            list(user_ids),
+            url,
+            content,
+        )
+
+    @staticmethod
+    def deliver(
+        user_ids: Sequence[int],
+        url: str,
+        content: str,
+    ) -> BulkNotificationDeliveryStats:
+        users_by_id = User.objects.in_bulk(user_ids)
+        success_count = 0
+        duplicate_count = 0
+        failure_count = 0
+
+        for user_id in user_ids:
+            user = users_by_id.get(user_id)
+            if user is None:
+                failure_count += 1
+                continue
+
+            try:
+                _, created = NotificationCreationService.create(
+                    user=user,
+                    url=url,
+                    content=content,
+                )
+            except Exception as error:
+                failure_count += 1
+                logger.error(
+                    'Bulk notification processing failed exception_type=%s',
+                    type(error).__name__,
+                )
+                continue
+
+            if created:
+                success_count += 1
+            else:
+                duplicate_count += 1
+
+        stats = BulkNotificationDeliveryStats(
+            requested_count=len(user_ids),
+            success_count=success_count,
+            duplicate_count=duplicate_count,
+            failure_count=failure_count,
+        )
+        logger.info(
+            'Bulk notification processing completed requested=%s '
+            'succeeded=%s duplicated=%s failed=%s',
+            stats.requested_count,
+            stats.success_count,
+            stats.duplicate_count,
+            stats.failure_count,
+        )
+        return stats

--- a/backend/src/board/services/notification_creation_service.py
+++ b/backend/src/board/services/notification_creation_service.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from django.contrib.auth.models import User
+from django.db import transaction
+
+from board.models import Notify
+
+
+class NotificationCreationService:
+    """Create a notification once before requesting external delivery."""
+
+    @staticmethod
+    def create(
+        user: User,
+        url: str,
+        content: str,
+        hidden_key: str | None = None,
+    ) -> tuple[Notify, bool]:
+        key = Notify.create_hash_key(
+            user=user,
+            url=url,
+            content=content,
+            hidden_key=hidden_key,
+        )
+        with transaction.atomic():
+            notify, created = Notify.objects.get_or_create(
+                key=key,
+                defaults={
+                    'user': user,
+                    'url': url,
+                    'content': content,
+                },
+            )
+
+        if created:
+            notify.send_notify()
+
+        return notify, created

--- a/backend/src/board/templates/admin/board/notify/bulk_send.html
+++ b/backend/src/board/templates/admin/board/notify/bulk_send.html
@@ -17,8 +17,38 @@
         {% csrf_token %}
 
         <div>
+            {% if confirmation %}
+            {{ form.url.as_hidden }}
+            {{ form.content.as_hidden }}
+            <input type="hidden" name="confirm" value="yes" />
+
             <fieldset class="module aligned">
-                <h2>전체 사용자에게 알림 발송</h2>
+                <h2>발송 대상 확인</h2>
+                <div class="form-row">
+                    <p><strong>현재 활성 사용자 {{ target_count }}명</strong>에게 알림 발송 작업을 예약합니다.</p>
+                    <p class="help">이미 동일한 알림이 있는 사용자는 중복 발송하지 않고 건너뜁니다.</p>
+                </div>
+                <div class="form-row">
+                    <div>
+                        <label>링크 URL:</label>
+                        <div class="readonly">{{ notification_url }}</div>
+                    </div>
+                </div>
+                <div class="form-row">
+                    <div>
+                        <label>알림 내용:</label>
+                        <div class="readonly">{{ notification_content|linebreaksbr }}</div>
+                    </div>
+                </div>
+            </fieldset>
+
+            <div class="submit-row">
+                <input type="submit" value="{{ target_count }}명에게 발송 예약" class="default" />
+                <a href="{% url 'admin:board_notify_changelist' %}" class="button cancel-link">취소</a>
+            </div>
+            {% else %}
+            <fieldset class="module aligned">
+                <h2>전체 활성 사용자에게 알림 발송</h2>
                 <div class="form-row">
                     {{ form.url.errors }}
                     <div>
@@ -43,9 +73,10 @@
             </fieldset>
 
             <div class="submit-row">
-                <input type="submit" value="전체 사용자에게 발송" class="default" />
+                <input type="submit" value="발송 대상 확인" class="default" />
                 <a href="{% url 'admin:board_notify_changelist' %}" class="button cancel-link">취소</a>
             </div>
+            {% endif %}
         </div>
     </form>
 </div>

--- a/backend/src/board/templates/admin/board/notify/change_list.html
+++ b/backend/src/board/templates/admin/board/notify/change_list.html
@@ -1,10 +1,12 @@
 {% extends "admin/change_list.html" %}
 
 {% block object-tools-items %}
+    {% if has_add_permission %}
     <li>
         <a href="bulk-send/" class="addlink">
-            전체 사용자에게 알림 발송
+            전체 활성 사용자에게 알림 발송
         </a>
     </li>
+    {% endif %}
     {{ block.super }}
 {% endblock %}

--- a/backend/src/board/tests/admin/test_notify_admin.py
+++ b/backend/src/board/tests/admin/test_notify_admin.py
@@ -1,0 +1,370 @@
+from datetime import timedelta
+from unittest.mock import patch
+
+from django.contrib import admin
+from django.contrib.admin import helpers
+from django.contrib.admin.models import ADDITION, CHANGE, LogEntry
+from django.contrib.auth.models import User
+from django.contrib.messages.storage.fallback import FallbackStorage
+from django.core.exceptions import PermissionDenied
+from django.template.response import TemplateResponse
+from django.test import RequestFactory, TestCase
+from django.utils import timezone
+
+from board.admin.notify import NotifyAdmin, NotifyAdminForm
+from board.models import Notify
+from board.services.bulk_notification_delivery_service import (
+    BulkNotificationDeliveryService,
+)
+
+
+class NotifyAdminTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.admin_user = User.objects.create_superuser(
+            username='notification-admin',
+            email='notification-admin@example.com',
+            password='test',
+        )
+        cls.user = User.objects.create_user(
+            username='notification-recipient',
+            password='test',
+        )
+        cls.inactive_user = User.objects.create_user(
+            username='inactive-notification-recipient',
+            password='test',
+            is_active=False,
+        )
+        cls.staff_without_permission = User.objects.create_user(
+            username='notification-staff',
+            password='test',
+            is_staff=True,
+        )
+
+    def setUp(self):
+        self.admin_instance = NotifyAdmin(Notify, admin.site)
+
+    def admin_request(
+        self,
+        method: str = 'get',
+        data: dict[str, object] | None = None,
+        *,
+        user: User | None = None,
+    ):
+        factory_method = getattr(RequestFactory(), method)
+        request = factory_method(
+            '/admin/board/notify/',
+            data=data or {},
+        )
+        request.user = user or self.admin_user
+        request.session = {}
+        request._messages = FallbackStorage(request)
+        return request
+
+    @staticmethod
+    def action_selection(action: str, object_ids: list[int]) -> dict[str, object]:
+        return {
+            helpers.ACTION_CHECKBOX_NAME: [str(object_id) for object_id in object_ids],
+            'action': action,
+            'select_across': '0',
+        }
+
+    @staticmethod
+    def message_text(request) -> str:
+        return ' '.join(str(message) for message in request._messages)
+
+    def create_notification(
+        self,
+        *,
+        user: User | None = None,
+        url: str = '/notification',
+        content: str = 'Notification content',
+        has_read: bool = False,
+    ) -> Notify:
+        recipient = user or self.user
+        return Notify.objects.create(
+            user=recipient,
+            key=Notify.create_hash_key(recipient, url, content),
+            url=url,
+            content=content,
+            has_read=has_read,
+        )
+
+    def test_form_allows_the_current_row_but_rejects_another_duplicate(self):
+        notification = self.create_notification()
+        form_data = {
+            'user': self.user.pk,
+            'url': notification.url,
+            'content': notification.content,
+            'has_read': '',
+        }
+
+        current_form = NotifyAdminForm(
+            data=form_data,
+            instance=notification,
+        )
+        duplicate_form = NotifyAdminForm(data=form_data)
+
+        self.assertTrue(current_form.is_valid(), current_form.errors)
+        self.assertFalse(duplicate_form.is_valid())
+        self.assertIn(
+            '이미 동일한 알림이 존재합니다.',
+            duplicate_form.non_field_errors(),
+        )
+
+    def test_admin_save_dispatches_add_but_never_resends_an_edit(self):
+        request = self.admin_request('post')
+        notification = Notify(
+            user=self.user,
+            url='/admin-created',
+            content='Created in Admin',
+        )
+
+        with patch.object(Notify, 'send_notify') as send_notify:
+            self.admin_instance.save_model(
+                request,
+                notification,
+                form=None,
+                change=False,
+            )
+            notification.content = 'Edited in Admin'
+            self.admin_instance.save_model(
+                request,
+                notification,
+                form=None,
+                change=True,
+            )
+
+        send_notify.assert_called_once()
+        notification.refresh_from_db()
+        self.assertEqual(notification.content, 'Edited in Admin')
+
+    def test_admin_save_hides_delivery_error_details(self):
+        request = self.admin_request('post')
+        notification = Notify(
+            user=self.user,
+            url='/admin-failure',
+            content='Created before delivery failure',
+        )
+
+        with patch.object(
+            Notify,
+            'send_notify',
+            side_effect=RuntimeError('telegram-token-secret'),
+        ):
+            self.admin_instance.save_model(
+                request,
+                notification,
+                form=None,
+                change=False,
+            )
+
+        self.assertTrue(Notify.objects.filter(pk=notification.pk).exists())
+        messages = self.message_text(request)
+        self.assertIn('외부 채널 전송을 예약하지 못했습니다.', messages)
+        self.assertNotIn('telegram-token-secret', messages)
+
+    def test_read_action_updates_timestamp_and_writes_audit_log(self):
+        notification = self.create_notification()
+        previous_updated_date = timezone.now() - timedelta(days=1)
+        Notify.objects.filter(pk=notification.pk).update(
+            updated_date=previous_updated_date,
+        )
+
+        self.admin_instance.mark_as_read(
+            self.admin_request('post'),
+            Notify.objects.filter(pk=notification.pk),
+        )
+
+        notification.refresh_from_db()
+        self.assertTrue(notification.has_read)
+        self.assertGreater(notification.updated_date, previous_updated_date)
+        self.assertTrue(
+            LogEntry.objects.filter(
+                object_id=str(notification.pk),
+                action_flag=CHANGE,
+                change_message__contains='읽음 상태로 변경',
+            ).exists(),
+        )
+
+    def test_read_action_rolls_back_when_audit_log_fails(self):
+        notification = self.create_notification()
+
+        with patch.object(
+            self.admin_instance,
+            'log_change',
+            side_effect=RuntimeError('audit unavailable'),
+        ):
+            with self.assertRaisesRegex(RuntimeError, 'audit unavailable'):
+                self.admin_instance.mark_as_read(
+                    self.admin_request('post'),
+                    Notify.objects.filter(pk=notification.pk),
+                )
+
+        notification.refresh_from_db()
+        self.assertFalse(notification.has_read)
+
+    def test_resend_requires_confirmation_and_isolates_failures(self):
+        first = self.create_notification(content='First')
+        second = self.create_notification(content='Second')
+        selection = self.action_selection(
+            'resend_notifications',
+            [first.pk, second.pk],
+        )
+        queryset = Notify.objects.filter(pk__in=[first.pk, second.pk])
+
+        confirmation = self.admin_instance.resend_notifications(
+            self.admin_request('post', selection),
+            queryset,
+        )
+
+        self.assertIsInstance(confirmation, TemplateResponse)
+        confirmation.render()
+
+        confirmed_request = self.admin_request(
+            'post',
+            {**selection, 'confirm': 'yes'},
+        )
+        with patch.object(
+            Notify,
+            'send_notify',
+            side_effect=[None, RuntimeError('provider-secret')],
+        ) as send_notify:
+            self.admin_instance.resend_notifications(
+                confirmed_request,
+                queryset,
+            )
+
+        self.assertEqual(send_notify.call_count, 2)
+        self.assertEqual(
+            LogEntry.objects.filter(
+                object_id__in=[str(first.pk), str(second.pk)],
+                action_flag=CHANGE,
+                change_message__contains='외부 알림 재발송 요청',
+            ).count(),
+            2,
+        )
+        messages = self.message_text(confirmed_request)
+        self.assertIn('1개의 알림을 외부 채널로 재발송했습니다.', messages)
+        self.assertIn('1개의 알림은 재발송하지 못했습니다.', messages)
+        self.assertNotIn('provider-secret', messages)
+
+    def test_resend_never_dispatches_when_audit_log_fails(self):
+        notification = self.create_notification()
+        request = self.admin_request(
+            'post',
+            {
+                **self.action_selection(
+                    'resend_notifications',
+                    [notification.pk],
+                ),
+                'confirm': 'yes',
+            },
+        )
+
+        with patch.object(
+            self.admin_instance,
+            'log_change',
+            side_effect=RuntimeError('audit unavailable'),
+        ):
+            with patch.object(Notify, 'send_notify') as send_notify:
+                self.admin_instance.resend_notifications(
+                    request,
+                    Notify.objects.filter(pk=notification.pk),
+                )
+
+        send_notify.assert_not_called()
+
+    def test_bulk_send_confirms_active_targets_then_audits_and_enqueues(self):
+        form_data = {
+            'url': '/admin/bulk',
+            'content': '<script>private bulk content</script>',
+        }
+        active_user_ids = list(
+            User.objects.filter(is_active=True).values_list('pk', flat=True),
+        )
+        request = self.admin_request(
+            'post',
+            form_data,
+        )
+
+        with patch.object(
+            BulkNotificationDeliveryService,
+            'enqueue',
+        ) as enqueue:
+            confirmation = self.admin_instance.bulk_send_view(request)
+
+        self.assertEqual(confirmation.status_code, 200)
+        self.assertContains(
+            confirmation,
+            f'현재 활성 사용자 {len(active_user_ids)}명',
+        )
+        self.assertNotContains(
+            confirmation,
+            '<script>private bulk content</script>',
+        )
+        self.assertContains(
+            confirmation,
+            '&lt;script&gt;private bulk content&lt;/script&gt;',
+            html=False,
+        )
+        enqueue.assert_not_called()
+        self.assertFalse(LogEntry.objects.filter(action_flag=ADDITION).exists())
+
+        confirmed_request = self.admin_request(
+            'post',
+            {**form_data, 'confirm': 'yes'},
+        )
+        with patch.object(
+            BulkNotificationDeliveryService,
+            'enqueue',
+        ) as enqueue:
+            response = self.admin_instance.bulk_send_view(confirmed_request)
+
+        self.assertEqual(response.status_code, 302)
+        enqueue.assert_called_once_with(
+            user_ids=active_user_ids,
+            url='/admin/bulk',
+            content='<script>private bulk content</script>',
+        )
+        self.assertEqual(Notify.objects.count(), 0)
+        audit_log = LogEntry.objects.get(action_flag=ADDITION)
+        self.assertIsNone(audit_log.object_id)
+        self.assertIn(str(len(active_user_ids)), audit_log.object_repr)
+        self.assertNotIn('/admin/bulk', audit_log.change_message)
+        self.assertNotIn('private bulk content', audit_log.change_message)
+
+    def test_bulk_send_requires_add_permission(self):
+        request = self.admin_request(
+            user=self.staff_without_permission,
+        )
+
+        with self.assertRaises(PermissionDenied):
+            self.admin_instance.bulk_send_view(request)
+
+    def test_bulk_send_does_not_enqueue_when_audit_log_fails(self):
+        request = self.admin_request(
+            'post',
+            {
+                'url': '/admin/bulk',
+                'content': 'Audited content',
+                'confirm': 'yes',
+            },
+        )
+
+        with patch.object(
+            LogEntry.objects,
+            'create',
+            side_effect=RuntimeError('audit unavailable'),
+        ):
+            with patch.object(
+                BulkNotificationDeliveryService,
+                'enqueue',
+            ) as enqueue:
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    'audit unavailable',
+                ):
+                    self.admin_instance.bulk_send_view(request)
+
+        enqueue.assert_not_called()

--- a/backend/src/board/tests/services/test_notification_creation_service.py
+++ b/backend/src/board/tests/services/test_notification_creation_service.py
@@ -1,0 +1,104 @@
+from unittest.mock import patch
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from board.models import Notify
+from board.modules.notify import create_notify
+from board.services.bulk_notification_delivery_service import (
+    BulkNotificationDeliveryService,
+)
+from board.services.notification_creation_service import (
+    NotificationCreationService,
+)
+
+
+class NotificationCreationServiceTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user(
+            username='notification-owner',
+            password='test',
+        )
+
+    def test_legacy_create_notify_creates_and_dispatches_only_once(self):
+        with patch.object(Notify, 'send_notify') as send_notify:
+            first_result = create_notify(
+                self.user,
+                '/notifications/once',
+                'Only once',
+            )
+            second_result = create_notify(
+                self.user,
+                '/notifications/once',
+                'Only once',
+            )
+
+        self.assertIsNone(first_result)
+        self.assertIsNone(second_result)
+        self.assertEqual(Notify.objects.count(), 1)
+        send_notify.assert_called_once()
+
+    def test_delivery_failure_keeps_the_created_notification(self):
+        with patch.object(
+            Notify,
+            'send_notify',
+            side_effect=RuntimeError('external-secret-value'),
+        ):
+            with self.assertRaisesRegex(
+                RuntimeError,
+                'external-secret-value',
+            ):
+                NotificationCreationService.create(
+                    self.user,
+                    '/notifications/failure',
+                    'Persist before delivery',
+                )
+
+        self.assertTrue(
+            Notify.objects.filter(
+                user=self.user,
+                url='/notifications/failure',
+                content='Persist before delivery',
+            ).exists(),
+        )
+
+    def test_bulk_delivery_isolates_duplicate_missing_and_failed_users(self):
+        duplicate_user = User.objects.create_user(
+            username='notification-duplicate',
+        )
+        failed_user = User.objects.create_user(
+            username='notification-failure',
+        )
+        missing_user_id = failed_user.pk + 1000
+
+        with patch.object(
+            NotificationCreationService,
+            'create',
+            side_effect=[
+                (object(), True),
+                (object(), False),
+                RuntimeError('sensitive-provider-error'),
+            ],
+        ) as create_notification:
+            with self.assertLogs('board.notification', level='INFO') as logs:
+                stats = BulkNotificationDeliveryService.deliver(
+                    [
+                        self.user.pk,
+                        duplicate_user.pk,
+                        failed_user.pk,
+                        missing_user_id,
+                    ],
+                    '/bulk',
+                    'Bulk content must not be logged',
+                )
+
+        self.assertEqual(create_notification.call_count, 3)
+        self.assertEqual(stats.requested_count, 4)
+        self.assertEqual(stats.success_count, 1)
+        self.assertEqual(stats.duplicate_count, 1)
+        self.assertEqual(stats.failure_count, 2)
+        log_output = ' '.join(logs.output)
+        self.assertNotIn('sensitive-provider-error', log_output)
+        self.assertNotIn('Bulk content must not be logged', log_output)
+        self.assertNotIn('/bulk', log_output)


### PR DESCRIPTION
## 🎯 Goal
- Prevent Django Admin notification edits from unexpectedly resending external messages.
- Make explicit resend and active-user bulk delivery permission-aware, confirmable, auditable, asynchronous, and safe on partial failure without changing public notification callers.

## 🔧 Core Changes
- Added self-excluding duplicate validation and limited automatic delivery to newly added Admin notifications.
- Added confirmation and per-record audit logging for explicit external resend, plus audited transactional read-status changes.
- Changed bulk delivery into a two-step active-user confirmation flow that records target counts and schedules background processing.
- Centralized race-safe notification creation while preserving the existing `create_notify` signature and `None` return behavior.
- Added focused Django unit tests for permission, duplicate, audit, rollback, escaping, compatibility, and partial-failure contracts.

## 🤔 Key Decisions
- Reused the existing background task processor so the Admin request no longer waits on every active user; introducing a new queue dependency is outside this compatibility-focused PR.
- Kept external message content and URLs out of audit and operational logs; only target and result counts are recorded.
- Kept a persisted notification when external delivery setup fails, matching the previous create-before-deliver behavior.

## 🧪 Verification Guide
### How to verify
1. Open Django Admin notifications, edit an existing notification, and confirm it saves without external resend.
2. Select notifications and choose external resend; verify confirmation appears and the Admin log records each request.
3. Open the active-user bulk send page, submit content, confirm the displayed target count, then verify the request reports a scheduled job rather than blocking.
4. Run `npm run server:test` and `npm run server:check-migrations`.

### Expected result
- Notification actions require the appropriate permission and explicit confirmation where duplicate delivery is possible.
- Bulk processing skips duplicate rows, isolates failures, exposes no message secrets in logs, and public callers retain their existing contract.
- All 1,255 backend tests pass and no migration is generated.

## ✅ Checklist
- [x] Lint completed (not applicable: no Islands code changed)
- [x] Type-check completed (not applicable: no Islands code changed)
- [x] Tests completed
- [x] Documentation updated (not needed: no public contract changed)