### PR TITLE
🐛 Protect service-owned admin records

### DIFF
--- a/backend/src/board/admin/connection.py
+++ b/backend/src/board/admin/connection.py
@@ -1,24 +1,69 @@
 from django.contrib import admin
+from django.db.models import BooleanField, Case, Value, When
 
 from board.models import TelegramSync
 
-from .service import AdminLinkService, AdminDisplayService
+from .mixins import ServiceOwnedRecordAdminMixin
+from .service import AdminDisplayService, AdminLinkService
 
 
 @admin.register(TelegramSync)
-class TelegramSyncAdmin(admin.ModelAdmin):
-    list_display = ['id', 'user_link', 'synced', 'created_date']
+class TelegramSyncAdmin(ServiceOwnedRecordAdminMixin, admin.ModelAdmin):
+    list_display = [
+        'id',
+        'user_link',
+        'synced',
+        'token_status',
+        'created_date',
+    ]
     search_fields = ['user__username']
     list_filter = [('created_date', admin.DateFieldListFilter)]
+    fields = [
+        'user_link',
+        'synced',
+        'token_status',
+        'auth_token_exp',
+        'created_date',
+    ]
+    readonly_fields = fields
     list_per_page = 30
 
     def get_queryset(self, request):
-        return super().get_queryset(request).select_related('user')
+        return super().get_queryset(request).select_related('user').defer(
+            'tid',
+            'auth_token',
+            'user__password',
+        ).annotate(
+            telegram_linked=Case(
+                When(tid='', then=Value(False)),
+                default=Value(True),
+                output_field=BooleanField(),
+            ),
+            pending_auth_token=Case(
+                When(auth_token='', then=Value(False)),
+                default=Value(True),
+                output_field=BooleanField(),
+            ),
+        )
 
     def user_link(self, obj):
         return AdminLinkService.create_user_link(obj.user)
     user_link.short_description = '사용자'
 
     def synced(self, obj: TelegramSync):
-        return AdminDisplayService.check_mark(obj.tid)
+        return AdminDisplayService.boolean_badge(
+            obj.telegram_linked,
+            true_text='연동됨',
+            false_text='연동 대기',
+        )
     synced.short_description = '연동 상태'
+    synced.admin_order_field = 'tid'
+
+    def token_status(self, obj: TelegramSync):
+        return AdminDisplayService.boolean_badge(
+            obj.pending_auth_token,
+            true_text='발급됨',
+            false_text='없음',
+        )
+    token_status.short_description = '인증 토큰'
+    token_status.admin_order_field = 'auth_token'

--- a/backend/src/board/admin/image.py
+++ b/backend/src/board/admin/image.py
@@ -3,7 +3,8 @@ from django.conf import settings
 
 from board.models import ImageCache
 
-from .service import AdminDisplayService
+from .mixins import ServiceOwnedRecordAdminMixin
+from .service import AdminDisplayService, AdminLinkService
 
 
 class ImageFilter(admin.SimpleListFilter):
@@ -26,14 +27,27 @@ class ImageFilter(admin.SimpleListFilter):
 
 
 @admin.register(ImageCache)
-class ImageCacheAdmin(admin.ModelAdmin):
+class ImageCacheAdmin(ServiceOwnedRecordAdminMixin, admin.ModelAdmin):
     search_fields = ['path']
 
-    list_display = ['id', 'file_size', 'image', 'open_image']
+    list_display = ['id', 'user_link', 'file_size', 'image', 'open_image']
+    fields = ['user_link', 'path', 'file_size', 'image', 'open_image']
+    readonly_fields = fields
     list_per_page = 30
+
+    def get_queryset(self, request):
+        return super().get_queryset(request).select_related('user').defer(
+            'key',
+            'user__password',
+        )
 
     def get_list_filter(self, request):
         return [ImageFilter]
+
+    def user_link(self, obj):
+        return AdminLinkService.create_user_link(obj.user)
+    user_link.short_description = '업로더'
+    user_link.admin_order_field = 'user__username'
 
     def file_size(self, obj):
         size = obj.size

--- a/backend/src/board/admin/mixins.py
+++ b/backend/src/board/admin/mixins.py
@@ -10,6 +10,18 @@ class ReadOnlyRecordAdminMixin:
         return super().has_change_permission(request, obj)
 
 
