### PR TITLE
🐛 Guard public admin actions

### DIFF
--- a/backend/src/board/admin/action_confirmation.py
+++ b/backend/src/board/admin/action_confirmation.py
@@ -12,14 +12,16 @@ def render_action_confirmation(
     title: str,
     warning: str,
     confirm_label: str,
+    is_destructive: bool = True,
 ) -> TemplateResponse:
-    """Render a reusable confirmation step for destructive Admin actions."""
+    """Render a reusable confirmation step for high-impact Admin actions."""
     object_count = queryset.count()
     context = {
         **model_admin.admin_site.each_context(request),
         'title': title,
         'warning': warning,
         'confirm_label': confirm_label,
+        'confirm_button_class': 'deletelink' if is_destructive else 'default',
         'object_count': object_count,
         'object_preview': list(queryset[:20]),
         'has_more_objects': object_count > 20,

--- a/backend/src/board/admin/banner.py
+++ b/backend/src/board/admin/banner.py
@@ -1,19 +1,101 @@
 """
 SiteNotice & SiteBanner Admin Configuration
 """
-from django.contrib import admin
-from django.http import HttpRequest
+from typing import Any
+
+from django.contrib import admin, messages
+from django.db import transaction
 from django.db.models import QuerySet
+from django.http import HttpRequest
 from django.utils.html import format_html
 
 from board.models import SiteNotice, SiteBanner
 
-from .service import AdminDisplayService
+from .action_confirmation import render_action_confirmation
 from .constants import LIST_PER_PAGE_DEFAULT, DATETIME_FORMAT_FULL
+from .service import AdminDisplayService
+
+
+class SiteContentActionAdminMixin:
+    """Keep site-content state changes timestamped and auditable."""
+
+    def _set_active_state(
+        self,
+        request: HttpRequest,
+        queryset: QuerySet,
+        *,
+        is_active: bool,
+        change_message: str,
+    ) -> int:
+        count = 0
+        with transaction.atomic():
+            selected_items = self.model.objects.select_for_update().filter(
+                pk__in=queryset.values('pk'),
+            )
+            for item in selected_items:
+                if item.is_active == is_active:
+                    continue
+                item.is_active = is_active
+                item.save(update_fields=['is_active', 'updated_date'])
+                self.log_change(request, item, change_message)
+                count += 1
+        return count
+
+    @admin.action(description='선택한 항목 활성화')
+    def activate_items(
+        self,
+        request: HttpRequest,
+        queryset: QuerySet,
+    ) -> Any:
+        inactive_items = queryset.filter(is_active=False)
+        if request.POST.get('confirm') != 'yes':
+            if not inactive_items.exists():
+                self.message_user(
+                    request,
+                    '활성화할 비활성 항목이 없습니다.',
+                    level=messages.WARNING,
+                )
+                return None
+            verbose_name = self.model._meta.verbose_name_plural
+            return render_action_confirmation(
+                request,
+                self,
+                inactive_items,
+                action_name='activate_items',
+                title=f'{verbose_name} 활성화 확인',
+                warning=(
+                    f'선택한 {verbose_name}는 활성화 즉시 서비스 화면에 '
+                    '노출될 수 있습니다.'
+                ),
+                confirm_label='활성화',
+                is_destructive=False,
+            )
+
+        count = self._set_active_state(
+            request,
+            inactive_items,
+            is_active=True,
+            change_message='Admin에서 활성화',
+        )
+        self.message_user(request, f'{count}개의 항목을 활성화했습니다.')
+
+    @admin.action(description='선택한 항목 비활성화')
+    def deactivate_items(
+        self,
+        request: HttpRequest,
+        queryset: QuerySet,
+    ) -> None:
+        count = self._set_active_state(
+            request,
+            queryset.filter(is_active=True),
+            is_active=False,
+            change_message='Admin에서 비활성화',
+        )
+        self.message_user(request, f'{count}개의 항목을 비활성화했습니다.')
 
 
 @admin.register(SiteNotice)
-class SiteNoticeAdmin(admin.ModelAdmin):
+class SiteNoticeAdmin(SiteContentActionAdminMixin, admin.ModelAdmin):
     """사이트 공지 관리 페이지"""
     search_fields = ['title', 'user__username', 'url']
 
@@ -73,19 +155,8 @@ class SiteNoticeAdmin(admin.ModelAdmin):
         return AdminDisplayService.date_display(obj.updated_date, DATETIME_FORMAT_FULL)
     updated_at.short_description = '수정일시'
 
-    def activate_items(self, request: HttpRequest, queryset: QuerySet[SiteNotice]) -> None:
-        count = queryset.update(is_active=True)
-        self.message_user(request, f'{count}개의 항목을 활성화했습니다.')
-    activate_items.short_description = '선택한 항목 활성화'
-
-    def deactivate_items(self, request: HttpRequest, queryset: QuerySet[SiteNotice]) -> None:
-        count = queryset.update(is_active=False)
-        self.message_user(request, f'{count}개의 항목을 비활성화했습니다.')
-    deactivate_items.short_description = '선택한 항목 비활성화'
-
-
 @admin.register(SiteBanner)
-class SiteBannerAdmin(admin.ModelAdmin):
+class SiteBannerAdmin(SiteContentActionAdminMixin, admin.ModelAdmin):
     """사이트 배너 관리 페이지"""
     search_fields = ['title', 'user__username', 'content_html']
 
@@ -149,13 +220,3 @@ class SiteBannerAdmin(admin.ModelAdmin):
     def updated_at(self, obj: SiteBanner) -> str:
         return AdminDisplayService.date_display(obj.updated_date, DATETIME_FORMAT_FULL)
     updated_at.short_description = '수정일시'
-
-    def activate_items(self, request: HttpRequest, queryset: QuerySet[SiteBanner]) -> None:
-        count = queryset.update(is_active=True)
-        self.message_user(request, f'{count}개의 항목을 활성화했습니다.')
-    activate_items.short_description = '선택한 항목 활성화'
-
-    def deactivate_items(self, request: HttpRequest, queryset: QuerySet[SiteBanner]) -> None:
-        count = queryset.update(is_active=False)
-        self.message_user(request, f'{count}개의 항목을 비활성화했습니다.')
-    deactivate_items.short_description = '선택한 항목 비활성화'

--- a/backend/src/board/admin/post.py
+++ b/backend/src/board/admin/post.py
@@ -502,11 +502,34 @@ class PostAdmin(admin.ModelAdmin):
             )
 
     @admin.action(description='선택한 포스트 공개 처리')
