### PR TITLE
🐛 Remove internal upload body size limit

### DIFF
--- a/backend/nginx.conf
+++ b/backend/nginx.conf
@@ -9,6 +9,10 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
+    # Upload size is controlled by the outer reverse proxy in self-hosted deployments.
+    # Do not impose nginx's default request-body limit inside the BLEX container.
+    client_max_body_size 0;
+
     # Logging
     access_log  /dev/stdout;
     error_log   /dev/stderr;


### PR DESCRIPTION
## 🎯 Goal
- Prevent the bundled nginx from unexpectedly rejecting self-hosted post image uploads at its default request-body limit.

## 🔧 Core Changes
- Disable the internal nginx request-body size check with `client_max_body_size 0`.
- Leave upload size policy to the operator-managed outer reverse proxy.

## 🤔 Key Decisions
- The BLEX container cannot know the upload policy of an external reverse proxy.
- The internal nginx is only the container gateway and should not impose a second hidden limit.

## 🧪 Verification Guide
### How to verify
1. Build the Docker image and confirm the bundled nginx configuration passes `nginx -t`.
2. Run BLEX behind the intended outer proxy.
3. Upload a post image larger than 1 MiB through the editor.

### Expected result
- The request is passed through the BLEX container nginx; any size rejection comes from the configured outer proxy.

## ✅ Checklist
- [ ] Lint completed
- [ ] Type-check completed
- [x] Tests completed
- [ ] Documentation updated (not needed for this configuration-only fix)