### PR TITLE
🐛 Preserve social provider admin URLs

### DIFF
--- a/backend/src/board/admin/auth.py
+++ b/backend/src/board/admin/auth.py
@@ -4,8 +4,9 @@ from django.contrib import admin, messages
 from django.db import transaction
 from django.db.models import QuerySet
 from django.http import HttpRequest
+from django.shortcuts import redirect
 
-from board.models import TwoFactorAuth, SocialAuth
+from board.models import SocialAuth, SocialAuthProvider, TwoFactorAuth
 from board.services.social_auth_connection_service import (
     SocialAuthConnectionService,
     SocialAuthDisconnectError,
@@ -21,6 +22,52 @@ from .mixins import (
     ReadOnlyRecordAdminMixin,
 )
 from .service import AdminDisplayService, AdminLinkService
+
+
+@admin.register(SocialAuthProvider)
+class SocialAuthProviderCompatibilityAdmin(admin.ModelAdmin):
+    """Preserve legacy Admin URLs without exposing provider secrets."""
+
+    canonical_settings_url = '/admin-settings/login'
+
+    def has_module_permission(self, request):
+        return False
+
+    def has_view_permission(self, request, obj=None):
+        return False
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+    def _redirect_to_canonical_settings(self):
+        return redirect(self.canonical_settings_url)
+
+    def changelist_view(self, request, extra_context=None):
+        return self._redirect_to_canonical_settings()
+
+    def add_view(self, request, form_url='', extra_context=None):
+        return self._redirect_to_canonical_settings()
+
+    def change_view(
+        self,
+        request,
+        object_id,
+        form_url='',
+        extra_context=None,
+    ):
+        return self._redirect_to_canonical_settings()
+
+    def delete_view(self, request, object_id, extra_context=None):
+        return self._redirect_to_canonical_settings()
+
+    def history_view(self, request, object_id, extra_context=None):
+        return self._redirect_to_canonical_settings()
 
 
 @admin.register(TwoFactorAuth)

--- a/backend/src/board/tests/admin/test_admin_navigation.py
+++ b/backend/src/board/tests/admin/test_admin_navigation.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 from django.contrib.auth.models import User
 from django.test import RequestFactory, TestCase
-from django.urls import NoReverseMatch, reverse
+from django.urls import reverse
 
 from board.models import (
     Comment,
@@ -110,9 +110,14 @@ class AdminNavigationTestCase(TestCase):
             if group_name != '제품 설정'
             for object_name in object_names
         }
+        visible_registered_models = {
+            model.__name__
+            for model, model_admin in admin.site._registry.items()
+            if model_admin.has_module_permission(self.admin_request())
+        }
         self.assertSetEqual(
             grouped_registered_models,
-            {model.__name__ for model in admin.site._registry},
+            visible_registered_models,
         )
 
     def test_admin_index_links_to_canonical_product_settings(self):
@@ -142,10 +147,45 @@ class AdminNavigationTestCase(TestCase):
         )
         self.assertEqual(board_index.status_code, 200)
 
-    def test_secret_provider_editor_is_not_registered(self):
-        self.assertNotIn(SocialAuthProvider, admin.site._registry)
-        with self.assertRaises(NoReverseMatch):
-            reverse('admin:board_socialauthprovider_changelist')
+    def test_secret_provider_legacy_urls_redirect_to_canonical_settings(self):
+        provider, _ = SocialAuthProvider.objects.get_or_create(key='github')
+        provider_admin = admin.site._registry[SocialAuthProvider]
+        request = self.admin_request()
+
+        self.assertFalse(provider_admin.has_module_permission(request))
+        self.assertFalse(provider_admin.has_view_permission(request, provider))
+        self.assertFalse(provider_admin.has_add_permission(request))
+        self.assertFalse(provider_admin.has_change_permission(request, provider))
+        self.assertFalse(provider_admin.has_delete_permission(request, provider))
+
+        self.client.force_login(self.admin_user)
+        legacy_urls = [
+            reverse('admin:board_socialauthprovider_changelist'),
+            reverse('admin:board_socialauthprovider_add'),
+            reverse(
+                'admin:board_socialauthprovider_change',
+                args=[provider.pk],
+            ),
+            reverse(
+                'admin:board_socialauthprovider_delete',
+                args=[provider.pk],
+            ),
+            reverse(
+                'admin:board_socialauthprovider_history',
+                args=[provider.pk],
+            ),
+        ]
+        for legacy_url in legacy_urls:
+            with self.subTest(legacy_url=legacy_url):
+                response = self.client.get(legacy_url)
+                self.assertRedirects(
+                    response,
+                    '/admin-settings/login',
+                    fetch_redirect_response=False,
+                )
+
+        index_response = self.client.get(reverse('admin:index'))
+        self.assertNotContains(index_response, 'Social auth provider')
 
     def test_registered_board_models_have_korean_admin_names(self):
         expected_names = {


### PR DESCRIPTION
## 🎯 Goal
- Restore the legacy `SocialAuthProvider` Django Admin URL contract removed by #540.
- Keep OAuth client secrets out of raw Admin forms while preserving saved deep links and internal `reverse()` calls.

## 🔧 Core Changes
- Register a hidden compatibility-only Admin for `SocialAuthProvider`.
- Preserve changelist, add, change, delete, and history URL names and redirect staff to the canonical `/admin-settings/login` UI.
- Keep all raw view/add/change/delete permissions disabled and exclude the compatibility Admin from navigation.
- Replace the previous `NoReverseMatch` assertion with redirect, permission, and menu-visibility regression coverage.

## 🤔 Key Decisions
- Preserve the Admin registration instead of reintroducing the secret editor: URL compatibility and secret safety are both retained.
- Redirect every legacy surface to the product settings UI rather than duplicating provider credential handling.
- No public URL, API, model, permission codename, schema, or stored data changes are introduced.

## 🧪 Verification Guide
### How to verify
1. Open any legacy `board_socialauthprovider` Admin URL as staff.
2. Confirm it redirects to `/admin-settings/login` and never renders provider secrets.
3. Confirm the provider model is absent from the Admin index while the canonical product settings link remains.

### Expected result
- All five legacy Admin URL names reverse successfully, raw mutations stay unavailable, and the full backend suite remains green.

## ✅ Checklist
- [x] Lint completed (backend-only change; Django system check passed)
- [x] Type-check completed (no typed frontend surface changed)
- [x] Tests completed (`1279` backend tests; `13` focused tests)
- [x] Documentation updated (not needed; no public behavior changed)