-    def make_visible(self, request: HttpRequest, queryset: QuerySet[Post]) -> None:
+    def make_visible(self, request: HttpRequest, queryset: QuerySet[Post]) -> Any:
         """Route visibility changes through the post domain service."""
+        active_posts = self._active_posts(queryset)
+        if request.POST.get('confirm') != 'yes':
+            if not active_posts.exists():
+                self.message_user(
+                    request,
+                    '공개 처리할 활성 포스트가 없습니다.',
+                    level=messages.WARNING,
+                )
+                return None
+            return render_action_confirmation(
+                request,
+                self,
+                active_posts,
+                action_name='make_visible',
+                title='포스트 공개 확인',
+                warning=(
+                    '발행된 포스트는 즉시 외부에 노출될 수 있으며, '
+                    '임시글과 예약글의 숨김 설정도 해제됩니다.'
+                ),
+                confirm_label='공개 처리',
+                is_destructive=False,
+            )
+
         count = 0
         failed = 0
-        for post in self._active_posts(queryset).select_related('config'):
+        for post in active_posts.select_related('config'):
             try:
                 with transaction.atomic():
                     updated_post = PostService.update_post(post, is_hide=False)
@@ -528,12 +551,34 @@ class PostAdmin(admin.ModelAdmin):
             )
 
     @admin.action(description='선택한 임시글 즉시 발행')
-    def publish_drafts(self, request: HttpRequest, queryset: QuerySet[Post]) -> None:
+    def publish_drafts(self, request: HttpRequest, queryset: QuerySet[Post]) -> Any:
         """Publish drafts with validation, timestamps, and notifications."""
         drafts = PostStatusService.filter_drafts(queryset).select_related(
             'content',
             'config',
         )
