### PR TITLE
🐛 Prevent delegated staff from managing admin accounts

### DIFF
--- a/backend/src/board/admin/user.py
+++ b/backend/src/board/admin/user.py
@@ -8,10 +8,12 @@ from django.contrib.auth.admin import (
     GroupAdmin as BaseGroupAdmin,
     UserAdmin as BaseUserAdmin,
 )
+from django.contrib.admin.utils import unquote
 from django.contrib.auth.models import Group, User
+from django.core.exceptions import PermissionDenied
 from django.http import HttpRequest
 from django.db import transaction
-from django.db.models import Count, Exists, OuterRef, QuerySet
+from django.db.models import Count, Exists, OuterRef, Q, QuerySet
 from django.urls import reverse
 from django.utils.html import format_html, format_html_join
 
@@ -277,13 +279,25 @@ class CustomUserAdmin(ConfirmedActionDeleteAdminMixin, BaseUserAdmin):
         return list(dict.fromkeys(readonly_fields))
 
     def has_change_permission(self, request, obj=None):
-        if (
-            obj is not None
-            and obj.is_superuser
-            and not request.user.is_superuser
-        ):
+        if not self.can_manage_user(request, obj):
             return False
         return super().has_change_permission(request, obj)
+
+    @staticmethod
+    def can_manage_user(request: HttpRequest, obj: User | None) -> bool:
+        if (
+            obj is None
+            or request.user.is_superuser
+            or obj.pk == request.user.pk
+        ):
+            return True
+        return not (obj.is_staff or obj.is_superuser)
+
+    def user_change_password(self, request, id, form_url=''):
+        user = self.get_object(request, unquote(id))
+        if user is not None and not self.can_manage_user(request, user):
+            raise PermissionDenied
+        return super().user_change_password(request, id, form_url)
 
     def has_change_profile_permission(self, request):
         return (
@@ -298,7 +312,7 @@ class CustomUserAdmin(ConfirmedActionDeleteAdminMixin, BaseUserAdmin):
     ) -> QuerySet[User]:
         if request.user.is_superuser:
             return queryset
-        return queryset.filter(is_superuser=False)
+        return queryset.filter(is_staff=False, is_superuser=False)
 
     def role_badge(self, obj):
         if hasattr(obj, 'profile'):
@@ -373,12 +387,12 @@ class CustomUserAdmin(ConfirmedActionDeleteAdminMixin, BaseUserAdmin):
         is_active: bool,
     ) -> Any:
         candidates = queryset.filter(is_active=not is_active)
-        protected_superuser_count = 0
+        protected_admin_count = 0
         if not request.user.is_superuser:
-            protected_superuser_count = candidates.filter(
-                is_superuser=True,
+            protected_admin_count = candidates.filter(
+                Q(is_staff=True) | Q(is_superuser=True),
             ).count()
-            candidates = candidates.filter(is_superuser=False)
+            candidates = self.mutable_users(request, candidates)
         action_name = 'activate_users' if is_active else 'deactivate_users'
         status_label = '활성화' if is_active else '비활성화'
         if request.POST.get('confirm') != 'yes':
@@ -420,6 +434,8 @@ class CustomUserAdmin(ConfirmedActionDeleteAdminMixin, BaseUserAdmin):
                     f'Admin에서 계정 {status_label}',
                 )
 
+        protected_admin_count += result.skipped_protected_admin_count
+
         self.message_user(
             request,
             f'{len(result.changed_users)}명의 사용자를 {status_label}했습니다.',
@@ -437,10 +453,10 @@ class CustomUserAdmin(ConfirmedActionDeleteAdminMixin, BaseUserAdmin):
                 '마지막 활성 슈퍼유저 계정은 비활성화하지 않았습니다.',
                 level=messages.WARNING,
             )
-        if protected_superuser_count:
+        if protected_admin_count:
             self.message_user(
                 request,
-                f'슈퍼유저 {protected_superuser_count}명은 변경하지 않았습니다.',
+                f'관리자 계정 {protected_admin_count}명은 변경하지 않았습니다.',
                 level=messages.WARNING,
             )
         return None

--- a/backend/src/board/services/user_management_service.py
+++ b/backend/src/board/services/user_management_service.py
@@ -29,6 +29,7 @@ class UserActiveStatusResult:
     changed_users: tuple[User, ...]
     skipped_self_count: int
     skipped_last_superuser_count: int
+    skipped_protected_admin_count: int
 
 
 class UserManagementService:
@@ -268,6 +269,7 @@ class UserManagementService:
         changed_users = []
         skipped_self_count = 0
         skipped_last_superuser_count = 0
+        skipped_protected_admin_count = 0
 
         for target in targets:
             if target.is_active == is_active:
@@ -275,6 +277,13 @@ class UserManagementService:
 
             if not is_active and target.pk == actor.pk:
                 skipped_self_count += 1
+                continue
+
+            if (
+                not actor.is_superuser
+                and (target.is_staff or target.is_superuser)
+            ):
+                skipped_protected_admin_count += 1
                 continue
 
             if not is_active and target.pk in active_superuser_ids:
@@ -291,4 +300,5 @@ class UserManagementService:
             changed_users=tuple(changed_users),
             skipped_self_count=skipped_self_count,
             skipped_last_superuser_count=skipped_last_superuser_count,
+            skipped_protected_admin_count=skipped_protected_admin_count,
         )

