### PR TITLE
🐛 Record Admin notification enqueue outcomes

### DIFF
--- a/backend/src/board/admin/notify.py
+++ b/backend/src/board/admin/notify.py
@@ -404,7 +404,7 @@ class NotifyAdmin(admin.ModelAdmin):
                 else:
                     content_type = ContentType.objects.get_for_model(Notify)
                     with transaction.atomic():
-                        LogEntry.objects.create(
+                        audit_log = LogEntry.objects.create(
                             user=request.user,
                             content_type=content_type,
                             object_id=None,
@@ -415,11 +415,37 @@ class NotifyAdmin(admin.ModelAdmin):
                                 f'대상 {target_count}명'
                             ),
                         )
-                    BulkNotificationDeliveryService.enqueue(
-                        user_ids=user_ids,
-                        url=url,
-                        content=content,
-                    )
+
+                    try:
+                        task_id = BulkNotificationDeliveryService.enqueue(
+                            user_ids=user_ids,
+                            url=url,
+                            content=content,
+                            audit_log_id=audit_log.pk,
+                        )
+                    except Exception as error:
+                        logger.error(
+                            'Admin bulk notification enqueue failed audit_log_id=%s '
+                            'exception_type=%s',
+                            audit_log.pk,
+                            type(error).__name__,
+                        )
+                        task_id = None
+
+                    if task_id is None:
+                        LogEntry.objects.filter(pk=audit_log.pk).update(
+                            change_message=(
+                                'Admin 전체 알림 발송 예약 실패: '
+                                f'대상 {target_count}명'
+                            ),
+                        )
+                        self.message_user(
+                            request,
+                            '알림 발송 작업을 예약하지 못했습니다.',
+                            level=messages.ERROR,
+                        )
+                        return redirect('..')
+
                     self.message_user(
                         request,
                         f'{target_count}명 대상 알림 발송 작업을 예약했습니다. '

--- a/backend/src/board/services/bulk_notification_delivery_service.py
+++ b/backend/src/board/services/bulk_notification_delivery_service.py
@@ -4,6 +4,7 @@ import logging
 from dataclasses import dataclass
 from typing import Sequence
 
+from django.contrib.admin.models import LogEntry
 from django.contrib.auth.models import User
 
 from modules.sub_task import SubTaskProcessor
@@ -27,12 +28,20 @@ class BulkNotificationDeliveryService:
     """Process an Admin bulk-notification request outside its HTTP request."""
 
     @staticmethod
-    def enqueue(user_ids: Sequence[int], url: str, content: str) -> None:
-        SubTaskProcessor.process(
+    def enqueue(
+        user_ids: Sequence[int],
+        url: str,
+        content: str,
+        *,
+        audit_log_id: int | None = None,
+    ) -> str | None:
+        """Return a task identifier only when the background queue accepted it."""
+        return SubTaskProcessor.submit(
             BulkNotificationDeliveryService.deliver,
             list(user_ids),
             url,
             content,
+            audit_log_id=audit_log_id,
         )
 
     @staticmethod
@@ -40,42 +49,60 @@ class BulkNotificationDeliveryService:
         user_ids: Sequence[int],
         url: str,
         content: str,
+        *,
+        audit_log_id: int | None = None,
     ) -> BulkNotificationDeliveryStats:
-        users_by_id = User.objects.in_bulk(user_ids)
-        success_count = 0
-        duplicate_count = 0
-        failure_count = 0
+        try:
+            users_by_id = User.objects.in_bulk(user_ids)
+            success_count = 0
+            duplicate_count = 0
+            failure_count = 0
 
-        for user_id in user_ids:
-            user = users_by_id.get(user_id)
-            if user is None:
-                failure_count += 1
-                continue
+            for user_id in user_ids:
+                user = users_by_id.get(user_id)
+                if user is None:
+                    failure_count += 1
+                    continue
 
-            try:
-                _, created = NotificationCreationService.create(
-                    user=user,
-                    url=url,
-                    content=content,
-                )
-            except Exception as error:
-                failure_count += 1
-                logger.error(
-                    'Bulk notification processing failed exception_type=%s',
-                    type(error).__name__,
-                )
-                continue
+                try:
+                    _, created = NotificationCreationService.create(
+                        user=user,
+                        url=url,
+                        content=content,
+                    )
+                except Exception as error:
+                    failure_count += 1
+                    logger.error(
+                        'Bulk notification processing failed exception_type=%s',
+                        type(error).__name__,
+                    )
+                    continue
 
-            if created:
-                success_count += 1
-            else:
-                duplicate_count += 1
+                if created:
+                    success_count += 1
+                else:
+                    duplicate_count += 1
 
-        stats = BulkNotificationDeliveryStats(
-            requested_count=len(user_ids),
-            success_count=success_count,
-            duplicate_count=duplicate_count,
-            failure_count=failure_count,
+            stats = BulkNotificationDeliveryStats(
+                requested_count=len(user_ids),
+                success_count=success_count,
+                duplicate_count=duplicate_count,
+                failure_count=failure_count,
+            )
+        except Exception as error:
+            BulkNotificationDeliveryService._record_audit_failure(
+                audit_log_id,
+                requested_count=len(user_ids),
+            )
+            logger.error(
+                'Bulk notification processing aborted exception_type=%s',
+                type(error).__name__,
+            )
+            raise
+
+        BulkNotificationDeliveryService._record_audit_outcome(
+            audit_log_id,
+            stats,
         )
         logger.info(
             'Bulk notification processing completed requested=%s '
@@ -86,3 +113,58 @@ class BulkNotificationDeliveryService:
             stats.failure_count,
         )
         return stats
+
+    @staticmethod
+    def _record_audit_outcome(
+        audit_log_id: int | None,
+        stats: BulkNotificationDeliveryStats,
+    ) -> None:
+        if audit_log_id is None:
+            return
+
+        message = (
+            'Admin 전체 알림 발송 처리 완료: '
+            f'대상 {stats.requested_count}명, '
+            f'생성 {stats.success_count}명, '
+            f'중복 {stats.duplicate_count}명, '
+            f'실패 {stats.failure_count}명'
+        )
+        BulkNotificationDeliveryService._update_audit_message(
+            audit_log_id,
+            message,
+        )
+
+    @staticmethod
+    def _record_audit_failure(
+        audit_log_id: int | None,
+        *,
+        requested_count: int,
+    ) -> None:
+        if audit_log_id is None:
+            return
+
+        BulkNotificationDeliveryService._update_audit_message(
+            audit_log_id,
+            f'Admin 전체 알림 발송 처리 실패: 대상 {requested_count}명',
+        )
+
+    @staticmethod
+    def _update_audit_message(audit_log_id: int, message: str) -> None:
+        try:
+            updated_count = LogEntry.objects.filter(pk=audit_log_id).update(
+                change_message=message,
+            )
+        except Exception as error:
+            logger.error(
+                'Bulk notification audit update failed audit_log_id=%s '
+                'exception_type=%s',
+                audit_log_id,
+                type(error).__name__,
+            )
+            return
+
+        if not updated_count:
+            logger.error(
+                'Bulk notification audit record missing audit_log_id=%s',
+                audit_log_id,
+            )

--- a/backend/src/board/tests/admin/test_notify_admin.py
+++ b/backend/src/board/tests/admin/test_notify_admin.py
@@ -409,21 +409,53 @@ class NotifyAdminTestCase(TestCase):
         with patch.object(
             BulkNotificationDeliveryService,
             'enqueue',
+            return_value='background-task-1',
         ) as enqueue:
             response = self.admin_instance.bulk_send_view(confirmed_request)
 
         self.assertEqual(response.status_code, 302)
+        audit_log = LogEntry.objects.get(action_flag=ADDITION)
         enqueue.assert_called_once_with(
             user_ids=active_user_ids,
             url='/admin/bulk',
             content='<script>private bulk content</script>',
+            audit_log_id=audit_log.pk,
         )
         self.assertEqual(Notify.objects.count(), 0)
-        audit_log = LogEntry.objects.get(action_flag=ADDITION)
         self.assertIsNone(audit_log.object_id)
         self.assertIn(str(len(active_user_ids)), audit_log.object_repr)
         self.assertNotIn('/admin/bulk', audit_log.change_message)
         self.assertNotIn('private bulk content', audit_log.change_message)
+
+    def test_bulk_send_marks_audit_log_when_enqueue_is_rejected(self):
+        form_data = {
+            'url': '/admin/bulk-private',
+            'content': 'Private bulk content',
+            'confirm': 'yes',
+        }
+        request = self.admin_request('post', form_data)
+
+        with patch.object(
+            BulkNotificationDeliveryService,
+            'enqueue',
+            return_value=None,
+        ) as enqueue:
+            response = self.admin_instance.bulk_send_view(request)
+
+        self.assertEqual(response.status_code, 302)
+        audit_log = LogEntry.objects.get(action_flag=ADDITION)
+        self.assertIn('예약 실패', audit_log.change_message)
+        self.assertNotIn('/admin/bulk-private', audit_log.change_message)
+        self.assertNotIn('Private bulk content', audit_log.change_message)
+        enqueue.assert_called_once_with(
+            user_ids=list(
+                User.objects.filter(is_active=True).values_list('pk', flat=True),
+            ),
+            url='/admin/bulk-private',
+            content='Private bulk content',
+            audit_log_id=audit_log.pk,
+        )
+        self.assertIn('알림 발송 작업을 예약하지 못했습니다.', self.message_text(request))
 
     def test_bulk_send_requires_add_permission(self):
         request = self.admin_request(

--- a/backend/src/board/tests/services/test_notification_creation_service.py
+++ b/backend/src/board/tests/services/test_notification_creation_service.py
@@ -1,6 +1,8 @@
 from unittest.mock import patch
 
+from django.contrib.admin.models import ADDITION, LogEntry
 from django.contrib.auth.models import User
+from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 
@@ -145,3 +147,87 @@ class NotificationCreationServiceTestCase(TestCase):
         self.assertNotIn('sensitive-provider-error', log_output)
         self.assertNotIn('Bulk content must not be logged', log_output)
         self.assertNotIn('/bulk', log_output)
+
+    def test_bulk_enqueue_returns_task_id_and_forwards_audit_log(self):
+        with patch(
+            'board.services.bulk_notification_delivery_service.'
+            'SubTaskProcessor.submit',
+            return_value='background-task-1',
+        ) as submit:
+            task_id = BulkNotificationDeliveryService.enqueue(
+                [self.user.pk],
+                '/bulk',
+                'Bulk content',
+                audit_log_id=123,
+            )
+
+        self.assertEqual(task_id, 'background-task-1')
+        submit.assert_called_once_with(
+            BulkNotificationDeliveryService.deliver,
+            [self.user.pk],
+            '/bulk',
+            'Bulk content',
+            audit_log_id=123,
+        )
+
+    def create_bulk_audit_log(self) -> LogEntry:
+        return LogEntry.objects.create(
+            user=self.user,
+            content_type=ContentType.objects.get_for_model(Notify),
+            object_id=None,
+            object_repr='전체 알림 발송 (2명)',
+            action_flag=ADDITION,
+            change_message='Admin 전체 알림 발송 예약: 대상 2명',
+        )
+
+    def test_bulk_delivery_records_redacted_audit_outcome(self):
+        duplicate_user = User.objects.create_user(
+            username='notification-audit-duplicate',
+        )
+        audit_log = self.create_bulk_audit_log()
+
+        with patch.object(
+            NotificationCreationService,
+            'create',
+            side_effect=[(object(), True), (object(), False)],
+        ):
+            BulkNotificationDeliveryService.deliver(
+                [self.user.pk, duplicate_user.pk],
+                '/bulk-private',
+                'Bulk private content',
+                audit_log_id=audit_log.pk,
+            )
+
+        audit_log.refresh_from_db()
+        self.assertIn('처리 완료', audit_log.change_message)
+        self.assertIn('대상 2명', audit_log.change_message)
+        self.assertIn('생성 1명', audit_log.change_message)
+        self.assertIn('중복 1명', audit_log.change_message)
+        self.assertIn('실패 0명', audit_log.change_message)
+        self.assertNotIn('/bulk-private', audit_log.change_message)
+        self.assertNotIn('Bulk private content', audit_log.change_message)
+
+    def test_bulk_delivery_records_audit_failure_before_reraising(self):
+        audit_log = self.create_bulk_audit_log()
+
+        with patch.object(
+            User.objects,
+            'in_bulk',
+            side_effect=RuntimeError('private provider failure'),
+        ):
+            with self.assertLogs('board.notification', level='ERROR') as logs:
+                with self.assertRaisesRegex(RuntimeError, 'private provider failure'):
+                    BulkNotificationDeliveryService.deliver(
+                        [self.user.pk, self.user.pk + 1],
+                        '/bulk-private',
+                        'Bulk private content',
+                        audit_log_id=audit_log.pk,
+                    )
+
+        audit_log.refresh_from_db()
+        self.assertIn('처리 실패', audit_log.change_message)
+        self.assertIn('대상 2명', audit_log.change_message)
+        log_output = ' '.join(logs.output)
+        self.assertNotIn('private provider failure', log_output)
+        self.assertNotIn('/bulk-private', log_output)
+        self.assertNotIn('Bulk private content', log_output)

--- a/backend/src/board/tests/test_sub_task_processor.py
+++ b/backend/src/board/tests/test_sub_task_processor.py
@@ -70,6 +70,17 @@ class SubTaskProcessorTestCase(SimpleTestCase):
             release.set()
             self.assertTrue(finished.wait(timeout=1))
 
+    def test_submit_returns_a_task_id_when_the_executor_accepts_it(self):
+        executor = self.create_executor()
+        completed = threading.Event()
+
+        with patch.object(sub_task_module, '_executor', executor):
+            task_id = SubTaskProcessor.submit(completed.set)
+
+        self.assertIsNotNone(task_id)
+        self.assertTrue(task_id.startswith('background-task-'))
+        self.assertTrue(completed.wait(timeout=1))
+
     def test_execution_failure_is_redacted_and_does_not_block_next_task(self):
         executor = self.create_executor()
         next_task_completed = threading.Event()
@@ -132,6 +143,19 @@ class SubTaskProcessorTestCase(SimpleTestCase):
         failure_record = captured.records[0]
         self.assertEqual(failure_record.background_task_stage, 'submit')
         self.assertEqual(failure_record.background_task_exception_type, 'RuntimeError')
+
+    def test_submit_returns_none_when_the_executor_rejects_the_task(self):
+        executor = Mock()
+        executor.submit.side_effect = RuntimeError('submission-private-error')
+
+        with patch.object(sub_task_module, '_executor', executor):
+            with self.assertLogs('board.sub_task', level='ERROR') as captured:
+                task_id = SubTaskProcessor.submit(lambda: None)
+
+        self.assertIsNone(task_id)
+        output = '\n'.join(captured.output)
+        self.assertIn('stage=submit', output)
+        self.assertNotIn('submission-private-error', output)
 
     def test_shutdown_waits_for_queued_tasks_without_cancelling_them(self):
         executor = self.create_executor()

--- a/backend/src/modules/sub_task.py
+++ b/backend/src/modules/sub_task.py
@@ -13,6 +13,12 @@ _task_ids = count(1)
 class SubTaskProcessor:
     @staticmethod
     def process(func: Callable, *args: Any, **kwargs: Any) -> None:
+        """Schedule a task without changing the legacy fire-and-forget contract."""
+        SubTaskProcessor.submit(func, *args, **kwargs)
+
+    @staticmethod
+    def submit(func: Callable, *args: Any, **kwargs: Any) -> str | None:
+        """Schedule a task and return its safe identifier when accepted."""
         task_id = f'background-task-{next(_task_ids)}'
         task_name, task_module, task_kind = SubTaskProcessor._get_task_metadata(func)
 
@@ -36,6 +42,9 @@ class SubTaskProcessor:
                 task_module=task_module,
                 task_kind=task_kind,
             )
+            return None
+
+        return task_id
 
     @staticmethod
     def _execute(


### PR DESCRIPTION
## 🎯 Goal
- Make Django Admin bulk-notification audits distinguish an accepted background task from a rejected submission or completed processing result.
- Avoid reporting a queued notification job when the in-process executor has rejected it.

## 🔧 Core Changes
- Keep the legacy fire-and-forget task API intact while adding an additive submission receipt for internal callers.
- Link bulk-notification audit records to accepted, completed, and failed creation-processing outcomes.
- Record aggregate counts only and keep notification content, destination URLs, and exception messages out of audit/log output.

## 🤔 Key Decisions
- Preserve SubTaskProcessor.process() signature and None return to retain existing callers.
- Record notification creation processing, not an overclaimed external Telegram delivery guarantee.
- Do not add a job model, migration, public API, or durable queue in this focused compatibility-safe change.

## 🧪 Verification Guide
### How to verify
1. In Django Admin, open Notifications > 전체 활성 사용자에게 알림 발송 and confirm a bulk message.
2. Inspect the Django Admin history entry after the background task processes it.
3. Simulate a rejected task submission or a processing failure.

### Expected result
- A successfully accepted job is shown as queued, then its audit entry records target, created, duplicate, and failed counts.
- A rejected or aborted job is marked as failed without exposing notification content, URLs, or exception text.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)