+        if request.POST.get('confirm') != 'yes':
+            if not drafts.exists():
+                self.message_user(
+                    request,
+                    '즉시 발행할 임시글이 없습니다.',
+                    level=messages.WARNING,
+                )
+                return None
+            return render_action_confirmation(
+                request,
+                self,
+                drafts,
+                action_name='publish_drafts',
+                title='임시글 즉시 발행 확인',
+                warning=(
+                    '선택한 임시글은 현재 시각에 발행되며 공개 설정에 따라 '
+                    '외부 노출과 구독 알림이 발생할 수 있습니다.'
+                ),
+                confirm_label='즉시 발행',
+                is_destructive=False,
+            )
+
         count = 0
         failed = 0
         for post in drafts:
@@ -584,8 +629,31 @@ class PostAdmin(admin.ModelAdmin):
         self,
         request: HttpRequest,
         queryset: QuerySet[Post],
-    ) -> None:
-        posts = list(queryset.filter(deleted_date__isnull=False))
+    ) -> Any:
+        trashed_queryset = queryset.filter(deleted_date__isnull=False)
+        if request.POST.get('confirm') != 'yes':
+            if not trashed_queryset.exists():
+                self.message_user(
+                    request,
+                    '복원할 휴지통 포스트가 없습니다.',
+                    level=messages.WARNING,
+                )
+                return None
+            return render_action_confirmation(
+                request,
+                self,
+                trashed_queryset,
+                action_name='restore_from_trash',
+                title='휴지통 포스트 복원 확인',
+                warning=(
+                    '기존에 발행 및 공개 상태였던 포스트는 복원 즉시 '
+                    '외부에 다시 노출될 수 있습니다.'
+                ),
+                confirm_label='복원',
+                is_destructive=False,
+            )
+
+        posts = list(trashed_queryset)
         with transaction.atomic():
             for post in posts:
                 restored_post = PostTrashService.restore_post(

--- a/backend/src/board/admin/series.py
+++ b/backend/src/board/admin/series.py
@@ -1,11 +1,16 @@
-from django.contrib import admin
-from django.db.models import Count, OuterRef, Q, Subquery
+from typing import Any
+
+from django.contrib import admin, messages
+from django.db import transaction
+from django.db.models import Count, OuterRef, Q, QuerySet, Subquery
+from django.http import HttpRequest
 from django.urls import reverse
 from django.utils.html import format_html
 
 from board.models import Series, Post
 from board.services.public_post_service import PublicPostService
 
+from .action_confirmation import render_action_confirmation
 from .service import AdminDisplayService, AdminLinkService
 from .constants import (
     COLOR_DANGER, COLOR_SUCCESS, COLOR_PRIMARY, COLOR_MUTED,
@@ -239,23 +244,112 @@ class SeriesAdmin(admin.ModelAdmin):
         return obj.updated_date.strftime('%Y-%m-%d %H:%M:%S')
     updated_at.short_description = '수정일시'
 
-    # Custom Actions
-    def make_hidden(self, request, queryset):
-        count = queryset.update(hide=True)
+    def _update_series_fields(
+        self,
+        request: HttpRequest,
+        queryset: QuerySet[Series],
+        *,
+        change_message: str,
+        **updates: object,
+    ) -> int:
+        count = 0
+        with transaction.atomic():
+            selected_series = Series.objects.select_for_update().filter(
+                pk__in=queryset.values('pk'),
+            )
+            for series in selected_series:
+                changed_fields = []
+                for field_name, value in updates.items():
+                    if getattr(series, field_name) == value:
+                        continue
+                    setattr(series, field_name, value)
+                    changed_fields.append(field_name)
+
+                if not changed_fields:
+                    continue
+
+                series.save(
+                    update_fields=[*changed_fields, 'updated_date'],
+                )
+                self.log_change(request, series, change_message)
+                count += 1
+        return count
+
+    @admin.action(description='선택한 시리즈 숨김 처리')
+    def make_hidden(
+        self,
+        request: HttpRequest,
+        queryset: QuerySet[Series],
+    ) -> None:
+        count = self._update_series_fields(
+            request,
+            queryset.filter(hide=False),
+            hide=True,
+            change_message='Admin에서 숨김 처리',
+        )
         self.message_user(request, f'{count}개의 시리즈를 숨김 처리했습니다.')
-    make_hidden.short_description = '선택한 시리즈 숨김 처리'
 
-    def make_visible(self, request, queryset):
-        count = queryset.update(hide=False)
+    @admin.action(description='선택한 시리즈 공개 처리')
+    def make_visible(
+        self,
+        request: HttpRequest,
+        queryset: QuerySet[Series],
+    ) -> Any:
+        hidden_series = queryset.filter(hide=True)
+        if request.POST.get('confirm') != 'yes':
+            if not hidden_series.exists():
+                self.message_user(
+                    request,
+                    '공개 처리할 숨김 시리즈가 없습니다.',
+                    level=messages.WARNING,
+                )
+                return None
+            return render_action_confirmation(
+                request,
+                self,
+                hidden_series,
+                action_name='make_visible',
+                title='시리즈 공개 확인',
+                warning=(
+                    '공개 포스트가 포함된 시리즈는 즉시 외부에 노출될 수 '
+                    '있습니다.'
+                ),
+                confirm_label='공개 처리',
+                is_destructive=False,
+            )
+
+        count = self._update_series_fields(
+            request,
+            hidden_series,
+            hide=False,
+            change_message='Admin에서 공개 처리',
+        )
         self.message_user(request, f'{count}개의 시리즈를 공개 처리했습니다.')
-    make_visible.short_description = '선택한 시리즈 공개 처리'
 
-    def set_layout_list(self, request, queryset):
-        count = queryset.update(layout='list')
+    @admin.action(description='레이아웃을 리스트로 변경')
+    def set_layout_list(
+        self,
+        request: HttpRequest,
+        queryset: QuerySet[Series],
+    ) -> None:
+        count = self._update_series_fields(
+            request,
+            queryset.exclude(layout='list'),
+            layout='list',
+            change_message='Admin에서 리스트 레이아웃으로 변경',
+        )
         self.message_user(request, f'{count}개의 시리즈를 리스트 레이아웃으로 변경했습니다.')
-    set_layout_list.short_description = '레이아웃을 리스트로 변경'
 
-    def set_layout_card(self, request, queryset):
-        count = queryset.update(layout='card')
+    @admin.action(description='레이아웃을 카드로 변경')
+    def set_layout_card(
+        self,
+        request: HttpRequest,
+        queryset: QuerySet[Series],
+    ) -> None:
+        count = self._update_series_fields(
+            request,
+            queryset.exclude(layout='card'),
+            layout='card',
+            change_message='Admin에서 카드 레이아웃으로 변경',
+        )
         self.message_user(request, f'{count}개의 시리즈를 카드 레이아웃으로 변경했습니다.')
-    set_layout_card.short_description = '레이아웃을 카드로 변경'

--- a/backend/src/board/templates/admin/board/confirm_action.html
+++ b/backend/src/board/templates/admin/board/confirm_action.html
@@ -32,7 +32,7 @@
     <input type="hidden" name="select_across" value="{{ select_across }}">
     <input type="hidden" name="confirm" value="yes">
     <div class="submit-row">
-      <input type="submit" value="{{ confirm_label }}" class="deletelink">
+      <input type="submit" value="{{ confirm_label }}" class="{{ confirm_button_class }}">
       <a href="{% url opts|admin_urlname:'changelist' %}" class="button cancel-link">취소</a>
     </div>
   </form>

--- a/backend/src/board/tests/admin/test_post_admin.py
+++ b/backend/src/board/tests/admin/test_post_admin.py
@@ -71,6 +71,19 @@ class AdminRequestMixin:
         request._messages = FallbackStorage(request)
         return request
 
+    @staticmethod
+    def action_selection(
+        action: str,
+        object_ids: list[int],
+    ) -> dict[str, object]:
+        return {
+            helpers.ACTION_CHECKBOX_NAME: [
+                str(object_id) for object_id in object_ids
+            ],
+            'action': action,
+            'select_across': '0',
+        }
+
     def create_post(self, *, published=True, title='Admin post'):
         published_date = timezone.now() if published else None
         post = Post.objects.create(
@@ -206,8 +219,28 @@ class PostAdminTestCase(AdminRequestMixin, TestCase):
         self.assertEqual(trashed.updated_date, original_updated_date)
         self.assertFalse(Post.objects.filter(pk=post.pk).exists())
 
+        restore_selection = self.action_selection(
+            'restore_from_trash',
+            [post.pk],
+        )
+        confirmation = self.admin_instance.restore_from_trash(
+            self.admin_request('post', restore_selection),
+            Post.all_objects.filter(pk=post.pk),
+        )
+
+        self.assertIsInstance(confirmation, TemplateResponse)
+        confirmation.render()
+        self.assertEqual(
+            confirmation.context_data['confirm_button_class'],
+            'default',
+        )
+        self.assertFalse(Post.objects.filter(pk=post.pk).exists())
+
         self.admin_instance.restore_from_trash(
-            self.admin_request('post'),
+            self.admin_request(
+                'post',
+                {**restore_selection, 'confirm': 'yes'},
+            ),
             Post.all_objects.filter(pk=post.pk),
         )
 
@@ -246,6 +279,10 @@ class PostAdminTestCase(AdminRequestMixin, TestCase):
 
         self.assertIsInstance(confirmation, TemplateResponse)
         confirmation.render()
+        self.assertEqual(
+            confirmation.context_data['confirm_button_class'],
+            'deletelink',
+        )
         self.assertTrue(Post.all_objects.filter(pk=trashed.pk).exists())
 
         confirmed_request = self.admin_request(
@@ -276,8 +313,25 @@ class PostAdminTestCase(AdminRequestMixin, TestCase):
             value=saved_reservation.isoformat(),
         )
 
+        publish_selection = self.action_selection(
+            'publish_drafts',
+            [draft.pk],
+        )
+        confirmation = self.admin_instance.publish_drafts(
+            self.admin_request('post', publish_selection),
+            Post.all_objects.filter(pk=draft.pk),
+        )
+
+        self.assertIsInstance(confirmation, TemplateResponse)
+        confirmation.render()
+        draft.refresh_from_db()
+        self.assertIsNone(draft.published_date)
+
         self.admin_instance.publish_drafts(
-            self.admin_request('post'),
+            self.admin_request(
+                'post',
+                {**publish_selection, 'confirm': 'yes'},
+            ),
             Post.all_objects.filter(pk=draft.pk),
         )
 
@@ -310,7 +364,13 @@ class PostAdminTestCase(AdminRequestMixin, TestCase):
         )
 
         self.admin_instance.publish_drafts(
-            self.admin_request('post'),
+            self.admin_request(
+                'post',
+                {
+                    **self.action_selection('publish_drafts', [draft.pk]),
+                    'confirm': 'yes',
+                },
+            ),
             Post.all_objects.filter(pk=draft.pk),
         )
 
@@ -347,6 +407,39 @@ class PostAdminTestCase(AdminRequestMixin, TestCase):
                 object_id=str(active.pk),
                 action_flag=CHANGE,
                 change_message__contains='숨김 처리',
+            ).exists(),
+        )
+
+        visible_selection = self.action_selection(
+            'make_visible',
+            [active.pk, trashed.pk],
+        )
+        confirmation = self.admin_instance.make_visible(
+            self.admin_request('post', visible_selection),
+            Post.all_objects.filter(pk__in=[active.pk, trashed.pk]),
+        )
+
+        self.assertIsInstance(confirmation, TemplateResponse)
+        active.config.refresh_from_db()
+        self.assertTrue(active.config.hide)
+
+        self.admin_instance.make_visible(
+            self.admin_request(
+                'post',
+                {**visible_selection, 'confirm': 'yes'},
+            ),
+            Post.all_objects.filter(pk__in=[active.pk, trashed.pk]),
+        )
+
+        active.config.refresh_from_db()
+        trashed.config.refresh_from_db()
+        self.assertFalse(active.config.hide)
+        self.assertFalse(trashed.config.hide)
+        self.assertTrue(
+            LogEntry.objects.filter(
+                object_id=str(active.pk),
+                action_flag=CHANGE,
+                change_message__contains='공개 처리',
             ).exists(),
         )
 

