### PR TITLE
🐛 Defer admin notification delivery

### DIFF
--- a/backend/src/board/admin/notify.py
+++ b/backend/src/board/admin/notify.py
@@ -298,20 +298,31 @@ class NotifyAdmin(admin.ModelAdmin):
         if change:
             return
 
-        try:
-            obj.send_notify()
-        except Exception as error:
-            logger.error(
-                'Admin notification delivery failed notification_id=%s '
-                'exception_type=%s',
-                obj.pk,
-                type(error).__name__,
-            )
-            self.message_user(
-                request,
-                '알림은 저장했지만 외부 채널 전송을 예약하지 못했습니다.',
-                level=messages.ERROR,
-            )
+        notification_id = obj.pk
+
+        def deliver_after_commit() -> None:
+            try:
+                notification = Notify.objects.select_related('user').get(
+                    pk=notification_id,
+                )
+                notification.send_notify()
+            except Exception as error:
+                logger.error(
+                    'Admin notification delivery failed notification_id=%s '
+                    'exception_type=%s',
+                    notification_id,
+                    type(error).__name__,
+                )
+                self.message_user(
+                    request,
+                    '알림은 저장했지만 외부 채널로 전송하지 못했습니다.',
+                    level=messages.ERROR,
+                )
+
+        transaction.on_commit(
+            deliver_after_commit,
+            using=obj._state.db,
+        )
 
     def get_urls(self):
         """Custom URL 추가"""

--- a/backend/src/board/tests/admin/test_notify_admin.py
+++ b/backend/src/board/tests/admin/test_notify_admin.py
@@ -7,6 +7,7 @@ from django.contrib.admin.models import ADDITION, CHANGE, LogEntry
 from django.contrib.auth.models import User
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.core.exceptions import PermissionDenied
+from django.db import transaction
 from django.template.response import TemplateResponse
 from django.test import RequestFactory, TestCase
 from django.utils import timezone
@@ -112,7 +113,7 @@ class NotifyAdminTestCase(TestCase):
             duplicate_form.non_field_errors(),
         )
 
-    def test_admin_save_dispatches_add_but_never_resends_an_edit(self):
+    def test_admin_save_dispatches_committed_add_but_never_resends_edit(self):
         request = self.admin_request('post')
         notification = Notify(
             user=self.user,
@@ -121,12 +122,14 @@ class NotifyAdminTestCase(TestCase):
         )
 
         with patch.object(Notify, 'send_notify') as send_notify:
-            self.admin_instance.save_model(
-                request,
-                notification,
-                form=None,
-                change=False,
-            )
+            with self.captureOnCommitCallbacks(execute=True) as callbacks:
+                self.admin_instance.save_model(
+                    request,
+                    notification,
+                    form=None,
+                    change=False,
+                )
+                send_notify.assert_not_called()
             notification.content = 'Edited in Admin'
             self.admin_instance.save_model(
                 request,
@@ -135,6 +138,7 @@ class NotifyAdminTestCase(TestCase):
                 change=True,
             )
 
+        self.assertEqual(len(callbacks), 1)
         send_notify.assert_called_once()
         notification.refresh_from_db()
         self.assertEqual(notification.content, 'Edited in Admin')
@@ -152,17 +156,47 @@ class NotifyAdminTestCase(TestCase):
             'send_notify',
             side_effect=RuntimeError('telegram-token-secret'),
         ):
-            self.admin_instance.save_model(
-                request,
-                notification,
-                form=None,
-                change=False,
-            )
+            with self.captureOnCommitCallbacks(execute=True):
+                self.admin_instance.save_model(
+                    request,
+                    notification,
+                    form=None,
+                    change=False,
+                )
 
         self.assertTrue(Notify.objects.filter(pk=notification.pk).exists())
         messages = self.message_text(request)
-        self.assertIn('외부 채널 전송을 예약하지 못했습니다.', messages)
+        self.assertIn('외부 채널로 전송하지 못했습니다.', messages)
         self.assertNotIn('telegram-token-secret', messages)
+
+    def test_admin_save_never_dispatches_rolled_back_notification(self):
+        request = self.admin_request('post')
+        notification = Notify(
+            user=self.user,
+            url='/admin-rolled-back',
+            content='Must never leave the transaction',
+        )
+
+        with patch.object(Notify, 'send_notify') as send_notify:
+            with self.captureOnCommitCallbacks(execute=True) as callbacks:
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    'audit transaction failed',
+                ):
+                    with transaction.atomic():
+                        self.admin_instance.save_model(
+                            request,
+                            notification,
+                            form=None,
+                            change=False,
+                        )
+                        raise RuntimeError('audit transaction failed')
+
+        self.assertEqual(callbacks, [])
+        send_notify.assert_not_called()
+        self.assertFalse(
+            Notify.objects.filter(url='/admin-rolled-back').exists(),
+        )
 
     def test_read_action_updates_timestamp_and_writes_audit_log(self):
         notification = self.create_notification()


### PR DESCRIPTION
## Summary
- dispatch Admin-created notifications only after the database transaction commits
- prevent rolled-back notification rows from producing external delivery side effects
- keep edits from re-sending notifications and redact delivery failures from Admin messages

## Compatibility
- no model, migration, API, public URL, or schema changes
- successful Admin creates retain the existing saved notification and delivery behavior

## Tests
- `npm run server:test` (1,294 tests)
- `node scripts/manage.mjs test board.tests.admin` (79 tests)
- focused notification/model/service tests (23 tests)
- `node scripts/manage.mjs check`
- `npm run server:check-migrations`
- `git diff --check`