### PR TITLE
♻️ Tighten admin list queries

### DIFF
--- a/backend/src/board/admin/auth.py
+++ b/backend/src/board/admin/auth.py
@@ -163,6 +163,25 @@ class TwoFactorAuthAdmin(
         return None
 
 
+class SocialAuthProviderFilter(admin.RelatedFieldListFilter):
+    """List providers without reading their client credentials."""
+
+    def field_choices(self, field, request, model_admin):
+        """Keep Django relation-filter semantics with a narrow select list."""
+        ordering = self.field_admin_ordering(field, request, model_admin)
+        queryset = field.remote_field.model._default_manager.complex_filter(
+            field.get_limit_choices_to(),
+        )
+        if ordering:
+            queryset = queryset.order_by(*ordering)
+        return list(
+            queryset.values_list(
+                field.remote_field.get_related_field().attname,
+                'key',
+            )
+        )
+
+
 @admin.register(SocialAuth)
 class SocialAuthAdmin(
     ConfirmedActionDeleteAdminMixin,
@@ -176,7 +195,10 @@ class SocialAuthAdmin(
         'created_date',
     ]
     search_fields = ['user__username', 'provider__key']
-    list_filter = ['provider', ('created_date', admin.DateFieldListFilter)]
+    list_filter = [
+        ('provider', SocialAuthProviderFilter),
+        ('created_date', admin.DateFieldListFilter),
+    ]
     fields = [
         'user_link',
         'provider',

--- a/backend/src/board/admin/comment.py
+++ b/backend/src/board/admin/comment.py
@@ -4,7 +4,15 @@ from typing import Any
 
 from django.contrib import admin, messages
 from django.db import transaction
-from django.db.models import Count, QuerySet
+from django.db.models import (
+    Count,
+    IntegerField,
+    OuterRef,
+    QuerySet,
+    Subquery,
+    Value,
+)
+from django.db.models.functions import Coalesce
 from django.http import HttpRequest
 from django.template.defaultfilters import truncatewords
 from django.utils.html import strip_tags, format_html
@@ -96,11 +104,19 @@ class CommentAdmin(
     date_hierarchy = 'created_date'
 
     def get_queryset(self, request):
+        like_counts = Comment.likes.through.objects.filter(
+            comment_id=OuterRef('pk'),
+        ).order_by().values('comment_id').annotate(
+            total=Count('pk'),
+        ).values('total')
         queryset = super().get_queryset(request).select_related(
             'author',
             'post',
         ).defer('author__password').annotate(
-            likes_count_annotated=Count('likes', distinct=True)
+            likes_count_annotated=Coalesce(
+                Subquery(like_counts, output_field=IntegerField()),
+                Value(0),
+            )
         )
         if is_admin_changelist_request(request, self.model):
             return queryset.defer('text_md')
@@ -255,10 +271,15 @@ class CommentAdmin(
                     level=messages.WARNING,
                 )
                 return None
+            preview_comments = (
+                active_comments.select_related(None)
+                .defer(None)
+                .only('pk', 'text_md')
+            )
             return render_action_confirmation(
                 request,
                 self,
-                active_comments,
+                preview_comments,
                 action_name='soft_delete_comments',
                 title='댓글 삭제 상태 전환 확인',
                 warning=(

--- a/backend/src/board/admin/post.py
+++ b/backend/src/board/admin/post.py
@@ -274,7 +274,7 @@ class PostAdmin(admin.ModelAdmin):
             total=Count('pk'),
         ).values('total')
 
-        return queryset.select_related(
+        queryset = queryset.select_related(
             'author', 'config', 'series'
         ).defer('author__password').prefetch_related('tags').annotate(
             likes_count=Coalesce(
@@ -293,6 +293,9 @@ class PostAdmin(admin.ModelAdmin):
                 Value(0),
             ),
         )
+        if is_admin_changelist_request(request, self.model):
+            return queryset.defer('series__text_md', 'series__text_html')
+        return queryset
 
     def get_actions(self, request):
         actions = super().get_actions(request)

--- a/backend/src/board/admin/user.py
+++ b/backend/src/board/admin/user.py
@@ -251,7 +251,12 @@ class CustomUserAdmin(ConfirmedActionDeleteAdminMixin, BaseUserAdmin):
             post_count=Count('post', distinct=True)
         )
         if is_admin_changelist_request(request, self.model):
-            return queryset.defer('password')
+            return queryset.defer(
+                'password',
+                'profile__bio',
+                'profile__about_md',
+                'profile__about_html',
+            )
         return queryset
 
     def get_readonly_fields(self, request, obj=None):

--- a/backend/src/board/admin/webhook.py
+++ b/backend/src/board/admin/webhook.py
@@ -12,6 +12,7 @@ from board.services.webhook_subscription_state_service import (
 )
 
 from .action_confirmation import render_action_confirmation
+from .mixins import is_admin_changelist_request
 from .service import AdminDisplayService, AdminLinkService
 
 
@@ -83,12 +84,19 @@ class WebhookSubscriptionAdmin(admin.ModelAdmin):
     ]
 
     def get_queryset(self, request):
-        return super().get_queryset(request).select_related(
+        queryset = super().get_queryset(request).select_related(
             'author__user',
         ).defer(
             'webhook_url',
             'author__user__password',
         )
+        if is_admin_changelist_request(request, self.model):
+            return queryset.defer(
+                'author__bio',
+                'author__about_md',
+                'author__about_html',
+            )
+        return queryset
 
     def author_link(self, obj: WebhookSubscription):
         if obj.author is None:

--- a/backend/src/board/context_processors.py
+++ b/backend/src/board/context_processors.py
@@ -17,12 +17,16 @@ def oauth_settings(request):
     """
     Add OAuth client IDs to template context
     """
+    resolver_match = getattr(request, 'resolver_match', None)
+    if resolver_match is not None and resolver_match.namespace == 'admin':
+        return {}
+
     providers = {
         provider.key: provider
         for provider in SocialAuthProvider.objects.filter(
             key__in=SocialAuthProviderService.supported_keys(),
             is_enabled=True,
-        )
+        ).only('key', 'client_id')
     }
     return {
         'GOOGLE_OAUTH_CLIENT_ID': providers.get('google').client_id

--- a/backend/src/board/tests/admin/test_admin_list_performance.py
+++ b/backend/src/board/tests/admin/test_admin_list_performance.py
@@ -1,15 +1,18 @@
 from datetime import timedelta
 
 from django.contrib import admin
+from django.contrib.admin import helpers
 from django.contrib.admin.models import CHANGE, LogEntry
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.db import connection
+from django.http import QueryDict
 from django.test import RequestFactory, TestCase
 from django.test.utils import CaptureQueriesContext
 from django.urls import resolve, reverse
 from django.utils import timezone
 
+from board.admin.auth import SocialAuthProviderFilter
 from board.admin.comment import CommentAdmin
 from board.admin.image import ImageCacheAdmin
 from board.admin.post import EditRequestAdmin, PinnedPostAdmin, PostAdmin
@@ -35,12 +38,14 @@ from board.models import (
     SiteBanner,
     SiteNotice,
     SocialAuth,
+    SocialAuthProvider,
     Tag,
     TelegramSync,
     TwoFactorAuth,
     UserConfigMeta,
     UserLinkMeta,
     UsernameChangeLog,
+    WebhookSubscription,
 )
 
 
@@ -158,6 +163,32 @@ class AdminListPerformanceTestCase(TestCase):
             bio='large profile bio ' * 100,
             about_md='large profile markdown ' * 500,
             about_html='<p>' + ('large profile html ' * 500) + '</p>',
+        )
+        cls.webhook = WebhookSubscription.objects.create(
+            scope='user',
+            author=cls.profile,
+            webhook_url='https://hooks.example.com/list-performance',
+            name='List performance webhook',
+        )
+        cls.social_provider, _ = SocialAuthProvider.objects.get_or_create(
+            key='github',
+            defaults={'client_id': 'list-performance-client-id'},
+        )
+        cls.social_auth = SocialAuth.objects.create(
+            user=cls.authors[0],
+            provider=cls.social_provider,
+            uid='list-performance-social-auth',
+            extra_data='{}',
+        )
+        cls.other_social_provider, _ = SocialAuthProvider.objects.get_or_create(
+            key='google',
+            defaults={'client_id': 'list-performance-google-client-id'},
+        )
+        cls.other_social_auth = SocialAuth.objects.create(
+            user=cls.authors[1],
+            provider=cls.other_social_provider,
+            uid='list-performance-other-social-auth',
+            extra_data='{}',
         )
         cls.form = Form.objects.create(
             user=cls.authors[0],
@@ -488,6 +519,143 @@ class AdminListPerformanceTestCase(TestCase):
                 response = self.client.get(reverse(url_name), {'q': 'list'})
                 self.assertEqual(response.status_code, 200)
                 self.assertIsNone(response.context['cl'].full_result_count)
+
+    def test_related_changelists_defer_large_relation_fields(self):
+        cases = (
+            (
+                Post,
+                self.public_posts[0].pk,
+                'series',
+                {'text_md', 'text_html'},
+            ),
+            (
+                User,
+                self.authors[0].pk,
+                'profile',
+                {'bio', 'about_md', 'about_html'},
+            ),
+            (
+                WebhookSubscription,
+                self.webhook.pk,
+                'author',
+                {'bio', 'about_md', 'about_html'},
+            ),
+        )
+
+        for model, object_id, relation_name, expected_fields in cases:
+            with self.subTest(model=model):
+                model_admin = admin.site._registry[model]
+                row = model_admin.get_queryset(
+                    self.changelist_request(model),
+                ).get(pk=object_id)
+                related = getattr(row, relation_name)
+
+                self.assertIsNotNone(related)
+                self.assertTrue(
+                    expected_fields.issubset(related.get_deferred_fields()),
+                )
+
+    def test_social_auth_provider_filter_avoids_credential_columns(self):
+        self.client.force_login(self.admin_user)
+        url = reverse(self.admin_url_name(SocialAuth, 'changelist'))
+
+        provider_field = SocialAuth._meta.get_field('provider')
+        with CaptureQueriesContext(connection) as provider_queries:
+            provider_filter = SocialAuthProviderFilter(
+                provider_field,
+                self.changelist_request(SocialAuth),
+                {},
+                SocialAuth,
+                admin.site._registry[SocialAuth],
+                field_path='provider',
+            )
+
+        self.assertEqual(len(provider_queries), 1)
+        self.assertEqual(provider_filter.lookup_kwarg, 'provider__id__exact')
+        provider_filter_query = provider_queries.captured_queries[0]['sql'].lower()
+        self.assertNotIn('client_id', provider_filter_query)
+        self.assertNotIn('client_secret', provider_filter_query)
+
+        filtered_response = self.client.get(
+            url,
+            {'provider__id__exact': self.social_provider.pk},
+        )
+        self.assertEqual(filtered_response.status_code, 200)
+        self.assertEqual(
+            list(
+                filtered_response.context['cl'].queryset.values_list(
+                    'pk',
+                    flat=True,
+                ),
+            ),
+            [self.social_auth.pk],
+        )
+
+        multi_value_params = QueryDict('', mutable=True)
+        multi_value_params.appendlist(
+            'provider__id__exact',
+            str(self.social_provider.pk),
+        )
+        multi_value_params.appendlist(
+            'provider__id__exact',
+            str(self.other_social_provider.pk),
+        )
+        multi_value_response = self.client.get(url, multi_value_params)
+        self.assertEqual(multi_value_response.status_code, 200)
+        self.assertCountEqual(
+            multi_value_response.context['cl'].queryset.values_list(
+                'pk',
+                flat=True,
+            ),
+            [self.social_auth.pk, self.other_social_auth.pk],
+        )
+
+    def test_comment_pagination_count_avoids_like_join(self):
+        with CaptureQueriesContext(connection) as queries:
+            self.comment_admin.get_queryset(
+                self.changelist_request(Comment),
+            ).count()
+
+        self.assertEqual(len(queries), 1)
+        self.assertNotIn(
+            'board_comment_likes',
+            queries.captured_queries[0]['sql'].lower(),
+        )
+
+    def test_comment_delete_confirmation_does_not_load_each_deferred_body(self):
+        comments = [
+            Comment.objects.create(
+                author=self.authors[0],
+                post=self.public_posts[0],
+                text_md=f'Confirmation comment {index}',
+                text_html=f'<p>Confirmation comment {index}</p>',
+            )
+            for index in range(5)
+        ]
+        request = self.changelist_request(Comment)
+        request.method = 'POST'
+        request.POST = QueryDict('', mutable=True)
+        request.POST['action'] = 'soft_delete_comments'
+        for comment in comments:
+            request.POST.appendlist(
+                helpers.ACTION_CHECKBOX_NAME,
+                str(comment.pk),
+            )
+        queryset = self.comment_admin.get_queryset(request).filter(
+            pk__in=[comment.pk for comment in comments],
+        )
+
+        with CaptureQueriesContext(connection) as queries:
+            response = self.comment_admin.soft_delete_comments(request, queryset)
+            response.render()
+
+        self.assertEqual(response.status_code, 200)
+        comment_queries = [
+            query['sql'].lower()
+            for query in queries.captured_queries
+            if 'from "board_comment"' in query['sql'].lower()
+        ]
+        self.assertEqual(len(comment_queries), 3)
 
     def test_changelists_defer_unused_large_fields(self):
         for model, object_id, expected_fields in self.large_field_cases():

--- a/backend/src/board/tests/test_context_processors.py
+++ b/backend/src/board/tests/test_context_processors.py
@@ -1,4 +1,8 @@
+from django.contrib.auth.models import User
+from django.db import connection
 from django.test import RequestFactory, TestCase
+from django.test.utils import CaptureQueriesContext
+from django.urls import resolve, reverse
 
 from board.context_processors import oauth_settings, site_settings
 from board.models import SiteSetting, SocialAuthProvider
@@ -22,13 +26,43 @@ class OAuthSettingsContextProcessorTestCase(TestCase):
             },
         )
 
-        with self.assertNumQueries(1):
+        with CaptureQueriesContext(connection) as queries:
             context = oauth_settings(RequestFactory().get('/'))
 
+        self.assertEqual(len(queries), 1)
+        provider_query = queries.captured_queries[0]['sql'].lower()
+        self.assertNotIn('client_secret', provider_query)
         self.assertEqual(context, {
             'GOOGLE_OAUTH_CLIENT_ID': 'google-client',
             'GITHUB_OAUTH_CLIENT_ID': '',
         })
+
+    def test_skips_oauth_settings_for_admin_templates(self):
+        path = reverse('admin:index')
+        request = RequestFactory().get(path)
+        request.resolver_match = resolve(path)
+
+        with self.assertNumQueries(0):
+            context = oauth_settings(request)
+
+        self.assertEqual(context, {})
+
+    def test_admin_index_does_not_query_oauth_providers(self):
+        admin_user = User.objects.create_superuser(
+            username='oauth-settings-admin',
+            email='oauth-settings-admin@example.com',
+            password='test',
+        )
+        self.client.force_login(admin_user)
+
+        with CaptureQueriesContext(connection) as queries:
+            response = self.client.get(reverse('admin:index'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(any(
+            'board_socialauthprovider' in query['sql'].lower()
+            for query in queries.captured_queries
+        ))
 
     def test_site_setting_is_reused_for_the_rest_of_the_request(self):
         SiteSetting.get_instance()


### PR DESCRIPTION
## 🎯 Goal
- Remove unnecessary credential, large-field, and aggregate work from Django Admin list paths without changing user-visible Admin behavior or public contracts.
- Apply the remaining low-risk findings from the Admin operations review.

## 🔧 Core Changes
- Defer large related bodies only on changelist requests while preserving complete change-view inspection.
- Replace the comment likes join with a correlated count and load only preview text for delete confirmation.
- Restrict OAuth context reads to public templates and select only the provider fields those templates use.
- Keep the social provider filter behavior while selecting only provider ID and key.

## 🤔 Key Decisions
- Use Django RelatedFieldListFilter semantics so provider__id__exact, repeated filter values, invalid lookup handling, and facets remain compatible.
- Keep Django Admin exact total-count UI instead of disabling show_full_result_count for performance.
- Protect the SQL behavior with Django unit tests rather than adding browser E2E coverage.

## 🧪 Verification Guide
### How to verify
1. Run npm run server:test.
2. Run npm run server:check-migrations.
3. Open Admin list and change views for posts, users, webhooks, comments, and social connections; confirm their existing controls and data remain available.

### Expected result
- All 1,346 backend tests pass, no migration is generated, Admin behavior and legacy filter URLs remain unchanged, and unused credentials or large relation bodies are not loaded by list pages.

## ✅ Checklist
- [x] Lint completed (not applicable: backend-only Django changes)
- [x] Type-check completed (not applicable: backend-only Django changes)
- [x] Tests completed
- [x] Documentation updated (not needed)