### PR TITLE
♻️ Trim remaining admin list queries

### DIFF
--- a/backend/src/board/admin/__init__.py
+++ b/backend/src/board/admin/__init__.py
@@ -14,6 +14,8 @@ from .user import *
 from django.contrib import admin
 from django.contrib.admin.models import LogEntry
 
+from .mixins import is_admin_changelist_request
+
 
 @admin.register(LogEntry)
 class LogEntryAdmin(admin.ModelAdmin):
@@ -22,7 +24,17 @@ class LogEntryAdmin(admin.ModelAdmin):
     search_fields = ['object_repr', 'user__username']
     readonly_fields = ['action_time', 'user', 'content_type', 'object_id', 'object_repr', 'action_flag', 'change_message']
     list_per_page = 50
+    show_full_result_count = False
     date_hierarchy = 'action_time'
+
+    def get_queryset(self, request):
+        queryset = super().get_queryset(request).select_related(
+            'user',
+            'content_type',
+        ).defer('user__password')
+        if is_admin_changelist_request(request, self.model):
+            return queryset.defer('change_message')
+        return queryset
 
     def has_add_permission(self, request):
         return False

--- a/backend/src/board/admin/auth.py
+++ b/backend/src/board/admin/auth.py
@@ -92,6 +92,7 @@ class TwoFactorAuthAdmin(
         return super().get_queryset(request).select_related('user').defer(
             'recovery_key',
             'totp_secret',
+            'user__password',
         )
 
     def user_link(self, obj: TwoFactorAuth):
@@ -200,6 +201,9 @@ class SocialAuthAdmin(
         ).defer(
             'uid',
             'extra_data',
+            'user__password',
+            'provider__client_id',
+            'provider__client_secret',
         )
 
     def user_link(self, obj: SocialAuth):

--- a/backend/src/board/admin/banner.py
+++ b/backend/src/board/admin/banner.py
@@ -13,6 +13,7 @@ from board.models import SiteNotice, SiteBanner
 
 from .action_confirmation import render_action_confirmation
 from .constants import LIST_PER_PAGE_DEFAULT, DATETIME_FORMAT_FULL
+from .mixins import is_admin_changelist_request
 from .service import AdminDisplayService
 
 
@@ -135,6 +136,11 @@ class SiteNoticeAdmin(SiteContentActionAdminMixin, admin.ModelAdmin):
 
     readonly_fields = ['created_at', 'updated_at']
 
+    def get_queryset(self, request):
+        return super().get_queryset(request).select_related(
+            'user',
+        ).defer('user__password')
+
     def scope_display(self, obj: SiteNotice) -> str:
         color = '#3b82f6' if obj.scope == 'global' else '#8b5cf6'
         return format_html(
@@ -200,6 +206,14 @@ class SiteBannerAdmin(SiteContentActionAdminMixin, admin.ModelAdmin):
     )
 
     readonly_fields = ['created_at', 'updated_at']
+
+    def get_queryset(self, request):
+        queryset = super().get_queryset(request).select_related(
+            'user',
+        ).defer('user__password')
+        if is_admin_changelist_request(request, self.model):
+            return queryset.defer('content_html')
+        return queryset
 
     def scope_display(self, obj: SiteBanner) -> str:
         color = '#3b82f6' if obj.scope == 'global' else '#8b5cf6'

--- a/backend/src/board/admin/comment.py
+++ b/backend/src/board/admin/comment.py
@@ -17,6 +17,7 @@ from .action_confirmation import render_action_confirmation
 from .mixins import (
     ConfirmedActionDeleteAdminMixin,
     ReadOnlyRecordAdminMixin,
+    is_admin_changelist_request,
 )
 from .service import AdminDisplayService, AdminLinkService
 from .constants import COLOR_MUTED, COLOR_DARKENED_BG, COLOR_WARNING, COLOR_DANGER, COLOR_TEXT, COLOR_BG, COLOR_BORDER
@@ -90,16 +91,20 @@ class CommentAdmin(
     list_display = ['id', 'content_preview', 'post_link', 'author_link', 'likes_display', 'status_badges', 'created_date']
     list_display_links = ['content_preview']
     list_per_page = 30
+    show_full_result_count = False
     save_on_top = True
     date_hierarchy = 'created_date'
 
     def get_queryset(self, request):
-        return super().get_queryset(request).select_related(
+        queryset = super().get_queryset(request).select_related(
             'author',
             'post',
         ).defer('author__password').annotate(
             likes_count_annotated=Count('likes', distinct=True)
         )
+        if is_admin_changelist_request(request, self.model):
+            return queryset.defer('text_md')
+        return queryset
 
     def author_link(self, obj):
         if obj.author:

--- a/backend/src/board/admin/form.py
+++ b/backend/src/board/admin/form.py
@@ -2,7 +2,7 @@ from django.contrib import admin
 
 from board.models import Form
 
-from .mixins import ReadOnlyRecordAdminMixin
+from .mixins import ReadOnlyRecordAdminMixin, is_admin_changelist_request
 from .service import AdminLinkService
 
 
@@ -30,11 +30,10 @@ class FormAdmin(ReadOnlyRecordAdminMixin, admin.ModelAdmin):
     readonly_fields = fields
 
     def get_queryset(self, request):
-        queryset = super().get_queryset(request).select_related('user')
-        if (
-            getattr(request, 'resolver_match', None)
-            and request.resolver_match.url_name == 'board_form_changelist'
-        ):
+        queryset = super().get_queryset(request).select_related(
+            'user',
+        ).defer('user__password')
+        if is_admin_changelist_request(request, self.model):
             return queryset.defer('content')
         return queryset
 

--- a/backend/src/board/admin/mixins.py
+++ b/backend/src/board/admin/mixins.py
@@ -1,3 +1,14 @@
+def is_admin_changelist_request(request, model) -> bool:
+    """Return whether a request resolves to the model's Admin list."""
+    resolver_match = getattr(request, 'resolver_match', None)
+    if resolver_match is None:
+        return False
+    opts = model._meta
+    return resolver_match.url_name == (
+        f'{opts.app_label}_{opts.model_name}_changelist'
+    )
+
+
 class ReadOnlyRecordAdminMixin:
     """Inspect externally owned or system-managed rows without editing them."""
 

--- a/backend/src/board/admin/notify.py
+++ b/backend/src/board/admin/notify.py
@@ -29,6 +29,7 @@ from .constants import (
     DATETIME_FORMAT_FULL,
     LIST_PER_PAGE_DEFAULT,
 )
+from .mixins import is_admin_changelist_request
 from .service import AdminDisplayService, AdminLinkService
 
 logger = logging.getLogger('board.notification')
@@ -106,6 +107,7 @@ class NotifyAdmin(admin.ModelAdmin):
     ]
     list_display_links = ['content_preview']
     list_per_page = LIST_PER_PAGE_DEFAULT
+    show_full_result_count = False
     date_hierarchy = 'created_date'
 
     fieldsets = (
@@ -124,7 +126,12 @@ class NotifyAdmin(admin.ModelAdmin):
     readonly_fields = ['key', 'created_at', 'updated_at']
 
     def get_queryset(self, request):
-        return super().get_queryset(request).select_related('user')
+        queryset = super().get_queryset(request).select_related(
+            'user',
+        ).defer('user__password')
+        if is_admin_changelist_request(request, self.model):
+            return queryset.defer('key')
+        return queryset
 
     def user_link(self, obj):
         return AdminLinkService.create_user_link(obj.user)

--- a/backend/src/board/admin/post.py
+++ b/backend/src/board/admin/post.py
@@ -34,7 +34,10 @@ from board.models import (
 )
 
 from .action_confirmation import render_action_confirmation
-from .mixins import ServiceOwnedRecordAdminMixin
+from .mixins import (
+    ServiceOwnedRecordAdminMixin,
+    is_admin_changelist_request,
+)
 from .service import AdminDisplayService, AdminLinkService
 from .constants import (
     LIST_PER_PAGE_DEFAULT,
@@ -98,10 +101,7 @@ class EditRequestAdmin(ServiceOwnedRecordAdminMixin, admin.ModelAdmin):
             'post',
             'user',
         ).defer('user__password')
-        if (
-            getattr(request, 'resolver_match', None)
-            and request.resolver_match.url_name == 'board_editrequest_changelist'
-        ):
+        if is_admin_changelist_request(request, self.model):
             return queryset.defer('content')
         return queryset
 
@@ -199,6 +199,7 @@ class PostAdmin(admin.ModelAdmin):
     ]
     list_display_links = ['title']
     list_per_page = LIST_PER_PAGE_DEFAULT
+    show_full_result_count = False
     save_on_top = True
     date_hierarchy = 'created_date'
     actions = [

--- a/backend/src/board/admin/revision.py
+++ b/backend/src/board/admin/revision.py
@@ -13,6 +13,7 @@ from board.services.post_revision_service import PostRevisionService
 
 from .action_confirmation import render_action_confirmation
 from .constants import LIST_PER_PAGE_DEFAULT
+from .mixins import is_admin_changelist_request
 from .service import AdminDisplayService, AdminLinkService
 
 
@@ -109,19 +110,24 @@ class EditHistoryAdmin(admin.ModelAdmin):
     ordering = ['-created_date', '-id']
     date_hierarchy = 'created_date'
     list_per_page = LIST_PER_PAGE_DEFAULT
+    show_full_result_count = False
 
     def get_queryset(self, request):
-        queryset = super().get_queryset(request).select_related(
+        is_changelist = is_admin_changelist_request(request, self.model)
+        relations = [
             'post',
             'post__author',
             'actor',
-            'restored_from',
+        ]
+        if not is_changelist:
+            relations.append('restored_from')
+        queryset = super().get_queryset(request).select_related(
+            *relations,
+        ).defer(
+            'post__author__password',
+            'actor__password',
         )
-        if (
-            getattr(request, 'resolver_match', None)
-            and request.resolver_match.url_name
-            == 'board_edithistory_changelist'
-        ):
+        if is_changelist:
             return queryset.defer(
                 'content',
                 'description',

--- a/backend/src/board/admin/series.py
+++ b/backend/src/board/admin/series.py
@@ -11,6 +11,7 @@ from board.models import Series, Post
 from board.services.public_post_service import PublicPostService
 
 from .action_confirmation import render_action_confirmation
+from .mixins import is_admin_changelist_request
 from .service import AdminDisplayService, AdminLinkService
 from .constants import (
     COLOR_DANGER, COLOR_SUCCESS, COLOR_PRIMARY, COLOR_MUTED,
@@ -65,7 +66,7 @@ class SeriesAdmin(admin.ModelAdmin):
         public_posts = PublicPostService.filter_public_posts(
             Post.objects,
         ).filter(series=OuterRef('pk')).order_by('pk')
-        return super().get_queryset(request).select_related(
+        queryset = super().get_queryset(request).select_related(
             'owner'
         ).defer('owner__password').annotate(
             count_posts=Count(
@@ -87,6 +88,9 @@ class SeriesAdmin(admin.ModelAdmin):
                 public_posts.values('image')[:1],
             ),
         )
+        if is_admin_changelist_request(request, self.model):
+            return queryset.defer('text_md', 'text_html')
+        return queryset
 
     fieldsets = (
         ('기본 정보', {

--- a/backend/src/board/admin/user.py
+++ b/backend/src/board/admin/user.py
@@ -31,6 +31,7 @@ from .action_confirmation import render_action_confirmation
 from .mixins import (
     ConfirmedActionDeleteAdminMixin,
     ReadOnlyRecordAdminMixin,
+    is_admin_changelist_request,
 )
 from .service import AdminDisplayService, AdminLinkService
 from .constants import COLOR_MUTED, COLOR_INFO, COLOR_BG, COLOR_TEXT
@@ -64,6 +65,7 @@ class EmailChangeAdmin(
     def get_queryset(self, request):
         return super().get_queryset(request).select_related('user').defer(
             'auth_token',
+            'user__password',
         )
 
     def user_link(self, obj: EmailChange):
@@ -143,7 +145,9 @@ class UsernameChangeLogAdmin(ReadOnlyRecordAdminMixin, admin.ModelAdmin):
     readonly_fields = fields
 
     def get_queryset(self, request):
-        return super().get_queryset(request).select_related('user')
+        return super().get_queryset(request).select_related('user').defer(
+            'user__password',
+        )
 
     def has_delete_permission(self, request, obj=None):
         return False
@@ -218,9 +222,14 @@ class CustomUserAdmin(ConfirmedActionDeleteAdminMixin, BaseUserAdmin):
     actions = ['make_editor', 'make_reader', 'activate_users', 'deactivate_users']
 
     def get_queryset(self, request):
-        return super().get_queryset(request).select_related('profile').annotate(
+        queryset = super().get_queryset(request).select_related(
+            'profile',
+        ).annotate(
             post_count=Count('post', distinct=True)
         )
+        if is_admin_changelist_request(request, self.model):
+            return queryset.defer('password')
+        return queryset
 
     def get_readonly_fields(self, request, obj=None):
         readonly_fields = list(super().get_readonly_fields(request, obj))
@@ -479,7 +488,9 @@ class UserConfigMetaAdmin(admin.ModelAdmin):
     search_fields = ['user__username', 'name', 'value']
 
     def get_queryset(self, request):
-        return super().get_queryset(request).select_related('user')
+        return super().get_queryset(request).select_related('user').defer(
+            'user__password',
+        )
 
     def user_link(self, obj):
         return AdminLinkService.create_user_link(obj.user)
@@ -495,7 +506,9 @@ class UserLinkMetaAdmin(admin.ModelAdmin):
     autocomplete_fields = ['user']
 
     def get_queryset(self, request):
-        return super().get_queryset(request).select_related('user')
+        return super().get_queryset(request).select_related('user').defer(
+            'user__password',
+        )
 
     def user_link(self, obj):
         return AdminLinkService.create_user_link(obj.user)
@@ -643,9 +656,14 @@ class ProfileAdmin(admin.ModelAdmin):
     readonly_fields = ['user_info', 'avatar_preview', 'cover_preview', 'total_posts']
 
     def get_queryset(self, request):
-        return super().get_queryset(request).select_related('user').annotate(
+        queryset = super().get_queryset(request).select_related(
+            'user',
+        ).defer('user__password').annotate(
             post_count=Count('user__post', distinct=True)
         )
+        if is_admin_changelist_request(request, self.model):
+            return queryset.defer('bio', 'about_md', 'about_html')
+        return queryset
 
     def user_link(self, obj):
         return AdminLinkService.create_user_link(obj.user)

--- a/backend/src/board/tests/admin/test_admin_list_performance.py
+++ b/backend/src/board/tests/admin/test_admin_list_performance.py
@@ -1,11 +1,13 @@
 from datetime import timedelta
 
 from django.contrib import admin
+from django.contrib.admin.models import CHANGE, LogEntry
 from django.contrib.auth.models import User
+from django.contrib.contenttypes.models import ContentType
 from django.db import connection
 from django.test import RequestFactory, TestCase
 from django.test.utils import CaptureQueriesContext
-from django.urls import reverse
+from django.urls import resolve, reverse
 from django.utils import timezone
 
 from board.admin.comment import CommentAdmin
@@ -17,17 +19,28 @@ from board.admin.user import ConfigAdmin
 from board.models import (
     Comment,
     Config,
+    EditHistory,
     EditRequest,
+    EmailChange,
+    Form,
     ImageCache,
+    Notify,
     Post,
     PostConfig,
     PostContent,
     PostLikes,
     PinnedPost,
+    Profile,
     Series,
+    SiteBanner,
+    SiteNotice,
+    SocialAuth,
     Tag,
     TelegramSync,
     TwoFactorAuth,
+    UserConfigMeta,
+    UserLinkMeta,
+    UsernameChangeLog,
 )
 
 
@@ -140,6 +153,85 @@ class AdminListPerformanceTestCase(TestCase):
             path='cache/list-preview.jpg',
             size=1024,
         )
+        cls.profile = Profile.objects.create(
+            user=cls.authors[0],
+            bio='large profile bio ' * 100,
+            about_md='large profile markdown ' * 500,
+            about_html='<p>' + ('large profile html ' * 500) + '</p>',
+        )
+        cls.form = Form.objects.create(
+            user=cls.authors[0],
+            title='List form',
+            content='large form content ' * 500,
+        )
+        cls.notification = Notify.objects.create(
+            user=cls.authors[0],
+            key='n' * 44,
+            url='/list-notification',
+            content='List notification content',
+        )
+        cls.revision = EditHistory.objects.create(
+            post=cls.public_posts[0],
+            actor=cls.authors[0],
+            title='List revision',
+            subtitle='List revision subtitle',
+            content='large revision content ' * 500,
+            content_excerpt='List revision excerpt',
+            description='List revision description',
+            tags=['list-tag'],
+        )
+        cls.site_notices = [
+            SiteNotice.objects.create(
+                scope='global',
+                user=None,
+                title='Global list notice',
+            ),
+            SiteNotice.objects.create(
+                scope='user',
+                user=cls.authors[0],
+                title='User list notice',
+            ),
+        ]
+        cls.site_banners = [
+            SiteBanner.objects.create(
+                scope='global',
+                user=None,
+                title='Global list banner',
+                content_html='<p>' + ('large banner html ' * 500) + '</p>',
+            ),
+            SiteBanner.objects.create(
+                scope='user',
+                user=cls.authors[0],
+                title='User list banner',
+                content_html='<p>User banner</p>',
+            ),
+        ]
+        UserConfigMeta.objects.create(
+            user=cls.authors[0],
+            name='list-setting',
+            value='true',
+        )
+        UserLinkMeta.objects.create(
+            user=cls.authors[0],
+            name='homepage',
+            value='https://example.com',
+        )
+        UsernameChangeLog.objects.create(
+            user=cls.authors[0],
+            username='previous-list-author',
+        )
+        cls.log_entry = LogEntry.objects.create(
+            user=cls.admin_user,
+            content_type=ContentType.objects.get_for_model(Post),
+            object_id=str(cls.public_posts[0].pk),
+            object_repr=str(cls.public_posts[0]),
+            action_flag=CHANGE,
+            change_message='large Admin change message ' * 100,
+        )
+        Series.objects.filter(pk=cls.series[0].pk).update(
+            text_md='large series markdown ' * 500,
+            text_html='<p>' + ('large series html ' * 500) + '</p>',
+        )
 
     @classmethod
     def create_post(
@@ -184,6 +276,51 @@ class AdminListPerformanceTestCase(TestCase):
         self.tag_admin = TagAdmin(Tag, admin.site)
         self.series_admin = SeriesAdmin(Series, admin.site)
         self.config_admin = ConfigAdmin(Config, admin.site)
+
+    @staticmethod
+    def admin_url_name(model, view_name: str) -> str:
+        opts = model._meta
+        return (
+            f'admin:{opts.app_label}_{opts.model_name}_{view_name}'
+        )
+
+    def changelist_request(self, model):
+        path = reverse(self.admin_url_name(model, 'changelist'))
+        request = RequestFactory().get(path)
+        request.user = self.admin_user
+        request.resolver_match = resolve(path)
+        return request
+
+    def change_request(self, model, object_id: int):
+        path = reverse(
+            self.admin_url_name(model, 'change'),
+            args=[object_id],
+        )
+        request = RequestFactory().get(path)
+        request.user = self.admin_user
+        request.resolver_match = resolve(path)
+        return request
+
+    def large_field_cases(self):
+        return (
+            (Comment, self.active_comment.pk, {'text_md'}),
+            (Notify, self.notification.pk, {'key'}),
+            (
+                EditHistory,
+                self.revision.pk,
+                {'content', 'description', 'tags', 'subtitle'},
+            ),
+            (Form, self.form.pk, {'content'}),
+            (Series, self.series[0].pk, {'text_md', 'text_html'}),
+            (SiteBanner, self.site_banners[0].pk, {'content_html'}),
+            (
+                Profile,
+                self.profile.pk,
+                {'bio', 'about_md', 'about_html'},
+            ),
+            (User, self.authors[0].pk, {'password'}),
+            (LogEntry, self.log_entry.pk, {'change_message'}),
+        )
 
     def test_post_list_loads_only_display_relations_in_two_queries(self):
         with CaptureQueriesContext(connection) as queries:
@@ -341,6 +478,80 @@ class AdminListPerformanceTestCase(TestCase):
         self.assertNotIn('auth_token', config_query)
         self.assertTrue(configs[0].telegram_linked)
         self.assertTrue(configs[0].two_factor_enabled)
+
+    def test_high_growth_changelists_do_not_run_unfiltered_counts(self):
+        self.client.force_login(self.admin_user)
+
+        for model in (Post, Comment, Notify, EditHistory, LogEntry):
+            url_name = self.admin_url_name(model, 'changelist')
+            with self.subTest(model=model):
+                response = self.client.get(reverse(url_name), {'q': 'list'})
+                self.assertEqual(response.status_code, 200)
+                self.assertIsNone(response.context['cl'].full_result_count)
+
+    def test_changelists_defer_unused_large_fields(self):
+        for model, object_id, expected_fields in self.large_field_cases():
+            with self.subTest(model=model):
+                model_admin = admin.site._registry[model]
+                row = model_admin.get_queryset(
+                    self.changelist_request(model),
+                ).get(pk=object_id)
+                self.assertTrue(
+                    expected_fields.issubset(row.get_deferred_fields()),
+                )
+
+    def test_change_views_keep_fields_needed_for_inspection_and_editing(self):
+        for model, object_id, expected_fields in self.large_field_cases():
+            with self.subTest(model=model):
+                model_admin = admin.site._registry[model]
+                row = model_admin.get_queryset(
+                    self.change_request(model, object_id),
+                ).get(pk=object_id)
+                self.assertTrue(
+                    expected_fields.isdisjoint(row.get_deferred_fields()),
+                )
+
+    def test_user_related_changelists_do_not_select_password_hashes(self):
+        models = (
+            EmailChange, UsernameChangeLog, User, UserConfigMeta,
+            UserLinkMeta, Profile, Comment, Notify, Form, Series,
+            SiteNotice, SiteBanner, TwoFactorAuth, SocialAuth, LogEntry,
+        )
+
+        for model in models:
+            with self.subTest(model=model):
+                model_admin = admin.site._registry[model]
+                queryset = model_admin.get_queryset(
+                    self.changelist_request(model),
+                )
+                self.assertNotIn('password', str(queryset.query).lower())
+
+        social_auth_query = admin.site._registry[SocialAuth].get_queryset(
+            self.changelist_request(SocialAuth),
+        )
+        social_auth_sql = str(social_auth_query.query).lower()
+        self.assertNotIn('client_id', social_auth_sql)
+        self.assertNotIn('client_secret', social_auth_sql)
+
+    def test_nullable_user_lists_select_displayed_users_once(self):
+        for model in (SiteNotice, SiteBanner):
+            with self.subTest(model=model):
+                model_admin = admin.site._registry[model]
+                with CaptureQueriesContext(connection) as queries:
+                    rows = list(
+                        model_admin.get_queryset(
+                            self.changelist_request(model),
+                        ),
+                    )
+                    for row in rows:
+                        if row.user is not None:
+                            str(row.user)
+
+                self.assertEqual(len(queries), 1)
+                self.assertNotIn(
+                    'password',
+                    queries.captured_queries[0]['sql'].lower(),
+                )
 
     def test_image_cache_list_uses_compact_lazy_previews(self):
         model_admin = ImageCacheAdmin(ImageCache, admin.site)


### PR DESCRIPTION
## 🎯 Goal
- Keep high-growth Django Admin lists responsive as posts, comments, notifications, revisions, and audit entries accumulate.
- Prevent list pages from loading password hashes, provider credentials, and large fields that they never render, without changing detail-page behavior.

## 🔧 Core Changes
- Skip the optional unfiltered result count on the five high-growth Admin lists.
- Defer list-only unused content, credential, and audit-message fields while retaining them on change/detail views.
- Select nullable user and audit relations explicitly to prevent per-row queries.
- Centralize Admin changelist request detection and cover the query contracts with backend unit tests.

## 🤔 Key Decisions
- Optimize only the changelist path for fields that detail pages still inspect or edit, preserving existing Admin workflows.
- Keep displayed relations eagerly loaded so field deferral cannot trade payload size for N+1 queries.
- Assert generated SQL and deferred-field behavior in unit tests instead of adding browser-level coverage.

## 🧪 Verification Guide
### How to verify
1. Run `node ./scripts/manage.mjs test board.tests.admin -v 2`.
2. Run `npm run server:check-migrations`.
3. Run `npm run server:test`.

### Expected result
- Admin lists render without extra per-row relation queries, omit unused sensitive/large columns, and do not run optional full counts; detail views retain their existing fields and all backend tests pass.

## ✅ Checklist
- [x] Lint completed (not applicable: backend-only change; `git diff --check` passed)
- [x] Type-check completed (not applicable: backend-only change)
- [x] Tests completed
- [x] Documentation updated (not needed: internal query behavior only)
