### PR TITLE
🐛 Preserve Admin action cancel context

### DIFF
--- a/backend/src/board/admin/action_confirmation.py
+++ b/backend/src/board/admin/action_confirmation.py
@@ -31,6 +31,7 @@ def render_action_confirmation(
         'action_checkbox_name': helpers.ACTION_CHECKBOX_NAME,
         'action_name': action_name,
         'select_across': request.POST.get('select_across', '0'),
+        'cancel_url': request.get_full_path(),
         'opts': model_admin.model._meta,
     }
     return TemplateResponse(

--- a/backend/src/board/templates/admin/board/confirm_action.html
+++ b/backend/src/board/templates/admin/board/confirm_action.html
@@ -1,5 +1,10 @@
 {% extends "admin/base_site.html" %}
-{% load i18n admin_urls %}
+{% load i18n admin_urls static %}
+
+{% block extrahead %}
+  {{ block.super }}
+  <script src="{% static 'admin/js/cancel.js' %}" async></script>
+{% endblock %}
 
 {% block breadcrumbs %}
 <div class="breadcrumbs">
@@ -33,7 +38,7 @@
     <input type="hidden" name="confirm" value="yes">
     <div class="submit-row">
       <input type="submit" value="{{ confirm_label }}" class="{{ confirm_button_class }}">
-      <a href="{% url opts|admin_urlname:'changelist' %}" class="button cancel-link">취소</a>
+      <a role="button" href="{{ cancel_url }}" class="button cancel-link">취소</a>
     </div>
   </form>
 </div>

--- a/backend/src/board/tests/admin/test_destructive_action_admin.py
+++ b/backend/src/board/tests/admin/test_destructive_action_admin.py
@@ -7,6 +7,7 @@ from django.contrib.auth.models import User
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.template.response import TemplateResponse
 from django.test import RequestFactory, TestCase
+from django.urls import reverse
 from django.utils import timezone
 
 from board.admin.comment import CommentAdmin
@@ -148,6 +149,32 @@ class DestructiveActionAdminTestCase(TestCase):
                 ),
             ),
         )
+
+    def test_confirmation_cancel_preserves_changelist_context(self):
+        comment = self.create_comment(content='Preserved action context')
+        changelist_url = reverse('admin:board_comment_changelist')
+        context_url = f'{changelist_url}?q=Preserved&edited__exact=0'
+        self.client.force_login(self.admin_user)
+
+        response = self.client.post(
+            context_url,
+            {
+                **self.action_selection(
+                    'soft_delete_comments',
+                    [comment.pk],
+                ),
+                'index': '0',
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['cancel_url'], context_url)
+        self.assertContains(response, 'admin/js/cancel.js')
+        self.assertContains(
+            response,
+            f'href="{context_url}"',
+        )
+        self.assertContains(response, 'class="button cancel-link"')
 
     def test_user_deactivation_confirms_skips_self_and_writes_audit(self):
         selection = self.action_selection(


### PR DESCRIPTION
## 🎯 Goal
- Keep Django Admin operators in their original filtered changelist when they cancel a high-impact action confirmation.
- Avoid losing in-progress selection context after opening a confirmation screen.

## 🔧 Core Changes
- Make the shared confirmation page return to its exact originating Admin URL as a no-JavaScript fallback.
- Reuse Django Admin’s standard cancel script so normal browser cancellation uses history navigation.
- Add an end-to-end Django test of the Admin action dispatch path with a filtered comment list.

## 🤔 Key Decisions
- Preserve the source path and query string rather than reconstructing filter parameters manually.
- Use Django’s built-in cancel behavior instead of a custom browser script.
- Keep selected IDs and action confirmation semantics unchanged; no model, migration, public API, or action contract changes.

## 🧪 Verification Guide
### How to verify
1. Open a filtered Django Admin changelist, select a record, and start a confirmation-required action.
2. Choose 취소.
3. Repeat with JavaScript disabled or opening the confirmation URL directly.

### Expected result
- Normal cancellation returns via browser history to the same list and retains browser selection context.
- The no-JavaScript fallback returns to the same changelist URL with its search, filters, and page query intact.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)