### PR TITLE
🐛 Mask admin webhook credentials

### DIFF
--- a/backend/src/board/admin/webhook.py
+++ b/backend/src/board/admin/webhook.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from django import forms
 from django.contrib import admin, messages
 from django.db import transaction
 from django.db.models import QuerySet
@@ -11,13 +12,64 @@ from board.services.webhook_subscription_state_service import (
 )
 
 from .action_confirmation import render_action_confirmation
+from .service import AdminDisplayService, AdminLinkService
+
+
+class WebhookSubscriptionAdminForm(forms.ModelForm):
+    """Treat webhook URLs as write-only bearer credentials in Admin."""
+
+    webhook_url = forms.URLField(
+        label='웹훅 URL',
+        max_length=500,
+        required=False,
+        help_text=(
+            '기존 URL은 표시하지 않습니다. 변경할 때만 새 URL을 '
+            '입력하세요.'
+        ),
+        widget=forms.PasswordInput(
+            render_value=False,
+            attrs={
+                'autocomplete': 'new-password',
+                'placeholder': '변경할 때만 입력',
+            },
+        ),
+    )
+
+    class Meta:
+        model = WebhookSubscription
+        fields = [
+            'scope',
+            'author',
+            'webhook_url',
+            'name',
+            'is_active',
+        ]
+
+    def clean_webhook_url(self) -> str:
+        webhook_url = self.cleaned_data.get('webhook_url', '').strip()
+        if webhook_url:
+            return webhook_url
+        if self.instance.pk is not None:
+            return WebhookSubscription.objects.only('webhook_url').get(
+                pk=self.instance.pk,
+            ).webhook_url
+        raise forms.ValidationError('웹훅 URL을 입력하세요.')
 
 
 @admin.register(WebhookSubscription)
 class WebhookSubscriptionAdmin(admin.ModelAdmin):
-    list_display = ['name', 'scope', 'author', 'is_active', 'failure_count', 'last_success_date', 'created_date']
+    form = WebhookSubscriptionAdminForm
+    list_display = [
+        'name',
+        'scope',
+        'author_link',
+        'is_active',
+        'failure_count',
+        'last_success_date',
+        'created_date',
+    ]
     list_filter = ['scope', 'is_active', 'failure_count', ('created_date', admin.DateFieldListFilter)]
-    search_fields = ['name', 'author__user__username', 'webhook_url']
+    search_fields = ['name', 'author__user__username']
     readonly_fields = [
         'created_date',
         'failure_count',
@@ -29,6 +81,21 @@ class WebhookSubscriptionAdmin(admin.ModelAdmin):
         'activate_subscriptions',
         'deactivate_subscriptions',
     ]
+
+    def get_queryset(self, request):
+        return super().get_queryset(request).select_related(
+            'author__user',
+        ).defer(
+            'webhook_url',
+            'author__user__password',
+        )
+
+    def author_link(self, obj: WebhookSubscription):
+        if obj.author is None:
+            return AdminDisplayService.empty_placeholder('전체 사용자')
+        return AdminLinkService.create_user_link(obj.author.user)
+    author_link.short_description = '대상'
+    author_link.admin_order_field = 'author__user__username'
 
     def get_readonly_fields(self, request, obj=None):
         readonly_fields = list(super().get_readonly_fields(request, obj))

