### PR TITLE
♻️ Bound admin list query costs

### DIFF
--- a/backend/src/board/admin/comment.py
+++ b/backend/src/board/admin/comment.py
@@ -94,7 +94,10 @@ class CommentAdmin(
     date_hierarchy = 'created_date'
 
     def get_queryset(self, request):
-        return super().get_queryset(request).select_related('author', 'post').prefetch_related('likes').annotate(
+        return super().get_queryset(request).select_related(
+            'author',
+            'post',
+        ).defer('author__password').annotate(
             likes_count_annotated=Count('likes', distinct=True)
         )
 
@@ -158,6 +161,8 @@ class CommentAdmin(
     author_info.short_description = '작성자 정보'
 
     def likes_count(self, obj):
+        if hasattr(obj, 'likes_count_annotated'):
+            return obj.likes_count_annotated
         return obj.likes.count()
     likes_count.short_description = '총 좋아요 수'
 

--- a/backend/src/board/admin/image.py
+++ b/backend/src/board/admin/image.py
@@ -30,7 +30,7 @@ class ImageCacheAdmin(admin.ModelAdmin):
     search_fields = ['path']
 
     list_display = ['id', 'file_size', 'image', 'open_image']
-    list_per_page = 50
+    list_per_page = 30
 
     def get_list_filter(self, request):
         return [ImageFilter]
@@ -46,7 +46,7 @@ class ImageCacheAdmin(admin.ModelAdmin):
     file_size.admin_order_field = 'size'
 
     def image(self, obj):
-        image_size = '480px'
+        image_size = '120px'
         media_path = settings.MEDIA_URL + obj.path
 
         if obj.path.endswith('.mp4'):

--- a/backend/src/board/admin/post.py
+++ b/backend/src/board/admin/post.py
@@ -6,17 +6,31 @@ from typing import Any
 from django.contrib import admin, messages
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
-from django.db.models import Count, QuerySet
+from django.db.models import (
+    Count,
+    IntegerField,
+    OuterRef,
+    QuerySet,
+    Subquery,
+    Value,
+)
+from django.db.models.functions import Coalesce
 from django.http import HttpRequest
 from django.utils import timezone
+from django.utils.html import format_html
 
 from board.services.post_revision_service import PostRevisionService
 from board.services.post_service import PostService, PostValidationError
 from board.services.post_status_service import PostStatusService
 from board.services.post_trash_service import PostTrashService
 from board.models import (
-    EditRequest, Post, PinnedPost,
-    PostConfig, PostContent,
+    Comment,
+    EditRequest,
+    PinnedPost,
+    Post,
+    PostConfig,
+    PostContent,
+    PostLikes,
 )
 
 from .action_confirmation import render_action_confirmation
@@ -60,6 +74,9 @@ class EditRequestAdmin(admin.ModelAdmin):
     list_per_page = LIST_PER_PAGE_DEFAULT
     search_fields = ['post__title']
 
+    def get_queryset(self, request):
+        return super().get_queryset(request).select_related('post')
+
 
 @admin.register(PinnedPost)
 class PinnedPostAdmin(admin.ModelAdmin):
@@ -67,6 +84,12 @@ class PinnedPostAdmin(admin.ModelAdmin):
     list_per_page = LIST_PER_PAGE_DEFAULT
     search_fields = ['post__title', 'user__username']
     autocomplete_fields = ['post', 'user']
+
+    def get_queryset(self, request):
+        return super().get_queryset(request).select_related(
+            'post',
+            'user',
+        ).defer('user__password')
 
 
 class PostContentInline(admin.StackedInline):
@@ -184,11 +207,41 @@ class PostAdmin(admin.ModelAdmin):
         ):
             queryset = queryset.filter(deleted_date__isnull=True)
 
+        likes_count = PostLikes.objects.filter(
+            post_id=OuterRef('pk'),
+        ).order_by().values('post_id').annotate(
+            total=Count('pk'),
+        ).values('total')
+        comments = Comment.objects.filter(
+            post_id=OuterRef('pk'),
+        ).order_by().values('post_id')
+        comments_count = comments.annotate(
+            total=Count('pk'),
+        ).values('total')
+        active_comments_count = comments.filter(
+            author__isnull=False,
+        ).annotate(
+            total=Count('pk'),
+        ).values('total')
+
         return queryset.select_related(
-            'author', 'content', 'config', 'series'
-        ).prefetch_related('tags', 'likes', 'comments').annotate(
-            likes_count=Count('likes', distinct=True),
-            comments_count=Count('comments', distinct=True)
+            'author', 'config', 'series'
+        ).defer('author__password').prefetch_related('tags').annotate(
+            likes_count=Coalesce(
+                Subquery(likes_count, output_field=IntegerField()),
+                Value(0),
+            ),
+            comments_count=Coalesce(
+                Subquery(comments_count, output_field=IntegerField()),
+                Value(0),
+            ),
+            active_comments_count=Coalesce(
+                Subquery(
+                    active_comments_count,
+                    output_field=IntegerField(),
+                ),
+                Value(0),
+            ),
         )
 
     def get_actions(self, request):
@@ -292,9 +345,24 @@ class PostAdmin(admin.ModelAdmin):
     likes_count.admin_order_field = 'likes_count'
 
     def comments_count(self, obj: Post) -> str:
-        count = obj.comments_count if hasattr(obj, 'comments_count') else obj.comments.count()
-        return AdminDisplayService.comment_count_badge(count)
-    comments_count.short_description = '댓글'
+        total_count = (
+            obj.comments_count
+            if hasattr(obj, 'comments_count')
+            else obj.comments.count()
+        )
+        active_count = (
+            obj.active_comments_count
+            if hasattr(obj, 'active_comments_count')
+            else obj.comments.filter(author__isnull=False).count()
+        )
+        deleted_count = total_count - active_count
+        return format_html(
+            '💬 {} <span style="color: var(--body-quiet-color, #666);">'
+            '(삭제 {})</span>',
+            active_count,
+            deleted_count,
+        )
+    comments_count.short_description = '댓글 (활성/삭제)'
     comments_count.admin_order_field = 'comments_count'
 
     def publish_status(self, obj: Post) -> str:
@@ -324,10 +392,14 @@ class PostAdmin(admin.ModelAdmin):
     image_preview.short_description = '이미지 미리보기'
 
     def total_likes(self, obj: Post) -> int:
+        if hasattr(obj, 'likes_count'):
+            return obj.likes_count
         return obj.likes.count()
     total_likes.short_description = '총 좋아요 수'
 
     def total_comments(self, obj: Post) -> int:
+        if hasattr(obj, 'comments_count'):
+            return obj.comments_count
         return obj.comments.count()
     total_comments.short_description = '총 댓글 수'
 

--- a/backend/src/board/admin/series.py
+++ b/backend/src/board/admin/series.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from django.db.models import Count
+from django.db.models import Count, OuterRef, Q, Subquery
 from django.urls import reverse
 from django.utils.html import format_html
 
@@ -9,7 +9,8 @@ from board.services.public_post_service import PublicPostService
 from .service import AdminDisplayService, AdminLinkService
 from .constants import (
     COLOR_DANGER, COLOR_SUCCESS, COLOR_PRIMARY, COLOR_MUTED,
-    COLOR_INFO, COLOR_DARKENED_BG, COLOR_TEXT, COLOR_BG, COLOR_BORDER
+    COLOR_INFO, COLOR_DARKENED_BG, COLOR_TEXT, COLOR_BG, COLOR_BORDER,
+    THUMBNAIL_SIZE,
 )
 
 
@@ -21,6 +22,9 @@ class SeriesPostInline(admin.TabularInline):
     extra = 0
     max_num = 0
     show_change_link = True
+
+    def get_queryset(self, request):
+        return super().get_queryset(request).select_related('config')
 
     def config_hide(self, obj):
         if hasattr(obj, 'config') and obj.config.hide:
@@ -53,10 +57,30 @@ class SeriesAdmin(admin.ModelAdmin):
     actions = ['make_hidden', 'make_visible', 'set_layout_list', 'set_layout_card']
 
     def get_queryset(self, request):
+        public_posts = PublicPostService.filter_public_posts(
+            Post.objects,
+        ).filter(series=OuterRef('pk')).order_by('pk')
         return super().get_queryset(request).select_related(
             'owner'
-        ).annotate(
-            count_posts=Count('posts', distinct=True)
+        ).defer('owner__password').annotate(
+            count_posts=Count(
+                'posts',
+                filter=Q(posts__deleted_date__isnull=True),
+                distinct=True,
+            ),
+            public_post_count=Count(
+                'posts',
+                filter=PublicPostService.build_public_filter('posts'),
+                distinct=True,
+            ),
+            trashed_post_count=Count(
+                'posts',
+                filter=Q(posts__deleted_date__isnull=False),
+                distinct=True,
+            ),
+            admin_thumbnail_name=Subquery(
+                public_posts.values('image')[:1],
+            ),
         )
 
     fieldsets = (
@@ -84,6 +108,8 @@ class SeriesAdmin(admin.ModelAdmin):
         'name',
         'owner_link',
         'count_posts',
+        'public_posts',
+        'trashed_posts',
         'layout_badge',
         'visibility_badge',
         'thumbnail_preview',
@@ -100,8 +126,29 @@ class SeriesAdmin(admin.ModelAdmin):
     def count_posts(self, obj):
         count = obj.count_posts if hasattr(obj, 'count_posts') else obj.posts.count()
         return format_html('📚 {}', count)
-    count_posts.short_description = '포스트 수'
+    count_posts.short_description = '활성 포스트'
     count_posts.admin_order_field = 'count_posts'
+
+    def public_posts(self, obj):
+        count = getattr(obj, 'public_post_count', None)
+        if count is None:
+            count = PublicPostService.filter_public_posts(
+                Post.all_objects.filter(series=obj),
+            ).count()
+        return count
+    public_posts.short_description = '공개 포스트'
+    public_posts.admin_order_field = 'public_post_count'
+
+    def trashed_posts(self, obj):
+        count = getattr(obj, 'trashed_post_count', None)
+        if count is None:
+            count = Post.all_objects.filter(
+                series=obj,
+                deleted_date__isnull=False,
+            ).count()
+        return count
+    trashed_posts.short_description = '휴지통'
+    trashed_posts.admin_order_field = 'trashed_post_count'
 
     def layout_badge(self, obj):
         if obj.layout == 'card':
@@ -128,11 +175,21 @@ class SeriesAdmin(admin.ModelAdmin):
     visibility_badge.short_description = '상태'
 
     def thumbnail_preview(self, obj):
-        thumbnail_url = obj.thumbnail()
+        thumbnail_name = getattr(obj, 'admin_thumbnail_name', None)
+        if hasattr(obj, 'admin_thumbnail_name'):
+            thumbnail_url = (
+                Post._meta.get_field('image').storage.url(thumbnail_name)
+                if thumbnail_name
+                else ''
+            )
+        else:
+            thumbnail_url = obj.thumbnail()
         if thumbnail_url:
-            return format_html(
-                '<img src="{}" style="width: 60px; height: 60px; object-fit: cover; border-radius: 6px;" />',
-                thumbnail_url
+            width, height = THUMBNAIL_SIZE
+            return AdminDisplayService.image_preview(
+                thumbnail_url,
+                width=width,
+                height=height,
             )
         return format_html(
             '<div style="width: 60px; height: 60px; background: {}; border-radius: 6px;"></div>',
@@ -141,24 +198,36 @@ class SeriesAdmin(admin.ModelAdmin):
     thumbnail_preview.short_description = ''
 
     def posts_summary(self, obj):
-        posts = obj.posts.all()
-        if not posts:
-            return format_html('<p style="color: {};">포스트 없음</p>', COLOR_MUTED)
+        if hasattr(obj, 'count_posts'):
+            active_posts = obj.count_posts
+            public_posts = obj.public_post_count
+            trashed_posts = obj.trashed_post_count
+        else:
+            active_posts = Post.all_objects.filter(
+                series=obj,
+                deleted_date__isnull=True,
+            ).count()
+            public_posts = PublicPostService.filter_public_posts(
+                Post.all_objects.filter(series=obj),
+            ).count()
+            trashed_posts = Post.all_objects.filter(
+                series=obj,
+                deleted_date__isnull=False,
+            ).count()
 
-        total_posts = posts.count()
-        public_posts = PublicPostService.filter_public_posts(posts).count()
-        non_public_posts = total_posts - public_posts
+        if active_posts == 0 and trashed_posts == 0:
+            return format_html('<p style="color: {};">포스트 없음</p>', COLOR_MUTED)
 
         return format_html(
             '<div style="background: {}; padding: 12px; border-radius: 6px; border: 1px solid {};">'
-            '<p style="margin: 4px 0; color: {};"><strong>총 포스트:</strong> {}</p>'
+            '<p style="margin: 4px 0; color: {};"><strong>활성 포스트:</strong> {}</p>'
             '<p style="margin: 4px 0; color: {};"><strong>공개 노출:</strong> <span style="color: {};">{}</span></p>'
-            '<p style="margin: 4px 0; color: {};"><strong>비공개 상태:</strong> <span style="color: {};">{}</span></p>'
+            '<p style="margin: 4px 0; color: {};"><strong>휴지통:</strong> <span style="color: {};">{}</span></p>'
             '</div>',
             COLOR_DARKENED_BG, COLOR_BORDER,
-            COLOR_TEXT, total_posts,
+            COLOR_TEXT, active_posts,
             COLOR_TEXT, COLOR_SUCCESS, public_posts,
-            COLOR_TEXT, COLOR_DANGER, non_public_posts
+            COLOR_TEXT, COLOR_DANGER, trashed_posts,
         )
     posts_summary.short_description = '포스트 요약'
 

--- a/backend/src/board/admin/service.py
+++ b/backend/src/board/admin/service.py
@@ -402,7 +402,7 @@ class AdminDisplayService:
     def video(video_url: str, max_width: str = '400px') -> SafeString:
         """비디오 표시 (최대 너비 지정)"""
         return format_html(
-            '<video controls style="max-width: {}; border-radius: 8px;"><source src="{}" type="video/mp4"></video>',
+            '<video controls preload="none" style="max-width: {}; border-radius: 8px;"><source src="{}" type="video/mp4"></video>',
             max_width, video_url
         )
 

--- a/backend/src/board/admin/tag.py
+++ b/backend/src/board/admin/tag.py
@@ -2,11 +2,12 @@ from typing import Any
 
 from django.contrib import admin, messages
 from django.db import transaction
-from django.db.models import Count, QuerySet
+from django.db.models import Count, Exists, OuterRef, Q, QuerySet
 from django.http import HttpRequest
 from django.utils.html import format_html
 
-from board.models import Tag
+from board.models import Post, Tag
+from board.services.public_post_service import PublicPostService
 
 from .action_confirmation import render_action_confirmation
 from .constants import (
@@ -22,7 +23,14 @@ class TagAdmin(ConfirmedActionDeleteAdminMixin, admin.ModelAdmin):
     search_fields = ['value']
     actions = ['clear_unused_tags']
 
-    list_display = ['tag_badge', 'count', 'has_image', 'usage_status']
+    list_display = [
+        'tag_badge',
+        'count',
+        'public_count',
+        'trash_count',
+        'has_image',
+        'usage_status',
+    ]
     list_display_links = ['tag_badge']
     list_per_page = 50
 
@@ -31,8 +39,29 @@ class TagAdmin(ConfirmedActionDeleteAdminMixin, admin.ModelAdmin):
     ]
 
     def get_queryset(self, request):
+        public_image_posts = PublicPostService.filter_public_posts(
+            Post.objects,
+        ).filter(
+            tags=OuterRef('pk'),
+            image__contains='images',
+        )
         return super().get_queryset(request).annotate(
-            post_count=Count('posts', distinct=True)
+            post_count=Count(
+                'posts',
+                filter=Q(posts__deleted_date__isnull=True),
+                distinct=True,
+            ),
+            public_post_count=Count(
+                'posts',
+                filter=PublicPostService.build_public_filter('posts'),
+                distinct=True,
+            ),
+            trashed_post_count=Count(
+                'posts',
+                filter=Q(posts__deleted_date__isnull=False),
+                distinct=True,
+            ),
+            has_public_image=Exists(public_image_posts),
         )
 
     def tag_badge(self, obj):
@@ -47,18 +76,49 @@ class TagAdmin(ConfirmedActionDeleteAdminMixin, admin.ModelAdmin):
             return format_html('<span style="color: {};">{}</span>', COLOR_WARNING, count)
         else:
             return format_html('<span style="color: {}; font-weight: 600;">{}</span>', COLOR_SUCCESS, count)
-    count.short_description = '사용 횟수'
+    count.short_description = '활성 포스트'
     count.admin_order_field = 'post_count'
 
+    def public_count(self, obj):
+        count = getattr(obj, 'public_post_count', None)
+        if count is None:
+            count = PublicPostService.filter_public_posts(
+                Post.all_objects.filter(tags=obj),
+            ).count()
+        return count
+    public_count.short_description = '공개 포스트'
+    public_count.admin_order_field = 'public_post_count'
+
+    def trash_count(self, obj):
+        count = getattr(obj, 'trashed_post_count', None)
+        if count is None:
+            count = Post.all_objects.filter(
+                tags=obj,
+                deleted_date__isnull=False,
+            ).count()
+        return count
+    trash_count.short_description = '휴지통'
+    trash_count.admin_order_field = 'trashed_post_count'
+
     def has_image(self, obj):
-        if obj.get_image():
+        has_image = getattr(obj, 'has_public_image', None)
+        if has_image is None:
+            has_image = bool(obj.get_image())
+        if has_image:
             return format_html('<span style="color: {};">✓ 있음</span>', COLOR_SUCCESS)
         return format_html('<span style="color: {};">✗ 없음</span>', COLOR_MUTED)
     has_image.short_description = '대표 이미지'
 
     def usage_status(self, obj):
         count = obj.post_count if hasattr(obj, 'post_count') else obj.posts.count()
+        trashed_count = getattr(obj, 'trashed_post_count', 0)
         if count == 0:
+            if trashed_count:
+                return format_html(
+                    '<span style="background: {}; color: {}; padding: 2px 8px; border-radius: 4px; font-size: 10px; opacity: 0.8;">휴지통 전용</span>',
+                    COLOR_WARNING,
+                    COLOR_BG,
+                )
             return format_html(
                 '<span style="background: {}; color: {}; padding: 2px 8px; border-radius: 4px; font-size: 10px; opacity: 0.8;">미사용</span>',
                 COLOR_DANGER, COLOR_BG

--- a/backend/src/board/admin/user.py
+++ b/backend/src/board/admin/user.py
@@ -8,13 +8,13 @@ from django.contrib.auth.models import User
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
 from django.http import HttpRequest
 from django.db import transaction
-from django.db.models import Count, QuerySet
+from django.db.models import Count, Exists, OuterRef, QuerySet
 from django.urls import reverse
 from django.utils.html import format_html, format_html_join
 
 from board.models import (
     UserConfigMeta, UserLinkMeta, Config, UsernameChangeLog,
-    EmailChange, Profile
+    EmailChange, Profile, TelegramSync, TwoFactorAuth
 )
 from board.constants.config_meta import CONFIG_TYPES
 from board.services.email_change_service import (
@@ -491,23 +491,45 @@ class ConfigAdmin(admin.ModelAdmin):
     search_fields = ['user__username']
 
     def get_queryset(self, request):
-        return super().get_queryset(request).select_related('user')
+        return super().get_queryset(request).select_related('user').only(
+            'id',
+            'user_id',
+            'user__id',
+            'user__username',
+        ).annotate(
+            telegram_linked=Exists(
+                TelegramSync.objects.filter(
+                    user_id=OuterRef('user_id'),
+                ).exclude(tid=''),
+            ),
+            two_factor_enabled=Exists(
+                TwoFactorAuth.objects.filter(
+                    user_id=OuterRef('user_id'),
+                ),
+            ),
+        )
 
     def user_link(self, obj):
         return AdminLinkService.create_user_link(obj.user)
     user_link.short_description = '사용자'
 
     def telegram_status(self, obj):
+        linked = getattr(obj, 'telegram_linked', None)
+        if linked is None:
+            linked = obj.has_telegram_id()
         return AdminDisplayService.boolean_badge(
-            obj.has_telegram_id(),
+            linked,
             true_text='연동됨',
             false_text='미연동'
         )
     telegram_status.short_description = '텔레그램'
 
     def two_factor_status(self, obj):
+        enabled = getattr(obj, 'two_factor_enabled', None)
+        if enabled is None:
+            enabled = obj.has_two_factor_auth()
         return AdminDisplayService.boolean_badge(
-            obj.has_two_factor_auth(),
+            enabled,
             true_text='활성화',
             false_text='비활성화'
         )

--- a/backend/src/board/tests/admin/test_admin_list_performance.py
+++ b/backend/src/board/tests/admin/test_admin_list_performance.py
@@ -1,0 +1,371 @@
+from datetime import timedelta
+
+from django.contrib import admin
+from django.contrib.auth.models import User
+from django.db import connection
+from django.test import RequestFactory, TestCase
+from django.test.utils import CaptureQueriesContext
+from django.urls import reverse
+from django.utils import timezone
+
+from board.admin.comment import CommentAdmin
+from board.admin.image import ImageCacheAdmin
+from board.admin.post import EditRequestAdmin, PinnedPostAdmin, PostAdmin
+from board.admin.series import SeriesAdmin, SeriesPostInline
+from board.admin.tag import TagAdmin
+from board.admin.user import ConfigAdmin
+from board.models import (
+    Comment,
+    Config,
+    EditRequest,
+    ImageCache,
+    Post,
+    PostConfig,
+    PostContent,
+    PostLikes,
+    PinnedPost,
+    Series,
+    Tag,
+    TelegramSync,
+    TwoFactorAuth,
+)
+
+
+class AdminListPerformanceTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.admin_user = User.objects.create_superuser(
+            username='list-performance-admin',
+            email='list-performance-admin@example.com',
+            password='test',
+        )
+        cls.authors = [
+            User.objects.create_user(
+                username=f'list-author-{index}',
+                password='test',
+            )
+            for index in range(4)
+        ]
+        cls.configs = [
+            Config.objects.create(user=author)
+            for author in cls.authors
+        ]
+        TelegramSync.objects.bulk_create([
+            TelegramSync(
+                user=author,
+                tid=f'encrypted-telegram-{index}',
+            )
+            for index, author in enumerate(cls.authors)
+        ])
+        TwoFactorAuth.objects.bulk_create([
+            TwoFactorAuth(
+                user=author,
+                recovery_key=f'encrypted-recovery-{index}',
+                totp_secret=f'encrypted-totp-{index}',
+            )
+            for index, author in enumerate(cls.authors)
+        ])
+
+        cls.series = []
+        cls.tags = []
+        cls.public_posts = []
+        for index, author in enumerate(cls.authors):
+            series = Series.objects.create(
+                owner=author,
+                name=f'List series {index}',
+                url=f'list-series-{index}',
+            )
+            tag = Tag.objects.create(value=f'list-tag-{index}')
+            public_post = cls.create_post(
+                author=author,
+                series=series,
+                tag=tag,
+                suffix=f'public-{index}',
+                published_date=timezone.now() - timedelta(days=1),
+                image=True,
+            )
+            cls.create_post(
+                author=author,
+                series=series,
+                tag=tag,
+                suffix=f'draft-{index}',
+                published_date=None,
+            )
+            cls.series.append(series)
+            cls.tags.append(tag)
+            cls.public_posts.append(public_post)
+
+        cls.trashed_post = cls.create_post(
+            author=cls.authors[0],
+            series=cls.series[0],
+            tag=cls.tags[0],
+            suffix='trashed',
+            published_date=timezone.now() - timedelta(days=2),
+            deleted=True,
+            image=True,
+        )
+        cls.trash_only_tag = Tag.objects.create(value='trash-only-tag')
+        cls.trashed_post.tags.add(cls.trash_only_tag)
+        cls.active_comment = Comment.objects.create(
+            author=cls.authors[0],
+            post=cls.public_posts[0],
+            text_md='Active comment',
+            text_html='<p>Active comment</p>',
+        )
+        cls.deleted_comment = Comment.objects.create(
+            author=None,
+            post=cls.public_posts[0],
+            text_md='Deleted comment',
+            text_html='<p>Deleted comment</p>',
+        )
+        cls.active_comment.likes.add(cls.authors[1])
+        PostLikes.objects.create(
+            post=cls.public_posts[0],
+            user=cls.authors[1],
+        )
+        for index, post in enumerate(cls.public_posts):
+            EditRequest.objects.create(
+                user=cls.authors[index],
+                post=post,
+                title=f'List edit request {index}',
+            )
+            PinnedPost.objects.create(
+                user=cls.authors[index],
+                post=post,
+                order=0,
+            )
+        ImageCache.objects.create(
+            user=cls.authors[0],
+            key='a' * 44,
+            path='cache/list-preview.jpg',
+            size=1024,
+        )
+
+    @classmethod
+    def create_post(
+        cls,
+        *,
+        author: User,
+        series: Series,
+        tag: Tag,
+        suffix: str,
+        published_date,
+        deleted: bool = False,
+        image: bool = False,
+    ) -> Post:
+        post = Post.objects.create(
+            author=author,
+            series=series,
+            title=f'List post {suffix}',
+            url=f'list-post-{suffix}',
+            published_date=published_date,
+        )
+        PostConfig.objects.create(post=post, hide=False)
+        PostContent.objects.create(
+            post=post,
+            content_html='<p>' + ('large admin body ' * 500) + '</p>',
+        )
+        post.tags.add(tag)
+        updates = {}
+        if deleted:
+            updates['deleted_date'] = timezone.now()
+        if image:
+            updates['image'] = f'images/title/{suffix}.jpg'
+        if updates:
+            Post.all_objects.filter(pk=post.pk).update(**updates)
+        return post
+
+    def setUp(self):
+        request = RequestFactory().get('/admin/')
+        request.user = self.admin_user
+        self.request = request
+        self.post_admin = PostAdmin(Post, admin.site)
+        self.comment_admin = CommentAdmin(Comment, admin.site)
+        self.tag_admin = TagAdmin(Tag, admin.site)
+        self.series_admin = SeriesAdmin(Series, admin.site)
+        self.config_admin = ConfigAdmin(Config, admin.site)
+
+    def test_post_list_loads_only_display_relations_in_two_queries(self):
+        with CaptureQueriesContext(connection) as queries:
+            posts = list(
+                self.post_admin.get_queryset(self.request).order_by('pk'),
+            )
+            for post in posts:
+                self.post_admin.thumbnail_preview(post)
+                self.post_admin.author_link(post)
+                self.post_admin.series_link(post)
+                self.post_admin.tags_preview(post)
+                self.post_admin.likes_count(post)
+                self.post_admin.comments_count(post)
+                self.post_admin.status_badges(post)
+                self.post_admin.total_likes(post)
+                self.post_admin.total_comments(post)
+
+        self.assertEqual(len(queries), 2)
+        post_query = queries.captured_queries[0]['sql'].lower()
+        self.assertNotIn('board_postcontent', post_query)
+        self.assertNotIn('password', post_query)
+        rendered_comments = str(
+            self.post_admin.comments_count(
+                next(post for post in posts if post.pk == self.public_posts[0].pk),
+            ),
+        )
+        self.assertIn('1', rendered_comments)
+        self.assertIn('삭제 1', rendered_comments)
+
+    def test_post_relation_lists_select_displayed_objects_once(self):
+        edit_request_admin = EditRequestAdmin(EditRequest, admin.site)
+        pinned_post_admin = PinnedPostAdmin(PinnedPost, admin.site)
+
+        with CaptureQueriesContext(connection) as edit_queries:
+            edit_requests = list(
+                edit_request_admin.get_queryset(self.request).order_by('pk'),
+            )
+            for edit_request in edit_requests:
+                str(edit_request.post)
+
+        with CaptureQueriesContext(connection) as pinned_queries:
+            pinned_posts = list(
+                pinned_post_admin.get_queryset(self.request).order_by('pk'),
+            )
+            for pinned_post in pinned_posts:
+                str(pinned_post.post)
+                str(pinned_post.user)
+
+        self.assertEqual(len(edit_queries), 1)
+        self.assertEqual(len(pinned_queries), 1)
+        self.assertNotIn(
+            'password',
+            pinned_queries.captured_queries[0]['sql'].lower(),
+        )
+
+    def test_comment_list_uses_annotated_like_counts_without_prefetch(self):
+        with CaptureQueriesContext(connection) as queries:
+            comments = list(
+                self.comment_admin.get_queryset(self.request).order_by('pk'),
+            )
+            for comment in comments:
+                self.comment_admin.content_preview(comment)
+                self.comment_admin.post_link(comment)
+                self.comment_admin.author_link(comment)
+                self.comment_admin.likes_display(comment)
+                self.comment_admin.likes_count(comment)
+
+        self.assertEqual(len(queries), 1)
+        active = next(
+            comment
+            for comment in comments
+            if comment.pk == self.active_comment.pk
+        )
+        self.assertEqual(active.likes_count_annotated, 1)
+
+    def test_tag_list_annotates_clear_post_states_and_image_presence(self):
+        with CaptureQueriesContext(connection) as queries:
+            tags = list(
+                self.tag_admin.get_queryset(self.request).order_by('pk'),
+            )
+            for tag in tags:
+                self.tag_admin.count(tag)
+                self.tag_admin.public_count(tag)
+                self.tag_admin.trash_count(tag)
+                self.tag_admin.has_image(tag)
+                self.tag_admin.usage_status(tag)
+
+        self.assertEqual(len(queries), 1)
+        target = next(tag for tag in tags if tag.pk == self.tags[0].pk)
+        self.assertEqual(target.post_count, 2)
+        self.assertEqual(target.public_post_count, 1)
+        self.assertEqual(target.trashed_post_count, 1)
+        self.assertTrue(target.has_public_image)
+        trash_only = next(
+            tag for tag in tags if tag.pk == self.trash_only_tag.pk
+        )
+        self.assertEqual(trash_only.post_count, 0)
+        self.assertEqual(trash_only.trashed_post_count, 1)
+        self.assertIn(
+            '휴지통 전용',
+            str(self.tag_admin.usage_status(trash_only)),
+        )
+
+    def test_series_list_and_inline_avoid_per_row_post_queries(self):
+        with CaptureQueriesContext(connection) as queries:
+            series_rows = list(
+                self.series_admin.get_queryset(self.request).order_by('pk'),
+            )
+            for series in series_rows:
+                self.series_admin.owner_link(series)
+                self.series_admin.count_posts(series)
+                self.series_admin.public_posts(series)
+                self.series_admin.trashed_posts(series)
+                self.series_admin.thumbnail_preview(series)
+                self.series_admin.posts_summary(series)
+
+        self.assertEqual(len(queries), 1)
+        target = next(
+            series
+            for series in series_rows
+            if series.pk == self.series[0].pk
+        )
+        self.assertEqual(target.count_posts, 2)
+        self.assertEqual(target.public_post_count, 1)
+        self.assertEqual(target.trashed_post_count, 1)
+
+        inline = SeriesPostInline(Series, admin.site)
+        with CaptureQueriesContext(connection) as inline_queries:
+            posts = list(
+                inline.get_queryset(self.request)
+                .filter(series=self.series[0])
+                .order_by('pk'),
+            )
+            for post in posts:
+                inline.config_hide(post)
+                inline.view_link(post)
+
+        self.assertEqual(len(inline_queries), 1)
+
+    def test_config_list_checks_integrations_without_loading_secrets(self):
+        with CaptureQueriesContext(connection) as queries:
+            configs = list(
+                self.config_admin.get_queryset(self.request).order_by('pk'),
+            )
+            for config in configs:
+                self.config_admin.user_link(config)
+                self.config_admin.telegram_status(config)
+                self.config_admin.two_factor_status(config)
+
+        self.assertEqual(len(queries), 1)
+        config_query = queries.captured_queries[0]['sql'].lower()
+        self.assertNotIn('password', config_query)
+        self.assertNotIn('totp_secret', config_query)
+        self.assertNotIn('recovery_key', config_query)
+        self.assertNotIn('auth_token', config_query)
+        self.assertTrue(configs[0].telegram_linked)
+        self.assertTrue(configs[0].two_factor_enabled)
+
+    def test_image_cache_list_uses_compact_lazy_previews(self):
+        model_admin = ImageCacheAdmin(ImageCache, admin.site)
+
+        image_preview = str(model_admin.image(ImageCache(path='cache.jpg')))
+        video_preview = str(model_admin.image(ImageCache(path='cache.mp4')))
+
+        self.assertEqual(model_admin.list_per_page, 30)
+        self.assertIn('max-width: 120px', image_preview)
+        self.assertIn('loading="lazy"', image_preview)
+        self.assertNotIn('480px', image_preview)
+        self.assertIn('max-width: 120px', video_preview)
+        self.assertIn('preload="none"', video_preview)
+
+    def test_optimized_admin_changelists_render_successfully(self):
+        self.client.force_login(self.admin_user)
+
+        for url_name in (
+            'admin:board_post_changelist',
+            'admin:board_comment_changelist',
+            'admin:board_tag_changelist',
+            'admin:board_series_changelist',
+            'admin:board_config_changelist',
+            'admin:board_imagecache_changelist',
+        ):
+            with self.subTest(url_name=url_name):
+                response = self.client.get(reverse(url_name))
+                self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
## 🎯 Goal
- Django Admin 목록의 행 수에 따라 반복되던 관계 조회와 불필요한 대용량·민감 필드 로딩을 제거합니다.
- 운영자가 포스트 수치를 활성·공개·휴지통 상태별로 오해 없이 확인하도록 합니다.

## 🔧 Core Changes
- Post 목록은 태그만 prefetch하고 좋아요·댓글 수는 상관 서브쿼리로 집계해 관계 객체와 본문 HTML을 로드하지 않습니다.
- Comment, Tag, Series, Config 목록의 좋아요·대표 이미지·썸네일·연동 상태 N+1을 annotation으로 제거했습니다.
- Tag와 Series에 활성·공개·휴지통 수치를 분리하고, 휴지통에서만 쓰이는 태그를 명확히 표시합니다.
- Series inline과 수정 요청·고정 포스트 목록의 표시 관계를 한 번에 조회합니다.
- 사용자 관계 조회에서 비밀번호·2FA 비밀값·인증 토큰을 목록 SQL에 싣지 않습니다.
- 이미지 캐시 미리보기를 120px/30개로 줄이고 비디오는 preload를 끕니다.

## 🤔 Key Decisions
- 공개 모델 메서드와 API 계약은 유지하고 Admin queryset 및 표시 로직만 최적화했습니다.
- 공개 포스트 판정은 기존 PublicPostService 조건을 재사용해 공개 화면과 의미가 어긋나지 않게 했습니다.
- E2E 대신 Django queryset·changelist 테스트로 쿼리 상한과 렌더링을 저렴하게 고정했습니다.

## 🧪 Verification Guide
### How to verify
1. Admin의 Post, Comment, Tag, Series, Config, Image cache 목록을 엽니다.
2. Tag와 Series에서 활성·공개·휴지통 수치 및 대표 이미지 상태를 확인합니다.
3. 포스트 댓글 열에서 활성/삭제 수치와 이미지 캐시의 작은 lazy preview를 확인합니다.

### Expected result
- 목록 데이터가 늘어도 Post는 태그 포함 2쿼리, Comment·Tag·Series·Config는 각 1쿼리로 행을 표시하고 기존 공개 동작은 유지됩니다.

## ✅ Checklist
- [x] Lint completed (Django system check and diff check)
- [x] Type-check completed (no frontend changes)
- [x] Tests completed (1,275 backend tests; 8 focused Admin tests)
- [x] Documentation updated (not needed; internal Admin behavior only)