--- a/backend/src/board/tests/admin/test_admin_permission_boundaries.py
+++ b/backend/src/board/tests/admin/test_admin_permission_boundaries.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.contrib.admin import helpers
 from django.contrib.auth.models import Group, Permission, User
 from django.contrib.contenttypes.models import ContentType
 from django.db import connection
@@ -9,6 +10,7 @@ from django.utils import translation
 
 from board.admin.user import CustomGroupAdmin, CustomUserAdmin
 from board.models import Post, Profile
+from board.services.user_management_service import UserManagementService
 
 
 class AdminPermissionBoundaryTestCase(TestCase):
@@ -29,6 +31,12 @@ class AdminPermissionBoundaryTestCase(TestCase):
             username='permission-target',
             email='permission-target@example.com',
             password='test',
+        )
+        cls.privileged_staff = User.objects.create_user(
+            username='privileged-staff',
+            email='privileged-staff@example.com',
+            password='original-password',
+            is_staff=True,
         )
         cls.target_profile, _ = Profile.objects.get_or_create(
             user=cls.target,
@@ -91,6 +99,84 @@ class AdminPermissionBoundaryTestCase(TestCase):
 
         self.assertEqual(change_response.status_code, 403)
         self.assertEqual(password_response.status_code, 403)
+
+    def test_delegated_staff_cannot_change_privileged_staff_or_password(self):
+        request = self.admin_request()
+
+        self.assertTrue(
+            self.user_admin.has_change_permission(request, self.staff),
+        )
+        self.assertFalse(
+            self.user_admin.has_change_permission(
+                request,
+                self.privileged_staff,
+            ),
+        )
+
+        self.client.force_login(self.staff)
+        change_response = self.client.post(
+            reverse(
+                'admin:auth_user_change',
+                args=[self.privileged_staff.pk],
+            ),
+            {'username': self.privileged_staff.username},
+        )
+        password_response = self.client.post(
+            reverse(
+                'admin:auth_user_password_change',
+                args=[self.privileged_staff.pk],
+            ),
+            {
+                'password1': 'replacement-password',
+                'password2': 'replacement-password',
+            },
+        )
+
+        self.assertEqual(change_response.status_code, 403)
+        self.assertEqual(password_response.status_code, 403)
+        self.privileged_staff.refresh_from_db()
+        self.assertTrue(self.privileged_staff.check_password('original-password'))
+
+    def test_delegated_staff_cannot_change_privileged_staff_active_state(self):
+        self.client.force_login(self.staff)
+
+        response = self.client.post(
+            reverse('admin:auth_user_changelist'),
+            {
+                helpers.ACTION_CHECKBOX_NAME: [str(self.privileged_staff.pk)],
+                'action': 'deactivate_users',
+                'select_across': '0',
+                'confirm': 'yes',
+            },
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.privileged_staff.refresh_from_db()
+        self.assertTrue(self.privileged_staff.is_active)
+
+    def test_user_active_status_service_protects_staff_for_delegated_actor(self):
+        result = UserManagementService.set_active_status(
+            self.staff,
+            [self.privileged_staff.pk],
+            is_active=False,
+        )
+
+        self.assertEqual(result.changed_users, ())
+        self.assertEqual(result.skipped_protected_admin_count, 1)
+        self.privileged_staff.refresh_from_db()
+        self.assertTrue(self.privileged_staff.is_active)
+
+    def test_superuser_keeps_staff_account_active_state_management(self):
+        result = UserManagementService.set_active_status(
+            self.superuser,
+            [self.privileged_staff.pk],
+            is_active=False,
+        )
+
+        self.assertEqual(result.changed_users, (self.privileged_staff,))
+        self.assertEqual(result.skipped_protected_admin_count, 0)
+        self.privileged_staff.refresh_from_db()
+        self.assertFalse(self.privileged_staff.is_active)
 
     def test_crafted_user_post_cannot_grant_privileged_fields(self):
         request = self.admin_request()
@@ -192,6 +278,12 @@ class AdminPermissionBoundaryTestCase(TestCase):
         self.assertTrue(
             set(self.user_admin.delegated_readonly_fields).isdisjoint(
                 readonly_fields,
+            ),
+        )
+        self.assertTrue(
+            self.user_admin.has_change_permission(
+                request,
+                self.privileged_staff,
             ),
         )
 


### PR DESCRIPTION
## 🎯 Goal
- Prevent a delegated `change_user` staff account from changing a separate staff account’s password, profile role, or active status.
- Keep legitimate self-service and superuser administration intact.

## 🔧 Core Changes
- Deny non-superusers from mutating other staff or superuser accounts in Django Admin, including the password endpoint.
- Exclude administrator accounts from delegated bulk role and active-state actions, with the same guard at the service boundary.
- Add low-cost Admin request and service regression tests for denied and allowed paths.

## 🤔 Key Decisions
- Preserve read-only inspection and a delegated staff member’s own account management; only cross-admin mutation is blocked.
- Keep superuser behavior unchanged and test it explicitly.

## 🧪 Verification Guide
### How to verify
1. Give a non-superuser staff account `change_user`.
2. Attempt to change another staff account, reset its password, or deactivate it from Admin.
3. Repeat the active-state operation as a superuser.

### Expected result
- Delegated staff requests are rejected or leave the administrator account unchanged.
- Superusers can still manage staff accounts.

## ✅ Checklist
- [x] Lint completed (not applicable: backend-only change)
- [x] Type-check completed (not applicable: backend-only change)
- [x] Tests completed (`npm run server:test`)
- [x] Documentation updated (not needed)