### PR TITLE
⚡ Optimize Admin relation autocomplete

### DIFF
--- a/backend/src/board/admin/banner.py
+++ b/backend/src/board/admin/banner.py
@@ -98,6 +98,7 @@ class SiteContentActionAdminMixin:
 @admin.register(SiteNotice)
 class SiteNoticeAdmin(SiteContentActionAdminMixin, admin.ModelAdmin):
     """사이트 공지 관리 페이지"""
+    autocomplete_fields = ['user']
     search_fields = ['title', 'user__username', 'url']
 
     list_filter = [
@@ -164,6 +165,7 @@ class SiteNoticeAdmin(SiteContentActionAdminMixin, admin.ModelAdmin):
 @admin.register(SiteBanner)
 class SiteBannerAdmin(SiteContentActionAdminMixin, admin.ModelAdmin):
     """사이트 배너 관리 페이지"""
+    autocomplete_fields = ['user']
     search_fields = ['title', 'user__username', 'content_html']
 
     list_filter = [

--- a/backend/src/board/admin/mixins.py
+++ b/backend/src/board/admin/mixins.py
@@ -9,6 +9,15 @@ def is_admin_changelist_request(request, model) -> bool:
     )
 
 
+def is_admin_autocomplete_request(request) -> bool:
+    """Return whether Django is resolving an Admin autocomplete request."""
+    resolver_match = getattr(request, 'resolver_match', None)
+    return (
+        resolver_match is not None
+        and resolver_match.url_name == 'autocomplete'
+    )
+
+
 class ReadOnlyRecordAdminMixin:
     """Inspect externally owned or system-managed rows without editing them."""
 

--- a/backend/src/board/admin/post.py
+++ b/backend/src/board/admin/post.py
@@ -36,6 +36,7 @@ from board.models import (
 from .action_confirmation import render_action_confirmation
 from .mixins import (
     ServiceOwnedRecordAdminMixin,
+    is_admin_autocomplete_request,
     is_admin_changelist_request,
 )
 from .service import AdminDisplayService, AdminLinkService
@@ -172,7 +173,7 @@ class PostAdmin(admin.ModelAdmin):
     search_fields = ['title', 'content__content_html', 'author__username', 'series__name', 'tags__value']
     ordering = ['-created_date']
     inlines = [PostContentInline, PostConfigInline]
-    autocomplete_fields = ['author', 'series']
+    autocomplete_fields = ['author', 'series', 'tags']
 
     list_filter = [
         PublishStatusFilter,
@@ -251,11 +252,11 @@ class PostAdmin(admin.ModelAdmin):
         if ordering:
             queryset = queryset.order_by(*ordering)
 
-        if (
-            getattr(request, 'resolver_match', None)
-            and request.resolver_match.url_name == 'autocomplete'
-        ):
-            queryset = queryset.filter(deleted_date__isnull=True)
+        if is_admin_autocomplete_request(request):
+            return queryset.filter(deleted_date__isnull=True).only(
+                'id',
+                'title',
+            )
 
         likes_count = PostLikes.objects.filter(
             post_id=OuterRef('pk'),

--- a/backend/src/board/admin/series.py
+++ b/backend/src/board/admin/series.py
@@ -11,7 +11,10 @@ from board.models import Series, Post
 from board.services.public_post_service import PublicPostService
 
 from .action_confirmation import render_action_confirmation
-from .mixins import is_admin_changelist_request
+from .mixins import (
+    is_admin_autocomplete_request,
+    is_admin_changelist_request,
+)
 from .service import AdminDisplayService, AdminLinkService
 from .constants import (
     COLOR_DANGER, COLOR_SUCCESS, COLOR_PRIMARY, COLOR_MUTED,
@@ -63,6 +66,9 @@ class SeriesAdmin(admin.ModelAdmin):
     actions = ['make_hidden', 'make_visible', 'set_layout_list', 'set_layout_card']
 
     def get_queryset(self, request):
+        if is_admin_autocomplete_request(request):
+            return super().get_queryset(request).only('id', 'name')
+
         public_posts = PublicPostService.filter_public_posts(
             Post.objects,
         ).filter(series=OuterRef('pk')).order_by('pk')

--- a/backend/src/board/admin/tag.py
+++ b/backend/src/board/admin/tag.py
@@ -14,7 +14,10 @@ from .constants import (
     COLOR_INFO, COLOR_BG, COLOR_DANGER, COLOR_WARNING,
     COLOR_SUCCESS, COLOR_MUTED, COLOR_TEXT
 )
-from .mixins import ConfirmedActionDeleteAdminMixin
+from .mixins import (
+    ConfirmedActionDeleteAdminMixin,
+    is_admin_autocomplete_request,
+)
 from .utilities import TagCleanerService
 
 
@@ -39,6 +42,12 @@ class TagAdmin(ConfirmedActionDeleteAdminMixin, admin.ModelAdmin):
     ]
 
     def get_queryset(self, request):
+        if is_admin_autocomplete_request(request):
+            return super().get_queryset(request).only(
+                'id',
+                'value',
+            ).order_by('value', 'pk')
+
         public_image_posts = PublicPostService.filter_public_posts(
             Post.objects,
         ).filter(

--- a/backend/src/board/admin/user.py
+++ b/backend/src/board/admin/user.py
@@ -33,6 +33,7 @@ from .action_confirmation import render_action_confirmation
 from .mixins import (
     ConfirmedActionDeleteAdminMixin,
     ReadOnlyRecordAdminMixin,
+    is_admin_autocomplete_request,
     is_admin_changelist_request,
 )
 from .permission_display import configure_permission_choice_field
@@ -275,6 +276,9 @@ class CustomUserAdmin(ConfirmedActionDeleteAdminMixin, BaseUserAdmin):
         return form_field
 
     def get_queryset(self, request):
+        if is_admin_autocomplete_request(request):
+            return super().get_queryset(request).only('id', 'username')
+
         queryset = super().get_queryset(request).select_related(
             'profile',
         ).annotate(
@@ -744,6 +748,16 @@ class ProfileAdmin(admin.ModelAdmin):
         )
 
     def get_queryset(self, request):
+        if is_admin_autocomplete_request(request):
+            return super().get_queryset(request).select_related(
+                'user',
+            ).only(
+                'id',
+                'user_id',
+                'user__id',
+                'user__username',
+            ).order_by('user__username', 'pk')
+
         queryset = super().get_queryset(request).select_related(
             'user',
         ).defer('user__password').annotate(

--- a/backend/src/board/admin/webhook.py
+++ b/backend/src/board/admin/webhook.py
@@ -60,6 +60,7 @@ class WebhookSubscriptionAdminForm(forms.ModelForm):
 @admin.register(WebhookSubscription)
 class WebhookSubscriptionAdmin(admin.ModelAdmin):
     form = WebhookSubscriptionAdminForm
+    autocomplete_fields = ['author']
     list_display = [
         'name',
         'scope',

--- a/backend/src/board/tests/admin/test_admin_list_performance.py
+++ b/backend/src/board/tests/admin/test_admin_list_performance.py
@@ -2,6 +2,10 @@ from datetime import timedelta
 
 from django.contrib import admin
 from django.contrib.admin import helpers
+from django.contrib.admin.widgets import (
+    AutocompleteSelect,
+    AutocompleteSelectMultiple,
+)
 from django.contrib.admin.models import CHANGE, LogEntry
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
@@ -332,6 +336,13 @@ class AdminListPerformanceTestCase(TestCase):
         request.resolver_match = resolve(path)
         return request
 
+    def autocomplete_request(self):
+        path = reverse('admin:autocomplete')
+        request = RequestFactory().get(path)
+        request.user = self.admin_user
+        request.resolver_match = resolve(path)
+        return request
+
     def large_field_cases(self):
         return (
             (Comment, self.active_comment.pk, {'text_md'}),
@@ -509,6 +520,124 @@ class AdminListPerformanceTestCase(TestCase):
         self.assertNotIn('auth_token', config_query)
         self.assertTrue(configs[0].telegram_linked)
         self.assertTrue(configs[0].two_factor_enabled)
+
+    def test_mutable_relation_forms_use_autocomplete_widgets(self):
+        cases = (
+            (
+                Post,
+                self.public_posts[0],
+                'author',
+                AutocompleteSelect,
+                self.authors[0].pk,
+            ),
+            (
+                Post,
+                self.public_posts[0],
+                'series',
+                AutocompleteSelect,
+                self.series[0].pk,
+            ),
+            (
+                Post,
+                self.public_posts[0],
+                'tags',
+                AutocompleteSelectMultiple,
+                self.tags[0].pk,
+            ),
+            (
+                SiteNotice,
+                self.site_notices[1],
+                'user',
+                AutocompleteSelect,
+                self.authors[0].pk,
+            ),
+            (
+                SiteBanner,
+                self.site_banners[1],
+                'user',
+                AutocompleteSelect,
+                self.authors[0].pk,
+            ),
+            (
+                WebhookSubscription,
+                self.webhook,
+                'author',
+                AutocompleteSelect,
+                self.profile.pk,
+            ),
+        )
+
+        for model, obj, field_name, widget_class, expected_value in cases:
+            with self.subTest(model=model, field_name=field_name):
+                model_admin = admin.site._registry[model]
+                form = model_admin.get_form(self.request, obj)(instance=obj)
+                widget = getattr(
+                    form.fields[field_name].widget,
+                    'widget',
+                    form.fields[field_name].widget,
+                )
+                self.assertIsInstance(widget, widget_class)
+                value = form[field_name].value()
+                if not isinstance(value, (list, tuple)):
+                    value = [value]
+                self.assertIn(
+                    str(expected_value),
+                    [str(item) for item in value],
+                )
+
+    def test_autocomplete_sources_skip_changelist_work(self):
+        cases = (
+            (User, self.authors[0].pk),
+            (Profile, self.profile.pk),
+            (Series, self.series[0].pk),
+            (Tag, self.tags[0].pk),
+            (Post, self.public_posts[0].pk),
+        )
+        request = self.autocomplete_request()
+
+        for model, object_id in cases:
+            with self.subTest(model=model):
+                model_admin = admin.site._registry[model]
+                queryset = model_admin.get_queryset(request).filter(
+                    pk=object_id,
+                )
+
+                self.assertFalse(queryset.query.annotations)
+                self.assertFalse(queryset._prefetch_related_lookups)
+                self.assertTrue(queryset.ordered)
+                with CaptureQueriesContext(connection) as queries:
+                    self.assertTrue(str(queryset.get()))
+
+                self.assertEqual(len(queries), 1)
+
+    def test_relation_autocomplete_searches_remain_available(self):
+        self.client.force_login(self.admin_user)
+        cases = (
+            (Post, 'author', self.authors[0].username),
+            (Post, 'series', self.series[0].name),
+            (Post, 'tags', self.tags[0].value),
+            (SiteNotice, 'user', self.authors[0].username),
+            (SiteBanner, 'user', self.authors[0].username),
+            (WebhookSubscription, 'author', self.authors[0].username),
+        )
+
+        for model, field_name, term in cases:
+            with self.subTest(model=model, field_name=field_name):
+                response = self.client.get(
+                    reverse('admin:autocomplete'),
+                    {
+                        'app_label': model._meta.app_label,
+                        'model_name': model._meta.model_name,
+                        'field_name': field_name,
+                        'term': term,
+                    },
+                )
+
+                self.assertEqual(response.status_code, 200)
+                result_texts = [
+                    result['text'] for result in response.json()['results']
+                ]
+                self.assertIn(term, result_texts)
 
     def test_high_growth_changelists_do_not_run_unfiltered_counts(self):
         self.client.force_login(self.admin_user)


### PR DESCRIPTION
## 🎯 Goal
- Prevent Django Admin relation forms from loading every related row as users, profiles, tags, and posts grow.
- Keep existing Admin selection and autocomplete behavior stable while reducing form and search query cost.

## 🔧 Core Changes
- Convert Post tags, Site Notice/Site Banner users, and Webhook Subscription authors to native Django Admin autocomplete fields.
- Give autocomplete source queries a lean path that skips changelist-only joins, aggregates, and prefetches.
- Add regression coverage for widgets, saved selections, search results, ordering, and query shape.

## 🤔 Key Decisions
- Use Django's built-in autocomplete so current Admin permissions and search policies remain in effect.
- Preserve selected relation values and retain the existing exclusion of trashed posts from Post autocomplete.
- Do not change public APIs, persisted data, or the database schema.

## 🧪 Verification Guide
### How to verify
1. Open Post, Site Notice, Site Banner, and Webhook Subscription create or edit forms in Django Admin.
2. Search and select authors, series, tags, users, or profiles through the relation fields.
3. Re-open existing records that already have a selected relation.

### Expected result
- Forms do not render all related rows up front; autocomplete returns matching records and existing selections stay visible.
- Post autocomplete still excludes trashed posts.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)