### PR TITLE
🐛 Protect privileged profile edits

### DIFF
--- a/backend/src/board/admin/user.py
+++ b/backend/src/board/admin/user.py
@@ -172,6 +172,14 @@ class ProfileInline(admin.StackedInline):
     model = Profile
     can_delete = False
     classes = ['collapse']
+    protected_readonly_fields = (
+        'role',
+        'bio',
+        'homepage',
+        'avatar',
+        'cover',
+        'analytics_share_url',
+    )
     fieldsets = (
         ('권한 설정', {
             'fields': ('role',),
@@ -183,6 +191,28 @@ class ProfileInline(admin.StackedInline):
             'fields': ('analytics_share_url',),
         }),
     )
+
+    @staticmethod
+    def can_manage_profile(request: HttpRequest, obj: User | None) -> bool:
+        if obj is None or request.user.is_superuser:
+            return True
+        return not (obj.is_staff or obj.is_superuser)
+
+    def get_readonly_fields(self, request, obj=None):
+        readonly_fields = list(super().get_readonly_fields(request, obj))
+        if not self.can_manage_profile(request, obj):
+            readonly_fields.extend(self.protected_readonly_fields)
+        return list(dict.fromkeys(readonly_fields))
+
+    def has_add_permission(self, request, obj):
+        if not self.can_manage_profile(request, obj):
+            return False
+        return super().has_add_permission(request, obj)
+
+    def has_change_permission(self, request, obj=None):
+        if not self.can_manage_profile(request, obj):
+            return False
+        return super().has_change_permission(request, obj)
 
 
 # Django User Admin 커스터마이징
@@ -697,6 +727,22 @@ class ProfileAdmin(admin.ModelAdmin):
 
     readonly_fields = ['user_info', 'avatar_preview', 'cover_preview', 'total_posts']
 
+    def formfield_for_foreignkey(self, db_field, request=None, **kwargs):
+        if (
+            db_field.name == 'user'
+            and request is not None
+            and not request.user.is_superuser
+        ):
+            kwargs['queryset'] = User.objects.filter(
+                is_staff=False,
+                is_superuser=False,
+            )
+        return super().formfield_for_foreignkey(
+            db_field,
+            request=request,
+            **kwargs,
+        )
+
     def get_queryset(self, request):
         queryset = super().get_queryset(request).select_related(
             'user',
@@ -706,6 +752,34 @@ class ProfileAdmin(admin.ModelAdmin):
         if is_admin_changelist_request(request, self.model):
             return queryset.defer('bio', 'about_md', 'about_html')
         return queryset
+
+    def has_change_permission(self, request, obj=None):
+        if not self.can_manage_profile(request, obj):
+            return False
+        return super().has_change_permission(request, obj)
+
+    def has_delete_permission(self, request, obj=None):
+        if not self.can_manage_profile(request, obj):
+            return False
+        return super().has_delete_permission(request, obj)
+
+    @staticmethod
+    def can_manage_profile(request: HttpRequest, obj: Profile | None) -> bool:
+        if obj is None or request.user.is_superuser:
+            return True
+        return not (obj.user.is_staff or obj.user.is_superuser)
+
+    @staticmethod
+    def mutable_profiles(
+        request: HttpRequest,
+        queryset: QuerySet[Profile],
+    ) -> QuerySet[Profile]:
+        if request.user.is_superuser:
+            return queryset
+        return queryset.filter(
+            user__is_staff=False,
+            user__is_superuser=False,
+        )
 
     def user_link(self, obj):
         return AdminLinkService.create_user_link(obj.user)
@@ -752,6 +826,7 @@ class ProfileAdmin(admin.ModelAdmin):
         *,
         role: str,
     ) -> int:
+        queryset = self.mutable_profiles(request, queryset)
         with transaction.atomic():
             profiles = list(queryset.select_for_update())
             count = UserRoleService.set_profiles_role(queryset, role)

--- a/backend/src/board/tests/admin/test_admin_permission_boundaries.py
+++ b/backend/src/board/tests/admin/test_admin_permission_boundaries.py
@@ -8,7 +8,7 @@ from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 from django.utils import translation
 
-from board.admin.user import CustomGroupAdmin, CustomUserAdmin
+from board.admin.user import CustomGroupAdmin, CustomUserAdmin, ProfileAdmin
 from board.models import (
     IntegrationSetting,
     LoginSetting,
@@ -34,6 +34,10 @@ class AdminPermissionBoundaryTestCase(TestCase):
             password='test',
             is_staff=True,
         )
