### PR TITLE
🐛 Use local date for public heatmap

### DIFF
--- a/backend/src/board/tests/api/test_user_api.py
+++ b/backend/src/board/tests/api/test_user_api.py
@@ -1,4 +1,6 @@
 import json
+from datetime import datetime, timezone as datetime_timezone
+from unittest.mock import patch
 
 from django.test import TestCase
 from django.core.cache import cache
@@ -42,11 +44,19 @@ class UserAPITestCase(TestCase):
 
     def test_public_heatmap_uses_one_activity_query(self):
         """공개 활동 세 종류는 UNION ALL 한 번으로 함께 조회한다."""
+        utc_midnight_boundary = datetime(
+            2026,
+            7,
+            17,
+            15,
+            30,
+            tzinfo=datetime_timezone.utc,
+        )
         post = Post.objects.create(
             url='heatmap-post',
             title='Heatmap Post',
             author=self.user,
-            published_date=timezone.now(),
+            published_date=utc_midnight_boundary,
         )
         PostConfig.objects.create(post=post, hide=False)
         Comment.objects.create(
@@ -54,15 +64,24 @@ class UserAPITestCase(TestCase):
             author=self.user,
             text_md='comment',
             text_html='<p>comment</p>',
+            created_date=utc_midnight_boundary,
         )
-        PostLikes.objects.create(post=post, user=self.user)
+        PostLikes.objects.create(
+            post=post,
+            user=self.user,
+            created_date=utc_midnight_boundary,
+        )
 
         # User lookup + combined activity query + request-scoped site setting.
-        with self.assertNumQueries(3):
-            response = self.client.get('/v1/users/@testuser/heatmap')
+        with patch(
+            'board.views.api.v1.author.timezone.now',
+            return_value=utc_midnight_boundary,
+        ):
+            with self.assertNumQueries(3):
+                response = self.client.get('/v1/users/@testuser/heatmap')
 
         self.assertEqual(response.status_code, 200)
-        today = timezone.localdate().strftime('%Y%m%d')
+        today = timezone.localtime(utc_midnight_boundary).strftime('%Y%m%d')
         body = json.loads(response.content)['body']
         self.assertEqual(body, {today: 3})
 

--- a/backend/src/board/views/api/v1/author.py
+++ b/backend/src/board/views/api/v1/author.py
@@ -28,7 +28,7 @@ def get_author_heatmap(request, username):
 
     if heatmap is None:
         # Generate heatmap data for the last year
-        end_date = timezone.now().date()
+        end_date = timezone.localdate()
         start_date = end_date - timedelta(days=365)
 
         # Aggregate each activity type in the database, then fetch the three


### PR DESCRIPTION
## Summary
- use the configured local date for the public heatmap one-year window
- keep activity-date grouping and range filtering in the same timezone across the UTC-to-local midnight boundary
- freeze the regression test at 00:30 KST so the boundary remains deterministic

## Compatibility
- no URL, response shape, cache key, query count, model, migration, or schema changes
- activity that was already returned keeps the same date key; the fix only restores records incorrectly omitted between local midnight and UTC midnight

## Tests
- `npm run server:test` (1,294 tests)
- `node scripts/manage.mjs test board.tests.api.test_user_api` (16 tests)
- focused midnight-boundary heatmap test
- `node scripts/manage.mjs check`
- `npm run server:check-migrations`
- `git diff --check`