--- a/backend/src/board/tests/admin/test_public_action_admin.py
+++ b/backend/src/board/tests/admin/test_public_action_admin.py
@@ -1,0 +1,237 @@
+from datetime import timedelta
+from unittest.mock import patch
+
+from django.contrib import admin
+from django.contrib.admin import helpers
+from django.contrib.admin.models import CHANGE, LogEntry
+from django.contrib.auth.models import User
+from django.contrib.contenttypes.models import ContentType
+from django.contrib.messages.storage.fallback import FallbackStorage
+from django.template.response import TemplateResponse
+from django.test import RequestFactory, TestCase
+from django.utils import timezone
+
+from board.admin.banner import SiteBannerAdmin, SiteNoticeAdmin
+from board.admin.series import SeriesAdmin
+from board.models import (
+    Series,
+    SiteBanner,
+    SiteContentScope,
+    SiteNotice,
+)
+
+
+class PublicActionAdminTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.admin_user = User.objects.create_superuser(
+            username='public-action-admin',
+            email='public-action-admin@example.com',
+            password='test',
+        )
+        cls.owner = User.objects.create_user(
+            username='series-owner',
+            password='test',
+        )
+
+    def setUp(self):
+        self.series_admin = SeriesAdmin(Series, admin.site)
+        self.notice_admin = SiteNoticeAdmin(SiteNotice, admin.site)
+        self.banner_admin = SiteBannerAdmin(SiteBanner, admin.site)
+
+    def admin_request(self, data=None):
+        request = RequestFactory().post('/admin/', data=data or {})
+        request.user = self.admin_user
+        request.session = {}
+        request._messages = FallbackStorage(request)
+        return request
+
+    @staticmethod
+    def action_selection(action: str, object_id: int) -> dict[str, object]:
+        return {
+            helpers.ACTION_CHECKBOX_NAME: [str(object_id)],
+            'action': action,
+            'select_across': '0',
+        }
+
+    @staticmethod
+    def change_log_exists(obj, message: str) -> bool:
+        return LogEntry.objects.filter(
+            content_type=ContentType.objects.get_for_model(obj),
+            object_id=str(obj.pk),
+            action_flag=CHANGE,
+            change_message__contains=message,
+        ).exists()
+
+    def admin_series_queryset(self, series: Series):
+        return self.series_admin.get_queryset(
+            self.admin_request(),
+        ).filter(pk=series.pk)
+
+    def test_series_publication_requires_confirmation_and_is_audited(self):
+        series = Series.objects.create(
+            owner=self.owner,
+            name='Hidden series',
+            url='hidden-series',
+            hide=True,
+        )
+        previous_updated_date = timezone.now() - timedelta(days=1)
+        Series.objects.filter(pk=series.pk).update(
+            updated_date=previous_updated_date,
+        )
+        selection = self.action_selection('make_visible', series.pk)
+
+        confirmation = self.series_admin.make_visible(
+            self.admin_request(selection),
+            self.admin_series_queryset(series),
+        )
+
+        self.assertIsInstance(confirmation, TemplateResponse)
+        confirmation.render()
+        self.assertEqual(
+            confirmation.context_data['confirm_button_class'],
+            'default',
+        )
+        series.refresh_from_db()
+        self.assertTrue(series.hide)
+        self.assertFalse(self.change_log_exists(series, '공개 처리'))
+
+        self.series_admin.make_visible(
+            self.admin_request({**selection, 'confirm': 'yes'}),
+            self.admin_series_queryset(series),
+        )
+
+        series.refresh_from_db()
+        self.assertFalse(series.hide)
+        self.assertGreater(series.updated_date, previous_updated_date)
+        self.assertTrue(self.change_log_exists(series, '공개 처리'))
+
+    def test_series_actions_update_timestamp_and_rollback_without_audit(self):
+        series = Series.objects.create(
+            owner=self.owner,
+            name='Audited series',
+            url='audited-series',
+            layout='list',
+            hide=False,
+        )
+        previous_updated_date = timezone.now() - timedelta(days=1)
+        Series.objects.filter(pk=series.pk).update(
+            updated_date=previous_updated_date,
+        )
+
+        self.series_admin.set_layout_card(
+            self.admin_request(),
+            self.admin_series_queryset(series),
+        )
+
+        series.refresh_from_db()
+        self.assertEqual(series.layout, 'card')
+        self.assertGreater(series.updated_date, previous_updated_date)
+        self.assertTrue(self.change_log_exists(series, '카드 레이아웃'))
+
+        with patch.object(
+            self.series_admin,
+            'log_change',
+            side_effect=RuntimeError('audit unavailable'),
+        ):
+            with self.assertRaisesRegex(RuntimeError, 'audit unavailable'):
+                self.series_admin.make_hidden(
+                    self.admin_request(),
+                    self.admin_series_queryset(series),
+                )
+
+        series.refresh_from_db()
+        self.assertFalse(series.hide)
+
+    def test_site_content_activation_requires_confirmation_and_is_audited(self):
+        admin_records = [
+            (
+                self.notice_admin,
+                SiteNotice.objects.create(
+                    scope=SiteContentScope.GLOBAL,
+                    title='Inactive notice',
+                    is_active=False,
+                ),
+            ),
+            (
+                self.banner_admin,
+                SiteBanner.objects.create(
+                    scope=SiteContentScope.GLOBAL,
+                    title='Inactive banner',
+                    is_active=False,
+                ),
+            ),
+        ]
+
+        for model_admin, item in admin_records:
+            with self.subTest(model=item._meta.label):
+                previous_updated_date = timezone.now() - timedelta(days=1)
+                item.__class__.objects.filter(pk=item.pk).update(
+                    updated_date=previous_updated_date,
+                )
+                selection = self.action_selection('activate_items', item.pk)
+
+                confirmation = model_admin.activate_items(
+                    self.admin_request(selection),
+                    item.__class__.objects.filter(pk=item.pk),
+                )
+
+                self.assertIsInstance(confirmation, TemplateResponse)
+                confirmation.render()
+                self.assertEqual(
+                    confirmation.context_data['confirm_button_class'],
+                    'default',
+                )
+                item.refresh_from_db()
+                self.assertFalse(item.is_active)
+                self.assertFalse(self.change_log_exists(item, '활성화'))
+
+                model_admin.activate_items(
+                    self.admin_request({**selection, 'confirm': 'yes'}),
+                    item.__class__.objects.filter(pk=item.pk),
+                )
+
+                item.refresh_from_db()
+                self.assertTrue(item.is_active)
+                self.assertGreater(item.updated_date, previous_updated_date)
+                self.assertTrue(self.change_log_exists(item, '활성화'))
+
+    def test_site_content_deactivation_is_audited_and_atomic(self):
+        notice = SiteNotice.objects.create(
+            scope=SiteContentScope.GLOBAL,
+            title='Active notice',
+            is_active=True,
+        )
+        previous_updated_date = timezone.now() - timedelta(days=1)
+        SiteNotice.objects.filter(pk=notice.pk).update(
+            updated_date=previous_updated_date,
+        )
+
+        self.notice_admin.deactivate_items(
+            self.admin_request(),
+            SiteNotice.objects.filter(pk=notice.pk),
+        )
+
+        notice.refresh_from_db()
+        self.assertFalse(notice.is_active)
+        self.assertGreater(notice.updated_date, previous_updated_date)
+        self.assertTrue(self.change_log_exists(notice, '비활성화'))
+
+        banner = SiteBanner.objects.create(
+            scope=SiteContentScope.GLOBAL,
+            title='Active banner',
+            is_active=True,
+        )
+        with patch.object(
+            self.banner_admin,
+            'log_change',
+            side_effect=RuntimeError('audit unavailable'),
+        ):
+            with self.assertRaisesRegex(RuntimeError, 'audit unavailable'):
+                self.banner_admin.deactivate_items(
+                    self.admin_request(),
+                    SiteBanner.objects.filter(pk=banner.pk),
+                )
+
+        banner.refresh_from_db()
+        self.assertTrue(banner.is_active)


### PR DESCRIPTION
## Summary
- require explicit confirmation before Admin actions can publish drafts, restore or expose posts, expose series, or activate notices and banners
- preserve destructive confirmation styling while using a non-destructive style for publication and activation
- replace unaudited Series and site-content bulk updates with timestamped, row-locked changes and Django Admin log entries
- roll state changes back when their audit entry cannot be written

## Compatibility
- no model, migration, database schema, API, or public URL changes
- existing domain services remain responsible for post visibility, publication, trash restoration, and notification behavior
- hide and deactivate actions remain immediate; only outward-publication actions gain a confirmation step

## Tests
- `npm run server:test` (1,298 tests)
- `node scripts/manage.mjs test board.tests.admin` (83 tests)
- focused public-action and post Admin tests (17 tests)
- realistic annotated Series Admin queryset tests (4 tests)
- `node scripts/manage.mjs check`
- `npm run server:check-migrations`
- `git diff --check`