### PR TITLE
🐛 Guard destructive admin actions

### DIFF
--- a/backend/src/board/admin/comment.py
+++ b/backend/src/board/admin/comment.py
@@ -1,21 +1,33 @@
 import re
 from html import unescape
+from typing import Any
 
-from django.contrib import admin
+from django.contrib import admin, messages
+from django.db import transaction
+from django.db.models import Count, QuerySet
+from django.http import HttpRequest
+from django.template.defaultfilters import truncatewords
 from django.utils.html import strip_tags, format_html
 from django.utils.safestring import mark_safe
-from django.template.defaultfilters import truncatewords
-from django.db.models import Count
 
 from board.models import Comment
+from board.services.comment_service import CommentService
 
-from .mixins import ReadOnlyRecordAdminMixin
+from .action_confirmation import render_action_confirmation
+from .mixins import (
+    ConfirmedActionDeleteAdminMixin,
+    ReadOnlyRecordAdminMixin,
+)
 from .service import AdminDisplayService, AdminLinkService
 from .constants import COLOR_MUTED, COLOR_DARKENED_BG, COLOR_WARNING, COLOR_DANGER, COLOR_TEXT, COLOR_BG, COLOR_BORDER
 
 
 @admin.register(Comment)
-class CommentAdmin(ReadOnlyRecordAdminMixin, admin.ModelAdmin):
+class CommentAdmin(
+    ConfirmedActionDeleteAdminMixin,
+    ReadOnlyRecordAdminMixin,
+    admin.ModelAdmin,
+):
     autocomplete_fields = ['post']
     search_fields = ['text_md', 'author__username', 'post__title']
 
@@ -25,7 +37,7 @@ class CommentAdmin(ReadOnlyRecordAdminMixin, admin.ModelAdmin):
         ('created_date', admin.DateFieldListFilter),
     ]
 
