### PR TITLE
🐛 Guard delegated admin permissions

### DIFF
--- a/backend/src/board/admin/user.py
+++ b/backend/src/board/admin/user.py
@@ -4,8 +4,11 @@ User & Profile Admin Configuration
 from typing import Any, Optional
 from django import forms
 from django.contrib import admin, messages
-from django.contrib.auth.models import User
-from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
+from django.contrib.auth.admin import (
+    GroupAdmin as BaseGroupAdmin,
+    UserAdmin as BaseUserAdmin,
+)
+from django.contrib.auth.models import Group, User
 from django.http import HttpRequest
 from django.db import transaction
 from django.db.models import Count, Exists, OuterRef, QuerySet
@@ -176,10 +179,33 @@ class ProfileInline(admin.StackedInline):
 
 
 # Django User Admin 커스터마이징
+admin.site.unregister(Group)
 admin.site.unregister(User)
+
+
+@admin.register(Group)
+class CustomGroupAdmin(BaseGroupAdmin):
+    """Keep delegated staff from changing permission bundles."""
+
+    def has_add_permission(self, request):
+        return request.user.is_superuser
+
+    def has_change_permission(self, request, obj=None):
+        return request.user.is_superuser
+
+    def has_delete_permission(self, request, obj=None):
+        return request.user.is_superuser
+
 
 @admin.register(User)
 class CustomUserAdmin(ConfirmedActionDeleteAdminMixin, BaseUserAdmin):
+    delegated_readonly_fields = (
+        'is_staff',
+        'is_superuser',
+        'groups',
+        'user_permissions',
+    )
+
     inlines = [ProfileInline, UserLinkMetaInline]
 
     list_display = ['username', 'email', 'role_badge', 'post_count', 'is_staff', 'is_active', 'date_joined']
@@ -198,8 +224,10 @@ class CustomUserAdmin(ConfirmedActionDeleteAdminMixin, BaseUserAdmin):
 
     def get_readonly_fields(self, request, obj=None):
         readonly_fields = list(super().get_readonly_fields(request, obj))
+        if not request.user.is_superuser:
+            readonly_fields.extend(self.delegated_readonly_fields)
         if obj is None:
-            return readonly_fields
+            return list(dict.fromkeys(readonly_fields))
 
         is_current_user = obj.pk == request.user.pk
         is_last_active_superuser = (
@@ -217,6 +245,30 @@ class CustomUserAdmin(ConfirmedActionDeleteAdminMixin, BaseUserAdmin):
                 'is_superuser',
             ])
         return list(dict.fromkeys(readonly_fields))
+
+    def has_change_permission(self, request, obj=None):
+        if (
+            obj is not None
+            and obj.is_superuser
+            and not request.user.is_superuser
+        ):
+            return False
+        return super().has_change_permission(request, obj)
+
+    def has_change_profile_permission(self, request):
+        return (
+            self.has_change_permission(request)
+            and request.user.has_perm('board.change_profile')
+        )
+
+    @staticmethod
+    def mutable_users(
+        request: HttpRequest,
+        queryset: QuerySet[User],
+    ) -> QuerySet[User]:
+        if request.user.is_superuser:
+            return queryset
+        return queryset.filter(is_superuser=False)
 
     def role_badge(self, obj):
         if hasattr(obj, 'profile'):
@@ -237,6 +289,7 @@ class CustomUserAdmin(ConfirmedActionDeleteAdminMixin, BaseUserAdmin):
         *,
         role: str,
     ) -> int:
+        queryset = self.mutable_users(request, queryset)
         with transaction.atomic():
             users = list(queryset.select_for_update().select_related('profile'))
             count = UserRoleService.set_users_role(queryset, role)
