### PR TITLE
🐛 Restrict high-risk product settings

### DIFF
--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/SettingsApp.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/SettingsApp.tsx
@@ -46,13 +46,21 @@ const GlobalBannerEditor = lazy(() => import('./pages/GlobalBannerSetting/compon
 export interface SettingsAppProps {
     isEditor: boolean;
     isStaff: boolean;
+    isSuperuser?: boolean;
     adminUrl?: string;
     settingsMode?: SettingsMode;
     basePath?: string;
     canUseTelegramIntegration?: boolean;
+    adminCapabilities?: Partial<AdminCapabilities>;
 }
 
 type SettingsMode = 'user' | 'admin';
+
+export interface AdminCapabilities {
+    canManageSiteSettings: boolean;
+    canManageLoginSettings: boolean;
+    canManageIntegrationSettings: boolean;
+}
 
 interface SettingsRouterContext {
     isEditor: boolean;
@@ -61,7 +69,15 @@ interface SettingsRouterContext {
     settingsMode: SettingsMode;
     basePath: string;
     canUseTelegramIntegration: boolean;
+    adminCapabilities: AdminCapabilities;
 }
+
+const getAdminDefaultPath = (adminCapabilities: AdminCapabilities) => {
+    if (adminCapabilities.canManageSiteSettings) return '/site-settings';
+    if (adminCapabilities.canManageLoginSettings) return '/login';
+    if (adminCapabilities.canManageIntegrationSettings) return '/integrations';
+    return '/global-notices';
+};
 
 // Root route
 const rootRoute = createRootRoute({
@@ -81,9 +97,9 @@ const settingsRoute = createRoute({
 
 const SettingsIndexRedirect = () => {
     const router = useRouter();
-    const { settingsMode } = router.options.context as SettingsRouterContext;
+    const { settingsMode, adminCapabilities } = router.options.context as SettingsRouterContext;
 
-    return <Navigate to={settingsMode === 'admin' ? '/site-settings' : '/notify'} replace />;
+    return <Navigate to={settingsMode === 'admin' ? getAdminDefaultPath(adminCapabilities) : '/notify'} replace />;
 };
 
 const editorOnly = (Component: ElementType) => {
@@ -101,19 +117,30 @@ const editorOnly = (Component: ElementType) => {
     return EditorOnlyRoute;
 };
 
-const staffOnly = (Component: ElementType) => {
-    const StaffOnlyRoute = (props: Record<string, unknown>) => {
+const adminCapabilityOnly = (
+    capability: keyof AdminCapabilities,
+    Component: ElementType
+) => {
+    const AdminCapabilityOnlyRoute = (props: Record<string, unknown>) => {
         const router = useRouter();
-        const { isStaff, settingsMode } = router.options.context as SettingsRouterContext;
+        const {
+            isStaff,
+            settingsMode,
+            adminCapabilities
+        } = router.options.context as SettingsRouterContext;
 
         if (!isStaff) {
-            return <Navigate to={settingsMode === 'admin' ? '/site-settings' : '/notify'} replace />;
+            return <Navigate to="/notify" replace />;
+        }
+
+        if (!adminCapabilities[capability]) {
+            return <Navigate to={settingsMode === 'admin' ? getAdminDefaultPath(adminCapabilities) : '/notify'} replace />;
         }
 
         return <Component {...props} />;
     };
 
-    return StaffOnlyRoute;
+    return AdminCapabilityOnlyRoute;
 };
 
 const telegramIntegrationOnly = (Component: ElementType) => {
@@ -247,25 +274,25 @@ const globalBannersRoute = createRoute({
 const siteSettingsRoute = createRoute({
     getParentRoute: () => settingsRoute,
     path: '/site-settings',
-    component: SiteSettingSetting
+    component: adminCapabilityOnly('canManageSiteSettings', SiteSettingSetting)
 });
 
 const loginRoute = createRoute({
     getParentRoute: () => settingsRoute,
     path: '/login',
-    component: LoginSetting
+    component: adminCapabilityOnly('canManageLoginSettings', LoginSetting)
 });
 
 const adminIntegrationRoute = createRoute({
     getParentRoute: () => settingsRoute,
     path: '/integrations',
-    component: staffOnly(AdminIntegrationSetting)
+    component: adminCapabilityOnly('canManageIntegrationSettings', AdminIntegrationSetting)
 });
 
 const seoAeoRoute = createRoute({
     getParentRoute: () => settingsRoute,
     path: '/seo-aeo',
-    component: SeoAeoSetting
+    component: adminCapabilityOnly('canManageSiteSettings', SeoAeoSetting)
 });
 
 const staticPagesRoute = createRoute({
@@ -397,13 +424,27 @@ const routeTree = rootRoute.addChildren([
 const SettingsApp = ({
     isEditor,
     isStaff,
+    isSuperuser = false,
     adminUrl,
     settingsMode = 'user',
     basePath,
-    canUseTelegramIntegration = false
+    canUseTelegramIntegration = false,
+    adminCapabilities
 }: SettingsAppProps) => {
     const normalizedSettingsMode = settingsMode === 'admin' ? 'admin' : 'user';
     const normalizedBasePath = basePath ?? (normalizedSettingsMode === 'admin' ? '/admin-settings' : '/settings');
+    const legacyStaffCapabilities = adminCapabilities === undefined && isStaff;
+    const normalizedAdminCapabilities: AdminCapabilities = {
+        canManageSiteSettings: isSuperuser
+            || adminCapabilities?.canManageSiteSettings === true
+            || legacyStaffCapabilities,
+        canManageLoginSettings: isSuperuser
+            || adminCapabilities?.canManageLoginSettings === true
+            || legacyStaffCapabilities,
+        canManageIntegrationSettings: isSuperuser
+            || adminCapabilities?.canManageIntegrationSettings === true
+            || legacyStaffCapabilities
+    };
 
     const router = createRouter({
         routeTree,
@@ -413,7 +454,8 @@ const SettingsApp = ({
             adminUrl,
             settingsMode: normalizedSettingsMode,
             basePath: normalizedBasePath,
-            canUseTelegramIntegration
+            canUseTelegramIntegration,
+            adminCapabilities: normalizedAdminCapabilities
         },
         defaultPreload: 'intent',
         basepath: normalizedBasePath

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/SettingsNavigation.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/components/SettingsNavigation.tsx
@@ -33,6 +33,7 @@ import {
     ENTRANCE_DURATION,
     INTERACTION_DURATION
 } from '@blex/ui/design-tokens';
+import type { AdminCapabilities } from '../SettingsApp';
 
 interface NavigationItem {
     name: string;
@@ -41,6 +42,7 @@ interface NavigationItem {
     requiresEditor?: boolean;
     requiresStaff?: boolean;
     requiresTelegramIntegration?: boolean;
+    requiresAdminCapability?: keyof AdminCapabilities;
 }
 
 interface NavigationSection {
@@ -63,6 +65,7 @@ interface SettingsRouterContext {
     settingsMode: SettingsMode;
     basePath: string;
     canUseTelegramIntegration: boolean;
+    adminCapabilities: AdminCapabilities;
 }
 
 const userNavigationSections: NavigationSection[] = [
@@ -161,19 +164,22 @@ const adminNavigationSections: NavigationSection[] = [
                 name: '블로그 커스텀',
                 path: '/site-settings',
                 icon: Palette,
-                requiresStaff: true
+                requiresStaff: true,
+                requiresAdminCapability: 'canManageSiteSettings'
             },
             {
                 name: '로그인 관리',
                 path: '/login',
                 icon: LogIn,
-                requiresStaff: true
+                requiresStaff: true,
+                requiresAdminCapability: 'canManageLoginSettings'
             },
             {
                 name: 'SEO/AEO',
                 path: '/seo-aeo',
                 icon: Bot,
-                requiresStaff: true
+                requiresStaff: true,
+                requiresAdminCapability: 'canManageSiteSettings'
             },
             {
                 name: '정적 페이지',
@@ -215,7 +221,8 @@ const adminNavigationSections: NavigationSection[] = [
                 name: '텔레그램',
                 path: '/integrations',
                 icon: Send,
-                requiresStaff: true
+                requiresStaff: true,
+                requiresAdminCapability: 'canManageIntegrationSettings'
             }
         ]
     },
@@ -253,11 +260,13 @@ const canShowItem = (
     item: NavigationItem,
     isEditor: boolean,
     isStaff: boolean,
-    canUseTelegramIntegration: boolean
+    canUseTelegramIntegration: boolean,
+    adminCapabilities: AdminCapabilities
 ) => (
     (!item.requiresEditor || isEditor)
     && (!item.requiresStaff || isStaff)
     && (!item.requiresTelegramIntegration || canUseTelegramIntegration)
+    && (!item.requiresAdminCapability || adminCapabilities[item.requiresAdminCapability])
 );
 
 const canShowSection = (section: NavigationSection, isEditor: boolean, isStaff: boolean) => (
@@ -273,16 +282,25 @@ const normalizePath = (path: string, basePath: string) => {
 const SettingsModeLink = ({
     settingsMode,
     isStaff,
+    adminCapabilities,
     mobile = false
 }: {
     settingsMode: SettingsMode;
     isStaff: boolean;
+    adminCapabilities: AdminCapabilities;
     mobile?: boolean;
 }) => {
     if (!isStaff) return null;
 
     const isAdminMode = settingsMode === 'admin';
-    const href = isAdminMode ? '/settings/notify' : '/admin-settings/site-settings';
+    const adminSettingsPath = adminCapabilities.canManageSiteSettings
+        ? '/admin-settings/site-settings'
+        : adminCapabilities.canManageLoginSettings
+            ? '/admin-settings/login'
+            : adminCapabilities.canManageIntegrationSettings
+                ? '/admin-settings/integrations'
+                : '/admin-settings/global-notices';
+    const href = isAdminMode ? '/settings/notify' : adminSettingsPath;
     const label = isAdminMode ? '내 설정으로 돌아가기' : '관리자 설정';
     const ModeIcon = isAdminMode ? ArrowLeft : Shield;
 
@@ -309,13 +327,14 @@ export const SettingsMobileNavigation = ({ currentPath }: SettingsNavigationProp
         adminUrl,
         settingsMode,
         basePath,
-        canUseTelegramIntegration
+        canUseTelegramIntegration,
+        adminCapabilities
     } = router.options.context as SettingsRouterContext;
     const settingsLabel = settingsMode === 'admin' ? '관리자 설정' : '설정';
     const navigationSections = getNavigationSections(settingsMode);
     const activeItem = navigationSections
         .flatMap(section => section.items)
-        .filter(item => canShowItem(item, isEditor, isStaff, canUseTelegramIntegration))
+        .filter(item => canShowItem(item, isEditor, isStaff, canUseTelegramIntegration, adminCapabilities))
         .find(item => (
             item.path !== 'admin'
             && normalizePath(currentPath, basePath) === normalizePath(item.path, basePath)
@@ -335,7 +354,7 @@ export const SettingsMobileNavigation = ({ currentPath }: SettingsNavigationProp
     };
 
     const renderNavItem = (item: NavigationItem) => {
-        if (!canShowItem(item, isEditor, isStaff, canUseTelegramIntegration)) return null;
+        if (!canShowItem(item, isEditor, isStaff, canUseTelegramIntegration, adminCapabilities)) return null;
 
         const isActive = item.path !== 'admin' && normalizePath(currentPath, basePath) === normalizePath(item.path, basePath);
         const baseClasses = `group flex min-h-11 items-center rounded-lg px-3 py-2.5 text-sm transition-all ${INTERACTION_DURATION} active:scale-95 motion-reduce:transform-none motion-reduce:transition-none`;
@@ -384,7 +403,9 @@ export const SettingsMobileNavigation = ({ currentPath }: SettingsNavigationProp
     const renderSection = (section: NavigationSection) => {
         if (!canShowSection(section, isEditor, isStaff)) return null;
 
-        const visibleItems = section.items.filter(item => canShowItem(item, isEditor, isStaff, canUseTelegramIntegration));
+        const visibleItems = section.items.filter(item => (
+            canShowItem(item, isEditor, isStaff, canUseTelegramIntegration, adminCapabilities)
+        ));
         if (visibleItems.length === 0) return null;
 
         return (
@@ -442,7 +463,12 @@ export const SettingsMobileNavigation = ({ currentPath }: SettingsNavigationProp
 
                             {isStaff && (
                                 <div className="-mt-5 mb-8">
-                                    <SettingsModeLink settingsMode={settingsMode} isStaff={isStaff} mobile />
+                                    <SettingsModeLink
+                                        settingsMode={settingsMode}
+                                        isStaff={isStaff}
+                                        adminCapabilities={adminCapabilities}
+                                        mobile
+                                    />
                                 </div>
                             )}
 
@@ -465,7 +491,8 @@ export const SettingsDesktopNavigation = ({ currentPath }: SettingsNavigationPro
         adminUrl,
         settingsMode,
         basePath,
-        canUseTelegramIntegration
+        canUseTelegramIntegration,
+        adminCapabilities
     } = router.options.context as SettingsRouterContext;
     const settingsLabel = settingsMode === 'admin' ? '관리자 설정' : '설정';
     const navigationSections = getNavigationSections(settingsMode);
@@ -476,7 +503,7 @@ export const SettingsDesktopNavigation = ({ currentPath }: SettingsNavigationPro
     };
 
     const renderNavItem = (item: NavigationItem) => {
-        if (!canShowItem(item, isEditor, isStaff, canUseTelegramIntegration)) return null;
+        if (!canShowItem(item, isEditor, isStaff, canUseTelegramIntegration, adminCapabilities)) return null;
 
         const isActive = item.path !== 'admin' && normalizePath(currentPath, basePath) === normalizePath(item.path, basePath);
         const baseClasses = `flex min-h-11 items-center rounded-lg px-3 text-sm transition-all ${INTERACTION_DURATION} active:scale-95 [@media(pointer:fine)]:min-h-9`;
@@ -526,7 +553,9 @@ export const SettingsDesktopNavigation = ({ currentPath }: SettingsNavigationPro
     const renderSection = (section: NavigationSection) => {
         if (!canShowSection(section, isEditor, isStaff)) return null;
 
-        const visibleItems = section.items.filter(item => canShowItem(item, isEditor, isStaff, canUseTelegramIntegration));
+        const visibleItems = section.items.filter(item => (
+            canShowItem(item, isEditor, isStaff, canUseTelegramIntegration, adminCapabilities)
+        ));
         if (visibleItems.length === 0) return null;
 
         return (
@@ -549,7 +578,11 @@ export const SettingsDesktopNavigation = ({ currentPath }: SettingsNavigationPro
                 </p>
                 {isStaff && (
                     <div className="mt-3">
-                        <SettingsModeLink settingsMode={settingsMode} isStaff={isStaff} />
+                        <SettingsModeLink
+                            settingsMode={settingsMode}
+                            isStaff={isStaff}
+                            adminCapabilities={adminCapabilities}
+                        />
                     </div>
                 )}
             </div>

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SiteSettingSetting/SiteSettingSetting.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/SiteSettingSetting/SiteSettingSetting.tsx
@@ -328,8 +328,12 @@ const SiteSettingSetting = () => {
         event?.preventDefault();
         updateMutation.mutate({
             site_name: siteName,
-            header_script: headerScript,
-            footer_script: footerScript
+            ...(settingData.canManageScripts
+                ? {
+                    header_script: headerScript,
+                    footer_script: footerScript
+                }
+                : {})
         });
     };
 
@@ -455,69 +459,71 @@ const SiteSettingSetting = () => {
                 </div>
             </section>
 
-            <section className="space-y-4" aria-labelledby="advanced-site-settings-title">
-                <h2 id="advanced-site-settings-title" className="text-base font-semibold text-content">
-                    고급 설정
-                </h2>
-                <details
-                    className="group overflow-hidden rounded-2xl bg-surface ring-1 ring-line/60"
-                    open={isGlobalCodeOpen}
-                    onToggle={(event) => setIsGlobalCodeOpen(event.currentTarget.open)}>
-                    <summary className="flex min-h-20 cursor-pointer list-none items-center gap-4 px-6 py-5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-line-strong md:px-8 [&::-webkit-details-marker]:hidden">
-                        <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-warning-surface text-warning">
-                            <Code2 aria-hidden="true" className="h-5 w-5" />
-                        </span>
-                        <span className="min-w-0 flex-1">
-                            <span className="block text-base font-semibold text-content">전역 코드</span>
-                            <span
-                                aria-live="polite"
-                                className={`mt-1 block text-sm ${isGlobalCodeDirty ? 'text-warning' : 'text-content-secondary'}`}>
-                                {globalCodeStatus}
+            {settingData.canManageScripts && (
+                <section className="space-y-4" aria-labelledby="advanced-site-settings-title">
+                    <h2 id="advanced-site-settings-title" className="text-base font-semibold text-content">
+                        고급 설정
+                    </h2>
+                    <details
+                        className="group overflow-hidden rounded-2xl bg-surface ring-1 ring-line/60"
+                        open={isGlobalCodeOpen}
+                        onToggle={(event) => setIsGlobalCodeOpen(event.currentTarget.open)}>
+                        <summary className="flex min-h-20 cursor-pointer list-none items-center gap-4 px-6 py-5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-line-strong md:px-8 [&::-webkit-details-marker]:hidden">
+                            <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-warning-surface text-warning">
+                                <Code2 aria-hidden="true" className="h-5 w-5" />
                             </span>
-                        </span>
-                        <ChevronDown
-                            aria-hidden="true"
-                            className="h-5 w-5 shrink-0 text-content-hint transition-transform group-open:rotate-180 motion-reduce:transition-none"
-                        />
-                    </summary>
+                            <span className="min-w-0 flex-1">
+                                <span className="block text-base font-semibold text-content">전역 코드</span>
+                                <span
+                                    aria-live="polite"
+                                    className={`mt-1 block text-sm ${isGlobalCodeDirty ? 'text-warning' : 'text-content-secondary'}`}>
+                                    {globalCodeStatus}
+                                </span>
+                            </span>
+                            <ChevronDown
+                                aria-hidden="true"
+                                className="h-5 w-5 shrink-0 text-content-hint transition-transform group-open:rotate-180 motion-reduce:transition-none"
+                            />
+                        </summary>
 
-                    {isGlobalCodeOpen && (
-                        <div className="space-y-6 border-t border-line px-6 py-6 md:px-8 md:py-8">
-                            <div className="flex gap-3 rounded-xl border border-warning-line bg-warning-surface p-4 text-warning">
-                                <AlertTriangle aria-hidden="true" className="mt-0.5 h-4 w-4 shrink-0" />
-                                <p className="text-xs leading-relaxed">
-                                    저장 즉시 모든 공개 페이지에 적용됩니다. 메타 태그와 먼저 불러올 코드는 {'<head>'} 안에,
-                                    나중에 불러올 스크립트는 {'</body>'} 직전에 삽입되므로 검증된 코드만 사용하세요.
-                                </p>
-                            </div>
-                            <div className="space-y-2">
-                                <div className="block text-sm font-semibold text-content">
-                                    Head 영역 코드
+                        {isGlobalCodeOpen && (
+                            <div className="space-y-6 border-t border-line px-6 py-6 md:px-8 md:py-8">
+                                <div className="flex gap-3 rounded-xl border border-warning-line bg-warning-surface p-4 text-warning">
+                                    <AlertTriangle aria-hidden="true" className="mt-0.5 h-4 w-4 shrink-0" />
+                                    <p className="text-xs leading-relaxed">
+                                        저장 즉시 모든 공개 페이지에 적용됩니다. 메타 태그와 먼저 불러올 코드는 {'<head>'} 안에,
+                                        나중에 불러올 스크립트는 {'</body>'} 직전에 삽입되므로 검증된 코드만 사용하세요.
+                                    </p>
                                 </div>
-                                <CodeEditor
-                                    ariaLabel="Head 영역 코드"
-                                    language="html"
-                                    value={headerScript}
-                                    onChange={setHeaderScript}
-                                    height="220px"
-                                />
-                            </div>
-                            <div className="space-y-2">
-                                <div className="block text-sm font-semibold text-content">
-                                    Body 하단 코드
+                                <div className="space-y-2">
+                                    <div className="block text-sm font-semibold text-content">
+                                        Head 영역 코드
+                                    </div>
+                                    <CodeEditor
+                                        ariaLabel="Head 영역 코드"
+                                        language="html"
+                                        value={headerScript}
+                                        onChange={setHeaderScript}
+                                        height="220px"
+                                    />
                                 </div>
-                                <CodeEditor
-                                    ariaLabel="Body 하단 코드"
-                                    language="html"
-                                    value={footerScript}
-                                    onChange={setFooterScript}
-                                    height="220px"
-                                />
+                                <div className="space-y-2">
+                                    <div className="block text-sm font-semibold text-content">
+                                        Body 하단 코드
+                                    </div>
+                                    <CodeEditor
+                                        ariaLabel="Body 하단 코드"
+                                        language="html"
+                                        value={footerScript}
+                                        onChange={setFooterScript}
+                                        height="220px"
+                                    />
+                                </div>
                             </div>
-                        </div>
-                    )}
-                </details>
-            </section>
+                        )}
+                    </details>
+                </section>
+            )}
 
             <div className="sticky bottom-0 z-10 -mx-4 flex justify-end bg-surface-page/95 px-4 py-3 backdrop-blur md:mx-0 md:px-0">
                 <Button

--- a/backend/islands/apps/remotes/src/lib/api/settings.ts
+++ b/backend/islands/apps/remotes/src/lib/api/settings.ts
@@ -660,6 +660,7 @@ export interface SiteSettingData {
     hasCustomIconDark: boolean;
     headerScript: string;
     footerScript: string;
+    canManageScripts: boolean;
     seoEnabled: boolean;
     robotsTxtExtraRules: string;
     robotsTxtDefault: string;

--- a/backend/src/board/services/admin_settings_audit_service.py
+++ b/backend/src/board/services/admin_settings_audit_service.py
@@ -1,0 +1,19 @@
+from django.contrib.admin.models import CHANGE, LogEntry
+from django.contrib.auth.models import User
+from django.contrib.contenttypes.models import ContentType
+from django.db.models import Model
+
+
+class AdminSettingsAuditService:
+    """Write redacted audit records for product settings mutations."""
+
+    @staticmethod
+    def record_change(*, user: User, target: Model, change_message: str) -> None:
+        LogEntry.objects.create(
+            user_id=user.pk,
+            content_type=ContentType.objects.get_for_model(target),
+            object_id=str(target.pk) if target.pk else None,
+            object_repr=str(target),
+            action_flag=CHANGE,
+            change_message=change_message,
+        )

--- a/backend/src/board/services/api_permission_service.py
+++ b/backend/src/board/services/api_permission_service.py
@@ -40,6 +40,17 @@ class ApiPermissionService:
         return None
 
     @staticmethod
+    def require_superuser(user: User | AnonymousUser) -> Optional[HttpResponse]:
+        staff_error = ApiPermissionService.require_staff(user)
+        if staff_error:
+            return staff_error
+
+        if not user.is_superuser:
+            return StatusError(ErrorCode.REJECT, '최고 관리자 권한이 필요합니다.')
+
+        return None
+
+    @staticmethod
     def require_owner(user: User | AnonymousUser, owner: User) -> Optional[HttpResponse]:
         login_error = ApiPermissionService.require_login(user)
         if login_error:

--- a/backend/src/board/services/brand_asset_service.py
+++ b/backend/src/board/services/brand_asset_service.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import re
+from collections.abc import Callable
 from io import BytesIO
 from typing import Any
 
@@ -10,11 +12,15 @@ from defusedxml import ElementTree
 from django.conf import settings
 from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
+from django.db import transaction
 from django.http import HttpRequest
 from PIL import Image, UnidentifiedImageError
 
 from board.models import SiteSetting
 from board.services.site_url_service import SiteUrlService
+
+
+logger = logging.getLogger(__name__)
 
 
 class BrandAssetError(Exception):
@@ -201,6 +207,7 @@ class BrandAssetService:
         svg_file,
         files,
         manifest_raw: str = '',
+        on_persist: Callable[[SiteSetting], None] | None = None,
     ) -> SiteSetting:
         BrandAssetService.validate_asset_target(asset_type, theme)
 
@@ -208,8 +215,6 @@ class BrandAssetService:
             raise BrandAssetError('기본 자산을 먼저 업로드해주세요.')
 
         svg_bytes = BrandAssetService.validate_svg(svg_file)
-        asset_hash = hashlib.sha256(svg_bytes).hexdigest()[:16]
-        base_path = f'brand/{asset_type}/{theme}/{asset_hash}'
         old_paths = BrandAssetService.collect_asset_paths(setting, asset_type, theme)
         old_path_set = set(old_paths)
         new_paths: list[str] = []
@@ -223,6 +228,13 @@ class BrandAssetService:
                 field_name = f'png_{size}'
                 png_contents[size] = BrandAssetService.validate_png(files.get(field_name), size)
             ico_bytes = BrandAssetService.validate_ico(files.get('favicon_ico'))
+
+        asset_hash = BrandAssetService.build_asset_hash(
+            svg_bytes,
+            png_contents,
+            ico_bytes,
+        )
+        base_path = f'brand/{asset_type}/{theme}/{asset_hash}'
 
         try:
             svg_path = f'{base_path}/{asset_type}.svg'
@@ -250,16 +262,33 @@ class BrandAssetService:
                 }
 
             BrandAssetService.set_asset_field(setting, asset_type, theme, svg_path)
-            setting.save()
+            update_fields = [
+                BrandAssetService.asset_field_name(asset_type, theme),
+                'updated_date',
+            ]
+            if asset_type == 'icon' and theme == 'default':
+                update_fields.append('icon_manifest')
+            with transaction.atomic():
+                setting.save(update_fields=update_fields)
+                if on_persist:
+                    on_persist(setting)
         except Exception:
             BrandAssetService.delete_storage_files(path for path in new_paths if path not in old_path_set)
             raise
 
-        BrandAssetService.delete_storage_files(path for path in old_paths if path not in new_paths)
+        BrandAssetService.schedule_storage_file_deletion(
+            path for path in old_paths if path not in new_paths
+        )
         return setting
 
     @staticmethod
-    def delete_asset(setting: SiteSetting, *, asset_type: str, theme: str) -> SiteSetting:
+    def delete_asset(
+        setting: SiteSetting,
+        *,
+        asset_type: str,
+        theme: str,
+        on_persist: Callable[[SiteSetting], None] | None = None,
+    ) -> SiteSetting:
         BrandAssetService.validate_asset_target(asset_type, theme)
         old_paths = BrandAssetService.collect_asset_paths(
             setting,
@@ -280,8 +309,12 @@ class BrandAssetService:
         else:
             setting.icon_svg_dark = ''
 
-        setting.save()
-        BrandAssetService.delete_storage_files(old_paths)
+        update_fields = BrandAssetService.asset_update_fields_for_delete(asset_type, theme)
+        with transaction.atomic():
+            setting.save(update_fields=[*update_fields, 'updated_date'])
+            if on_persist:
+                on_persist(setting)
+        BrandAssetService.schedule_storage_file_deletion(old_paths)
         return setting
 
     @staticmethod
@@ -297,13 +330,47 @@ class BrandAssetService:
 
     @staticmethod
     def set_asset_field(setting: SiteSetting, asset_type: str, theme: str, path: str) -> None:
-        field_name = {
+        setattr(
+            setting,
+            BrandAssetService.asset_field_name(asset_type, theme),
+            path,
+        )
+
+    @staticmethod
+    def asset_field_name(asset_type: str, theme: str) -> str:
+        return {
             ('logo', 'default'): 'logo_svg',
             ('logo', 'dark'): 'logo_svg_dark',
             ('icon', 'default'): 'icon_svg',
             ('icon', 'dark'): 'icon_svg_dark',
         }[(asset_type, theme)]
-        setattr(setting, field_name, path)
+
+    @staticmethod
+    def asset_update_fields_for_delete(asset_type: str, theme: str) -> list[str]:
+        if asset_type == 'logo' and theme == 'default':
+            return ['logo_svg', 'logo_svg_dark']
+        if asset_type == 'icon' and theme == 'default':
+            return ['icon_svg', 'icon_svg_dark', 'icon_manifest']
+        return [BrandAssetService.asset_field_name(asset_type, theme)]
+
+    @staticmethod
+    def build_asset_hash(
+        svg_bytes: bytes,
+        png_contents: dict[int, bytes],
+        ico_bytes: bytes | None,
+    ) -> str:
+        digest = hashlib.sha256()
+        contents = [svg_bytes]
+        contents.extend(
+            png_contents[size]
+            for size in BrandAssetService.REQUIRED_ICON_PNG_SIZES
+            if size in png_contents
+        )
+        contents.append(ico_bytes or b'')
+        for content in contents:
+            digest.update(len(content).to_bytes(8, byteorder='big'))
+            digest.update(content)
+        return digest.hexdigest()[:16]
 
     @staticmethod
     def collect_asset_paths(
@@ -477,3 +544,22 @@ class BrandAssetService:
         for path in paths:
             if path and default_storage.exists(path):
                 default_storage.delete(path)
+
+    @staticmethod
+    def schedule_storage_file_deletion(paths) -> None:
+        paths_to_delete = tuple(path for path in paths if path)
+        if not paths_to_delete:
+            return
+
+        transaction.on_commit(
+            lambda: BrandAssetService.delete_storage_files_after_commit(paths_to_delete),
+        )
+
+    @staticmethod
+    def delete_storage_files_after_commit(paths) -> None:
+        for path in paths:
+            try:
+                if default_storage.exists(path):
+                    default_storage.delete(path)
+            except Exception:
+                logger.exception('Failed to remove an obsolete brand asset file after commit.')

--- a/backend/src/board/services/product_settings_permission_service.py
+++ b/backend/src/board/services/product_settings_permission_service.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from django.contrib.auth.models import AnonymousUser, User
+from django.http import HttpResponse
+
+from board.models import SiteSetting
+from board.modules.response import ErrorCode, StatusError
+from board.services.api_permission_service import ApiPermissionService
+
+
+class ProductSettingsPermissionService:
+    """Permission policy for site-wide product settings."""
+
+    @staticmethod
+    def is_active_staff(user: User | AnonymousUser) -> bool:
+        return bool(user.is_authenticated and user.is_active and user.is_staff)
+
+    @classmethod
+    def can_manage_site_settings(cls, user: User | AnonymousUser) -> bool:
+        if not cls.is_active_staff(user):
+            return False
+
+        return bool(
+            user.is_superuser
+            or user.has_perm(
+                f'{SiteSetting._meta.app_label}.change_{SiteSetting._meta.model_name}',
+            )
+        )
+
+    @classmethod
+    def can_manage_login_settings(cls, user: User | AnonymousUser) -> bool:
+        return cls.is_active_staff(user) and user.is_superuser
+
+    @classmethod
+    def can_manage_integration_settings(cls, user: User | AnonymousUser) -> bool:
+        return cls.is_active_staff(user) and user.is_superuser
+
+    @classmethod
+    def can_manage_global_code(cls, user: User | AnonymousUser) -> bool:
+        return cls.is_active_staff(user) and user.is_superuser
+
+    @classmethod
+    def require_site_settings(
+        cls,
+        user: User | AnonymousUser,
+    ) -> Optional[HttpResponse]:
+        staff_error = ApiPermissionService.require_staff(user)
+        if staff_error:
+            return staff_error
+
+        if not cls.can_manage_site_settings(user):
+            return StatusError(ErrorCode.REJECT, '사이트 설정 변경 권한이 필요합니다.')
+
+        return None
+
+    @staticmethod
+    def require_login_settings(user: User | AnonymousUser) -> Optional[HttpResponse]:
+        return ApiPermissionService.require_superuser(user)
+
+    @staticmethod
+    def require_integration_settings(user: User | AnonymousUser) -> Optional[HttpResponse]:
+        return ApiPermissionService.require_superuser(user)
+
+    @staticmethod
+    def require_global_code(user: User | AnonymousUser) -> Optional[HttpResponse]:
+        return ApiPermissionService.require_superuser(user)
+
+    @classmethod
+    def get_capabilities(cls, user: User | AnonymousUser) -> dict[str, bool]:
+        return {
+            'canManageSiteSettings': cls.can_manage_site_settings(user),
+            'canManageLoginSettings': cls.can_manage_login_settings(user),
+            'canManageIntegrationSettings': cls.can_manage_integration_settings(user),
+        }

--- a/backend/src/board/templates/board/settings.html
+++ b/backend/src/board/templates/board/settings.html
@@ -12,6 +12,6 @@
 
 {% block content %}
 <div>
-    {% island_component 'SettingsApp' isEditor=is_editor isStaff=is_staff adminUrl=admin_url settingsMode=settings_mode basePath=settings_base_path canUseTelegramIntegration=can_use_telegram_integration %}
+    {% island_component 'SettingsApp' isEditor=is_editor isStaff=is_staff isSuperuser=is_superuser adminUrl=admin_url settingsMode=settings_mode basePath=settings_base_path canUseTelegramIntegration=can_use_telegram_integration adminCapabilities=admin_capabilities %}
 </div>
 {% endblock %}

--- a/backend/src/board/tests/admin/test_admin_navigation.py
+++ b/backend/src/board/tests/admin/test_admin_navigation.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 from django.contrib.auth.models import User
+from django.contrib.auth.models import Permission
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
 from django.utils import translation
@@ -41,10 +42,21 @@ class AdminNavigationTestCase(TestCase):
             email='navigation-admin@example.com',
             password='test',
         )
+        cls.delegated_staff = User.objects.create_user(
+            username='navigation-staff',
+            email='navigation-staff@example.com',
+            password='test',
+            is_staff=True,
+        )
+        site_setting_permission = Permission.objects.get(
+            content_type__app_label='board',
+            codename='change_sitesetting',
+        )
+        cls.delegated_staff.user_permissions.add(site_setting_permission)
 
-    def admin_request(self, path='/admin/'):
+    def admin_request(self, path='/admin/', user=None):
         request = RequestFactory().get(path)
-        request.user = self.admin_user
+        request.user = user or self.admin_user
         return request
 
     def test_admin_site_groups_every_registered_model_by_operator_task(self):
@@ -152,6 +164,25 @@ class AdminNavigationTestCase(TestCase):
             reverse('admin:app_list', args=['board']),
         )
         self.assertEqual(board_index.status_code, 200)
+
+    def test_delegated_staff_only_sees_authorized_product_settings(self):
+        """Django Admin 제품 설정 탐색도 API 권한 정책을 따른다."""
+        app_list = admin.site.get_app_list(
+            self.admin_request(user=self.delegated_staff),
+        )
+        product_settings = next(
+            app for app in app_list
+            if app['app_label'] == 'blex_product-settings'
+        )
+
+        self.assertEqual(
+            [model['object_name'] for model in product_settings['models']],
+            ['ProductSiteSettings', 'ProductSeoSettings'],
+        )
+        self.assertEqual(
+            [model['admin_url'] for model in product_settings['models']],
+            ['/admin-settings/site-settings', '/admin-settings/seo-aeo'],
+        )
 
     def test_secret_provider_legacy_urls_redirect_to_canonical_settings(self):
         provider, _ = SocialAuthProvider.objects.get_or_create(key='github')

--- a/backend/src/board/tests/api/test_integration_setting.py
+++ b/backend/src/board/tests/api/test_integration_setting.py
@@ -1,5 +1,6 @@
 import json
 
+from django.contrib.admin.models import CHANGE, LogEntry
 from django.test import TestCase
 from django.test.client import Client
 
@@ -18,6 +19,12 @@ class IntegrationSettingAPITestCase(TestCase):
         )
         Profile.objects.create(user=cls.staff_user)
 
+        cls.superuser = User.objects.create_superuser(
+            username='integration-superuser',
+            password='test',
+            email='integration-superuser@test.com',
+        )
+
         cls.normal_user = User.objects.create_user(
             username='integrationnormal',
             password='test',
@@ -27,9 +34,11 @@ class IntegrationSettingAPITestCase(TestCase):
 
     def setUp(self):
         self.client = Client(HTTP_USER_AGENT='Mozilla/5.0')
-        self.client.login(username='integrationstaff', password='test')
+        self.client.login(username='integration-superuser', password='test')
+        self.delegated_staff_client = Client(HTTP_USER_AGENT='Mozilla/5.0')
+        self.delegated_staff_client.login(username='integrationstaff', password='test')
 
-    def test_get_integration_settings_requires_staff(self):
+    def test_get_integration_settings_requires_superuser(self):
         guest_client = Client(HTTP_USER_AGENT='Mozilla/5.0')
         response = guest_client.get('/v1/integration-settings')
 
@@ -41,6 +50,13 @@ class IntegrationSettingAPITestCase(TestCase):
         normal_client = Client(HTTP_USER_AGENT='Mozilla/5.0')
         normal_client.login(username='integrationnormal', password='test')
         response = normal_client.get('/v1/integration-settings')
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'ERROR')
+        self.assertEqual(content['errorCode'], 'error:RJ')
+
+        response = self.delegated_staff_client.get('/v1/integration-settings')
 
         self.assertEqual(response.status_code, 200)
         content = json.loads(response.content)
@@ -72,6 +88,34 @@ class IntegrationSettingAPITestCase(TestCase):
         self.assertNotEqual(setting.telegram_bot_token, 'telegram-token')
         self.assertEqual(IntegrationSettingService.decrypt_secret(setting.telegram_bot_token), 'telegram-token')
 
+        audit_log = LogEntry.objects.get(
+            user=self.superuser,
+            action_flag=CHANGE,
+            change_message='Updated notification integration settings',
+        )
+        self.assertEqual(audit_log.object_id, '1')
+        self.assertNotIn('telegram-token', audit_log.change_message)
+
+    def test_delegated_staff_cannot_update_integration_settings(self):
+        """텔레그램 토큰 설정은 최고 관리자만 변경할 수 있다."""
+        response = self.delegated_staff_client.put(
+            '/v1/integration-settings',
+            json.dumps({
+                'telegram_enabled': True,
+                'telegram_bot_username': 'unauthorized_bot',
+                'telegram_bot_token': 'unauthorized-token',
+            }),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'ERROR')
+        self.assertEqual(content['errorCode'], 'error:RJ')
+        setting = IntegrationSetting.get_instance()
+        self.assertFalse(setting.telegram_enabled)
+        self.assertEqual(setting.telegram_bot_token, '')
+
     def test_enable_telegram_requires_username_and_token(self):
         response = self.client.put(
             '/v1/integration-settings',
@@ -86,6 +130,11 @@ class IntegrationSettingAPITestCase(TestCase):
         content = json.loads(response.content)
         self.assertEqual(content['status'], 'ERROR')
         self.assertEqual(content['errorCode'], 'error:VA')
+
+        setting = IntegrationSetting.get_instance()
+        self.assertFalse(setting.telegram_enabled)
+        self.assertEqual(setting.telegram_bot_username, '')
+        self.assertEqual(setting.telegram_bot_token, '')
 
         response = self.client.put(
             '/v1/integration-settings',

--- a/backend/src/board/tests/api/test_login_setting.py
+++ b/backend/src/board/tests/api/test_login_setting.py
@@ -1,5 +1,6 @@
 import json
 
+from django.contrib.admin.models import CHANGE, LogEntry
 from django.test import TestCase
 from django.test.client import Client
 
@@ -19,6 +20,12 @@ class LoginSettingAPITestCase(TestCase):
         )
         Profile.objects.create(user=cls.staff_user)
 
+        cls.superuser = User.objects.create_superuser(
+            username='login-superuser',
+            password='test',
+            email='login-superuser@test.com',
+        )
+
         cls.normal_user = User.objects.create_user(
             username='normaluser',
             password='test',
@@ -28,7 +35,9 @@ class LoginSettingAPITestCase(TestCase):
 
     def setUp(self):
         self.client = Client(HTTP_USER_AGENT='Mozilla/5.0')
-        self.client.login(username='staffuser', password='test')
+        self.client.login(username='login-superuser', password='test')
+        self.delegated_staff_client = Client(HTTP_USER_AGENT='Mozilla/5.0')
+        self.delegated_staff_client.login(username='staffuser', password='test')
 
     def test_oauth_credentials_use_one_provider_query(self):
         SocialAuthProvider.objects.update_or_create(
@@ -65,6 +74,27 @@ class LoginSettingAPITestCase(TestCase):
         content = json.loads(response.content)
         self.assertEqual(content['status'], 'ERROR')
         self.assertEqual(content['errorCode'], 'error:RJ')
+
+    def test_delegated_staff_cannot_access_login_settings(self):
+        """로그인 설정과 자격증명은 일반 staff에게 노출되지 않는다."""
+        for method, payload in (
+            ('get', None),
+            ('put', json.dumps({'welcome_notification_message': 'Unauthorized'})),
+        ):
+            with self.subTest(method=method):
+                if method == 'get':
+                    response = self.delegated_staff_client.get('/v1/login-settings')
+                else:
+                    response = self.delegated_staff_client.put(
+                        '/v1/login-settings',
+                        payload,
+                        content_type='application/json',
+                    )
+
+                self.assertEqual(response.status_code, 200)
+                content = json.loads(response.content)
+                self.assertEqual(content['status'], 'ERROR')
+                self.assertEqual(content['errorCode'], 'error:RJ')
 
     def test_get_login_settings_does_not_expose_secret_values(self):
         setting = LoginSetting.get_instance()
@@ -151,6 +181,15 @@ class LoginSettingAPITestCase(TestCase):
         )
         self.assertTrue(body_google['hasClientSecret'])
         self.assertNotIn('clientSecret', body_google)
+
+        audit_log = LogEntry.objects.get(
+            user=self.superuser,
+            action_flag=CHANGE,
+            change_message='Updated login and security settings',
+        )
+        self.assertEqual(audit_log.object_id, '1')
+        self.assertNotIn('hcaptcha-secret', audit_log.change_message)
+        self.assertNotIn('google-secret', audit_log.change_message)
 
     def test_update_social_auth_provider_keeps_existing_secret_when_blank(self):
         SocialAuthProvider.objects.update_or_create(
@@ -245,3 +284,30 @@ class LoginSettingAPITestCase(TestCase):
         content = json.loads(response.content)
         self.assertEqual(content['status'], 'ERROR')
         self.assertEqual(content['errorCode'], 'error:VA')
+
+    def test_invalid_login_setting_update_rolls_back_all_changes(self):
+        """유효하지 않은 인증 설정은 같은 요청의 다른 변경도 저장하지 않는다."""
+        setting = LoginSetting.get_instance()
+        setting.welcome_notification_message = 'Existing message'
+        setting.save()
+
+        response = self.client.put(
+            '/v1/login-settings',
+            json.dumps({
+                'welcome_notification_message': 'Should not persist',
+                'hcaptcha_enabled': True,
+                'hcaptcha_site_key': '',
+            }),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'ERROR')
+        self.assertEqual(content['errorCode'], 'error:VA')
+        setting.refresh_from_db()
+        self.assertEqual(setting.welcome_notification_message, 'Existing message')
+        self.assertFalse(LogEntry.objects.filter(
+            user=self.superuser,
+            change_message='Updated login and security settings',
+        ).exists())

--- a/backend/src/board/tests/api/test_site_setting.py
+++ b/backend/src/board/tests/api/test_site_setting.py
@@ -2,9 +2,14 @@ import json
 import shutil
 import tempfile
 from io import BytesIO
+from pathlib import Path
+from unittest.mock import patch
 
 from django.test import TestCase, override_settings
 from django.test.client import Client
+from django.contrib.admin.models import CHANGE, LogEntry
+from django.contrib.auth.models import Permission
+from django.db import transaction
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.files.storage import default_storage
 from PIL import Image
@@ -27,6 +32,17 @@ class SiteSettingAPITestCase(TestCase):
             is_staff=True,
         )
         Profile.objects.create(user=cls.staff_user)
+        site_setting_permission = Permission.objects.get(
+            content_type__app_label='board',
+            codename='change_sitesetting',
+        )
+        cls.staff_user.user_permissions.add(site_setting_permission)
+
+        cls.superuser = User.objects.create_superuser(
+            username='sitesuperuser',
+            password='test',
+            email='sitesuperuser@test.com',
+        )
 
         cls.normal_user = User.objects.create_user(
             username='normaluser',
@@ -35,9 +51,19 @@ class SiteSettingAPITestCase(TestCase):
         )
         Profile.objects.create(user=cls.normal_user)
 
+        cls.restricted_staff = User.objects.create_user(
+            username='restrictedstaff',
+            password='test',
+            email='restrictedstaff@test.com',
+            is_staff=True,
+        )
+        Profile.objects.create(user=cls.restricted_staff)
+
     def setUp(self):
         self.client = Client(HTTP_USER_AGENT='Mozilla/5.0')
         self.client.login(username='staffuser', password='test')
+        self.superuser_client = Client(HTTP_USER_AGENT='Mozilla/5.0')
+        self.superuser_client.login(username='sitesuperuser', password='test')
         self.media_root = tempfile.mkdtemp()
         self.media_override = override_settings(MEDIA_ROOT=self.media_root)
         self.media_override.enable()
@@ -115,6 +141,7 @@ class SiteSettingAPITestCase(TestCase):
         body = content['body']
         self.assertIn('headerScript', body)
         self.assertIn('footerScript', body)
+        self.assertFalse(body['canManageScripts'])
         self.assertIn('seoEnabled', body)
         self.assertTrue(body['seoEnabled'])
         self.assertIn('robotsTxtExtraRules', body)
@@ -136,12 +163,12 @@ class SiteSettingAPITestCase(TestCase):
         self.assertIn('512', body['iconPngUrls'])
         self.assertIn('updatedDate', body)
 
-    def test_update_single_field(self):
-        """사이트 설정 개별 필드 업데이트 테스트"""
+    def test_superuser_can_update_global_code(self):
+        """최고 관리자는 전역 코드를 수정할 수 있다."""
         data = {
             'header_script': '<script>console.log("header")</script>',
         }
-        response = self.client.put(
+        response = self.superuser_client.put(
             '/v1/site-settings',
             json.dumps(data),
             content_type='application/json'
@@ -155,8 +182,8 @@ class SiteSettingAPITestCase(TestCase):
         setting = SiteSetting.get_instance()
         self.assertEqual(setting.header_script, '<script>console.log("header")</script>')
 
-    def test_update_multiple_fields(self):
-        """사이트 설정 복수 필드 업데이트 테스트"""
+    def test_superuser_can_update_multiple_site_setting_fields(self):
+        """최고 관리자는 전역 코드와 일반 사이트 설정을 함께 수정할 수 있다."""
         data = {
             'header_script': '<script>header</script>',
             'footer_script': '<script>footer</script>',
@@ -165,7 +192,7 @@ class SiteSettingAPITestCase(TestCase):
             'robots_txt_extra_rules': 'User-agent: ExampleBot\nDisallow: /private/',
             'aeo_enabled': True,
         }
-        response = self.client.put(
+        response = self.superuser_client.put(
             '/v1/site-settings',
             json.dumps(data),
             content_type='application/json'
@@ -190,6 +217,114 @@ class SiteSettingAPITestCase(TestCase):
         self.assertFalse(setting.seo_enabled)
         self.assertEqual(setting.robots_txt_extra_rules, 'User-agent: ExampleBot\nDisallow: /private/')
         self.assertTrue(setting.aeo_enabled)
+
+    def test_delegated_staff_cannot_read_or_update_global_code(self):
+        """사이트 설정 권한만 가진 staff는 전역 코드를 보거나 수정할 수 없다."""
+        setting = SiteSetting.get_instance()
+        setting.header_script = '<script>keep-secret</script>'
+        setting.footer_script = '<script>keep-footer</script>'
+        setting.save()
+
+        response = self.client.get('/v1/site-settings')
+
+        self.assertEqual(response.status_code, 200)
+        body = json.loads(response.content)['body']
+        self.assertFalse(body['canManageScripts'])
+        self.assertEqual(body['headerScript'], '')
+        self.assertEqual(body['footerScript'], '')
+
+        response = self.client.put(
+            '/v1/site-settings',
+            json.dumps({
+                'site_name': 'Should not save',
+                'header_script': '<script>replacement</script>',
+            }),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'ERROR')
+        self.assertEqual(content['errorCode'], 'error:RJ')
+        setting.refresh_from_db()
+        self.assertEqual(setting.site_name, 'BLEX')
+        self.assertEqual(setting.header_script, '<script>keep-secret</script>')
+        self.assertEqual(setting.footer_script, '<script>keep-footer</script>')
+
+    def test_delegated_staff_can_update_safe_site_setting_fields(self):
+        """명시적 사이트 설정 권한은 안전한 브랜딩과 검색 설정에만 적용된다."""
+        response = self.client.put(
+            '/v1/site-settings',
+            json.dumps({
+                'site_name': 'Delegated Blog',
+                'seo_enabled': False,
+                'robots_txt_extra_rules': 'User-agent: ExampleBot',
+                'aeo_enabled': True,
+            }),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'DONE')
+        self.assertEqual(content['body']['siteName'], 'Delegated Blog')
+        self.assertEqual(content['body']['headerScript'], '')
+
+        setting = SiteSetting.get_instance()
+        self.assertEqual(setting.site_name, 'Delegated Blog')
+        self.assertFalse(setting.seo_enabled)
+        self.assertEqual(setting.robots_txt_extra_rules, 'User-agent: ExampleBot')
+        self.assertTrue(setting.aeo_enabled)
+
+    def test_delegated_site_update_preserves_newer_global_code(self):
+        """안전 필드 저장은 오래된 전역 코드 값을 다시 쓰지 않는다."""
+        setting = SiteSetting.get_instance()
+        setting.header_script = '<script>stale</script>'
+        setting.save()
+        original_get_instance = SiteSetting.get_instance
+
+        def get_stale_setting():
+            stale_setting = original_get_instance()
+            SiteSetting.objects.filter(pk=stale_setting.pk).update(
+                header_script='<script>protected</script>',
+            )
+            return stale_setting
+
+        with patch(
+            'board.views.api.v1.site_setting.SiteSetting.get_instance',
+            side_effect=get_stale_setting,
+        ):
+            response = self.client.put(
+                '/v1/site-settings',
+                json.dumps({'site_name': 'Delegated Blog'}),
+                content_type='application/json',
+            )
+
+        self.assertEqual(json.loads(response.content)['status'], 'DONE')
+        setting.refresh_from_db()
+        self.assertEqual(setting.site_name, 'Delegated Blog')
+        self.assertEqual(setting.header_script, '<script>protected</script>')
+
+    def test_site_setting_mutations_record_redacted_audit_entries(self):
+        """설정 변경은 비밀값 없이 관리자 감사 로그에 남는다."""
+        response = self.superuser_client.put(
+            '/v1/site-settings',
+            json.dumps({
+                'site_name': 'Audited Blog',
+                'header_script': '<script>do-not-log</script>',
+            }),
+            content_type='application/json',
+        )
+
+        self.assertEqual(json.loads(response.content)['status'], 'DONE')
+        audit_log = LogEntry.objects.get(
+            user=self.superuser,
+            action_flag=CHANGE,
+            change_message='Updated site settings',
+        )
+        self.assertEqual(audit_log.object_id, '1')
+        self.assertNotIn('do-not-log', audit_log.change_message)
+
     def test_public_social_providers_only_returns_enabled_configured_providers(self):
         """로그인 화면에는 사용 가능하고 Client ID/Secret이 있는 제공자만 내려준다."""
         SocialAuthProvider.objects.update_or_create(
@@ -279,14 +414,14 @@ class SiteSettingAPITestCase(TestCase):
     def test_singleton_behavior(self):
         """싱글톤 동작 확인 - 여러 번 저장해도 하나의 인스턴스"""
         data1 = {'header_script': 'first'}
-        self.client.put(
+        self.superuser_client.put(
             '/v1/site-settings',
             json.dumps(data1),
             content_type='application/json'
         )
 
         data2 = {'footer_script': 'second'}
-        self.client.put(
+        self.superuser_client.put(
             '/v1/site-settings',
             json.dumps(data2),
             content_type='application/json'
@@ -316,6 +451,30 @@ class SiteSettingAPITestCase(TestCase):
         self.assertEqual(content['status'], 'ERROR')
         self.assertEqual(content['errorCode'], 'error:RJ')
 
+    def test_staff_without_site_setting_permission_cannot_access_api(self):
+        """is_staff만으로는 사이트 설정 API를 조회하거나 변경할 수 없다."""
+        client = Client(HTTP_USER_AGENT='Mozilla/5.0')
+        client.login(username='restrictedstaff', password='test')
+
+        for method, payload in (
+            ('get', None),
+            ('put', json.dumps({'site_name': 'Unauthorized'})),
+        ):
+            with self.subTest(method=method):
+                if method == 'get':
+                    response = client.get('/v1/site-settings')
+                else:
+                    response = client.put(
+                        '/v1/site-settings',
+                        payload,
+                        content_type='application/json',
+                    )
+
+                self.assertEqual(response.status_code, 200)
+                content = json.loads(response.content)
+                self.assertEqual(content['status'], 'ERROR')
+                self.assertEqual(content['errorCode'], 'error:RJ')
+
     def test_staff_can_upload_logo_svg(self):
         response = self.client.post('/v1/site-settings/brand-assets', {
             'asset_type': 'logo',
@@ -329,8 +488,153 @@ class SiteSettingAPITestCase(TestCase):
         self.assertTrue(content['body']['hasCustomLogo'])
         self.assertTrue(content['body']['logoSvgUrl'].startswith('/resources/media/brand/logo/default/'))
 
+        self.assertTrue(LogEntry.objects.filter(
+            user=self.staff_user,
+            action_flag=CHANGE,
+            change_message='Uploaded a brand asset',
+        ).exists())
+
         setting = SiteSetting.get_instance()
         self.assertTrue(setting.logo_svg.name.startswith('brand/logo/default/'))
+
+    def test_brand_asset_upload_preserves_global_code_from_stale_instance(self):
+        """브랜드 자산 저장은 오래된 인스턴스의 전역 코드를 저장하지 않는다."""
+        stale_setting = SiteSetting.get_instance()
+        stale_setting.header_script = '<script>stale</script>'
+        stale_setting.save()
+        SiteSetting.objects.filter(pk=stale_setting.pk).update(
+            header_script='<script>protected</script>',
+        )
+
+        BrandAssetService.upload_asset(
+            stale_setting,
+            asset_type='logo',
+            theme='default',
+            svg_file=self.make_svg_upload(name='stale-logo.svg'),
+            files={},
+        )
+
+        setting = SiteSetting.get_instance()
+        self.assertEqual(setting.header_script, '<script>protected</script>')
+        self.assertTrue(setting.logo_svg)
+
+    def test_brand_asset_delete_preserves_global_code_from_stale_instance(self):
+        """브랜드 자산 삭제도 오래된 인스턴스의 전역 코드를 저장하지 않는다."""
+        self.client.post('/v1/site-settings/brand-assets', {
+            'asset_type': 'logo',
+            'theme': 'default',
+            'svg': self.make_svg_upload(name='delete-stale-logo.svg'),
+        })
+        stale_setting = SiteSetting.get_instance()
+        stale_setting.header_script = '<script>stale</script>'
+        stale_setting.save()
+        SiteSetting.objects.filter(pk=stale_setting.pk).update(
+            header_script='<script>protected</script>',
+        )
+
+        BrandAssetService.delete_asset(
+            stale_setting,
+            asset_type='logo',
+            theme='default',
+        )
+
+        setting = SiteSetting.get_instance()
+        self.assertEqual(setting.header_script, '<script>protected</script>')
+        self.assertFalse(setting.logo_svg)
+
+    def test_brand_asset_upload_rolls_back_when_audit_record_fails(self):
+        """감사 기록이 실패하면 새 브랜드 파일과 DB 변경을 남기지 않는다."""
+        with patch(
+            'board.views.api.v1.site_setting.AdminSettingsAuditService.record_change',
+            side_effect=RuntimeError('audit failed'),
+        ):
+            with self.assertRaisesRegex(RuntimeError, 'audit failed'):
+                self.client.post('/v1/site-settings/brand-assets', {
+                    'asset_type': 'logo',
+                    'theme': 'default',
+                    'svg': self.make_svg_upload(name='audit-failure-logo.svg'),
+                })
+
+        setting = SiteSetting.get_instance()
+        self.assertFalse(setting.logo_svg)
+        self.assertEqual(list(Path(self.media_root).rglob('*.svg')), [])
+
+    def test_brand_asset_delete_rolls_back_when_audit_record_fails(self):
+        """감사 기록이 실패하면 기존 브랜드 파일과 DB 경로를 유지한다."""
+        self.client.post('/v1/site-settings/brand-assets', {
+            'asset_type': 'logo',
+            'theme': 'default',
+            'svg': self.make_svg_upload(name='audit-delete-logo.svg'),
+        })
+        setting = SiteSetting.get_instance()
+        logo_path = setting.logo_svg.name
+
+        with patch(
+            'board.views.api.v1.site_setting.AdminSettingsAuditService.record_change',
+            side_effect=RuntimeError('audit failed'),
+        ):
+            with self.assertRaisesRegex(RuntimeError, 'audit failed'):
+                self.client.delete(
+                    '/v1/site-settings/brand-assets',
+                    json.dumps({'asset_type': 'logo', 'theme': 'default'}),
+                    content_type='application/json',
+                )
+
+        setting.refresh_from_db()
+        self.assertEqual(setting.logo_svg.name, logo_path)
+        self.assertTrue(default_storage.exists(logo_path))
+
+    def test_brand_asset_replacement_keeps_old_storage_when_outer_transaction_rolls_back(self):
+        """외부 트랜잭션이 실패하면 기존 자산 파일은 삭제하지 않는다."""
+        self.client.post('/v1/site-settings/brand-assets', {
+            'asset_type': 'logo',
+            'theme': 'default',
+            'svg': self.make_svg_upload(name='rollback-original-logo.svg'),
+        })
+        original_path = SiteSetting.get_instance().logo_svg.name
+
+        with self.assertRaisesRegex(RuntimeError, 'force rollback'):
+            with transaction.atomic():
+                setting = SiteSetting.objects.select_for_update().get(pk=1)
+                BrandAssetService.upload_asset(
+                    setting,
+                    asset_type='logo',
+                    theme='default',
+                    svg_file=self.make_svg_upload(name='rollback-replacement-logo.svg'),
+                    files={},
+                )
+                raise RuntimeError('force rollback')
+
+        setting = SiteSetting.get_instance()
+        self.assertEqual(setting.logo_svg.name, original_path)
+        self.assertTrue(default_storage.exists(original_path))
+
+    def test_brand_asset_replacement_deletes_old_storage_after_commit(self):
+        """이전 자산은 DB 변경이 커밋된 뒤에만 정리한다."""
+        self.client.post('/v1/site-settings/brand-assets', {
+            'asset_type': 'logo',
+            'theme': 'default',
+            'svg': self.make_svg_upload(name='commit-original-logo.svg'),
+        })
+        original_path = SiteSetting.get_instance().logo_svg.name
+
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post('/v1/site-settings/brand-assets', {
+                'asset_type': 'logo',
+                'theme': 'default',
+                'svg': self.make_svg_upload(
+                    content=(
+                        b'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">'
+                        b'<circle cx="32" cy="32" r="32" fill="#222222"/>'
+                        b'</svg>'
+                    ),
+                    name='commit-replacement-logo.svg',
+                ),
+            })
+            self.assertEqual(json.loads(response.content)['status'], 'DONE')
+            self.assertTrue(default_storage.exists(original_path))
+
+        self.assertFalse(default_storage.exists(original_path))
 
     def test_replacing_default_logo_keeps_dark_logo(self):
         self.client.post('/v1/site-settings/brand-assets', {

--- a/backend/src/board/tests/templates/test_settings.py
+++ b/backend/src/board/tests/templates/test_settings.py
@@ -1,5 +1,6 @@
 from urllib.parse import unquote
 
+from django.contrib.auth.models import Permission
 from django.test import TestCase
 from django.test.client import Client
 
@@ -76,7 +77,28 @@ class SettingsViewTestCase(TestCase):
         body = self.decode_body(response)
         self.assertIn('"settingsMode": "admin"', body)
         self.assertIn('"basePath": "/admin-settings"', body)
+        self.assertIn('"isSuperuser": false', body)
+        self.assertIn('"canManageSiteSettings": false', body)
+        self.assertIn('"canManageLoginSettings": false', body)
+        self.assertIn('"canManageIntegrationSettings": false', body)
         self.assertContains(response, '관리자 설정 | BLEX')
+
+    def test_staff_with_site_setting_permission_receives_site_capability(self):
+        """명시적 사이트 설정 권한은 Settings island에만 전달한다."""
+        permission = Permission.objects.get(
+            content_type__app_label='board',
+            codename='change_sitesetting',
+        )
+        self.staff.user_permissions.add(permission)
+        self.client.login(username='settings-staff', password='password123')
+
+        response = self.client.get('/admin-settings/site-settings')
+
+        self.assertEqual(response.status_code, 200)
+        body = self.decode_body(response)
+        self.assertIn('"canManageSiteSettings": true', body)
+        self.assertIn('"canManageLoginSettings": false', body)
+        self.assertIn('"canManageIntegrationSettings": false', body)
 
     def test_reader_gets_404_for_admin_settings_namespace(self):
         client = Client(raise_request_exception=False)

--- a/backend/src/board/views/api/v1/integration_setting.py
+++ b/backend/src/board/views/api/v1/integration_setting.py
@@ -1,23 +1,27 @@
+from django.db import transaction
 from django.http import Http404
 
 from board.models import IntegrationSetting
 from board.modules.response import ErrorCode, StatusDone, StatusError
-from board.services.api_permission_service import ApiPermissionService
+from board.services.admin_settings_audit_service import AdminSettingsAuditService
 from board.services.api_request_body_service import ApiRequestBodyService
 from board.services.integration_setting_service import (
     IntegrationSettingConfigurationError,
     IntegrationSettingService,
 )
+from board.services.product_settings_permission_service import ProductSettingsPermissionService
 
 
 def integration_settings(request):
     """
-    IntegrationSetting GET/PUT API endpoint (staff only)
+    IntegrationSetting GET/PUT API endpoint.
 
     GET /v1/integration-settings - Get current integration settings
     PUT /v1/integration-settings - Update integration settings
     """
-    permission_error = ApiPermissionService.require_staff(request.user)
+    permission_error = ProductSettingsPermissionService.require_integration_settings(
+        request.user,
+    )
     if permission_error:
         return permission_error
 
@@ -32,11 +36,17 @@ def integration_settings(request):
             return body_error
 
         try:
-            IntegrationSettingService.update_admin_config(setting, put_data)
+            with transaction.atomic():
+                IntegrationSettingService.update_admin_config(setting, put_data)
+                setting.save()
+                AdminSettingsAuditService.record_change(
+                    user=request.user,
+                    target=setting,
+                    change_message='Updated notification integration settings',
+                )
         except IntegrationSettingConfigurationError as error:
             return StatusError(ErrorCode.VALIDATE, error.message)
 
-        setting.save()
         return StatusDone(IntegrationSettingService.serialize_admin_config(setting))
 
     raise Http404

--- a/backend/src/board/views/api/v1/login_setting.py
+++ b/backend/src/board/views/api/v1/login_setting.py
@@ -1,10 +1,12 @@
+from django.db import transaction
 from django.http import Http404
 
 from board.models import LoginSetting
 from board.modules.response import ErrorCode, StatusDone, StatusError
-from board.services.api_permission_service import ApiPermissionService
+from board.services.admin_settings_audit_service import AdminSettingsAuditService
 from board.services.api_request_body_service import ApiRequestBodyService
 from board.services.hcaptcha_service import HCaptchaConfigurationError, HCaptchaService
+from board.services.product_settings_permission_service import ProductSettingsPermissionService
 from board.services.social_auth_provider_service import SocialAuthProviderService
 
 
@@ -21,12 +23,14 @@ def serialize_login_setting(setting):
 
 def login_settings(request):
     """
-    LoginSetting GET/PUT API endpoint (staff only)
+    LoginSetting GET/PUT API endpoint.
 
     GET /v1/login-settings - Get current login settings
     PUT /v1/login-settings - Update login settings
     """
-    permission_error = ApiPermissionService.require_staff(request.user)
+    permission_error = ProductSettingsPermissionService.require_login_settings(
+        request.user,
+    )
     if permission_error:
         return permission_error
 
@@ -38,24 +42,32 @@ def login_settings(request):
     if request.method == 'PUT':
         put_data = ApiRequestBodyService.parse_json_or_empty_for_legacy_only(request)
 
-        if 'welcome_notification_message' in put_data:
-            setting.welcome_notification_message = put_data['welcome_notification_message']
-
-        if 'welcome_notification_url' in put_data:
-            setting.welcome_notification_url = put_data['welcome_notification_url']
-
-        if 'account_deletion_redirect_url' in put_data:
-            setting.account_deletion_redirect_url = put_data['account_deletion_redirect_url']
-
         try:
-            HCaptchaService.update_admin_config(setting, put_data)
+            with transaction.atomic():
+                if 'welcome_notification_message' in put_data:
+                    setting.welcome_notification_message = put_data['welcome_notification_message']
+
+                if 'welcome_notification_url' in put_data:
+                    setting.welcome_notification_url = put_data['welcome_notification_url']
+
+                if 'account_deletion_redirect_url' in put_data:
+                    setting.account_deletion_redirect_url = put_data['account_deletion_redirect_url']
+
+                HCaptchaService.update_admin_config(setting, put_data)
+
+                if 'social_auth_providers' in put_data:
+                    SocialAuthProviderService.update_admin_providers(
+                        put_data['social_auth_providers'],
+                    )
+
+                setting.save()
+                AdminSettingsAuditService.record_change(
+                    user=request.user,
+                    target=setting,
+                    change_message='Updated login and security settings',
+                )
         except HCaptchaConfigurationError as error:
             return StatusError(ErrorCode.VALIDATE, error.message)
-
-        if 'social_auth_providers' in put_data:
-            SocialAuthProviderService.update_admin_providers(put_data['social_auth_providers'])
-
-        setting.save()
 
         return StatusDone(serialize_login_setting(setting))
 

--- a/backend/src/board/views/api/v1/site_setting.py
+++ b/backend/src/board/views/api/v1/site_setting.py
@@ -1,16 +1,27 @@
+from django.db import transaction
 from django.http import Http404
+
 from board.models import SiteSetting
 from board.modules.response import ErrorCode, StatusDone, StatusError
-from board.services.api_permission_service import ApiPermissionService
+from board.services.admin_settings_audit_service import AdminSettingsAuditService
 from board.services.api_request_body_service import ApiRequestBodyService
 from board.services.agent_content_service import AgentContentService
 from board.services.brand_asset_service import BrandAssetError, BrandAssetService
+from board.services.product_settings_permission_service import ProductSettingsPermissionService
+
+
+GLOBAL_CODE_FIELDS = frozenset({'header_script', 'footer_script'})
 
 
 def serialize_site_setting(request, setting):
+    can_manage_scripts = ProductSettingsPermissionService.can_manage_global_code(
+        request.user,
+    )
+
     return {
-        'header_script': setting.header_script,
-        'footer_script': setting.footer_script,
+        'header_script': setting.header_script if can_manage_scripts else '',
+        'footer_script': setting.footer_script if can_manage_scripts else '',
+        'can_manage_scripts': can_manage_scripts,
         'seo_enabled': setting.seo_enabled,
         'robots_txt_extra_rules': setting.robots_txt_extra_rules,
         'robots_txt_default': AgentContentService.build_default_robots_txt(request, setting),
@@ -22,12 +33,14 @@ def serialize_site_setting(request, setting):
 
 def site_settings(request):
     """
-    SiteSetting GET/PUT API endpoint (staff only)
+    SiteSetting GET/PUT API endpoint.
 
     GET /v1/site-settings - Get current site settings
     PUT /v1/site-settings - Update site settings
     """
-    permission_error = ApiPermissionService.require_staff(request.user)
+    permission_error = ProductSettingsPermissionService.require_site_settings(
+        request.user,
+    )
     if permission_error:
         return permission_error
 
@@ -39,30 +52,54 @@ def site_settings(request):
     if request.method == 'PUT':
         put_data = ApiRequestBodyService.parse_json_or_empty_for_legacy_only(request)
 
-        if 'header_script' in put_data:
-            setting.header_script = put_data['header_script']
-
-        if 'footer_script' in put_data:
-            setting.footer_script = put_data['footer_script']
+        if GLOBAL_CODE_FIELDS.intersection(put_data):
+            global_code_error = ProductSettingsPermissionService.require_global_code(
+                request.user,
+            )
+            if global_code_error:
+                return global_code_error
 
         if 'site_name' in put_data:
             site_name = put_data['site_name']
             normalized_site_name = site_name.strip() if isinstance(site_name, str) else ''
             if len(normalized_site_name) > 80:
                 return StatusError(ErrorCode.VALIDATE, '사이트 이름은 80자 이하여야 합니다.')
-            setting.site_name = normalized_site_name or BrandAssetService.DEFAULT_SITE_NAME
 
-        if 'seo_enabled' in put_data:
-            setting.seo_enabled = put_data['seo_enabled'] is True
+        with transaction.atomic():
+            setting = SiteSetting.objects.select_for_update().get(pk=setting.pk)
+            update_fields = ['updated_date']
 
-        if 'robots_txt_extra_rules' in put_data:
-            extra_rules = put_data['robots_txt_extra_rules']
-            setting.robots_txt_extra_rules = extra_rules if isinstance(extra_rules, str) else ''
+            if 'header_script' in put_data:
+                setting.header_script = put_data['header_script']
+                update_fields.append('header_script')
 
-        if 'aeo_enabled' in put_data:
-            setting.aeo_enabled = put_data['aeo_enabled'] is True
+            if 'footer_script' in put_data:
+                setting.footer_script = put_data['footer_script']
+                update_fields.append('footer_script')
 
-        setting.save()
+            if 'site_name' in put_data:
+                setting.site_name = normalized_site_name or BrandAssetService.DEFAULT_SITE_NAME
+                update_fields.append('site_name')
+
+            if 'seo_enabled' in put_data:
+                setting.seo_enabled = put_data['seo_enabled'] is True
+                update_fields.append('seo_enabled')
+
+            if 'robots_txt_extra_rules' in put_data:
+                extra_rules = put_data['robots_txt_extra_rules']
+                setting.robots_txt_extra_rules = extra_rules if isinstance(extra_rules, str) else ''
+                update_fields.append('robots_txt_extra_rules')
+
+            if 'aeo_enabled' in put_data:
+                setting.aeo_enabled = put_data['aeo_enabled'] is True
+                update_fields.append('aeo_enabled')
+
+            setting.save(update_fields=update_fields)
+            AdminSettingsAuditService.record_change(
+                user=request.user,
+                target=setting,
+                change_message='Updated site settings',
+            )
 
         return StatusDone(serialize_site_setting(request, setting))
 
@@ -70,7 +107,9 @@ def site_settings(request):
 
 
 def site_setting_brand_assets(request):
-    permission_error = ApiPermissionService.require_staff(request.user)
+    permission_error = ProductSettingsPermissionService.require_site_settings(
+        request.user,
+    )
     if permission_error:
         return permission_error
 
@@ -78,14 +117,21 @@ def site_setting_brand_assets(request):
 
     if request.method == 'POST':
         try:
-            BrandAssetService.upload_asset(
-                setting,
-                asset_type=request.POST.get('asset_type', ''),
-                theme=request.POST.get('theme', ''),
-                svg_file=request.FILES.get('svg'),
-                files=request.FILES,
-                manifest_raw=request.POST.get('manifest', ''),
-            )
+            with transaction.atomic():
+                setting = SiteSetting.objects.select_for_update().get(pk=setting.pk)
+                BrandAssetService.upload_asset(
+                    setting,
+                    asset_type=request.POST.get('asset_type', ''),
+                    theme=request.POST.get('theme', ''),
+                    svg_file=request.FILES.get('svg'),
+                    files=request.FILES,
+                    manifest_raw=request.POST.get('manifest', ''),
+                    on_persist=lambda changed_setting: AdminSettingsAuditService.record_change(
+                        user=request.user,
+                        target=changed_setting,
+                        change_message='Uploaded a brand asset',
+                    ),
+                )
         except BrandAssetError as error:
             return StatusError(ErrorCode.VALIDATE, error.message)
 
@@ -94,11 +140,18 @@ def site_setting_brand_assets(request):
     if request.method == 'DELETE':
         data = ApiRequestBodyService.parse_json_or_empty_for_legacy_only(request)
         try:
-            BrandAssetService.delete_asset(
-                setting,
-                asset_type=data.get('asset_type', request.GET.get('asset_type', '')),
-                theme=data.get('theme', request.GET.get('theme', '')),
-            )
+            with transaction.atomic():
+                setting = SiteSetting.objects.select_for_update().get(pk=setting.pk)
+                BrandAssetService.delete_asset(
+                    setting,
+                    asset_type=data.get('asset_type', request.GET.get('asset_type', '')),
+                    theme=data.get('theme', request.GET.get('theme', '')),
+                    on_persist=lambda changed_setting: AdminSettingsAuditService.record_change(
+                        user=request.user,
+                        target=changed_setting,
+                        change_message='Deleted a brand asset',
+                    ),
+                )
         except BrandAssetError as error:
             return StatusError(ErrorCode.VALIDATE, error.message)
 

--- a/backend/src/board/views/settings.py
+++ b/backend/src/board/views/settings.py
@@ -5,6 +5,7 @@ from django.urls import reverse
 
 from board.services.integration_setting_service import IntegrationSettingService
 from board.services.authoring_permission_service import AuthoringPermissionService
+from board.services.product_settings_permission_service import ProductSettingsPermissionService
 
 
 ADMIN_SETTINGS_PREFIXES = (
@@ -62,10 +63,14 @@ def _build_settings_context(request, settings_mode, base_path):
     return {
         'is_editor': AuthoringPermissionService.is_active_editor(request.user),
         'is_staff': request.user.is_staff,
+        'is_superuser': request.user.is_superuser,
         'admin_url': admin_url,
         'settings_mode': settings_mode,
         'settings_base_path': base_path,
         'can_use_telegram_integration': can_use_telegram_integration,
+        'admin_capabilities': ProductSettingsPermissionService.get_capabilities(
+            request.user,
+        ),
         'settings_title': '관리자 설정' if settings_mode == 'admin' else '설정',
     }
 

--- a/backend/src/main/admin_site.py
+++ b/backend/src/main/admin_site.py
@@ -2,6 +2,8 @@ from django.contrib.admin import AdminSite
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
+from board.services.product_settings_permission_service import ProductSettingsPermissionService
+
 
 class BlexAdminSite(AdminSite):
     site_header = _('BLEX administration')
@@ -70,14 +72,30 @@ class BlexAdminSite(AdminSite):
     )
 
     product_settings = (
-        ('ProductSiteSettings', _('Site settings'), '/admin-settings/site-settings'),
-        ('ProductLoginSettings', _('Login and security settings'), '/admin-settings/login'),
+        (
+            'ProductSiteSettings',
+            _('Site settings'),
+            '/admin-settings/site-settings',
+            'can_manage_site_settings',
+        ),
+        (
+            'ProductLoginSettings',
+            _('Login and security settings'),
+            '/admin-settings/login',
+            'can_manage_login_settings',
+        ),
         (
             'ProductIntegrationSettings',
             _('Notification integration settings'),
             '/admin-settings/integrations',
+            'can_manage_integration_settings',
         ),
-        ('ProductSeoSettings', _('SEO and AEO settings'), '/admin-settings/seo-aeo'),
+        (
+            'ProductSeoSettings',
+            _('SEO and AEO settings'),
+            '/admin-settings/seo-aeo',
+            'can_manage_site_settings',
+        ),
     )
 
     @staticmethod
@@ -93,7 +111,7 @@ class BlexAdminSite(AdminSite):
             'models': models,
         }
 
-    def _build_product_settings_group(self):
+    def _build_product_settings_group(self, request):
         models = [
             {
                 'name': name,
@@ -108,8 +126,12 @@ class BlexAdminSite(AdminSite):
                 'add_url': None,
                 'view_only': True,
             }
-            for object_name, name, url in self.product_settings
+            for object_name, name, url, capability in self.product_settings
+            if getattr(ProductSettingsPermissionService, capability)(request.user)
         ]
+        if not models:
+            return None
+
         return self._build_group(
             'product-settings',
             _('Product settings'),
@@ -129,7 +151,9 @@ class BlexAdminSite(AdminSite):
         for model_key, model_name in self.model_name_overrides.items():
             if model_key in available_models:
                 available_models[model_key]['name'] = model_name
-        grouped_apps = [self._build_product_settings_group()]
+        grouped_apps = []
+        if product_settings_group := self._build_product_settings_group(request):
+            grouped_apps.append(product_settings_group)
 
         for key, name, model_keys in self.navigation_groups:
             models = [


### PR DESCRIPTION
## 🎯 Goal
- Limit site-wide settings access to the roles that need it and prevent delegated staff from reading or changing raw global code and credentials.
- Site settings previously shared a staff-wide boundary even though they include public-page scripts, OAuth credentials, CAPTCHA configuration, and integration secrets.

## 🔧 Core Changes
- Separate safe SiteSetting permissions from superuser-only login, integration, and global-code operations in APIs, Django Admin navigation, and the Settings island.
- Redact raw scripts for delegated staff, add only additive capability fields, and preserve existing routes and authorized response fields.
- Record redacted product-setting audit entries; make setting changes and brand-asset audit writes atomic, protect against stale-instance writes, and clean obsolete assets only after commit.

## 🤔 Key Decisions
- Delegated staff with `change_sitesetting` can manage branding and SEO/AEO settings; raw global scripts, OAuth/CAPTCHA configuration, and notification integration settings require a superuser.
- The server remains the authority for every mutation and read. UI capability checks only avoid inaccessible navigation and do not replace API authorization.
- Locked, field-limited saves preserve concurrent superuser-only code changes; post-commit storage cleanup avoids a rolled-back database row pointing at a deleted old asset.

## 🧪 Verification Guide
### How to verify
1. As a superuser, open Site settings, Login settings, and Notification integration settings; update their permitted fields.
2. As delegated staff with only `change_sitesetting`, confirm only Site settings and SEO/AEO appear, raw scripts are blank, and attempted script/login/integration API mutations are rejected.
3. Check Django Admin `LogEntry` after mutations, then run `npm run server:test`.

### Expected result
- Existing settings URLs and normal authorized API contracts continue to work.
- Sensitive settings have no direct delegated-staff read/write path, audit messages contain no secrets or raw scripts, and all 1,326 server tests pass.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (not needed; no public contract documentation changed)