-    actions = ['mark_as_heart', 'unmark_as_heart', 'delete_selected_comments']
+    actions = ['mark_as_heart', 'unmark_as_heart', 'soft_delete_comments']
 
     fieldsets = (
         ('기본 정보', {
@@ -153,19 +165,117 @@ class CommentAdmin(ReadOnlyRecordAdminMixin, admin.ModelAdmin):
         return obj.created_date.strftime('%Y-%m-%d %H:%M:%S')
     created_at.short_description = '작성일시'
 
-    # Custom Actions
-    def mark_as_heart(self, request, queryset):
-        count = queryset.update(heart=True)
-        self.message_user(request, f'{count}개의 댓글을 하트로 표시했습니다.')
-    mark_as_heart.short_description = '선택한 댓글을 하트로 표시'
+    def set_heart_status(
+        self,
+        request: HttpRequest,
+        queryset: QuerySet[Comment],
+        *,
+        heart: bool,
+    ) -> int:
+        with transaction.atomic():
+            comments = list(
+                queryset.select_for_update().exclude(heart=heart),
+            )
+            status_label = '하트 표시' if heart else '하트 해제'
+            for comment in comments:
+                comment.heart = heart
+                comment.save(update_fields=['heart'])
+                self.log_change(
+                    request,
+                    comment,
+                    f'Admin에서 {status_label}',
+                )
+        return len(comments)
 
-    def unmark_as_heart(self, request, queryset):
-        count = queryset.update(heart=False)
-        self.message_user(request, f'{count}개의 댓글의 하트를 해제했습니다.')
-    unmark_as_heart.short_description = '선택한 댓글의 하트 해제'
+    @admin.action(
+        description='선택한 댓글을 하트로 표시',
+        permissions=['change'],
+    )
+    def mark_as_heart(
+        self,
+        request: HttpRequest,
+        queryset: QuerySet[Comment],
+    ) -> None:
+        count = self.set_heart_status(
+            request,
+            queryset,
+            heart=True,
+        )
+        self.message_user(
+            request,
+            f'{count}개의 댓글을 하트로 표시했습니다.',
+            level=messages.SUCCESS,
+        )
 
-    def delete_selected_comments(self, request, queryset):
-        count = queryset.count()
-        queryset.delete()
-        self.message_user(request, f'{count}개의 댓글을 삭제했습니다.')
-    delete_selected_comments.short_description = '선택한 댓글 삭제'
+    @admin.action(
+        description='선택한 댓글의 하트 해제',
+        permissions=['change'],
+    )
+    def unmark_as_heart(
+        self,
+        request: HttpRequest,
+        queryset: QuerySet[Comment],
+    ) -> None:
+        count = self.set_heart_status(
+            request,
+            queryset,
+            heart=False,
+        )
+        self.message_user(
+            request,
+            f'{count}개의 댓글의 하트를 해제했습니다.',
+            level=messages.SUCCESS,
+        )
+
+    @admin.action(
+        description='선택한 댓글을 삭제 상태로 전환',
+        permissions=['delete'],
+    )
+    def soft_delete_comments(
+        self,
+        request: HttpRequest,
+        queryset: QuerySet[Comment],
+    ) -> Any:
+        active_comments = queryset.filter(author__isnull=False)
+        if request.POST.get('confirm') != 'yes':
+            if not active_comments.exists():
+                self.message_user(
+                    request,
+                    '삭제 상태로 전환할 댓글이 없습니다.',
+                    level=messages.WARNING,
+                )
+                return None
+            return render_action_confirmation(
+                request,
+                self,
+                active_comments,
+                action_name='soft_delete_comments',
+                title='댓글 삭제 상태 전환 확인',
+                warning=(
+                    '댓글 행과 답글 관계는 유지되며 공개 화면에는 삭제된 '
+                    '댓글로 표시됩니다. 작성자 연결은 복구할 수 없습니다.'
+                ),
+                confirm_label='댓글 삭제 상태로 전환',
+            )
+
+        with transaction.atomic():
+            comments = list(
+                active_comments.select_for_update().select_related(
+                    'author',
+                    'post',
+                ),
+            )
+            for comment in comments:
+                CommentService.delete_comment(comment)
+                self.log_change(
+                    request,
+                    comment,
+                    'Admin에서 댓글 삭제 상태로 전환',
+                )
+
+        self.message_user(
+            request,
+            f'{len(comments)}개의 댓글을 삭제 상태로 전환했습니다.',
+            level=messages.SUCCESS,
+        )
+        return None

--- a/backend/src/board/admin/tag.py
+++ b/backend/src/board/admin/tag.py
@@ -1,18 +1,26 @@
-from django.contrib import admin
-from django.db.models import Count
+from typing import Any
+
+from django.contrib import admin, messages
+from django.db import transaction
+from django.db.models import Count, QuerySet
+from django.http import HttpRequest
 from django.utils.html import format_html
 
 from board.models import Tag
+
+from .action_confirmation import render_action_confirmation
 from .constants import (
     COLOR_INFO, COLOR_BG, COLOR_DANGER, COLOR_WARNING,
     COLOR_SUCCESS, COLOR_MUTED, COLOR_TEXT
 )
+from .mixins import ConfirmedActionDeleteAdminMixin
+from .utilities import TagCleanerService
 
 
 @admin.register(Tag)
-class TagAdmin(admin.ModelAdmin):
+class TagAdmin(ConfirmedActionDeleteAdminMixin, admin.ModelAdmin):
     search_fields = ['value']
-    actions = ['clear_unused_tags', 'merge_tags']
+    actions = ['clear_unused_tags']
 
     list_display = ['tag_badge', 'count', 'has_image', 'usage_status']
     list_display_links = ['tag_badge']
@@ -72,15 +80,68 @@ class TagAdmin(admin.ModelAdmin):
             )
     usage_status.short_description = '사용 상태'
 
-    # Custom Actions
-    def clear_unused_tags(self, request, queryset):
-        count = 0
-        total = 0
-        for tag in queryset:
-            total += 1
-            tag_count = tag.post_count if hasattr(tag, 'post_count') else tag.posts.count()
-            if tag_count == 0:
-                count += 1
-                tag.delete()
-        self.message_user(request, f'{total}개의 태그 중 참조가 없는 {count}개의 태그를 삭제했습니다.')
-    clear_unused_tags.short_description = '선택한 태그 중 미사용 태그 삭제'
+    @admin.action(
+        description='선택한 태그 중 미사용 태그 삭제',
+        permissions=['delete'],
+    )
+    def clear_unused_tags(
+        self,
+        request: HttpRequest,
+        queryset: QuerySet[Tag],
+    ) -> Any:
+        unused_tags = TagCleanerService.filter_unused(queryset)
+        if request.POST.get('confirm') != 'yes':
+            if not unused_tags.exists():
+                self.message_user(
+                    request,
+                    '선택한 항목에 미사용 태그가 없습니다.',
+                    level=messages.WARNING,
+                )
+                return None
+            return render_action_confirmation(
+                request,
+                self,
+                unused_tags,
+                action_name='clear_unused_tags',
+                title='미사용 태그 삭제 확인',
+                warning=(
+                    '현재 어떤 포스트에서도 참조하지 않는 태그만 삭제합니다. '
+                    '삭제한 태그는 복구할 수 없습니다.'
+                ),
+                confirm_label='미사용 태그 삭제',
+            )
+
+        selected_ids = list(queryset.values_list('pk', flat=True))
+        with transaction.atomic():
+            unused_ids = list(
+                TagCleanerService.filter_unused(
+                    Tag.objects.filter(pk__in=selected_ids),
+                ).values_list('pk', flat=True),
+            )
+            locked_tags = list(
+                Tag.objects.select_for_update().filter(pk__in=unused_ids),
+            )
+            locked_ids = [tag.pk for tag in locked_tags]
+            confirmed_unused_ids = set(
+                TagCleanerService.filter_unused(
+                    Tag.objects.filter(pk__in=locked_ids),
+                ).values_list('pk', flat=True),
+            )
+            deletable_tags = [
+                tag for tag in locked_tags
+                if tag.pk in confirmed_unused_ids
+            ]
+            self.log_deletions(request, deletable_tags)
+            count, _ = TagCleanerService.clean_selected_unused_tags(
+                Tag.objects.filter(
+                    pk__in=[tag.pk for tag in deletable_tags],
+                ),
+                execute=True,
+            )
+
+        self.message_user(
+            request,
+            f'{count}개의 미사용 태그를 삭제했습니다.',
+            level=messages.SUCCESS,
+        )
+        return None

--- a/backend/src/board/admin/user.py
+++ b/backend/src/board/admin/user.py
@@ -22,6 +22,7 @@ from board.services.email_change_service import (
     EmailChangeService,
 )
 from board.services.user_role_service import UserRoleService
+from board.services.user_management_service import UserManagementService
 
 from .action_confirmation import render_action_confirmation
 from .mixins import (
@@ -178,7 +179,7 @@ class ProfileInline(admin.StackedInline):
 admin.site.unregister(User)
 
 @admin.register(User)
-class CustomUserAdmin(BaseUserAdmin):
+class CustomUserAdmin(ConfirmedActionDeleteAdminMixin, BaseUserAdmin):
     inlines = [ProfileInline, UserLinkMetaInline]
 
     list_display = ['username', 'email', 'role_badge', 'post_count', 'is_staff', 'is_active', 'date_joined']
@@ -195,6 +196,28 @@ class CustomUserAdmin(BaseUserAdmin):
             post_count=Count('post', distinct=True)
         )
 
+    def get_readonly_fields(self, request, obj=None):
+        readonly_fields = list(super().get_readonly_fields(request, obj))
+        if obj is None:
+            return readonly_fields
+
+        is_current_user = obj.pk == request.user.pk
+        is_last_active_superuser = (
+            obj.is_active
+            and obj.is_superuser
+            and not User.objects.filter(
+                is_active=True,
+                is_superuser=True,
+            ).exclude(pk=obj.pk).exists()
+        )
+        if is_current_user or is_last_active_superuser:
+            readonly_fields.extend([
+                'is_active',
+                'is_staff',
+                'is_superuser',
+            ])
+        return list(dict.fromkeys(readonly_fields))
+
     def role_badge(self, obj):
         if hasattr(obj, 'profile'):
             return AdminDisplayService.role_badge(obj.profile.role)
@@ -207,25 +230,155 @@ class CustomUserAdmin(BaseUserAdmin):
     post_count.short_description = '포스트 수'
     post_count.admin_order_field = 'post_count'
 
-    def make_editor(self, request: HttpRequest, queryset: QuerySet[User]) -> None:
-        count = UserRoleService.set_users_role(queryset, Profile.Role.EDITOR)
+    def set_users_role(
+        self,
+        request: HttpRequest,
+        queryset: QuerySet[User],
+        *,
+        role: str,
+    ) -> int:
+        with transaction.atomic():
+            users = list(queryset.select_for_update().select_related('profile'))
+            count = UserRoleService.set_users_role(queryset, role)
+            role_label = '작가' if role == Profile.Role.EDITOR else '독자'
+            for user in users:
+                if hasattr(user, 'profile'):
+                    self.log_change(
+                        request,
+                        user,
+                        f'Admin에서 {role_label} 역할로 변경',
+                    )
+        return count
+
+    @admin.action(
+        description='선택한 사용자를 작가로 변경',
+        permissions=['change'],
+    )
+    def make_editor(
+        self,
+        request: HttpRequest,
+        queryset: QuerySet[User],
+    ) -> None:
+        count = self.set_users_role(
+            request,
+            queryset,
+            role=Profile.Role.EDITOR,
+        )
         self.message_user(request, f'{count}명의 사용자를 작가로 변경했습니다.')
-    make_editor.short_description = '선택한 사용자를 작가로 변경'
 
-    def make_reader(self, request: HttpRequest, queryset: QuerySet[User]) -> None:
-        count = UserRoleService.set_users_role(queryset, Profile.Role.READER)
+    @admin.action(
+        description='선택한 사용자를 독자로 변경',
+        permissions=['change'],
+    )
+    def make_reader(
+        self,
+        request: HttpRequest,
+        queryset: QuerySet[User],
+    ) -> None:
+        count = self.set_users_role(
+            request,
+            queryset,
+            role=Profile.Role.READER,
+        )
         self.message_user(request, f'{count}명의 사용자를 독자로 변경했습니다.')
-    make_reader.short_description = '선택한 사용자를 독자로 변경'
 
-    def activate_users(self, request: HttpRequest, queryset: QuerySet[User]) -> None:
-        count = queryset.update(is_active=True)
-        self.message_user(request, f'{count}명의 사용자를 활성화했습니다.')
-    activate_users.short_description = '선택한 사용자 활성화'
+    def set_users_active_status(
+        self,
+        request: HttpRequest,
+        queryset: QuerySet[User],
+        *,
+        is_active: bool,
+    ) -> Any:
+        candidates = queryset.filter(is_active=not is_active)
+        action_name = 'activate_users' if is_active else 'deactivate_users'
+        status_label = '활성화' if is_active else '비활성화'
+        if request.POST.get('confirm') != 'yes':
+            if not candidates.exists():
+                self.message_user(
+                    request,
+                    f'{status_label}할 사용자가 없습니다.',
+                    level=messages.WARNING,
+                )
+                return None
+            warning = (
+                '선택한 계정의 로그인과 API 접근을 다시 허용합니다.'
+                if is_active
+                else (
+                    '선택한 계정은 즉시 로그인과 API 접근이 차단됩니다. '
+                    '현재 관리자와 마지막 활성 슈퍼유저는 건너뜁니다.'
+                )
+            )
+            return render_action_confirmation(
+                request,
+                self,
+                candidates,
+                action_name=action_name,
+                title=f'사용자 {status_label} 확인',
+                warning=warning,
+                confirm_label=f'사용자 {status_label}',
+            )
 
-    def deactivate_users(self, request: HttpRequest, queryset: QuerySet[User]) -> None:
-        count = queryset.update(is_active=False)
-        self.message_user(request, f'{count}명의 사용자를 비활성화했습니다.')
-    deactivate_users.short_description = '선택한 사용자 비활성화'
+        with transaction.atomic():
+            result = UserManagementService.set_active_status(
+                request.user,
+                candidates.values_list('pk', flat=True),
+                is_active=is_active,
+            )
+            for user in result.changed_users:
+                self.log_change(
+                    request,
+                    user,
+                    f'Admin에서 계정 {status_label}',
+                )
+
+        self.message_user(
+            request,
+            f'{len(result.changed_users)}명의 사용자를 {status_label}했습니다.',
+            level=messages.SUCCESS,
+        )
+        if result.skipped_self_count:
+            self.message_user(
+                request,
+                '현재 로그인한 관리자 계정은 비활성화하지 않았습니다.',
+                level=messages.WARNING,
+            )
+        if result.skipped_last_superuser_count:
+            self.message_user(
+                request,
+                '마지막 활성 슈퍼유저 계정은 비활성화하지 않았습니다.',
+                level=messages.WARNING,
+            )
+        return None
+
+    @admin.action(
+        description='선택한 사용자 활성화',
+        permissions=['change'],
+    )
+    def activate_users(
+        self,
+        request: HttpRequest,
+        queryset: QuerySet[User],
+    ) -> Any:
+        return self.set_users_active_status(
+            request,
+            queryset,
+            is_active=True,
+        )
+
+    @admin.action(
+        description='선택한 사용자 비활성화',
+        permissions=['change'],
+    )
+    def deactivate_users(
+        self,
+        request: HttpRequest,
+        queryset: QuerySet[User],
+    ) -> Any:
+        return self.set_users_active_status(
+            request,
+            queryset,
+            is_active=False,
+        )
 
 
 @admin.register(UserConfigMeta)
@@ -445,12 +598,53 @@ class ProfileAdmin(admin.ModelAdmin):
         return obj.user.post_set.count()
     total_posts.short_description = '총 포스트 수'
 
-    def set_role_editor(self, request: HttpRequest, queryset: QuerySet[Profile]) -> None:
-        count = UserRoleService.set_profiles_role(queryset, Profile.Role.EDITOR)
-        self.message_user(request, f'{count}명의 프로필을 작가로 변경했습니다.')
-    set_role_editor.short_description = '역할을 작가로 변경'
+    def set_profiles_role(
+        self,
+        request: HttpRequest,
+        queryset: QuerySet[Profile],
+        *,
+        role: str,
+    ) -> int:
+        with transaction.atomic():
+            profiles = list(queryset.select_for_update())
+            count = UserRoleService.set_profiles_role(queryset, role)
+            role_label = '작가' if role == Profile.Role.EDITOR else '독자'
+            for profile in profiles:
+                self.log_change(
+                    request,
+                    profile,
+                    f'Admin에서 {role_label} 역할로 변경',
+                )
+        return count
 
-    def set_role_reader(self, request: HttpRequest, queryset: QuerySet[Profile]) -> None:
-        count = UserRoleService.set_profiles_role(queryset, Profile.Role.READER)
+    @admin.action(
+        description='역할을 작가로 변경',
+        permissions=['change'],
+    )
+    def set_role_editor(
+        self,
+        request: HttpRequest,
+        queryset: QuerySet[Profile],
+    ) -> None:
+        count = self.set_profiles_role(
+            request,
+            queryset,
+            role=Profile.Role.EDITOR,
+        )
+        self.message_user(request, f'{count}명의 프로필을 작가로 변경했습니다.')
+
+    @admin.action(
+        description='역할을 독자로 변경',
+        permissions=['change'],
+    )
+    def set_role_reader(
+        self,
+        request: HttpRequest,
+        queryset: QuerySet[Profile],
+    ) -> None:
+        count = self.set_profiles_role(
+            request,
+            queryset,
+            role=Profile.Role.READER,
+        )
         self.message_user(request, f'{count}명의 프로필을 독자로 변경했습니다.')
-    set_role_reader.short_description = '역할을 독자로 변경'

--- a/backend/src/board/admin/utilities/tag_cleaner.py
+++ b/backend/src/board/admin/utilities/tag_cleaner.py
@@ -1,22 +1,29 @@
 """
 태그 정리 서비스 - 미사용 태그 찾기 및 삭제
 """
-from typing import List, Dict, Any, Tuple
-from django.db.models import Count
+from typing import Any, Dict, List, Tuple
 
-from board.models import Post, Tag
+from django.db.models import Count, QuerySet
+
+from board.models import Tag
 
 
 class TagCleanerService:
     """태그 정리 서비스"""
 
     @staticmethod
+    def filter_unused(tags: QuerySet[Tag]) -> QuerySet[Tag]:
+        return tags.annotate(
+            cleanup_post_count=Count('posts', distinct=True),
+        ).filter(cleanup_post_count=0)
+
+    @staticmethod
     def get_unused_tags() -> List[Dict[str, Any]]:
         """미사용 태그 목록 조회"""
         # 포스트가 없는 태그 찾기
-        tags = Tag.objects.annotate(
-            post_count=Count('posts')
-        ).filter(post_count=0).order_by('value')
+        tags = TagCleanerService.filter_unused(
+            Tag.objects.all(),
+        ).order_by('value')
 
         unused_tags = []
         for tag in tags:
@@ -60,14 +67,23 @@ class TagCleanerService:
     @staticmethod
     def clean_unused_tags(execute: bool = False) -> Tuple[int, List[str]]:
         """미사용 태그 삭제"""
-        tags = Tag.objects.annotate(
-            post_count=Count('posts')
-        ).filter(post_count=0)
+        return TagCleanerService.clean_selected_unused_tags(
+            Tag.objects.all(),
+            execute=execute,
+        )
 
-        tag_names = [tag.value for tag in tags]
-        count = tags.count()
+    @staticmethod
+    def clean_selected_unused_tags(
+        tags: QuerySet[Tag],
+        *,
+        execute: bool = False,
+    ) -> Tuple[int, List[str]]:
+        unused_tags = TagCleanerService.filter_unused(tags)
+
+        tag_names = list(unused_tags.values_list('value', flat=True))
+        count = len(tag_names)
 
         if execute:
-            tags.delete()
+            unused_tags.delete()
 
         return count, tag_names

--- a/backend/src/board/admin/webhook.py
+++ b/backend/src/board/admin/webhook.py
@@ -1,6 +1,16 @@
-from django.contrib import admin
+from typing import Any
+
+from django.contrib import admin, messages
+from django.db import transaction
+from django.db.models import QuerySet
+from django.http import HttpRequest
 
 from board.models import WebhookSubscription
+from board.services.webhook_subscription_state_service import (
+    WebhookSubscriptionStateService,
+)
+
+from .action_confirmation import render_action_confirmation
 
 
 @admin.register(WebhookSubscription)
@@ -8,16 +18,158 @@ class WebhookSubscriptionAdmin(admin.ModelAdmin):
     list_display = ['name', 'scope', 'author', 'is_active', 'failure_count', 'last_success_date', 'created_date']
     list_filter = ['scope', 'is_active', 'failure_count', ('created_date', admin.DateFieldListFilter)]
     search_fields = ['name', 'author__user__username', 'webhook_url']
-    readonly_fields = ['created_date', 'failure_count', 'last_success_date']
+    readonly_fields = [
+        'created_date',
+        'failure_count',
+        'last_success_date',
+    ]
     list_per_page = 30
-    actions = ['reset_failure_count', 'activate_subscriptions']
+    actions = [
+        'reset_failure_count',
+        'activate_subscriptions',
+        'deactivate_subscriptions',
+    ]
 
-    @admin.action(description='실패 횟수 초기화 및 재활성화')
-    def reset_failure_count(self, request, queryset):
-        queryset.update(failure_count=0, is_active=True)
-        self.message_user(request, f'{queryset.count()}개의 웹훅을 초기화하고 재활성화했습니다.')
+    def get_readonly_fields(self, request, obj=None):
+        readonly_fields = list(super().get_readonly_fields(request, obj))
+        if obj is not None:
+            readonly_fields.append('is_active')
+        return readonly_fields
 
-    @admin.action(description='선택한 웹훅 활성화')
-    def activate_subscriptions(self, request, queryset):
-        queryset.update(is_active=True)
-        self.message_user(request, f'{queryset.count()}개의 웹훅을 활성화했습니다.')
+    def set_subscription_state(
+        self,
+        request: HttpRequest,
+        queryset: QuerySet[WebhookSubscription],
+        *,
+        is_active: bool,
+        reset_failure_count: bool = False,
+    ) -> int:
+        with transaction.atomic():
+            subscriptions = list(queryset.select_for_update())
+            for subscription in subscriptions:
+                WebhookSubscriptionStateService.set_active(
+                    subscription,
+                    is_active=is_active,
+                    reset_failure_count=reset_failure_count,
+                )
+                if reset_failure_count:
+                    change_message = (
+                        'Admin에서 실패 횟수 초기화 및 웹훅 재활성화'
+                    )
+                elif is_active:
+                    change_message = 'Admin에서 웹훅 활성화'
+                else:
+                    change_message = 'Admin에서 웹훅 비활성화'
+                self.log_change(
+                    request,
+                    subscription,
+                    change_message,
+                )
+        return len(subscriptions)
+
+    @admin.action(
+        description='실패 횟수 초기화 및 재활성화',
+        permissions=['change'],
+    )
+    def reset_failure_count(
+        self,
+        request: HttpRequest,
+        queryset: QuerySet[WebhookSubscription],
+    ) -> Any:
+        targets = queryset.exclude(is_active=True, failure_count=0)
+        if request.POST.get('confirm') != 'yes':
+            if not targets.exists():
+                self.message_user(
+                    request,
+                    '초기화하거나 재활성화할 웹훅이 없습니다.',
+                    level=messages.WARNING,
+                )
+                return None
+            return render_action_confirmation(
+                request,
+                self,
+                targets,
+                action_name='reset_failure_count',
+                title='웹훅 실패 상태 초기화 확인',
+                warning=(
+                    '실패 횟수를 0으로 초기화하고 외부 URL 전송을 다시 '
+                    '활성화합니다.'
+                ),
+                confirm_label='초기화 및 재활성화',
+            )
+
+        count = self.set_subscription_state(
+            request,
+            targets,
+            is_active=True,
+            reset_failure_count=True,
+        )
+        self.message_user(
+            request,
+            f'{count}개의 웹훅을 초기화하고 재활성화했습니다.',
+            level=messages.SUCCESS,
+        )
+        return None
+
+    @admin.action(
+        description='선택한 웹훅 활성화',
+        permissions=['change'],
+    )
+    def activate_subscriptions(
+        self,
+        request: HttpRequest,
+        queryset: QuerySet[WebhookSubscription],
+    ) -> Any:
+        targets = queryset.filter(is_active=False)
+        if request.POST.get('confirm') != 'yes':
+            if not targets.exists():
+                self.message_user(
+                    request,
+                    '활성화할 웹훅이 없습니다.',
+                    level=messages.WARNING,
+                )
+                return None
+            return render_action_confirmation(
+                request,
+                self,
+                targets,
+                action_name='activate_subscriptions',
+                title='웹훅 활성화 확인',
+                warning=(
+                    '선택한 웹훅의 외부 URL로 다음 포스트 알림부터 '
+                    '전송을 다시 시작합니다. 실패 횟수는 유지됩니다.'
+                ),
+                confirm_label='웹훅 활성화',
+            )
+
+        count = self.set_subscription_state(
+            request,
+            targets,
+            is_active=True,
+        )
+        self.message_user(
+            request,
+            f'{count}개의 웹훅을 활성화했습니다.',
+            level=messages.SUCCESS,
+        )
+        return None
+
+    @admin.action(
+        description='선택한 웹훅 비활성화',
+        permissions=['change'],
+    )
+    def deactivate_subscriptions(
+        self,
+        request: HttpRequest,
+        queryset: QuerySet[WebhookSubscription],
+    ) -> None:
+        count = self.set_subscription_state(
+            request,
+            queryset.filter(is_active=True),
+            is_active=False,
+        )
+        self.message_user(
+            request,
+            f'{count}개의 웹훅을 비활성화했습니다.',
+            level=messages.SUCCESS,
+        )

--- a/backend/src/board/services/user_management_service.py
+++ b/backend/src/board/services/user_management_service.py
@@ -4,6 +4,9 @@ Staff-facing user management service.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+from dataclasses import dataclass
+
 from django.contrib.auth.models import User
 from django.db import transaction
 from django.db.models import Count, IntegerField, OuterRef, Q, Subquery, Value
@@ -19,6 +22,13 @@ class UserManagementError(Exception):
     def __init__(self, message: str):
         super().__init__(message)
         self.message = message
+
+
+@dataclass(frozen=True)
+class UserActiveStatusResult:
+    changed_users: tuple[User, ...]
+    skipped_self_count: int
+    skipped_last_superuser_count: int
 
 
 class UserManagementService:
@@ -232,3 +242,53 @@ class UserManagementService:
 
         target.post_count = target.post_set.count()
         return UserManagementService.serialize_user(target)
+
+    @staticmethod
+    @transaction.atomic
+    def set_active_status(
+        actor: User,
+        user_ids: Iterable[int],
+        *,
+        is_active: bool,
+    ) -> UserActiveStatusResult:
+        target_ids = set(user_ids)
+        locked_users = list(
+            User.objects.select_for_update().filter(
+                Q(pk__in=target_ids)
+                | Q(is_active=True, is_superuser=True),
+            ).order_by('pk'),
+        )
+        targets = [user for user in locked_users if user.pk in target_ids]
+        active_superuser_ids = {
+            user.pk
+            for user in locked_users
+            if user.is_active and user.is_superuser
+        }
+        remaining_active_superusers = len(active_superuser_ids)
+        changed_users = []
+        skipped_self_count = 0
+        skipped_last_superuser_count = 0
+
+        for target in targets:
+            if target.is_active == is_active:
+                continue
+
+            if not is_active and target.pk == actor.pk:
+                skipped_self_count += 1
+                continue
+
+            if not is_active and target.pk in active_superuser_ids:
+                if remaining_active_superusers <= 1:
+                    skipped_last_superuser_count += 1
+                    continue
+                remaining_active_superusers -= 1
+
+            target.is_active = is_active
+            target.save(update_fields=['is_active'])
+            changed_users.append(target)
+
+        return UserActiveStatusResult(
+            changed_users=tuple(changed_users),
+            skipped_self_count=skipped_self_count,
+            skipped_last_superuser_count=skipped_last_superuser_count,
+        )

--- a/backend/src/board/services/webhook_subscription_state_service.py
+++ b/backend/src/board/services/webhook_subscription_state_service.py
@@ -23,3 +23,17 @@ class WebhookSubscriptionStateService:
         if channel.failure_count >= channel.MAX_FAILURES:
             channel.is_active = False
         channel.save(update_fields=['failure_count', 'is_active'])
+
+    @staticmethod
+    def set_active(
+        channel: 'WebhookSubscription',
+        *,
+        is_active: bool,
+        reset_failure_count: bool = False,
+    ) -> None:
+        channel.is_active = is_active
+        update_fields = ['is_active']
+        if reset_failure_count:
+            channel.failure_count = 0
+            update_fields.append('failure_count')
+        channel.save(update_fields=update_fields)

--- a/backend/src/board/tests/admin/test_destructive_action_admin.py
+++ b/backend/src/board/tests/admin/test_destructive_action_admin.py
@@ -1,0 +1,573 @@
+from unittest.mock import patch
+
+from django.contrib import admin
+from django.contrib.admin import helpers
+from django.contrib.admin.models import CHANGE, DELETION, LogEntry
+from django.contrib.auth.models import User
+from django.contrib.messages.storage.fallback import FallbackStorage
+from django.template.response import TemplateResponse
+from django.test import RequestFactory, TestCase
+from django.utils import timezone
+
+from board.admin.comment import CommentAdmin
+from board.admin.tag import TagAdmin
+from board.admin.user import CustomUserAdmin, ProfileAdmin
+from board.admin.webhook import WebhookSubscriptionAdmin
+from board.models import (
+    Comment,
+    Post,
+    Profile,
+    SiteContentScope,
+    Tag,
+    WebhookSubscription,
+)
+from board.services.comment_service import CommentService
+from board.services.webhook_subscription_state_service import (
+    WebhookSubscriptionStateService,
+)
+
+
+class DestructiveActionAdminTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.admin_user = User.objects.create_superuser(
+            username='safety-admin',
+            email='safety-admin@example.com',
+            password='test',
+        )
+        cls.staff_user = User.objects.create_user(
+            username='safety-staff',
+            password='test',
+            is_staff=True,
+        )
+        cls.managed_user = User.objects.create_user(
+            username='managed-user',
+            password='test',
+        )
+        cls.author = User.objects.create_user(
+            username='comment-author',
+            password='test',
+        )
+        cls.managed_profile, _ = Profile.objects.get_or_create(
+            user=cls.managed_user,
+            defaults={'role': Profile.Role.EDITOR},
+        )
+        cls.author_profile, _ = Profile.objects.get_or_create(
+            user=cls.author,
+        )
+        cls.post = Post.objects.create(
+            author=cls.author,
+            title='Admin safety post',
+            url='admin-safety-post',
+            published_date=timezone.now(),
+        )
+
+    def setUp(self):
+        self.user_admin = CustomUserAdmin(User, admin.site)
+        self.profile_admin = ProfileAdmin(Profile, admin.site)
+        self.comment_admin = CommentAdmin(Comment, admin.site)
+        self.tag_admin = TagAdmin(Tag, admin.site)
+        self.webhook_admin = WebhookSubscriptionAdmin(
+            WebhookSubscription,
+            admin.site,
+        )
+
+    def admin_request(
+        self,
+        method: str = 'get',
+        data: dict[str, object] | None = None,
+        *,
+        user: User | None = None,
+    ):
+        factory_method = getattr(RequestFactory(), method)
+        request = factory_method('/admin/', data=data or {})
+        request.user = user or self.admin_user
+        request.session = {}
+        request._messages = FallbackStorage(request)
+        return request
+
+    @staticmethod
+    def action_selection(
+        action: str,
+        object_ids: list[int],
+    ) -> dict[str, object]:
+        return {
+            helpers.ACTION_CHECKBOX_NAME: [
+                str(object_id) for object_id in object_ids
+            ],
+            'action': action,
+            'select_across': '0',
+        }
+
+    def create_comment(
+        self,
+        *,
+        parent: Comment | None = None,
+        content: str = 'Admin managed comment',
+    ) -> Comment:
+        return Comment.objects.create(
+            author=self.author,
+            post=self.post,
+            parent=parent,
+            text_md=content,
+            text_html=f'<p>{content}</p>',
+        )
+
+    def create_webhook(
+        self,
+        *,
+        is_active: bool = False,
+        failure_count: int = 2,
+    ) -> WebhookSubscription:
+        return WebhookSubscription.objects.create(
+            scope=SiteContentScope.GLOBAL,
+            author=None,
+            webhook_url=(
+                f'https://hooks.example.com/{WebhookSubscription.objects.count()}'
+            ),
+            name='Admin webhook',
+            is_active=is_active,
+            failure_count=failure_count,
+        )
+
+    def test_user_admin_prevents_direct_delete_and_self_access_changes(self):
+        request = self.admin_request()
+
+        self.assertNotIn('delete_selected', self.user_admin.get_actions(request))
+        self.assertFalse(
+            self.user_admin.has_delete_permission(
+                request,
+                self.managed_user,
+            ),
+        )
+        self.assertTrue(
+            {'is_active', 'is_staff', 'is_superuser'}.issubset(
+                self.user_admin.get_readonly_fields(
+                    request,
+                    self.admin_user,
+                ),
+            ),
+        )
+
+    def test_user_deactivation_confirms_skips_self_and_writes_audit(self):
+        selection = self.action_selection(
+            'deactivate_users',
+            [self.admin_user.pk, self.managed_user.pk],
+        )
+        queryset = User.objects.filter(
+            pk__in=[self.admin_user.pk, self.managed_user.pk],
+        )
+
+        confirmation = self.user_admin.deactivate_users(
+            self.admin_request('post', selection),
+            queryset,
+        )
+
+        self.assertIsInstance(confirmation, TemplateResponse)
+        confirmation.render()
+        self.managed_user.refresh_from_db()
+        self.assertTrue(self.managed_user.is_active)
+
+        self.user_admin.deactivate_users(
+            self.admin_request(
+                'post',
+                {**selection, 'confirm': 'yes'},
+            ),
+            queryset,
+        )
+
+        self.admin_user.refresh_from_db()
+        self.managed_user.refresh_from_db()
+        self.assertTrue(self.admin_user.is_active)
+        self.assertFalse(self.managed_user.is_active)
+        self.assertTrue(
+            LogEntry.objects.filter(
+                object_id=str(self.managed_user.pk),
+                action_flag=CHANGE,
+                change_message__contains='계정 비활성화',
+            ).exists(),
+        )
+        self.assertFalse(
+            LogEntry.objects.filter(
+                object_id=str(self.admin_user.pk),
+                change_message__contains='계정 비활성화',
+            ).exists(),
+        )
+
+    def test_user_deactivation_preserves_last_active_superuser(self):
+        selection = self.action_selection(
+            'deactivate_users',
+            [self.admin_user.pk],
+        )
+
+        self.assertTrue(
+            {'is_active', 'is_staff', 'is_superuser'}.issubset(
+                self.user_admin.get_readonly_fields(
+                    self.admin_request(user=self.staff_user),
+                    self.admin_user,
+                ),
+            ),
+        )
+
+        self.user_admin.deactivate_users(
+            self.admin_request(
+                'post',
+                {**selection, 'confirm': 'yes'},
+                user=self.staff_user,
+            ),
+            User.objects.filter(pk=self.admin_user.pk),
+        )
+
+        self.admin_user.refresh_from_db()
+        self.assertTrue(self.admin_user.is_active)
+
+    def test_user_status_change_rolls_back_when_audit_fails(self):
+        selection = self.action_selection(
+            'deactivate_users',
+            [self.managed_user.pk],
+        )
+
+        with patch.object(
+            self.user_admin,
+            'log_change',
+            side_effect=RuntimeError('audit unavailable'),
+        ):
+            with self.assertRaisesRegex(RuntimeError, 'audit unavailable'):
+                self.user_admin.deactivate_users(
+                    self.admin_request(
+                        'post',
+                        {**selection, 'confirm': 'yes'},
+                    ),
+                    User.objects.filter(pk=self.managed_user.pk),
+                )
+
+        self.managed_user.refresh_from_db()
+        self.assertTrue(self.managed_user.is_active)
+
+    def test_user_activation_confirms_and_restores_access(self):
+        User.objects.filter(pk=self.managed_user.pk).update(is_active=False)
+        selection = self.action_selection(
+            'activate_users',
+            [self.managed_user.pk],
+        )
+        queryset = User.objects.filter(pk=self.managed_user.pk)
+
+        confirmation = self.user_admin.activate_users(
+            self.admin_request('post', selection),
+            queryset,
+        )
+        self.assertIsInstance(confirmation, TemplateResponse)
+
+        self.user_admin.activate_users(
+            self.admin_request(
+                'post',
+                {**selection, 'confirm': 'yes'},
+            ),
+            queryset,
+        )
+
+        self.managed_user.refresh_from_db()
+        self.assertTrue(self.managed_user.is_active)
+        self.assertTrue(
+            LogEntry.objects.filter(
+                object_id=str(self.managed_user.pk),
+                action_flag=CHANGE,
+                change_message__contains='계정 활성화',
+            ).exists(),
+        )
+
+    def test_role_actions_are_audited_and_roll_back_with_the_audit(self):
+        self.user_admin.make_reader(
+            self.admin_request('post'),
+            User.objects.filter(pk=self.managed_user.pk),
+        )
+
+        self.managed_profile.refresh_from_db()
+        self.assertEqual(self.managed_profile.role, Profile.Role.READER)
+        self.assertTrue(
+            LogEntry.objects.filter(
+                object_id=str(self.managed_user.pk),
+                action_flag=CHANGE,
+                change_message__contains='독자 역할로 변경',
+            ).exists(),
+        )
+
+        with patch.object(
+            self.profile_admin,
+            'log_change',
+            side_effect=RuntimeError('audit unavailable'),
+        ):
+            with self.assertRaisesRegex(RuntimeError, 'audit unavailable'):
+                self.profile_admin.set_role_editor(
+                    self.admin_request('post'),
+                    Profile.objects.filter(pk=self.managed_profile.pk),
+                )
+
+        self.managed_profile.refresh_from_db()
+        self.assertEqual(self.managed_profile.role, Profile.Role.READER)
+
+    def test_comment_delete_uses_soft_delete_and_preserves_replies(self):
+        parent = self.create_comment(content='Parent comment')
+        reply = self.create_comment(parent=parent, content='Reply comment')
+        selection = self.action_selection(
+            'soft_delete_comments',
+            [parent.pk],
+        )
+        queryset = Comment.objects.filter(pk=parent.pk)
+        request = self.admin_request('post', selection)
+
+        self.assertNotIn(
+            'delete_selected',
+            self.comment_admin.get_actions(request),
+        )
+        self.assertFalse(
+            self.comment_admin.has_delete_permission(request, parent),
+        )
+        confirmation = self.comment_admin.soft_delete_comments(
+            request,
+            queryset,
+        )
+        self.assertIsInstance(confirmation, TemplateResponse)
+        confirmation.render()
+
+        with patch.object(
+            CommentService,
+            'delete_comment',
+            wraps=CommentService.delete_comment,
+        ) as delete_comment:
+            self.comment_admin.soft_delete_comments(
+                self.admin_request(
+                    'post',
+                    {**selection, 'confirm': 'yes'},
+                ),
+                queryset,
+            )
+
+        delete_comment.assert_called_once()
+        parent.refresh_from_db()
+        self.assertIsNone(parent.author)
+        self.assertTrue(Comment.objects.filter(pk=parent.pk).exists())
+        self.assertTrue(Comment.objects.filter(pk=reply.pk).exists())
+        self.assertTrue(
+            LogEntry.objects.filter(
+                object_id=str(parent.pk),
+                action_flag=CHANGE,
+                change_message__contains='댓글 삭제 상태로 전환',
+            ).exists(),
+        )
+        self.assertFalse(
+            LogEntry.objects.filter(
+                object_id=str(parent.pk),
+                action_flag=DELETION,
+            ).exists(),
+        )
+
+    def test_comment_mutations_roll_back_when_audit_fails(self):
+        comment = self.create_comment()
+        confirmed_delete = {
+            **self.action_selection('soft_delete_comments', [comment.pk]),
+            'confirm': 'yes',
+        }
+
+        with patch.object(
+            self.comment_admin,
+            'log_change',
+            side_effect=RuntimeError('audit unavailable'),
+        ):
+            with self.assertRaisesRegex(RuntimeError, 'audit unavailable'):
+                self.comment_admin.soft_delete_comments(
+                    self.admin_request('post', confirmed_delete),
+                    Comment.objects.filter(pk=comment.pk),
+                )
+
+        comment.refresh_from_db()
+        self.assertIsNotNone(comment.author)
+
+        self.comment_admin.mark_as_heart(
+            self.admin_request('post'),
+            Comment.objects.filter(pk=comment.pk),
+        )
+        comment.refresh_from_db()
+        self.assertTrue(comment.heart)
+        self.assertTrue(
+            LogEntry.objects.filter(
+                object_id=str(comment.pk),
+                action_flag=CHANGE,
+                change_message__contains='하트 표시',
+            ).exists(),
+        )
+
+    def test_unused_tag_cleanup_confirms_and_keeps_referenced_tags(self):
+        used_tag = Tag.objects.create(value='admin-used-tag')
+        unused_tag = Tag.objects.create(value='admin-unused-tag')
+        self.post.tags.add(used_tag)
+        selection = self.action_selection(
+            'clear_unused_tags',
+            [used_tag.pk, unused_tag.pk],
+        )
+        queryset = Tag.objects.filter(pk__in=[used_tag.pk, unused_tag.pk])
+        request = self.admin_request('post', selection)
+
+        actions = self.tag_admin.get_actions(request)
+        self.assertNotIn('delete_selected', actions)
+        self.assertNotIn('merge_tags', actions)
+        self.assertFalse(
+            self.tag_admin.has_delete_permission(request, used_tag),
+        )
+        confirmation = self.tag_admin.clear_unused_tags(request, queryset)
+        self.assertIsInstance(confirmation, TemplateResponse)
+        self.assertEqual(confirmation.context_data['object_count'], 1)
+        confirmation.render()
+
+        self.tag_admin.clear_unused_tags(
+            self.admin_request(
+                'post',
+                {**selection, 'confirm': 'yes'},
+            ),
+            queryset,
+        )
+
+        self.assertTrue(Tag.objects.filter(pk=used_tag.pk).exists())
+        self.assertFalse(Tag.objects.filter(pk=unused_tag.pk).exists())
+        self.assertTrue(self.post.tags.filter(pk=used_tag.pk).exists())
+        self.assertTrue(
+            LogEntry.objects.filter(
+                object_id=str(unused_tag.pk),
+                action_flag=DELETION,
+            ).exists(),
+        )
+
+    def test_unused_tag_cleanup_rolls_back_when_audit_fails(self):
+        unused_tag = Tag.objects.create(value='admin-audit-tag')
+        confirmed_cleanup = {
+            **self.action_selection('clear_unused_tags', [unused_tag.pk]),
+            'confirm': 'yes',
+        }
+
+        with patch.object(
+            self.tag_admin,
+            'log_deletions',
+            side_effect=RuntimeError('audit unavailable'),
+        ):
+            with self.assertRaisesRegex(RuntimeError, 'audit unavailable'):
+                self.tag_admin.clear_unused_tags(
+                    self.admin_request('post', confirmed_cleanup),
+                    Tag.objects.filter(pk=unused_tag.pk),
+                )
+
+        self.assertTrue(Tag.objects.filter(pk=unused_tag.pk).exists())
+
+    def test_webhook_actions_use_state_service_confirmation_and_audit(self):
+        webhook = self.create_webhook()
+        selection = self.action_selection(
+            'activate_subscriptions',
+            [webhook.pk],
+        )
+        queryset = WebhookSubscription.objects.filter(pk=webhook.pk)
+        request = self.admin_request('post', selection)
+
+        self.assertIn(
+            'is_active',
+            self.webhook_admin.get_readonly_fields(request, webhook),
+        )
+        confirmation = self.webhook_admin.activate_subscriptions(
+            request,
+            queryset,
+        )
+        self.assertIsInstance(confirmation, TemplateResponse)
+
+        with patch.object(
+            WebhookSubscriptionStateService,
+            'set_active',
+            wraps=WebhookSubscriptionStateService.set_active,
+        ) as set_active:
+            self.webhook_admin.activate_subscriptions(
+                self.admin_request(
+                    'post',
+                    {**selection, 'confirm': 'yes'},
+                ),
+                queryset,
+            )
+
+        set_active.assert_called_once()
+        webhook.refresh_from_db()
+        self.assertTrue(webhook.is_active)
+        self.assertEqual(webhook.failure_count, 2)
+        self.assertTrue(
+            LogEntry.objects.filter(
+                object_id=str(webhook.pk),
+                action_flag=CHANGE,
+                change_message__contains='웹훅 활성화',
+            ).exists(),
+        )
+
+        WebhookSubscription.objects.filter(pk=webhook.pk).update(
+            is_active=False,
+            failure_count=3,
+        )
+        reset_selection = self.action_selection(
+            'reset_failure_count',
+            [webhook.pk],
+        )
+        reset_confirmation = self.webhook_admin.reset_failure_count(
+            self.admin_request('post', reset_selection),
+            queryset,
+        )
+        self.assertIsInstance(reset_confirmation, TemplateResponse)
+
+        self.webhook_admin.reset_failure_count(
+            self.admin_request(
+                'post',
+                {**reset_selection, 'confirm': 'yes'},
+            ),
+            queryset,
+        )
+        webhook.refresh_from_db()
+        self.assertTrue(webhook.is_active)
+        self.assertEqual(webhook.failure_count, 0)
+        self.assertTrue(
+            LogEntry.objects.filter(
+                object_id=str(webhook.pk),
+                action_flag=CHANGE,
+                change_message__contains='실패 횟수 초기화',
+            ).exists(),
+        )
+
+        self.webhook_admin.deactivate_subscriptions(
+            self.admin_request('post'),
+            queryset,
+        )
+        webhook.refresh_from_db()
+        self.assertFalse(webhook.is_active)
+        self.assertTrue(
+            LogEntry.objects.filter(
+                object_id=str(webhook.pk),
+                action_flag=CHANGE,
+                change_message__contains='웹훅 비활성화',
+            ).exists(),
+        )
+
+    def test_webhook_activation_rolls_back_when_audit_fails(self):
+        webhook = self.create_webhook()
+        confirmed_activation = {
+            **self.action_selection(
+                'activate_subscriptions',
+                [webhook.pk],
+            ),
+            'confirm': 'yes',
+        }
+
+        with patch.object(
+            self.webhook_admin,
+            'log_change',
+            side_effect=RuntimeError('audit unavailable'),
+        ):
+            with self.assertRaisesRegex(RuntimeError, 'audit unavailable'):
+                self.webhook_admin.activate_subscriptions(
+                    self.admin_request('post', confirmed_activation),
+                    WebhookSubscription.objects.filter(pk=webhook.pk),
+                )
+
+        webhook.refresh_from_db()
+        self.assertFalse(webhook.is_active)
+        self.assertEqual(webhook.failure_count, 2)


### PR DESCRIPTION
## 🎯 Goal
- Django Admin에서 계정 접근, 댓글 삭제 상태, 미사용 태그, 웹훅 전송 상태를 실수로 변경하는 위험을 줄입니다.
- 기존 공개 URL, API 응답, 모델, DB 스키마와 서비스 동작의 하위 호환성을 유지합니다.

## 🔧 Core Changes
- 사용자 활성화/비활성화에 확인 단계와 현재 관리자·마지막 활성 슈퍼유저 보호를 적용했습니다.
- 댓글은 하드 삭제 대신 기존 소프트 삭제 서비스를 사용하고 답글 관계를 보존합니다.
- 태그는 확인 후 실행 시점에도 미사용 상태를 재검증하며, 존재하지 않던 병합 액션을 제거했습니다.
- 웹훅 활성화·실패 초기화·비활성화를 상태 서비스로 통일했습니다.
- 변경 작업에 트랜잭션과 Django Admin 감사 로그를 추가했습니다.

## 🤔 Key Decisions
- 공개 계약이나 DB 구조를 바꾸지 않고 Admin 진입점만 강화했습니다.
- 비가역 작업은 확인을 요구하고, 웹훅 비활성화처럼 즉시 되돌릴 수 있는 작업은 바로 실행합니다.
- 댓글 행과 답글 연결은 삭제하지 않고 기존 CommentService의 삭제 상태 표현을 그대로 따릅니다.

## 🧪 Verification Guide
### How to verify
1. Admin 사용자 목록에서 활성화/비활성화를 실행하고 확인 화면과 보호 안내를 확인합니다.
2. 댓글 삭제 상태 전환, 미사용 태그 삭제, 웹훅 상태 액션을 실행합니다.
3. Admin 로그에 각 변경이 기록되고 실패 시 데이터가 롤백되는지 테스트로 확인합니다.

### Expected result
- 위험 작업은 확인과 보호 규칙을 거치며 기존 공개 동작과 스키마는 바뀌지 않습니다.

## ✅ Checklist
- [x] Lint completed (Python system check and diff check)
- [x] Type-check completed (no frontend changes)
- [x] Tests completed (1,267 backend tests; 12 focused Admin tests)
- [x] Documentation updated (not needed; internal Admin behavior only)