@@ -252,7 +305,7 @@ class CustomUserAdmin(ConfirmedActionDeleteAdminMixin, BaseUserAdmin):
 
     @admin.action(
         description='선택한 사용자를 작가로 변경',
-        permissions=['change'],
+        permissions=['change_profile'],
     )
     def make_editor(
         self,
@@ -268,7 +321,7 @@ class CustomUserAdmin(ConfirmedActionDeleteAdminMixin, BaseUserAdmin):
 
     @admin.action(
         description='선택한 사용자를 독자로 변경',
-        permissions=['change'],
+        permissions=['change_profile'],
     )
     def make_reader(
         self,
@@ -290,6 +343,12 @@ class CustomUserAdmin(ConfirmedActionDeleteAdminMixin, BaseUserAdmin):
         is_active: bool,
     ) -> Any:
         candidates = queryset.filter(is_active=not is_active)
+        protected_superuser_count = 0
+        if not request.user.is_superuser:
+            protected_superuser_count = candidates.filter(
+                is_superuser=True,
+            ).count()
+            candidates = candidates.filter(is_superuser=False)
         action_name = 'activate_users' if is_active else 'deactivate_users'
         status_label = '활성화' if is_active else '비활성화'
         if request.POST.get('confirm') != 'yes':
@@ -346,6 +405,12 @@ class CustomUserAdmin(ConfirmedActionDeleteAdminMixin, BaseUserAdmin):
             self.message_user(
                 request,
                 '마지막 활성 슈퍼유저 계정은 비활성화하지 않았습니다.',
+                level=messages.WARNING,
+            )
+        if protected_superuser_count:
+            self.message_user(
+                request,
+                f'슈퍼유저 {protected_superuser_count}명은 변경하지 않았습니다.',
                 level=messages.WARNING,
             )
         return None

--- a/backend/src/board/tests/admin/test_admin_permission_boundaries.py
+++ b/backend/src/board/tests/admin/test_admin_permission_boundaries.py
@@ -1,0 +1,172 @@
+from django.contrib import admin
+from django.contrib.auth.models import Group, Permission, User
+from django.test import RequestFactory, TestCase
+from django.urls import reverse
+
+from board.admin.user import CustomGroupAdmin, CustomUserAdmin
+from board.models import Profile
+
+
+class AdminPermissionBoundaryTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.superuser = User.objects.create_superuser(
+            username='permission-root',
+            email='permission-root@example.com',
+            password='test',
+        )
+        cls.staff = User.objects.create_user(
+            username='delegated-user-admin',
+            email='delegated-user-admin@example.com',
+            password='test',
+            is_staff=True,
+        )
+        cls.target = User.objects.create_user(
+            username='permission-target',
+            email='permission-target@example.com',
+            password='test',
+        )
+        cls.target_profile, _ = Profile.objects.get_or_create(
+            user=cls.target,
+            defaults={'role': Profile.Role.READER},
+        )
+        cls.group = Group.objects.create(name='delegated-group')
+        cls.staff.user_permissions.add(
+            Permission.objects.get(codename='change_user'),
+            Permission.objects.get(codename='change_group'),
+        )
+
+    def setUp(self):
+        self.staff = User.objects.get(pk=self.staff.pk)
+        self.user_admin = CustomUserAdmin(User, admin.site)
+        self.group_admin = CustomGroupAdmin(Group, admin.site)
+
+    def admin_request(self):
+        request = RequestFactory().get('/admin/')
+        request.user = self.staff
+        return request
+
+    def test_delegated_staff_cannot_change_superuser_or_password(self):
+        request = self.admin_request()
+
+        self.assertFalse(
+            self.user_admin.has_change_permission(request, self.superuser),
+        )
+
+        self.client.force_login(self.staff)
+        change_response = self.client.post(
+            reverse('admin:auth_user_change', args=[self.superuser.pk]),
+            {'username': self.superuser.username},
+        )
+        password_response = self.client.get(
+            reverse(
+                'admin:auth_user_password_change',
+                args=[self.superuser.pk],
+            ),
+        )
+
+        self.assertEqual(change_response.status_code, 403)
+        self.assertEqual(password_response.status_code, 403)
+
+    def test_crafted_user_post_cannot_grant_privileged_fields(self):
+        request = self.admin_request()
+        readonly_fields = set(
+            self.user_admin.get_readonly_fields(request, self.target),
+        )
+
+        self.assertTrue(
+            set(self.user_admin.delegated_readonly_fields).issubset(
+                readonly_fields,
+            ),
+        )
+
+        self.client.force_login(self.staff)
+        response = self.client.post(
+            reverse('admin:auth_user_change', args=[self.target.pk]),
+            {
+                'username': self.target.username,
+                'first_name': '',
+                'last_name': '',
+                'email': self.target.email,
+                'is_active': 'on',
+                'date_joined_0': self.target.date_joined.strftime('%Y-%m-%d'),
+                'date_joined_1': self.target.date_joined.strftime('%H:%M:%S'),
+                'is_staff': 'on',
+                'is_superuser': 'on',
+                'groups': [str(self.group.pk)],
+                'user_permissions': [
+                    str(Permission.objects.get(codename='change_user').pk),
+                ],
+                '_save': 'Save',
+            },
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.target.refresh_from_db()
+        self.assertFalse(self.target.is_staff)
+        self.assertFalse(self.target.is_superuser)
+        self.assertFalse(self.target.groups.exists())
+        self.assertFalse(self.target.user_permissions.exists())
+
+    def test_user_role_actions_require_profile_change_permission(self):
+        request = self.admin_request()
+
+        self.assertNotIn('make_editor', self.user_admin.get_actions(request))
+        self.assertNotIn('make_reader', self.user_admin.get_actions(request))
+
+        self.staff.user_permissions.add(
+            Permission.objects.get(codename='change_profile'),
+        )
+        self.staff = User.objects.get(pk=self.staff.pk)
+
+        actions = self.user_admin.get_actions(self.admin_request())
+        self.assertIn('make_editor', actions)
+        self.assertIn('make_reader', actions)
+
+    def test_group_permission_bundles_are_superuser_only(self):
+        request = self.admin_request()
+
+        self.assertFalse(self.group_admin.has_add_permission(request))
+        self.assertFalse(
+            self.group_admin.has_change_permission(request, self.group),
+        )
+        self.assertFalse(
+            self.group_admin.has_delete_permission(request, self.group),
+        )
+
+        self.client.force_login(self.staff)
+        response = self.client.post(
+            reverse('admin:auth_group_change', args=[self.group.pk]),
+            {
+                'name': 'privileged-group',
+                'permissions': [
+                    str(Permission.objects.get(codename='change_user').pk),
+                ],
+                '_save': 'Save',
+            },
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.group.refresh_from_db()
+        self.assertEqual(self.group.name, 'delegated-group')
+        self.assertFalse(self.group.permissions.exists())
+
+    def test_superuser_keeps_existing_privilege_management(self):
+        request = RequestFactory().get('/admin/')
+        request.user = self.superuser
+
+        self.assertTrue(self.group_admin.has_add_permission(request))
+        self.assertTrue(
+            self.group_admin.has_change_permission(request, self.group),
+        )
+        self.assertTrue(
+            self.group_admin.has_delete_permission(request, self.group),
+        )
+        readonly_fields = set(
+            self.user_admin.get_readonly_fields(request, self.target),
+        )
+        self.assertTrue(
+            set(self.user_admin.delegated_readonly_fields).isdisjoint(
+                readonly_fields,
+            ),
+        )


### PR DESCRIPTION
## Summary

- prevent delegated staff from changing superuser accounts or privileged user fields
- restrict group permission bundle management to superusers
- require profile change permission for reader/editor role actions
- keep existing superuser management behavior and Admin URLs intact

## Changes

- make `is_staff`, `is_superuser`, groups, and direct permissions read-only for non-superuser staff
- exclude superusers from delegated user role and activation actions
- add focused permission-boundary regression tests

## Compatibility

- no model, migration, public URL, API, or database behavior changes
- superusers retain the existing user and group management surface
- delegated staff retain ordinary user management allowed by their existing permissions

## Test Plan

- [x] `npm run server:test` (1,284 tests)
- [x] `node scripts/manage.mjs check`
- [x] `npm run server:check-migrations`
- [x] `git diff --check`