+        cls.staff_profile = Profile.objects.create(
+            user=cls.staff,
+            role=Profile.Role.READER,
+        )
         cls.target = User.objects.create_user(
             username='permission-target',
             email='permission-target@example.com',
@@ -43,6 +47,16 @@ class AdminPermissionBoundaryTestCase(TestCase):
             username='privileged-staff',
             email='privileged-staff@example.com',
             password='original-password',
+            is_staff=True,
+        )
+        cls.privileged_staff_profile = Profile.objects.create(
+            user=cls.privileged_staff,
+            role=Profile.Role.READER,
+        )
+        cls.privileged_user_without_profile = User.objects.create_user(
+            username='privileged-without-profile',
+            email='privileged-without-profile@example.com',
+            password='test',
             is_staff=True,
         )
         cls.target_profile, _ = Profile.objects.get_or_create(
@@ -59,6 +73,7 @@ class AdminPermissionBoundaryTestCase(TestCase):
         self.staff = User.objects.get(pk=self.staff.pk)
         self.user_admin = CustomUserAdmin(User, admin.site)
         self.group_admin = CustomGroupAdmin(Group, admin.site)
+        self.profile_admin = ProfileAdmin(Profile, admin.site)
 
     def admin_request(self):
         request = RequestFactory().get('/admin/')
@@ -239,6 +254,296 @@ class AdminPermissionBoundaryTestCase(TestCase):
         actions = self.user_admin.get_actions(self.admin_request())
         self.assertIn('make_editor', actions)
         self.assertIn('make_reader', actions)
+
+    def test_delegated_staff_cannot_change_or_delete_privileged_profiles(self):
+        self.staff.user_permissions.add(
+            Permission.objects.get(codename='change_profile'),
+            Permission.objects.get(codename='delete_profile'),
+        )
+        self.staff = User.objects.get(pk=self.staff.pk)
+        request = self.admin_request()
+
+        self.assertFalse(
+            self.profile_admin.has_change_permission(
+                request,
+                self.privileged_staff_profile,
+            ),
+        )
+        self.assertFalse(
+            self.profile_admin.has_delete_permission(
+                request,
+                self.privileged_staff_profile,
+            ),
+        )
+
+        self.client.force_login(self.staff)
+        change_response = self.client.post(
+            reverse(
+                'admin:board_profile_change',
+                args=[self.privileged_staff_profile.pk],
+            ),
+            {'role': Profile.Role.EDITOR},
+        )
+        delete_response = self.client.post(
+            reverse(
+                'admin:board_profile_delete',
+                args=[self.privileged_staff_profile.pk],
+            ),
+        )
+
+        self.assertEqual(change_response.status_code, 403)
+        self.assertEqual(delete_response.status_code, 403)
+        self.privileged_staff_profile.refresh_from_db()
+        self.assertEqual(self.privileged_staff_profile.role, Profile.Role.READER)
+
+    def test_delegated_bulk_delete_keeps_mixed_privileged_profiles(self):
+        self.staff.user_permissions.add(
+            Permission.objects.get(codename='delete_profile'),
+            Permission.objects.get(codename='view_profile'),
+        )
+        self.staff = User.objects.get(pk=self.staff.pk)
+        self.client.force_login(self.staff)
+        selection = {
+            helpers.ACTION_CHECKBOX_NAME: [
+                str(self.target_profile.pk),
+                str(self.privileged_staff_profile.pk),
+            ],
+            'action': 'delete_selected',
+            'select_across': '0',
+        }
+
+        confirmation_response = self.client.post(
+            reverse('admin:board_profile_changelist'),
+            selection,
+        )
+        confirmed_response = self.client.post(
+            reverse('admin:board_profile_changelist'),
+            {**selection, 'post': 'yes'},
+        )
+
+        self.assertEqual(confirmation_response.status_code, 200)
+        self.assertEqual(confirmed_response.status_code, 403)
+        self.assertTrue(
+            Profile.objects.filter(pk=self.target_profile.pk).exists(),
+        )
+        self.assertTrue(
+            Profile.objects.filter(
+                pk=self.privileged_staff_profile.pk,
+            ).exists(),
+        )
+
+    def test_delegated_profile_role_action_skips_privileged_profiles(self):
+        self.staff.user_permissions.add(
+            Permission.objects.get(codename='change_profile'),
+        )
+        self.staff = User.objects.get(pk=self.staff.pk)
+        self.client.force_login(self.staff)
+
+        response = self.client.post(
+            reverse('admin:board_profile_changelist'),
+            {
+                helpers.ACTION_CHECKBOX_NAME: [
+                    str(self.target_profile.pk),
+                    str(self.privileged_staff_profile.pk),
+                ],
+                'action': 'set_role_editor',
+                'select_across': '0',
+            },
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.target_profile.refresh_from_db()
+        self.privileged_staff_profile.refresh_from_db()
+        self.assertEqual(self.target_profile.role, Profile.Role.EDITOR)
+        self.assertEqual(
+            self.privileged_staff_profile.role,
+            Profile.Role.READER,
+        )
+
+    def test_delegated_staff_cannot_create_profile_for_privileged_user(self):
+        self.staff.user_permissions.add(
+            Permission.objects.get(codename='add_profile'),
+        )
+        self.staff = User.objects.get(pk=self.staff.pk)
+        self.client.force_login(self.staff)
+
+        response = self.client.post(
+            reverse('admin:board_profile_add'),
+            {
+                'user': str(self.privileged_user_without_profile.pk),
+                'role': Profile.Role.EDITOR,
+                '_save': 'Save',
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(
+            Profile.objects.filter(
+                user=self.privileged_user_without_profile,
+            ).exists(),
+        )
+
+    def test_delegated_staff_cannot_change_own_profile_role_through_user_inline(self):
+        self.staff.user_permissions.add(
+            Permission.objects.get(codename='change_profile'),
+        )
+        self.staff = User.objects.get(pk=self.staff.pk)
+        self.client.force_login(self.staff)
+
+        response = self.client.post(
+            reverse('admin:auth_user_change', args=[self.staff.pk]),
+            {
+                'username': self.staff.username,
+                'first_name': '',
+                'last_name': '',
+                'email': self.staff.email,
+                'is_active': 'on',
+                'date_joined_0': self.staff.date_joined.strftime('%Y-%m-%d'),
+                'date_joined_1': self.staff.date_joined.strftime('%H:%M:%S'),
+                'profile-TOTAL_FORMS': '1',
+                'profile-INITIAL_FORMS': '1',
+                'profile-MIN_NUM_FORMS': '0',
+                'profile-MAX_NUM_FORMS': '1',
+                'profile-0-id': str(self.staff_profile.pk),
+                'profile-0-role': Profile.Role.EDITOR,
+                '_save': 'Save',
+            },
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.staff_profile.refresh_from_db()
+        self.assertEqual(self.staff_profile.role, Profile.Role.READER)
+
+    def test_delegated_staff_cannot_add_own_profile_through_user_inline(self):
+        self.staff_profile.delete()
+        self.staff.user_permissions.add(
+            Permission.objects.get(codename='add_profile'),
+        )
+        self.staff = User.objects.get(pk=self.staff.pk)
+        self.client.force_login(self.staff)
+
+        response = self.client.post(
+            reverse('admin:auth_user_change', args=[self.staff.pk]),
+            {
+                'username': self.staff.username,
+                'first_name': '',
+                'last_name': '',
+                'email': self.staff.email,
+                'is_active': 'on',
+                'date_joined_0': self.staff.date_joined.strftime('%Y-%m-%d'),
+                'date_joined_1': self.staff.date_joined.strftime('%H:%M:%S'),
+                'profile-TOTAL_FORMS': '1',
+                'profile-INITIAL_FORMS': '0',
+                'profile-MIN_NUM_FORMS': '0',
+                'profile-MAX_NUM_FORMS': '1',
+                'profile-0-role': Profile.Role.EDITOR,
+                '_save': 'Save',
+            },
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(Profile.objects.filter(user=self.staff).exists())
+
+    def test_superuser_can_manage_privileged_profiles_through_user_inline(self):
+        self.client.force_login(self.superuser)
+
+        change_response = self.client.post(
+            reverse('admin:auth_user_change', args=[self.privileged_staff.pk]),
+            {
+                'username': self.privileged_staff.username,
+                'first_name': '',
+                'last_name': '',
+                'email': self.privileged_staff.email,
+                'is_active': 'on',
+                'date_joined_0': self.privileged_staff.date_joined.strftime(
+                    '%Y-%m-%d',
+                ),
+                'date_joined_1': self.privileged_staff.date_joined.strftime(
+                    '%H:%M:%S',
+                ),
+                'profile-TOTAL_FORMS': '1',
+                'profile-INITIAL_FORMS': '1',
+                'profile-MIN_NUM_FORMS': '0',
+                'profile-MAX_NUM_FORMS': '1',
+                'profile-0-id': str(self.privileged_staff_profile.pk),
+                'profile-0-role': Profile.Role.EDITOR,
+                'userlinkmeta_set-TOTAL_FORMS': '0',
+                'userlinkmeta_set-INITIAL_FORMS': '0',
+                'userlinkmeta_set-MIN_NUM_FORMS': '0',
+                'userlinkmeta_set-MAX_NUM_FORMS': '1000',
+                '_save': 'Save',
+            },
+        )
+        add_response = self.client.post(
+            reverse(
+                'admin:auth_user_change',
+                args=[self.privileged_user_without_profile.pk],
+            ),
+            {
+                'username': self.privileged_user_without_profile.username,
+                'first_name': '',
+                'last_name': '',
+                'email': self.privileged_user_without_profile.email,
+                'is_active': 'on',
+                'date_joined_0': (
+                    self.privileged_user_without_profile.date_joined.strftime(
+                        '%Y-%m-%d',
+                    )
+                ),
+                'date_joined_1': (
+                    self.privileged_user_without_profile.date_joined.strftime(
+                        '%H:%M:%S',
+                    )
+                ),
+                'profile-TOTAL_FORMS': '1',
+                'profile-INITIAL_FORMS': '0',
+                'profile-MIN_NUM_FORMS': '0',
+                'profile-MAX_NUM_FORMS': '1',
+                'profile-0-role': Profile.Role.EDITOR,
+                'userlinkmeta_set-TOTAL_FORMS': '0',
+                'userlinkmeta_set-INITIAL_FORMS': '0',
+                'userlinkmeta_set-MIN_NUM_FORMS': '0',
+                'userlinkmeta_set-MAX_NUM_FORMS': '1000',
+                '_save': 'Save',
+            },
+        )
+
+        self.assertEqual(change_response.status_code, 302)
+        self.assertEqual(add_response.status_code, 302)
+        self.privileged_staff_profile.refresh_from_db()
+        self.assertEqual(self.privileged_staff_profile.role, Profile.Role.EDITOR)
+        self.assertEqual(
+            Profile.objects.get(
+                user=self.privileged_user_without_profile,
+            ).role,
+            Profile.Role.EDITOR,
+        )
+
+    def test_superuser_keeps_privileged_profile_management(self):
+        request = self.superuser_request()
+
+        self.assertTrue(
+            self.profile_admin.has_change_permission(
+                request,
+                self.privileged_staff_profile,
+            ),
+        )
+        self.assertTrue(
+            self.profile_admin.has_delete_permission(
+                request,
+                self.privileged_staff_profile,
+            ),
+        )
+
+        count = self.profile_admin.set_profiles_role(
+            request,
+            Profile.objects.filter(pk=self.privileged_staff_profile.pk),
+            role=Profile.Role.EDITOR,
+        )
+
+        self.assertEqual(count, 1)
+        self.privileged_staff_profile.refresh_from_db()
+        self.assertEqual(self.privileged_staff_profile.role, Profile.Role.EDITOR)
 
     def test_group_permission_bundles_are_superuser_only(self):
         request = self.admin_request()


### PR DESCRIPTION
## 🎯 Goal
- Prevent delegated Django Admin staff from changing or deleting profiles that belong to staff or superuser accounts.
- Close the matching User Admin Profile inline path while preserving normal-user and superuser workflows.

## 🔧 Core Changes
- Deny direct Profile Admin changes/deletes for privileged account profiles and exclude them from delegated role actions.
- Limit delegated Profile forms to ordinary users and make privileged User Profile inlines non-mutating.
- Add regression coverage for direct, bulk, creation, inline, and superuser paths.

## 🤔 Key Decisions
- Reuse the existing user-management boundary: a delegated staff member cannot change own role or a staff/superuser role.
- Keep read access unchanged; only unsafe mutations are blocked.
- Do not change APIs, persisted data, or database schema.

## 🧪 Verification Guide
### How to verify
1. As delegated staff with Profile permissions, try direct change/delete, mixed bulk delete, linking, and role change for staff/superuser profiles.
2. Try modifying or creating the actor's own Profile through User Admin inline.
3. As superuser, modify and create a privileged user's Profile through the same inline.

### Expected result
- Delegated staff can manage ordinary profiles only; all privileged-profile mutations are rejected.
- Superusers retain their existing Admin workflows.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)