### PR TITLE
🐛 Secure notification destinations

### DIFF
--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/NotifySetting/components/NotificationsSection.tsx
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/NotifySetting/components/NotificationsSection.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import {
     BellOff,
     ChevronRight,
@@ -5,6 +6,8 @@ import {
     Send,
     Settings2
 } from '@blex/ui/icons';
+import { Button } from '~/components/shared';
+import { toast } from '~/utils/toast';
 import { SETTINGS_LIST_TITLE } from '~/styles/settingsStyles';
 import {
     SettingsEmptyState,
@@ -13,6 +16,7 @@ import {
     SettingsListItem
 } from '../../../components';
 import { markNotificationAsRead, type NotifyItem } from '~/lib/api/settings';
+import { getSafeNotificationNavigationUrl } from '../notificationNavigation';
 
 interface NotificationsSectionProps {
     notifyList: NotifyItem[];
@@ -25,16 +29,44 @@ const NotificationsSection = ({
     showTelegramIntegration,
     onOpenConfig
 }: NotificationsSectionProps) => {
+    const [locallyReadNotificationIds, setLocallyReadNotificationIds] = useState<Set<number>>(
+        () => new Set()
+    );
+    const [markingReadNotificationId, setMarkingReadNotificationId] = useState<number | null>(null);
 
-    const handleClickNotify = async (notify: NotifyItem) => {
-        if (!notify.isRead) {
-            try {
-                await markNotificationAsRead(notify.id);
-            } catch {
-                // Silently handle error
+    const isNotificationRead = (notify: NotifyItem) => {
+        return notify.isRead || locallyReadNotificationIds.has(notify.id);
+    };
+
+    const markAsRead = async (notify: NotifyItem) => {
+        if (isNotificationRead(notify)) return;
+
+        setMarkingReadNotificationId(notify.id);
+        try {
+            const { data } = await markNotificationAsRead(notify.id);
+            if (data.status === 'DONE') {
+                setLocallyReadNotificationIds((notificationIds) => {
+                    const nextNotificationIds = new Set(notificationIds);
+                    nextNotificationIds.add(notify.id);
+                    return nextNotificationIds;
+                });
+                window.dispatchEvent(new CustomEvent(
+                    'blex:notification-read',
+                    { detail: { notificationId: notify.id } }
+                ));
+            } else {
+                toast.error(data.errorMessage || '알림을 읽음으로 표시하지 못했습니다.');
             }
+        } catch {
+            toast.error('알림을 읽음으로 표시하지 못했습니다.');
+        } finally {
+            setMarkingReadNotificationId(null);
         }
-        window.location.assign(notify.url);
+    };
+
+    const handleClickNotify = async (notify: NotifyItem, targetUrl: string) => {
+        await markAsRead(notify);
+        window.location.assign(targetUrl);
     };
 
     return (
@@ -75,30 +107,54 @@ const NotificationsSection = ({
             {/* Notification list */}
             <div className="space-y-3">
                 {notifyList.length > 0 ? (
-                    notifyList.map((item) => (
-                        <SettingsListItem
-                            key={item.id}
-                            className="items-start"
-                            onClick={() => handleClickNotify(item)}
-                            actions={
-                                <div className="flex-shrink-0 self-center text-content-hint">
-                                    <ChevronRight aria-hidden="true" className="h-4 w-4" />
+                    notifyList.map((item) => {
+                        const targetUrl = getSafeNotificationNavigationUrl(
+                            item.url,
+                            window.location.href
+                        );
+                        const isRead = isNotificationRead(item);
+
+                        return (
+                            <SettingsListItem
+                                key={item.id}
+                                className="items-start"
+                                onClick={targetUrl
+                                    ? () => handleClickNotify(item, targetUrl)
+                                    : undefined}
+                                actions={
+                                    <div className="flex-shrink-0 self-center text-content-hint">
+                                        {targetUrl ? (
+                                            <ChevronRight aria-hidden="true" className="h-4 w-4" />
+                                        ) : !isRead ? (
+                                            <Button
+                                                density="compact"
+                                                variant="ghost"
+                                                size="sm"
+                                                className="min-h-11! [@media(pointer:fine)]:min-h-9!"
+                                                isLoading={markingReadNotificationId === item.id}
+                                                onClick={() => markAsRead(item)}>
+                                                읽음으로 표시
+                                            </Button>
+                                        ) : (
+                                            <span className="text-xs">링크를 열 수 없음</span>
+                                        )}
+                                    </div>
+                                }>
+                                <div className={`${SETTINGS_LIST_TITLE} ${!isRead ? 'font-semibold text-content' : 'font-medium text-content-secondary'} mb-1.5 leading-relaxed`}>
+                                    {item.content}
                                 </div>
-                            }>
-                            <div className={`${SETTINGS_LIST_TITLE} ${!item.isRead ? 'font-semibold text-content' : 'font-medium text-content-secondary'} mb-1.5 leading-relaxed`}>
-                                {item.content}
-                            </div>
-                            <div className="flex items-center gap-2 text-xs text-content-hint">
-                                <Clock aria-hidden="true" className="h-3.5 w-3.5" />
-                                <span>{item.createdDate}</span>
-                                {!item.isRead && (
-                                    <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-bold bg-danger-surface text-danger border border-danger-line">
-                                        NEW
-                                    </span>
-                                )}
-                            </div>
-                        </SettingsListItem>
-                    ))
+                                <div className="flex items-center gap-2 text-xs text-content-hint">
+                                    <Clock aria-hidden="true" className="h-3.5 w-3.5" />
+                                    <span>{item.createdDate}</span>
+                                    {!isRead && (
+                                        <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-bold bg-danger-surface text-danger border border-danger-line">
+                                            NEW
+                                        </span>
+                                    )}
+                                </div>
+                            </SettingsListItem>
+                        );
+                    })
                 ) : (
                     <SettingsEmptyState
                         icon={<BellOff aria-hidden="true" className="h-5 w-5" />}

--- a/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/NotifySetting/notificationNavigation.ts
+++ b/backend/islands/apps/remotes/src/components/remotes/SettingsApp/pages/NotifySetting/notificationNavigation.ts
@@ -1,0 +1,23 @@
+const ALLOWED_PROTOCOLS = new Set(['http:', 'https:']);
+
+/**
+ * Validate stored notification destinations before assigning browser location.
+ * Legacy records remain readable, but executable schemes are never navigated.
+ */
+export const getSafeNotificationNavigationUrl = (
+    url: string,
+    baseUrl: string
+): string | null => {
+    try {
+        const normalizedUrl = url.trim();
+        const parsedUrl = new URL(normalizedUrl, baseUrl);
+
+        if (!ALLOWED_PROTOCOLS.has(parsedUrl.protocol)) {
+            return null;
+        }
+
+        return normalizedUrl;
+    } catch {
+        return null;
+    }
+};

--- a/backend/islands/apps/remotes/test/notificationNavigation.test.mjs
+++ b/backend/islands/apps/remotes/test/notificationNavigation.test.mjs
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import { getSafeNotificationNavigationUrl } from '../src/components/remotes/SettingsApp/pages/NotifySetting/notificationNavigation.ts';
+
+const BASE_URL = 'https://blex.example/settings/notify';
+
+describe('getSafeNotificationNavigationUrl', () => {
+    test('keeps relative and HTTPS notification destinations', () => {
+        assert.equal(
+            getSafeNotificationNavigationUrl('/@author/post', BASE_URL),
+            '/@author/post'
+        );
+        assert.equal(
+            getSafeNotificationNavigationUrl(
+                'https://blex.example/notice',
+                BASE_URL
+            ),
+            'https://blex.example/notice'
+        );
+        assert.equal(
+            getSafeNotificationNavigationUrl('http://blex/welcome', BASE_URL),
+            'http://blex/welcome'
+        );
+    });
+
+    test('refuses executable or malformed legacy destinations', () => {
+        for (const url of [
+            'javascript:alert(1)',
+            'data:text/html,unsafe',
+            'mailto:admin@example.com',
+            'http://[invalid',
+            'http://',
+            'https://',
+            '//',
+            String.raw`\\javascript:alert(1)`,
+            String.raw`\\[invalid`
+        ]) {
+            assert.equal(
+                getSafeNotificationNavigationUrl(url, BASE_URL),
+                null
+            );
+        }
+    });
+});

--- a/backend/src/board/admin/notify.py
+++ b/backend/src/board/admin/notify.py
@@ -9,19 +9,21 @@ from django.contrib import admin, messages
 from django.contrib.admin.models import ADDITION, LogEntry
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
-from django.core.exceptions import PermissionDenied
+from django.core.exceptions import PermissionDenied, ValidationError
 from django.db import transaction
 from django.db.models import QuerySet
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import redirect, render
 from django.template.defaultfilters import truncatewords
 from django.urls import path
+from django.utils.html import format_html
 from django.utils import timezone
 
 from board.models import Notify
 from board.services.bulk_notification_delivery_service import (
     BulkNotificationDeliveryService,
 )
+from board.services.notification_url_service import NotificationUrlService
 
 from .action_confirmation import render_action_confirmation
 from .constants import (
@@ -41,6 +43,9 @@ class NotifyAdminForm(forms.ModelForm):
     class Meta:
         model = Notify
         fields = ['user', 'url', 'content', 'has_read']
+
+    def clean_url(self) -> str:
+        return NotificationUrlService.validate(self.cleaned_data['url'])
 
     def clean(self) -> dict[str, Any]:
         cleaned_data = super().clean()
@@ -80,6 +85,10 @@ class BulkNotificationForm(forms.Form):
         widget=forms.Textarea(attrs={'rows': 5, 'style': 'width: 100%;'}),
         help_text='모든 활성 사용자에게 전송될 알림 메시지'
     )
+
+    def clean_url(self) -> str:
+        url = self.cleaned_data['url'] or '/'
+        return NotificationUrlService.validate(url)
 
 
 @admin.register(Notify)
@@ -125,6 +134,15 @@ class NotifyAdmin(admin.ModelAdmin):
 
     readonly_fields = ['key', 'created_at', 'updated_at']
 
+    def has_bulk_send_permission(self, request: HttpRequest) -> bool:
+        """Whole-site notification delivery is reserved for superusers."""
+        return request.user.is_superuser
+
+    def changelist_view(self, request, extra_context=None):
+        extra_context = extra_context or {}
+        extra_context['can_bulk_send'] = self.has_bulk_send_permission(request)
+        return super().changelist_view(request, extra_context=extra_context)
+
     def get_queryset(self, request):
         queryset = super().get_queryset(request).select_related(
             'user',
@@ -146,7 +164,14 @@ class NotifyAdmin(admin.ModelAdmin):
     read_status.short_description = '읽음 상태'
 
     def url_link(self, obj):
-        return AdminLinkService.create_external_link(obj.url)
+        try:
+            url = NotificationUrlService.validate(obj.url)
+        except ValidationError:
+            return format_html(
+                '<span style="color: #b91c1c;">{}</span>',
+                '안전하지 않은 URL',
+            )
+        return AdminLinkService.create_external_link(url)
     url_link.short_description = 'URL'
 
     def created_at(self, obj: Notify) -> str:
@@ -345,7 +370,7 @@ class NotifyAdmin(admin.ModelAdmin):
 
     def bulk_send_view(self, request: HttpRequest) -> HttpResponse:
         """일괄 알림 발송 페이지"""
-        if not self.has_add_permission(request):
+        if not self.has_bulk_send_permission(request):
             raise PermissionDenied
 
         confirmation = False

--- a/backend/src/board/services/notification_creation_service.py
+++ b/backend/src/board/services/notification_creation_service.py
@@ -4,6 +4,7 @@ from django.contrib.auth.models import User
 from django.db import transaction
 
 from board.models import Notify
+from board.services.notification_url_service import NotificationUrlService
 
 
 class NotificationCreationService:
@@ -16,6 +17,7 @@ class NotificationCreationService:
         content: str,
         hidden_key: str | None = None,
     ) -> tuple[Notify, bool]:
+        url = NotificationUrlService.validate(url)
         key = Notify.create_hash_key(
             user=user,
             url=url,

--- a/backend/src/board/services/notification_url_service.py
+++ b/backend/src/board/services/notification_url_service.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import ipaddress
+import re
+from urllib.parse import urlsplit
+
+from django.core.exceptions import ValidationError
+
+
+class NotificationUrlService:
+    """Keep notification destinations safe for browser navigation."""
+
+    ALLOWED_SCHEMES = frozenset({'http', 'https'})
+    BROWSER_HOSTNAME_PATTERN = re.compile(r'^[A-Za-z0-9._-]+$')
+
+    @staticmethod
+    def validate(url: str) -> str:
+        """Allow relative paths and HTTP(S) URLs, but reject executable schemes."""
+        if not isinstance(url, str):
+            raise ValidationError('올바른 알림 URL을 입력해주세요.')
+
+        normalized_url = url.strip()
+        if any(ord(character) < 32 for character in normalized_url):
+            raise ValidationError('알림 URL에는 제어 문자를 사용할 수 없습니다.')
+        if '\\' in normalized_url:
+            raise ValidationError('알림 URL에는 역슬래시를 사용할 수 없습니다.')
+
+        try:
+            parsed_url = urlsplit(normalized_url)
+        except ValueError as error:
+            raise ValidationError('올바른 알림 URL을 입력해주세요.') from error
+        scheme = parsed_url.scheme.lower()
+        if scheme and scheme not in NotificationUrlService.ALLOWED_SCHEMES:
+            raise ValidationError(
+                '알림 URL은 상대 경로 또는 HTTP(S) URL이어야 합니다.',
+            )
+
+        if scheme:
+            NotificationUrlService._validate_http_url(normalized_url)
+        elif normalized_url.startswith('//'):
+            NotificationUrlService._validate_http_url(
+                f'https:{normalized_url}',
+            )
+
+        return normalized_url
+
+    @staticmethod
+    def _validate_http_url(url: str) -> None:
+        try:
+            parsed_url = urlsplit(url)
+            hostname = parsed_url.hostname
+            parsed_url.port
+        except ValueError as error:
+            raise ValidationError('올바른 알림 URL을 입력해주세요.') from error
+
+        if not hostname:
+            raise ValidationError('올바른 알림 URL을 입력해주세요.')
+
+        try:
+            ipaddress.ip_address(hostname)
+            return
+        except ValueError:
+            pass
+
+        try:
+            ascii_hostname = hostname.encode('idna').decode('ascii')
+        except UnicodeError as error:
+            raise ValidationError('올바른 알림 URL을 입력해주세요.') from error
+
+        if (
+            not NotificationUrlService.BROWSER_HOSTNAME_PATTERN.fullmatch(
+                ascii_hostname,
+            )
+            or ascii_hostname.replace('.', '').isdigit()
+        ):
+            raise ValidationError('올바른 알림 URL을 입력해주세요.')

--- a/backend/src/board/templates/admin/board/notify/change_list.html
+++ b/backend/src/board/templates/admin/board/notify/change_list.html
@@ -1,7 +1,7 @@
 {% extends "admin/change_list.html" %}
 
 {% block object-tools-items %}
-    {% if has_add_permission %}
+    {% if can_bulk_send %}
     <li>
         <a href="bulk-send/" class="addlink">
             전체 활성 사용자에게 알림 발송

--- a/backend/src/board/templates/components/header.html
+++ b/backend/src/board/templates/components/header.html
@@ -43,7 +43,7 @@
                     {% endif %}
 
                     <div class="relative" x-data="{ open: false, unreadCount: 0 }" x-init="
-                        fetch('/v1/setting/unread-notify')
+                        const refreshUnreadCount = () => fetch('/v1/setting/unread-notify')
                             .then(res => res.json())
                             .then(data => {
                                 if (data.status === 'DONE' && data.body) {
@@ -51,6 +51,8 @@
                                 }
                             })
                             .catch(err => console.error('Failed to fetch unread count:', err));
+                        refreshUnreadCount();
+                        window.addEventListener('blex:notification-read', refreshUnreadCount);
                     ">
                         <button
                             @click="open = !open"
@@ -120,7 +122,7 @@
                     {% endif %}
 
                     <div class="relative" x-data="{ unreadCount: 0 }" x-init="
-                        fetch('/v1/setting/unread-notify')
+                        const refreshUnreadCount = () => fetch('/v1/setting/unread-notify')
                             .then(res => res.json())
                             .then(data => {
                                 if (data.status === 'DONE' && data.body) {
@@ -128,6 +130,8 @@
                                 }
                             })
                             .catch(err => console.error('Failed to fetch unread count:', err));
+                        refreshUnreadCount();
+                        window.addEventListener('blex:notification-read', refreshUnreadCount);
                     ">
                         <a
                             href="/settings/notify"

--- a/backend/src/board/tests/admin/test_notify_admin.py
+++ b/backend/src/board/tests/admin/test_notify_admin.py
@@ -4,15 +4,16 @@ from unittest.mock import patch
 from django.contrib import admin
 from django.contrib.admin import helpers
 from django.contrib.admin.models import ADDITION, CHANGE, LogEntry
-from django.contrib.auth.models import User
+from django.contrib.auth.models import Permission, User
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
 from django.template.response import TemplateResponse
 from django.test import RequestFactory, TestCase
+from django.urls import reverse
 from django.utils import timezone
 
-from board.admin.notify import NotifyAdmin, NotifyAdminForm
+from board.admin.notify import BulkNotificationForm, NotifyAdmin, NotifyAdminForm
 from board.models import Notify
 from board.services.bulk_notification_delivery_service import (
     BulkNotificationDeliveryService,
@@ -112,6 +113,62 @@ class NotifyAdminTestCase(TestCase):
             '이미 동일한 알림이 존재합니다.',
             duplicate_form.non_field_errors(),
         )
+
+    def test_notification_forms_reject_executable_url_schemes(self):
+        admin_form = NotifyAdminForm(data={
+            'user': self.user.pk,
+            'url': 'javascript:unsafe',
+            'content': 'Unsafe destination',
+            'has_read': '',
+        })
+        bulk_form = BulkNotificationForm(data={
+            'url': 'data:text/html,unsafe',
+            'content': 'Unsafe bulk destination',
+        })
+        malformed_form = BulkNotificationForm(data={
+            'url': 'http://[invalid',
+            'content': 'Malformed destination',
+        })
+
+        self.assertFalse(admin_form.is_valid())
+        self.assertFalse(bulk_form.is_valid())
+        self.assertFalse(malformed_form.is_valid())
+        self.assertTrue(
+            any(
+                '상대 경로 또는 HTTP(S) URL' in error
+                for error in admin_form.errors['url']
+            ),
+        )
+        self.assertIn('올바른 알림 URL을 입력해주세요.', malformed_form.errors['url'])
+        self.assertTrue(
+            any(
+                '상대 경로 또는 HTTP(S) URL' in error
+                for error in bulk_form.errors['url']
+            ),
+        )
+
+    def test_url_link_does_not_render_unsafe_legacy_destination(self):
+        notification = self.create_notification(url='javascript:unsafe')
+
+        rendered_link = str(self.admin_instance.url_link(notification))
+
+        self.assertIn('안전하지 않은 URL', rendered_link)
+        self.assertNotIn('href=', rendered_link)
+        self.assertNotIn('javascript:unsafe', rendered_link)
+
+    def test_notification_forms_reject_incomplete_http_urls(self):
+        for url in ('http://', 'https://', '//'):
+            with self.subTest(url=url):
+                form = BulkNotificationForm(data={
+                    'url': url,
+                    'content': 'Incomplete destination',
+                })
+
+                self.assertFalse(form.is_valid())
+                self.assertIn(
+                    '올바른 알림 URL을 입력해주세요.',
+                    form.errors['url'],
+                )
 
     def test_admin_save_dispatches_committed_add_but_never_resends_edit(self):
         request = self.admin_request('post')
@@ -375,6 +432,59 @@ class NotifyAdminTestCase(TestCase):
 
         with self.assertRaises(PermissionDenied):
             self.admin_instance.bulk_send_view(request)
+
+    def test_bulk_send_requires_superuser_even_with_add_permission(self):
+        delegated_staff = User.objects.create_user(
+            username='delegated-notification-admin',
+            password='test',
+            is_staff=True,
+        )
+        delegated_staff.user_permissions.add(
+            Permission.objects.get(codename='add_notify'),
+            Permission.objects.get(codename='view_notify'),
+        )
+        request = self.admin_request(user=delegated_staff)
+
+        self.assertFalse(self.admin_instance.has_bulk_send_permission(request))
+        with self.assertRaises(PermissionDenied):
+            self.admin_instance.bulk_send_view(request)
+
+        self.client.force_login(delegated_staff)
+        changelist = self.client.get(reverse('admin:board_notify_changelist'))
+
+        self.assertEqual(changelist.status_code, 200)
+        self.assertNotContains(changelist, '전체 활성 사용자에게 알림 발송')
+
+    def test_superuser_can_open_bulk_send_from_the_changelist(self):
+        self.client.force_login(self.admin_user)
+
+        changelist = self.client.get(reverse('admin:board_notify_changelist'))
+        bulk_send = self.client.get(reverse('admin:board_notify_bulk_send'))
+
+        self.assertEqual(changelist.status_code, 200)
+        self.assertContains(changelist, '전체 활성 사용자에게 알림 발송')
+        self.assertEqual(bulk_send.status_code, 200)
+
+    def test_bulk_send_rejects_unsafe_url_before_confirmation(self):
+        request = self.admin_request(
+            'post',
+            {
+                'url': 'javascript:unsafe',
+                'content': 'Unsafe bulk destination',
+                'confirm': 'yes',
+            },
+        )
+
+        with patch.object(
+            BulkNotificationDeliveryService,
+            'enqueue',
+        ) as enqueue:
+            response = self.admin_instance.bulk_send_view(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '상대 경로 또는 HTTP(S) URL')
+        enqueue.assert_not_called()
+        self.assertFalse(LogEntry.objects.filter(action_flag=ADDITION).exists())
 
     def test_bulk_send_does_not_enqueue_when_audit_log_fails(self):
         request = self.admin_request(

--- a/backend/src/board/tests/api/test_login_setting.py
+++ b/backend/src/board/tests/api/test_login_setting.py
@@ -311,3 +311,47 @@ class LoginSettingAPITestCase(TestCase):
             user=self.superuser,
             change_message='Updated login and security settings',
         ).exists())
+
+    def test_update_rejects_unsafe_welcome_notification_url(self):
+        setting = LoginSetting.get_instance()
+        setting.welcome_notification_message = 'Existing message'
+        setting.welcome_notification_url = '/existing'
+        setting.save()
+
+        response = self.client.put(
+            '/v1/login-settings',
+            json.dumps({
+                'welcome_notification_message': 'Should not persist',
+                'welcome_notification_url': 'javascript:unsafe',
+            }),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'ERROR')
+        self.assertEqual(content['errorCode'], 'error:VA')
+        setting.refresh_from_db()
+        self.assertEqual(setting.welcome_notification_message, 'Existing message')
+        self.assertEqual(setting.welcome_notification_url, '/existing')
+        self.assertFalse(LogEntry.objects.filter(
+            user=self.superuser,
+            change_message='Updated login and security settings',
+        ).exists())
+
+    def test_update_keeps_single_label_welcome_notification_hosts(self):
+        response = self.client.put(
+            '/v1/login-settings',
+            json.dumps({
+                'welcome_notification_url': 'https://intranet/welcome',
+            }),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content['status'], 'DONE')
+        self.assertEqual(
+            content['body']['welcomeNotificationUrl'],
+            'https://intranet/welcome',
+        )

--- a/backend/src/board/tests/services/test_notification_creation_service.py
+++ b/backend/src/board/tests/services/test_notification_creation_service.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 from django.contrib.auth.models import User
+from django.core.exceptions import ValidationError
 from django.test import TestCase
 
 from board.models import Notify
@@ -11,6 +12,7 @@ from board.services.bulk_notification_delivery_service import (
 from board.services.notification_creation_service import (
     NotificationCreationService,
 )
+from board.services.notification_url_service import NotificationUrlService
 
 
 class NotificationCreationServiceTestCase(TestCase):
@@ -62,6 +64,47 @@ class NotificationCreationServiceTestCase(TestCase):
                 content='Persist before delivery',
             ).exists(),
         )
+
+    def test_create_rejects_executable_notification_url(self):
+        with self.assertRaises(ValidationError):
+            NotificationCreationService.create(
+                self.user,
+                'javascript:unsafe',
+                'Unsafe destination',
+            )
+
+        self.assertFalse(
+            Notify.objects.filter(content='Unsafe destination').exists(),
+        )
+
+    def test_create_rejects_incomplete_http_notification_urls(self):
+        for url in (
+            'http://',
+            'https://',
+            '//',
+            r'\\javascript:unsafe',
+            r'\\[invalid',
+        ):
+            with self.subTest(url=url):
+                with self.assertRaises(ValidationError):
+                    NotificationCreationService.create(
+                        self.user,
+                        url,
+                        'Incomplete destination',
+                    )
+
+        self.assertFalse(
+            Notify.objects.filter(content='Incomplete destination').exists(),
+        )
+
+    def test_url_validator_keeps_single_label_http_hosts(self):
+        for url in (
+            'http://blex/welcome',
+            'https://intranet/path',
+            '//internal-service/notice',
+        ):
+            with self.subTest(url=url):
+                self.assertEqual(NotificationUrlService.validate(url), url)
 
     def test_bulk_delivery_isolates_duplicate_missing_and_failed_users(self):
         duplicate_user = User.objects.create_user(

--- a/backend/src/board/tests/templates/test_settings.py
+++ b/backend/src/board/tests/templates/test_settings.py
@@ -50,6 +50,16 @@ class SettingsViewTestCase(TestCase):
         self.assertIn('"basePath": "/settings"', body)
         self.assertIn('"canUseTelegramIntegration": false', body)
 
+    def test_notification_read_event_refreshes_header_badges(self):
+        self.client.login(username='settings-reader', password='password123')
+
+        response = self.client.get('/settings/notify')
+
+        self.assertEqual(response.status_code, 200)
+        body = self.decode_body(response)
+        self.assertEqual(body.count('blex:notification-read'), 2)
+        self.assertEqual(body.count('refreshUnreadCount();'), 2)
+
     def test_user_settings_enable_telegram_integration_when_bot_configured(self):
         setting = IntegrationSetting.get_instance()
         setting.telegram_enabled = True

--- a/backend/src/board/views/api/v1/login_setting.py
+++ b/backend/src/board/views/api/v1/login_setting.py
@@ -1,4 +1,5 @@
 from django.db import transaction
+from django.core.exceptions import ValidationError
 from django.http import Http404
 
 from board.models import LoginSetting
@@ -6,6 +7,7 @@ from board.modules.response import ErrorCode, StatusDone, StatusError
 from board.services.admin_settings_audit_service import AdminSettingsAuditService
 from board.services.api_request_body_service import ApiRequestBodyService
 from board.services.hcaptcha_service import HCaptchaConfigurationError, HCaptchaService
+from board.services.notification_url_service import NotificationUrlService
 from board.services.product_settings_permission_service import ProductSettingsPermissionService
 from board.services.social_auth_provider_service import SocialAuthProviderService
 
@@ -48,7 +50,9 @@ def login_settings(request):
                     setting.welcome_notification_message = put_data['welcome_notification_message']
 
                 if 'welcome_notification_url' in put_data:
-                    setting.welcome_notification_url = put_data['welcome_notification_url']
+                    setting.welcome_notification_url = NotificationUrlService.validate(
+                        put_data['welcome_notification_url'],
+                    )
 
                 if 'account_deletion_redirect_url' in put_data:
                     setting.account_deletion_redirect_url = put_data['account_deletion_redirect_url']
@@ -66,6 +70,8 @@ def login_settings(request):
                     target=setting,
                     change_message='Updated login and security settings',
                 )
+        except ValidationError as error:
+            return StatusError(ErrorCode.VALIDATE, error.messages[0])
         except HCaptchaConfigurationError as error:
             return StatusError(ErrorCode.VALIDATE, error.message)
 


### PR DESCRIPTION
## 🎯 Goal
- Block executable or malformed notification destinations before they can be stored or opened.
- Preserve current relative, HTTP(S), self-hosted, and intranet notification links without altering existing records.

## 🔧 Core Changes
- Validate new notification URLs consistently in Admin, bulk delivery, the creation service, and login settings.
- Restrict whole-site notification delivery to superusers.
- Render legacy unsafe destinations as non-navigable while allowing users to mark them read.
- Refresh the existing header unread count after that read action.

## 🤔 Key Decisions
- Existing notification rows are neither migrated nor deleted, so stored data and API shape remain compatible.
- The validator allows relative, protocol-relative, and HTTP(S) URLs, including single-label internal hosts, while denying executable schemes and malformed browser-navigation inputs.

## 🧪 Verification Guide
### How to verify
1. Try javascript:, data:, malformed HTTP(S), and raw backslash values in notification Admin, bulk, and welcome-notification settings.
2. Sign in as delegated notification staff: whole-site delivery is hidden and its direct route is forbidden; a superuser can still open it.
3. View a legacy unsafe notification: it does not navigate, can be marked read, and the header unread badge updates.

### Expected result
- Unsafe destinations are never saved or navigated, while compatible safe links and existing data continue to work.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (not needed: no public contract change)