### PR TITLE
⚡ Optimize Admin list counts

### DIFF
--- a/backend/src/board/admin/auth.py
+++ b/backend/src/board/admin/auth.py
@@ -29,6 +29,7 @@ class SocialAuthProviderCompatibilityAdmin(admin.ModelAdmin):
     """Preserve legacy Admin URLs without exposing provider secrets."""
 
     canonical_settings_url = '/admin-settings/login'
+    show_full_result_count = False
 
     def has_module_permission(self, request):
         return False

--- a/backend/src/board/admin/banner.py
+++ b/backend/src/board/admin/banner.py
@@ -20,6 +20,8 @@ from .service import AdminDisplayService
 class SiteContentActionAdminMixin:
     """Keep site-content state changes timestamped and auditable."""
 
+    show_full_result_count = False
+
     def _set_active_state(
         self,
         request: HttpRequest,

--- a/backend/src/board/admin/mixins.py
+++ b/backend/src/board/admin/mixins.py
@@ -21,6 +21,8 @@ def is_admin_autocomplete_request(request) -> bool:
 class ReadOnlyRecordAdminMixin:
     """Inspect externally owned or system-managed rows without editing them."""
 
+    show_full_result_count = False
+
     def has_add_permission(self, request):
         return False
 

--- a/backend/src/board/admin/series.py
+++ b/backend/src/board/admin/series.py
@@ -52,6 +52,7 @@ class SeriesAdmin(admin.ModelAdmin):
     inlines = [SeriesPostInline]
     autocomplete_fields = ['owner']
     search_fields = ['name', 'owner__username', 'text_md']
+    show_full_result_count = False
 
     # autocomplete 지원
     ordering = ['name']

--- a/backend/src/board/admin/tag.py
+++ b/backend/src/board/admin/tag.py
@@ -25,6 +25,7 @@ from .utilities import TagCleanerService
 class TagAdmin(ConfirmedActionDeleteAdminMixin, admin.ModelAdmin):
     search_fields = ['value']
     actions = ['clear_unused_tags']
+    show_full_result_count = False
 
     list_display = [
         'tag_badge',

--- a/backend/src/board/admin/user.py
+++ b/backend/src/board/admin/user.py
@@ -225,6 +225,8 @@ admin.site.unregister(User)
 class CustomGroupAdmin(BaseGroupAdmin):
     """Keep delegated staff from changing permission bundles."""
 
+    show_full_result_count = False
+
     def formfield_for_manytomany(self, db_field, request=None, **kwargs):
         form_field = super().formfield_for_manytomany(
             db_field,
@@ -247,6 +249,7 @@ class CustomGroupAdmin(BaseGroupAdmin):
 
 @admin.register(User)
 class CustomUserAdmin(ConfirmedActionDeleteAdminMixin, BaseUserAdmin):
+    show_full_result_count = False
     delegated_readonly_fields = (
         'is_staff',
         'is_superuser',
@@ -552,6 +555,7 @@ class UserConfigMetaAdmin(admin.ModelAdmin):
     form = UserConfigMetaForm
 
     autocomplete_fields = ['user']
+    show_full_result_count = False
 
     def get_form(self, request, obj=None, **kwargs):
         if obj:
@@ -580,6 +584,7 @@ class UserLinkMetaAdmin(admin.ModelAdmin):
     list_filter = ['name']
     search_fields = ['user__username', 'name', 'value']
     autocomplete_fields = ['user']
+    show_full_result_count = False
 
     def get_queryset(self, request):
         return super().get_queryset(request).select_related('user').defer(
@@ -599,6 +604,7 @@ class UserLinkMetaAdmin(admin.ModelAdmin):
 @admin.register(Config)
 class ConfigAdmin(admin.ModelAdmin):
     autocomplete_fields = ['user']
+    show_full_result_count = False
 
     fieldsets = (
         ('사용자 정보', {
@@ -694,6 +700,7 @@ class ConfigAdmin(admin.ModelAdmin):
 class ProfileAdmin(admin.ModelAdmin):
     """프로필 관리 페이지"""
     autocomplete_fields = ['user']
+    show_full_result_count = False
 
     list_display = ['id', 'user_link', 'role_badge', 'avatar_preview', 'analytics_status', 'post_count']
     list_display_links = ['id']

--- a/backend/src/board/admin/webhook.py
+++ b/backend/src/board/admin/webhook.py
@@ -61,6 +61,7 @@ class WebhookSubscriptionAdminForm(forms.ModelForm):
 class WebhookSubscriptionAdmin(admin.ModelAdmin):
     form = WebhookSubscriptionAdminForm
     autocomplete_fields = ['author']
+    show_full_result_count = False
     list_display = [
         'name',
         'scope',

--- a/backend/src/board/tests/admin/test_admin_list_performance.py
+++ b/backend/src/board/tests/admin/test_admin_list_performance.py
@@ -7,7 +7,7 @@ from django.contrib.admin.widgets import (
     AutocompleteSelectMultiple,
 )
 from django.contrib.admin.models import CHANGE, LogEntry
-from django.contrib.auth.models import User
+from django.contrib.auth.models import Group, User
 from django.contrib.contenttypes.models import ContentType
 from django.db import connection
 from django.http import QueryDict
@@ -647,7 +647,22 @@ class AdminListPerformanceTestCase(TestCase):
             with self.subTest(model=model):
                 response = self.client.get(reverse(url_name), {'q': 'list'})
                 self.assertEqual(response.status_code, 200)
+                self.assertIsInstance(response.context['cl'].result_count, int)
                 self.assertIsNone(response.context['cl'].full_result_count)
+
+    def test_project_model_admins_disable_redundant_full_result_counts(self):
+        models = [
+            model
+            for model in admin.site._registry
+            if model._meta.app_label == 'board'
+        ]
+        models.extend([User, Group, LogEntry])
+
+        for model in models:
+            with self.subTest(model=model):
+                self.assertFalse(
+                    admin.site._registry[model].show_full_result_count,
+                )
 
     def test_related_changelists_defer_large_relation_fields(self):
         cases = (


### PR DESCRIPTION
## 🎯 Goal
- Remove the redundant unfiltered full-result COUNT query from every project Django Admin list.
- Keep filtered result counts and pagination behavior intact while making large Admin lists cheaper to open.

## 🔧 Core Changes
- Apply the existing no-full-count policy to all project-managed Admin registrations, including users, groups, profile/configuration, content, and integration records.
- Reuse shared Admin mixins where the policy applies and set it explicitly on the remaining list Admins.
- Add a small registry-based unit test so newly registered project Admins cannot accidentally re-enable the redundant count.

## 🤔 Key Decisions
- Preserve the exact filtered result count used by Django pagination; only the auxiliary unfiltered total is skipped.
- Do not introduce an approximate count, custom paginator, model change, migration, or public API change.
- Keep the existing high-growth changelist runtime test and extend it to assert the retained result-count contract.

## 🧪 Verification Guide
### How to verify
1. Open a filtered Django Admin list such as Posts, Comments, Users, Series, or Webhook subscriptions.
2. Confirm matching rows, current result count, page navigation, filters, search, and actions still work.
3. Run the Admin list-performance tests.

### Expected result
- The current filtered result count remains available for pagination.
- Django does not calculate or display the extra unfiltered full-result count for project Admin lists.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)