+class ServiceOwnedRecordAdminMixin(ReadOnlyRecordAdminMixin):
+    """Expose service-owned rows for inspection without raw CRUD paths."""
+
+    def get_actions(self, request):
+        actions = super().get_actions(request)
+        actions.pop('delete_selected', None)
+        return actions
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+
 class ConfirmedActionDeleteAdminMixin:
     """Disable Django deletes while retaining delete permission for actions."""
 

--- a/backend/src/board/admin/post.py
+++ b/backend/src/board/admin/post.py
@@ -34,6 +34,7 @@ from board.models import (
 )
 
 from .action_confirmation import render_action_confirmation
+from .mixins import ServiceOwnedRecordAdminMixin
 from .service import AdminDisplayService, AdminLinkService
 from .constants import (
     LIST_PER_PAGE_DEFAULT,
@@ -69,27 +70,75 @@ class PublishStatusFilter(admin.SimpleListFilter):
 
 
 @admin.register(EditRequest)
-class EditRequestAdmin(admin.ModelAdmin):
-    list_display = ['id', 'post', 'created_date']
+class EditRequestAdmin(ServiceOwnedRecordAdminMixin, admin.ModelAdmin):
+    list_display = [
+        'id',
+        'post_link',
+        'user_link',
+        'title',
+        'is_merged',
+        'created_date',
+    ]
     list_per_page = LIST_PER_PAGE_DEFAULT
-    search_fields = ['post__title']
+    search_fields = ['post__title', 'user__username', 'title']
+    list_filter = ['is_merged', ('created_date', admin.DateFieldListFilter)]
+    fields = [
+        'post_link',
+        'user_link',
+        'title',
+        'content',
+        'is_merged',
+        'created_date',
+        'updated_date',
+    ]
+    readonly_fields = fields
 
     def get_queryset(self, request):
-        return super().get_queryset(request).select_related('post')
+        queryset = super().get_queryset(request).select_related(
+            'post',
+            'user',
+        ).defer('user__password')
+        if (
+            getattr(request, 'resolver_match', None)
+            and request.resolver_match.url_name == 'board_editrequest_changelist'
+        ):
+            return queryset.defer('content')
+        return queryset
+
+    def post_link(self, obj: EditRequest):
+        return AdminLinkService.create_post_link(obj.post)
+    post_link.short_description = '포스트'
+    post_link.admin_order_field = 'post__title'
+
+    def user_link(self, obj: EditRequest):
+        return AdminLinkService.create_user_link(obj.user)
+    user_link.short_description = '요청자'
+    user_link.admin_order_field = 'user__username'
 
 
 @admin.register(PinnedPost)
-class PinnedPostAdmin(admin.ModelAdmin):
-    list_display = ['id', 'post', 'user', 'order']
+class PinnedPostAdmin(ServiceOwnedRecordAdminMixin, admin.ModelAdmin):
+    list_display = ['id', 'post_link', 'user_link', 'order', 'created_date']
     list_per_page = LIST_PER_PAGE_DEFAULT
     search_fields = ['post__title', 'user__username']
-    autocomplete_fields = ['post', 'user']
+    fields = ['post_link', 'user_link', 'order', 'created_date']
+    readonly_fields = fields
 
     def get_queryset(self, request):
         return super().get_queryset(request).select_related(
             'post',
             'user',
         ).defer('user__password')
+
+    def post_link(self, obj: PinnedPost):
+        return AdminLinkService.create_post_link(obj.post)
+    post_link.short_description = '포스트'
+    post_link.admin_order_field = 'post__title'
+
+    def user_link(self, obj: PinnedPost):
+        return AdminLinkService.create_user_link(obj.user)
+    user_link.short_description = '사용자'
+    user_link.admin_order_field = 'user__username'
 
 
 class PostContentInline(admin.StackedInline):
@@ -274,6 +323,10 @@ class PostAdmin(admin.ModelAdmin):
     def save_related(self, request, form, formsets, change):
         super().save_related(request, form, formsets, change)
         post = form.instance
+        if not change:
+            PostContent.objects.get_or_create(post=post)
+            PostConfig.objects.get_or_create(post=post)
+
         previous_snapshot = getattr(
             post,
             '_admin_previous_snapshot',

--- a/backend/src/board/tests/admin/test_managed_record_admin.py
+++ b/backend/src/board/tests/admin/test_managed_record_admin.py
@@ -1,0 +1,212 @@
+from types import SimpleNamespace
+
+from django.contrib import admin
+from django.contrib.auth.models import User
+from django.test import RequestFactory, TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from board.admin.connection import TelegramSyncAdmin
+from board.admin.image import ImageCacheAdmin
+from board.admin.post import EditRequestAdmin, PinnedPostAdmin, PostAdmin
+from board.models import (
+    EditRequest,
+    ImageCache,
+    PinnedPost,
+    Post,
+    PostConfig,
+    PostContent,
+    TelegramSync,
+)
+
+
+class DummyPostAdminForm:
+    def __init__(self, instance):
+        self.instance = instance
+
+    def save_m2m(self):
+        return None
+
+
+class ManagedRecordAdminTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.admin_user = User.objects.create_superuser(
+            username='managed-record-admin',
+            email='managed-record-admin@example.com',
+            password='test',
+        )
+        cls.user = User.objects.create_user(
+            username='managed-record-owner',
+            password='test',
+        )
+        cls.post = Post.objects.create(
+            author=cls.user,
+            title='Managed record post',
+            url='managed-record-post',
+            published_date=timezone.now(),
+        )
+        PostContent.objects.create(
+            post=cls.post,
+            content_html='<p>Managed post</p>',
+        )
+        PostConfig.objects.create(post=cls.post)
+        cls.telegram = TelegramSync.objects.create(
+            user=cls.user,
+            tid='telegram-chat-secret',
+            auth_token='87654321',
+        )
+        cls.pinned = PinnedPost.objects.create(
+            user=cls.user,
+            post=cls.post,
+            order=0,
+        )
+        cls.edit_request = EditRequest.objects.create(
+            user=cls.user,
+            post=cls.post,
+            title='Managed edit request',
+            content='large-edit-request-content-secret',
+        )
+        cls.image_cache = ImageCache.objects.create(
+            user=cls.user,
+            key='managed-image-cache-secret-key'.ljust(44, 'x'),
+            path='cache/managed-record.jpg',
+            size=1024,
+        )
+
+    def setUp(self):
+        self.telegram_admin = TelegramSyncAdmin(TelegramSync, admin.site)
+        self.pinned_admin = PinnedPostAdmin(PinnedPost, admin.site)
+        self.edit_request_admin = EditRequestAdmin(EditRequest, admin.site)
+        self.image_cache_admin = ImageCacheAdmin(ImageCache, admin.site)
+
+    def admin_request(self, path='/admin/'):
+        request = RequestFactory().get(path)
+        request.user = self.admin_user
+        return request
+
+    def test_service_owned_records_are_inspectable_without_raw_crud(self):
+        request = self.admin_request()
+        records = [
+            (self.telegram_admin, self.telegram),
+            (self.pinned_admin, self.pinned),
+            (self.edit_request_admin, self.edit_request),
+            (self.image_cache_admin, self.image_cache),
+        ]
+
+        for model_admin, record in records:
+            with self.subTest(model=type(record).__name__):
+                self.assertTrue(
+                    model_admin.has_view_permission(request, record),
+                )
+                self.assertFalse(model_admin.has_add_permission(request))
+                self.assertFalse(
+                    model_admin.has_change_permission(request, record),
+                )
+                self.assertFalse(
+                    model_admin.has_delete_permission(request, record),
+                )
+                self.assertNotIn(
+                    'delete_selected',
+                    model_admin.get_actions(request),
+                )
+
+    def test_existing_changelist_and_detail_urls_remain_viewable(self):
+        self.client.force_login(self.admin_user)
+        records = [
+            ('board_telegramsync', self.telegram),
+            ('board_pinnedpost', self.pinned),
+            ('board_editrequest', self.edit_request),
+            ('board_imagecache', self.image_cache),
+        ]
+
+        for url_prefix, record in records:
+            with self.subTest(url_prefix=url_prefix):
+                changelist = self.client.get(
+                    reverse(f'admin:{url_prefix}_changelist'),
+                )
+                detail = self.client.get(
+                    reverse(
+                        f'admin:{url_prefix}_change',
+                        args=[record.pk],
+                    ),
+                )
+                self.assertEqual(changelist.status_code, 200)
+                self.assertEqual(detail.status_code, 200)
+                self.assertNotContains(detail, 'name="_save"')
+
+    def test_sensitive_and_large_values_are_not_loaded_for_lists(self):
+        telegram = self.telegram_admin.get_queryset(
+            self.admin_request(),
+        ).get(pk=self.telegram.pk)
+        image_cache = self.image_cache_admin.get_queryset(
+            self.admin_request(),
+        ).get(pk=self.image_cache.pk)
+        edit_request_request = self.admin_request()
+        edit_request_request.resolver_match = SimpleNamespace(
+            url_name='board_editrequest_changelist',
+        )
+        edit_request = self.edit_request_admin.get_queryset(
+            edit_request_request,
+        ).get(pk=self.edit_request.pk)
+
+        self.assertTrue(
+            {'tid', 'auth_token'}.issubset(
+                telegram.get_deferred_fields(),
+            ),
+        )
+        self.assertIn('password', telegram.user.get_deferred_fields())
+        self.assertTrue(telegram.telegram_linked)
+        self.assertTrue(telegram.pending_auth_token)
+        self.assertIn('key', image_cache.get_deferred_fields())
+        self.assertIn('content', edit_request.get_deferred_fields())
+
+        self.client.force_login(self.admin_user)
+        telegram_response = self.client.get(
+            reverse(
+                'admin:board_telegramsync_change',
+                args=[self.telegram.pk],
+            ),
+        )
+        image_response = self.client.get(
+            reverse(
+                'admin:board_imagecache_change',
+                args=[self.image_cache.pk],
+            ),
+        )
+        edit_list_response = self.client.get(
+            reverse('admin:board_editrequest_changelist'),
+        )
+        rendered = b''.join([
+            telegram_response.content,
+            image_response.content,
+            edit_list_response.content,
+        ])
+
+        self.telegram.refresh_from_db()
+        for hidden_value in (
+            self.telegram.tid,
+            self.telegram.auth_token,
+            self.image_cache.key,
+            self.edit_request.content,
+        ):
+            self.assertNotIn(hidden_value.encode(), rendered)
+
+    def test_admin_created_post_gets_required_related_records(self):
+        post = Post.objects.create(
+            author=self.user,
+            title='Admin-created draft',
+            url='admin-created-draft',
+        )
+        self.assertFalse(PostContent.objects.filter(post=post).exists())
+        self.assertFalse(PostConfig.objects.filter(post=post).exists())
+
+        PostAdmin(Post, admin.site).save_related(
+            self.admin_request(),
+            DummyPostAdminForm(post),
+            [],
+            change=False,
+        )
+
+        self.assertTrue(PostContent.objects.filter(post=post).exists())
+        self.assertTrue(PostConfig.objects.filter(post=post).exists())


### PR DESCRIPTION
## Summary

- make Telegram links, pinned posts, edit requests, and image-cache rows inspectable but not raw CRUD-managed in Django Admin
- avoid loading or rendering Telegram credentials, image cache keys, and edit-request bodies on list pages
- preserve existing Admin list/detail URLs and make Admin-created posts structurally complete

## Changes

- add a reusable service-owned read-only Admin boundary
- replace raw relation controls with linked, read-only operational views
- annotate Telegram status without selecting encrypted IDs or one-time tokens
- defer large edit-request content on changelists
- create missing `PostContent` and `PostConfig` rows after an Admin post add
- add focused URL, permission, secret-redaction, and post-integrity regression tests

## Compatibility

- no model, migration, public URL, API, or database schema changes
- existing Django Admin changelist and detail URLs remain viewable
- existing post add URL remains available and now creates required related rows
- product-owned mutation flows and service invariants remain authoritative

## Test Plan

- [x] `npm run server:test` (1,288 tests)
- [x] `node scripts/manage.mjs test board.tests.admin` (73 tests)
- [x] `node scripts/manage.mjs check`
- [x] `npm run server:check-migrations`
- [x] `git diff --check`