--- a/backend/src/board/tests/admin/test_webhook_admin.py
+++ b/backend/src/board/tests/admin/test_webhook_admin.py
@@ -1,0 +1,135 @@
+from django.contrib import admin
+from django.contrib.auth.models import User
+from django.db import connection
+from django.test import RequestFactory, TestCase
+from django.test.utils import CaptureQueriesContext
+from django.urls import reverse
+
+from board.admin.webhook import (
+    WebhookSubscriptionAdmin,
+    WebhookSubscriptionAdminForm,
+)
+from board.models import Profile, SiteContentScope, WebhookSubscription
+
+
+class WebhookSubscriptionAdminTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.admin_user = User.objects.create_superuser(
+            username='webhook-secret-admin',
+            email='webhook-secret-admin@example.com',
+            password='test',
+        )
+        cls.user = User.objects.create_user(
+            username='webhook-secret-owner',
+            password='test',
+        )
+        cls.profile = Profile.objects.create(user=cls.user)
+        cls.secret_url = (
+            'https://hooks.example.com/services/private/bearer-token-secret'
+        )
+        cls.subscription = WebhookSubscription.objects.create(
+            scope=SiteContentScope.USER,
+            author=cls.profile,
+            webhook_url=cls.secret_url,
+            name='Private webhook',
+        )
+
+    def setUp(self):
+        self.model_admin = WebhookSubscriptionAdmin(
+            WebhookSubscription,
+            admin.site,
+        )
+
+    def admin_request(self):
+        request = RequestFactory().get('/admin/board/webhooksubscription/')
+        request.user = self.admin_user
+        return request
+
+    def form_data(self, *, webhook_url=''):
+        return {
+            'scope': SiteContentScope.USER,
+            'author': str(self.profile.pk),
+            'webhook_url': webhook_url,
+            'name': 'Private webhook',
+            'is_active': 'on',
+        }
+
+    def test_existing_secret_is_not_selected_for_changelists(self):
+        with CaptureQueriesContext(connection) as queries:
+            subscriptions = list(
+                self.model_admin.get_queryset(self.admin_request()),
+            )
+            for subscription in subscriptions:
+                self.model_admin.author_link(subscription)
+
+        self.assertEqual(len(queries), 1)
+        self.assertNotIn(
+            'webhook_url',
+            queries.captured_queries[0]['sql'].lower(),
+        )
+        self.assertIn(
+            'webhook_url',
+            subscriptions[0].get_deferred_fields(),
+        )
+        self.assertIn(
+            'password',
+            subscriptions[0].author.user.get_deferred_fields(),
+        )
+
+    def test_change_page_uses_blank_password_field_without_secret(self):
+        self.client.force_login(self.admin_user)
+
+        response = self.client.get(
+            reverse(
+                'admin:board_webhooksubscription_change',
+                args=[self.subscription.pk],
+            ),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'type=password', html=False)
+        self.assertContains(response, 'name=webhook_url', html=False)
+        self.assertNotContains(response, self.secret_url)
+        self.assertNotContains(response, 'bearer-token-secret')
+
+    def test_blank_existing_url_preserves_stored_subscription(self):
+        form = WebhookSubscriptionAdminForm(
+            data=self.form_data(),
+            instance=WebhookSubscription.objects.get(
+                pk=self.subscription.pk,
+            ),
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+        form.save()
+
+        self.subscription.refresh_from_db()
+        self.assertEqual(self.subscription.webhook_url, self.secret_url)
+
+    def test_explicit_new_url_replaces_stored_subscription(self):
+        new_url = 'https://hooks.example.com/services/replacement/secret'
+        form = WebhookSubscriptionAdminForm(
+            data=self.form_data(webhook_url=new_url),
+            instance=WebhookSubscription.objects.get(
+                pk=self.subscription.pk,
+            ),
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+        form.save()
+
+        self.subscription.refresh_from_db()
+        self.assertEqual(self.subscription.webhook_url, new_url)
+
+    def test_new_subscription_still_requires_url(self):
+        form = WebhookSubscriptionAdminForm(data={
+            'scope': SiteContentScope.GLOBAL,
+            'author': '',
+            'webhook_url': '',
+            'name': 'Missing URL',
+            'is_active': 'on',
+        })
+
+        self.assertFalse(form.is_valid())
+        self.assertIn('웹훅 URL을 입력하세요.', form.errors['webhook_url'])


### PR DESCRIPTION
## Summary

- treat webhook URLs as write-only bearer credentials in Django Admin
- keep existing URLs unchanged when operators leave the credential field blank
- avoid selecting secret URLs or related user passwords on changelists

## Changes

- render the webhook URL with a non-repopulating password widget
- require a URL for new subscriptions and replace existing values only when a new URL is submitted
- remove secret URL search and use a constant-query linked target column
- add form, rendering, query, and compatibility regression tests

## Compatibility

- no model, migration, public URL, API, or database schema changes
- existing webhook subscription values and Admin URLs remain intact
- blank edits preserve the stored URL; explicit valid URLs continue to replace it
- webhook delivery and public API behavior are unchanged

## Test Plan

- [x] `npm run server:test` (1,293 tests)
- [x] `node scripts/manage.mjs test board.tests.admin` (78 tests)
- [x] focused Admin and webhook API tests (46 tests)
- [x] `node scripts/manage.mjs check`
- [x] `npm run server:check-migrations`
- [x] `git diff --check`
