### PR TITLE
🐛 Harden public output and webhook security boundaries

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -218,6 +218,7 @@ jobs:
           --env-file samples/.env \
           --env DEBUG=FALSE \
           --env SITE_URL=http://127.0.0.1:18080 \
+          --env SECURE_SSL_REDIRECT=FALSE \
           --publish 127.0.0.1:18080:80 \
           blex:ci
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,7 +9,7 @@ COPY ./islands/packages/editor/package.json /app/islands/packages/editor/package
 
 WORKDIR /app/islands
 
-ARG PNPM_VERSION=11.12.0
+ARG PNPM_VERSION=11.17.0
 RUN npm i -g pnpm@${PNPM_VERSION}
 RUN pnpm i --frozen-lockfile
 

--- a/backend/islands/apps/remotes/package.json
+++ b/backend/islands/apps/remotes/package.json
@@ -55,7 +55,7 @@
         "eslint": "^9.39.5",
         "eslint-plugin-react-compiler": "19.1.0-rc.2",
         "glob": "^13.0.6",
-        "postcss": "^8.5.16",
+        "postcss": "^8.5.24",
         "react-grab": "^0.1.48",
         "rollup-plugin-visualizer": "^7.0.1",
         "sass": "^1.101.0",

--- a/backend/islands/package.json
+++ b/backend/islands/package.json
@@ -23,5 +23,5 @@
     "engines": {
         "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
     },
-    "packageManager": "pnpm@11.12.0"
+    "packageManager": "pnpm@11.17.0"
 }

--- a/backend/islands/pnpm-lock.yaml
+++ b/backend/islands/pnpm-lock.yaml
@@ -6,12 +6,13 @@ settings:
 
 overrides:
   '@babel/core': 7.29.6
-  dompurify: 3.4.11
+  dompurify: 3.4.12
   esbuild: 0.28.1
   form-data: 4.0.6
-  js-yaml: 4.2.0
+  js-yaml: 4.3.0
   linkify-it: 5.0.1
   markdown-it: 14.2.0
+  minimatch: 10.2.5
 
 importers:
 
@@ -19,19 +20,19 @@ importers:
     devDependencies:
       '@baejino/eslint-config':
         specifier: ^0.1.1
-        version: 0.1.1(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
+        version: 0.1.1(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
       '@baejino/eslint-config-react':
         specifier: ^0.1.1
-        version: 0.1.1(eslint@9.39.5(jiti@2.7.0))
+        version: 0.1.1(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))
       eslint:
         specifier: ^9.39.5
-        version: 9.39.5(jiti@2.7.0)
+        version: 9.39.5(jiti@2.7.0)(supports-color@7.2.0)
       glob:
         specifier: ^13.0.6
         version: 13.0.6
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.16)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.24)(supports-color@7.2.0)(typescript@5.9.3)(yaml@2.9.0)
       turbo:
         specifier: ^2.10.4
         version: 2.10.4
@@ -91,7 +92,7 @@ importers:
         version: 3.15.12
       axios:
         specifier: ^1.18.1
-        version: 1.18.1
+        version: 1.18.1(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
       driver.js:
         specifier: ^1.6.0
         version: 1.6.0
@@ -112,17 +113,17 @@ importers:
         version: 7.81.0(react@19.2.7)
       styled-jsx:
         specifier: ^5.1.7
-        version: 5.1.7(@babel/core@7.29.6)(react@19.2.7)
+        version: 5.1.7(@babel/core@7.29.6(supports-color@7.2.0))(react@19.2.7)
       zod:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
       '@baejino/eslint-config':
         specifier: ^0.1.1
-        version: 0.1.1(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
+        version: 0.1.1(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
       '@baejino/eslint-config-react':
         specifier: ^0.1.1
-        version: 0.1.1(eslint@9.39.5(jiti@2.7.0))
+        version: 0.1.1(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))
       '@playwright/test':
         specifier: ^1.61.1
         version: 1.61.1
@@ -146,7 +147,7 @@ importers:
         version: 6.0.3(babel-plugin-react-compiler@1.0.0)(vite@8.1.4(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(yaml@2.9.0))
       autoprefixer:
         specifier: ^10.5.2
-        version: 10.5.2(postcss@8.5.16)
+        version: 10.5.2(postcss@8.5.24)
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
@@ -155,16 +156,16 @@ importers:
         version: 5.0.0
       eslint:
         specifier: ^9.39.5
-        version: 9.39.5(jiti@2.7.0)
+        version: 9.39.5(jiti@2.7.0)(supports-color@7.2.0)
       eslint-plugin-react-compiler:
         specifier: 19.1.0-rc.2
-        version: 19.1.0-rc.2(eslint@9.39.5(jiti@2.7.0))
+        version: 19.1.0-rc.2(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)
       glob:
         specifier: ^13.0.6
         version: 13.0.6
       postcss:
-        specifier: ^8.5.16
-        version: 8.5.16
+        specifier: ^8.5.24
+        version: 8.5.24
       react-grab:
         specifier: ^0.1.48
         version: 0.1.48(react@19.2.7)
@@ -2139,9 +2140,6 @@ packages:
   babel-plugin-react-compiler@1.0.0:
     resolution: {integrity: sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -2156,12 +2154,9 @@ packages:
     peerDependencies:
       react: '>=17.0.1'
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
-
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   browserslist@4.28.5:
     resolution: {integrity: sha512-Cu2E6QejHWzuDMTkuwgpABFgDfZrXLQq5V13YOACZx4mFAG4IwGTbTfHPMr4WtxlHoXSM8FIuRwYYCz5XiabaQ==}
@@ -2250,9 +2245,6 @@ packages:
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
@@ -2343,8 +2335,8 @@ packages:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
 
-  dompurify@3.4.11:
-    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
+  dompurify@3.4.12:
+    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
 
   driver.js@1.6.0:
     resolution: {integrity: sha512-gryo9QS7AZhz8J0bmdf42dwaTzcd1BgSJLnaSM7cPJbu8bTW8wIEuiGDy4MoCvB4Sr8wA9g5o2G9EFNVYZGeVQ==}
@@ -2834,8 +2826,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -3021,9 +3013,6 @@ packages:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
 
-  minimatch@3.1.5:
-    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
-
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -3040,8 +3029,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.15:
-    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3195,8 +3184,12 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.16:
-    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.24:
+    resolution: {integrity: sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==}
     engines: {node: ^10 || ^12 || >=14}
 
   powershell-utils@0.1.0:
@@ -3838,20 +3831,20 @@ snapshots:
 
   '@babel/compat-data@7.29.7': {}
 
-  '@babel/core@7.29.6':
+  '@babel/core@7.29.6(supports-color@7.2.0)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
       '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.6)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.6(supports-color@7.2.0))(supports-color@7.2.0)
       '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@7.2.0)
       '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -3878,41 +3871,41 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.6)':
+  '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.6(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@7.2.0)
       '@babel/helper-annotate-as-pure': 7.29.7
-      '@babel/helper-member-expression-to-functions': 7.29.7
+      '@babel/helper-member-expression-to-functions': 7.29.7(supports-color@7.2.0)
       '@babel/helper-optimise-call-expression': 7.29.7
-      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.6)
-      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.6(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7(supports-color@7.2.0)
+      '@babel/traverse': 7.29.7(supports-color@7.2.0)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-globals@7.29.7': {}
 
-  '@babel/helper-member-expression-to-functions@7.29.7':
+  '@babel/helper-member-expression-to-functions@7.29.7(supports-color@7.2.0)':
     dependencies:
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@7.2.0)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-imports@7.29.7':
+  '@babel/helper-module-imports@7.29.7(supports-color@7.2.0)':
     dependencies:
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@7.2.0)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.6)':
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.6(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
-      '@babel/core': 7.29.6
-      '@babel/helper-module-imports': 7.29.7
+      '@babel/core': 7.29.6(supports-color@7.2.0)
+      '@babel/helper-module-imports': 7.29.7(supports-color@7.2.0)
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -3922,18 +3915,18 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.29.7': {}
 
-  '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.6)':
+  '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.6(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
-      '@babel/core': 7.29.6
-      '@babel/helper-member-expression-to-functions': 7.29.7
+      '@babel/core': 7.29.6(supports-color@7.2.0)
+      '@babel/helper-member-expression-to-functions': 7.29.7(supports-color@7.2.0)
       '@babel/helper-optimise-call-expression': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-skip-transparent-expression-wrappers@7.29.7':
+  '@babel/helper-skip-transparent-expression-wrappers@7.29.7(supports-color@7.2.0)':
     dependencies:
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@7.2.0)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -3953,10 +3946,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
-  '@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.29.6)':
+  '@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.29.6(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
-      '@babel/core': 7.29.6
-      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.6)
+      '@babel/core': 7.29.6(supports-color@7.2.0)
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.6(supports-color@7.2.0))(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -3967,7 +3960,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
 
-  '@babel/traverse@7.29.7':
+  '@babel/traverse@7.29.7(supports-color@7.2.0)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
@@ -3975,7 +3968,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -3984,18 +3977,18 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
-  '@baejino/eslint-config-react@0.1.1(eslint@9.39.5(jiti@2.7.0))':
+  '@baejino/eslint-config-react@0.1.1(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))':
     dependencies:
-      eslint: 9.39.5(jiti@2.7.0)
-      eslint-plugin-react: 7.37.5(eslint@9.39.5(jiti@2.7.0))
-      eslint-plugin-react-hooks: 5.2.0(eslint@9.39.5(jiti@2.7.0))
-      eslint-plugin-react-refresh: 0.4.26(eslint@9.39.5(jiti@2.7.0))
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@7.2.0)
+      eslint-plugin-react: 7.37.5(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))
+      eslint-plugin-react-hooks: 5.2.0(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))
+      eslint-plugin-react-refresh: 0.4.26(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))
 
-  '@baejino/eslint-config@0.1.1(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)':
+  '@baejino/eslint-config@0.1.1(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
     dependencies:
       '@eslint/js': 9.39.5
-      eslint: 9.39.5(jiti@2.7.0)
-      typescript-eslint: 8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@7.2.0)
+      typescript-eslint: 8.63.0(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -4132,18 +4125,18 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.5(jiti@2.7.0))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))':
     dependencies:
-      eslint: 9.39.5(jiti@2.7.0)
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@7.2.0)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.21.2':
+  '@eslint/config-array@0.21.2(supports-color@7.2.0)':
     dependencies:
       '@eslint/object-schema': 2.1.7
-      debug: 4.4.3
-      minimatch: 3.1.5
+      debug: 4.4.3(supports-color@7.2.0)
+      minimatch: 10.2.5
     transitivePeerDependencies:
       - supports-color
 
@@ -4155,16 +4148,16 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/eslintrc@3.3.6':
+  '@eslint/eslintrc@3.3.6(supports-color@7.2.0)':
     dependencies:
       ajv: 6.15.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.2.0
-      minimatch: 3.1.5
+      js-yaml: 4.3.0
+      minimatch: 10.2.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
@@ -4928,7 +4921,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.2
       '@tailwindcss/oxide': 4.3.2
-      postcss: 8.5.16
+      postcss: 8.5.23
       tailwindcss: 4.3.2
 
   '@tailwindcss/vite@4.3.2(vite@8.1.4(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(yaml@2.9.0))':
@@ -5238,15 +5231,15 @@ snapshots:
 
   '@types/use-sync-external-store@0.0.6': {}
 
-  '@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.63.0(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.63.0
-      '@typescript-eslint/type-utils': 8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.63.0(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.63.0(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.63.0
-      eslint: 9.39.5(jiti@2.7.0)
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@7.2.0)
       ignore: 7.0.6
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -5254,23 +5247,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.63.0
       '@typescript-eslint/types': 8.63.0
-      '@typescript-eslint/typescript-estree': 8.63.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.63.0(supports-color@7.2.0)(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.63.0
-      debug: 4.4.3
-      eslint: 9.39.5(jiti@2.7.0)
+      debug: 4.4.3(supports-color@7.2.0)
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@7.2.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.63.0(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.63.0(supports-color@7.2.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.63.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.63.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -5284,13 +5277,13 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.63.0(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.63.0
-      '@typescript-eslint/typescript-estree': 8.63.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
-      debug: 4.4.3
-      eslint: 9.39.5(jiti@2.7.0)
+      '@typescript-eslint/typescript-estree': 8.63.0(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.63.0(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      debug: 4.4.3(supports-color@7.2.0)
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@7.2.0)
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -5298,13 +5291,13 @@ snapshots:
 
   '@typescript-eslint/types@8.63.0': {}
 
-  '@typescript-eslint/typescript-estree@8.63.0(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.63.0(supports-color@7.2.0)(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.63.0(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.63.0(supports-color@7.2.0)(typescript@5.9.3)
       '@typescript-eslint/tsconfig-utils': 8.63.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.63.0
       '@typescript-eslint/visitor-keys': 8.63.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       minimatch: 10.2.5
       semver: 7.8.5
       tinyglobby: 0.2.17
@@ -5313,13 +5306,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.63.0(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.5(jiti@2.7.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))
       '@typescript-eslint/scope-manager': 8.63.0
       '@typescript-eslint/types': 8.63.0
-      '@typescript-eslint/typescript-estree': 8.63.0(typescript@5.9.3)
-      eslint: 9.39.5(jiti@2.7.0)
+      '@typescript-eslint/typescript-estree': 8.63.0(supports-color@7.2.0)(typescript@5.9.3)
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@7.2.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -5348,9 +5341,9 @@ snapshots:
 
   acorn@8.17.0: {}
 
-  agent-base@6.0.2:
+  agent-base@6.0.2(supports-color@7.2.0):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -5451,24 +5444,24 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  autoprefixer@10.5.2(postcss@8.5.16):
+  autoprefixer@10.5.2(postcss@8.5.24):
     dependencies:
       browserslist: 4.28.5
       caniuse-lite: 1.0.30001803
       fraction.js: 5.3.4
       picocolors: 1.1.1
-      postcss: 8.5.16
+      postcss: 8.5.24
       postcss-value-parser: 4.2.0
 
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  axios@1.18.1:
+  axios@1.18.1(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0):
     dependencies:
-      follow-redirects: 1.16.0
+      follow-redirects: 1.16.0(debug@4.4.3(supports-color@7.2.0))
       form-data: 4.0.6
-      https-proxy-agent: 5.0.1
+      https-proxy-agent: 5.0.1(supports-color@7.2.0)
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
@@ -5478,8 +5471,6 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
-  balanced-match@1.0.2: {}
-
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.10.42: {}
@@ -5488,12 +5479,7 @@ snapshots:
     dependencies:
       react: 19.2.7
 
-  brace-expansion@1.1.16:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -5580,8 +5566,6 @@ snapshots:
 
   commander@4.1.1: {}
 
-  concat-map@0.0.1: {}
-
   confbox@0.1.8: {}
 
   consola@3.4.2: {}
@@ -5618,9 +5602,11 @@ snapshots:
 
   date-fns@4.4.0: {}
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@7.2.0):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 7.2.0
 
   deep-is@0.1.4: {}
 
@@ -5661,7 +5647,7 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
-  dompurify@3.4.11:
+  dompurify@3.4.12:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -5826,27 +5812,27 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-plugin-react-compiler@19.1.0-rc.2(eslint@9.39.5(jiti@2.7.0)):
+  eslint-plugin-react-compiler@19.1.0-rc.2(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0):
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@7.2.0)
       '@babel/parser': 7.29.7
-      '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.29.6)
-      eslint: 9.39.5(jiti@2.7.0)
+      '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.29.6(supports-color@7.2.0))(supports-color@7.2.0)
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@7.2.0)
       hermes-parser: 0.25.1
       zod: 3.25.76
       zod-validation-error: 3.5.4(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-hooks@5.2.0(eslint@9.39.5(jiti@2.7.0)):
+  eslint-plugin-react-hooks@5.2.0(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0)):
     dependencies:
-      eslint: 9.39.5(jiti@2.7.0)
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@7.2.0)
 
-  eslint-plugin-react-refresh@0.4.26(eslint@9.39.5(jiti@2.7.0)):
+  eslint-plugin-react-refresh@0.4.26(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0)):
     dependencies:
-      eslint: 9.39.5(jiti@2.7.0)
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@7.2.0)
 
-  eslint-plugin-react@7.37.5(eslint@9.39.5(jiti@2.7.0)):
+  eslint-plugin-react@7.37.5(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0)):
     dependencies:
       array-includes: 3.1.9
       array.prototype.findlast: 1.2.5
@@ -5854,11 +5840,11 @@ snapshots:
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
       es-iterator-helpers: 1.4.0
-      eslint: 9.39.5(jiti@2.7.0)
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@7.2.0)
       estraverse: 5.3.0
       hasown: 2.0.4
       jsx-ast-utils: 3.3.5
-      minimatch: 3.1.5
+      minimatch: 10.2.5
       object.entries: 1.1.9
       object.fromentries: 2.0.8
       object.values: 1.2.1
@@ -5879,14 +5865,14 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@9.39.5(jiti@2.7.0):
+  eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.5(jiti@2.7.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.21.2
+      '@eslint/config-array': 0.21.2(supports-color@7.2.0)
       '@eslint/config-helpers': 0.4.2
       '@eslint/core': 0.17.0
-      '@eslint/eslintrc': 3.3.6
+      '@eslint/eslintrc': 3.3.6(supports-color@7.2.0)
       '@eslint/js': 9.39.5
       '@eslint/plugin-kit': 0.4.1
       '@humanfs/node': 0.16.8
@@ -5896,7 +5882,7 @@ snapshots:
       ajv: 6.15.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -5912,7 +5898,7 @@ snapshots:
       is-glob: 4.0.3
       json-stable-stringify-without-jsonify: 1.0.1
       lodash.merge: 4.6.2
-      minimatch: 3.1.5
+      minimatch: 10.2.5
       natural-compare: 1.4.0
       optionator: 0.9.4
     optionalDependencies:
@@ -5972,7 +5958,9 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  follow-redirects@1.16.0: {}
+  follow-redirects@1.16.0(debug@4.4.3(supports-color@7.2.0)):
+    optionalDependencies:
+      debug: 4.4.3(supports-color@7.2.0)
 
   for-each@0.3.5:
     dependencies:
@@ -6097,10 +6085,10 @@ snapshots:
 
   highlight.js@11.11.1: {}
 
-  https-proxy-agent@5.0.1:
+  https-proxy-agent@5.0.1(supports-color@7.2.0):
     dependencies:
-      agent-base: 6.0.2
-      debug: 4.4.3
+      agent-base: 6.0.2(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -6270,7 +6258,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.2.0:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -6410,11 +6398,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
-
-  minimatch@3.1.5:
-    dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 5.0.8
 
   minipass@7.1.3: {}
 
@@ -6427,7 +6411,7 @@ snapshots:
 
   monaco-editor@0.55.1:
     dependencies:
-      dompurify: 3.4.11
+      dompurify: 3.4.12
       marked: 14.0.0
 
   ms@2.1.3: {}
@@ -6438,7 +6422,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.15: {}
+  nanoid@3.3.16: {}
 
   natural-compare@1.4.0: {}
 
@@ -6582,19 +6566,25 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.16)(yaml@2.9.0):
+  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.24)(yaml@2.9.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.7.0
-      postcss: 8.5.16
+      postcss: 8.5.24
       yaml: 2.9.0
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.16:
+  postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.15
+      nanoid: 3.3.16
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.24:
+    dependencies:
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -7039,12 +7029,12 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  styled-jsx@5.1.7(@babel/core@7.29.6)(react@19.2.7):
+  styled-jsx@5.1.7(@babel/core@7.29.6(supports-color@7.2.0))(react@19.2.7):
     dependencies:
       client-only: 0.0.1
       react: 19.2.7
     optionalDependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@7.2.0)
 
   sucrase@3.35.1:
     dependencies:
@@ -7097,18 +7087,18 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(jiti@2.7.0)(postcss@8.5.16)(typescript@5.9.3)(yaml@2.9.0):
+  tsup@8.5.1(jiti@2.7.0)(postcss@8.5.24)(supports-color@7.2.0)(typescript@5.9.3)(yaml@2.9.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.28.1)
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       esbuild: 0.28.1
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.16)(yaml@2.9.0)
+      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.24)(yaml@2.9.0)
       resolve-from: 5.0.0
       rollup: 4.62.2
       source-map: 0.7.6
@@ -7117,7 +7107,7 @@ snapshots:
       tinyglobby: 0.2.17
       tree-kill: 1.2.2
     optionalDependencies:
-      postcss: 8.5.16
+      postcss: 8.5.24
       typescript: 5.9.3
     transitivePeerDependencies:
       - jiti
@@ -7171,13 +7161,13 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typescript-eslint@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3):
+  typescript-eslint@8.63.0(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.63.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.63.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
-      eslint: 9.39.5(jiti@2.7.0)
+      '@typescript-eslint/eslint-plugin': 8.63.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.63.0(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.63.0(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.63.0(eslint@9.39.5(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@7.2.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -7226,7 +7216,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
-      postcss: 8.5.16
+      postcss: 8.5.23
       rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/backend/islands/pnpm-workspace.yaml
+++ b/backend/islands/pnpm-workspace.yaml
@@ -6,11 +6,15 @@ allowBuilds:
   '@parcel/watcher': true
   esbuild: true
 
+minimumReleaseAgeExclude:
+  - postcss@8.5.24
+
 overrides:
   '@babel/core': 7.29.6
-  dompurify: 3.4.11
+  dompurify: 3.4.12
   esbuild: 0.28.1
   form-data: 4.0.6
-  js-yaml: 4.2.0
+  js-yaml: 4.3.0
   linkify-it: 5.0.1
   markdown-it: 14.2.0
+  minimatch: 10.2.5

--- a/backend/src/board/admin/webhook.py
+++ b/backend/src/board/admin/webhook.py
@@ -10,6 +10,7 @@ from board.models import WebhookSubscription
 from board.services.webhook_subscription_state_service import (
     WebhookSubscriptionStateService,
 )
+from board.services.webhook_url_service import WebhookUrlService
 
 from .action_confirmation import render_action_confirmation
 from .mixins import is_admin_changelist_request
@@ -49,6 +50,8 @@ class WebhookSubscriptionAdminForm(forms.ModelForm):
     def clean_webhook_url(self) -> str:
         webhook_url = self.cleaned_data.get('webhook_url', '').strip()
         if webhook_url:
+            if not WebhookUrlService.is_safe_url(webhook_url):
+                raise forms.ValidationError('내부 네트워크를 가리키는 웹훅 URL은 사용할 수 없습니다.')
             return webhook_url
         if self.instance.pk is not None:
             return WebhookSubscription.objects.only('webhook_url').get(

--- a/backend/src/board/feeds.py
+++ b/backend/src/board/feeds.py
@@ -6,6 +6,7 @@ from django.contrib.auth.models import User
 from django.urls import reverse
 
 from board.models import Post
+from board.html_utils import sanitize_content_html
 from board.services.agent_content_service import AgentContentService
 from board.modules.time import convert_to_localtime
 from board.services.brand_asset_service import BrandAssetService
@@ -54,7 +55,11 @@ class SitePostsFeed(Feed):
         return item.title
 
     def item_description(self, item):
-        return re.sub(r'[\x00-\x08\x0B-\x0C\x0E-\x1F]', '', item.content.content_html)
+        return re.sub(
+            r'[\x00-\x08\x0B-\x0C\x0E-\x1F]',
+            '',
+            sanitize_content_html(item.content.content_html),
+        )
 
     def item_link(self, item):
         return item.get_absolute_url()
@@ -94,7 +99,11 @@ class UserPostsFeed(Feed):
         return item.title
 
     def item_description(self, item):
-        return re.sub(r'[\x00-\x08\x0B-\x0C\x0E-\x1F]', '', item.content.content_html)
+        return re.sub(
+            r'[\x00-\x08\x0B-\x0C\x0E-\x1F]',
+            '',
+            sanitize_content_html(item.content.content_html),
+        )
 
     def item_link(self, item):
         return item.get_absolute_url()

--- a/backend/src/board/html_utils.py
+++ b/backend/src/board/html_utils.py
@@ -1,7 +1,10 @@
 """
 Utility functions for the board app
 """
+from html import unescape
 import re
+from urllib.parse import urlsplit
+
 from bs4 import BeautifulSoup
 
 
@@ -38,64 +41,310 @@ class HtmlSanitizer:
         'pre': ['class'],
     }
 
-    DANGEROUS_CSS_PATTERNS = ['expression', 'import', 'behavior', '@import']
+    # HTML emitted by the Tiptap editor and the Markdown renderer.  This is
+    # deliberately separate from ALLOWED_TAGS because site banners have a
+    # smaller, legacy allowlist and are managed by staff.
+    CONTENT_ALLOWED_TAGS = [
+        'a', 'blockquote', 'br', 'code', 'del', 'div', 'em', 'figcaption',
+        'figure', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'hr', 'i', 'iframe',
+        'img', 'li', 'mark', 'ol', 'p', 'pre', 's', 'small', 'source',
+        'span', 'strong', 'sub', 'sup', 'table', 'tbody', 'td', 'tfoot',
+        'th', 'thead', 'tr', 'u', 'ul', 'video',
+    ]
+
+    CONTENT_ALLOWED_ATTRIBUTES = {
+        'a': ['class', 'href', 'rel', 'target', 'title'],
+        'blockquote': ['class'],
+        'code': ['class'],
+        'div': ['class', 'id', 'style'],
+        'figcaption': ['class', 'style'],
+        'figure': ['class', 'style'],
+        'h1': ['class', 'id'],
+        'h2': ['class', 'id'],
+        'h3': ['class', 'id'],
+        'h4': ['class', 'id'],
+        'h5': ['class', 'id'],
+        'h6': ['class', 'id'],
+        'iframe': [
+            'allow', 'allowfullscreen', 'class', 'frameborder', 'height',
+            'loading', 'src', 'style', 'title', 'width',
+        ],
+        'img': [
+            'alt', 'class', 'data-aspect-ratio', 'data-src', 'height',
+            'loading', 'src', 'srcset', 'style', 'title', 'width',
+        ],
+        'li': ['class'],
+        'ol': ['class', 'start'],
+        'p': ['class', 'id', 'style'],
+        'pre': ['class'],
+        'source': ['data-src', 'src', 'type'],
+        'span': ['class', 'id', 'style'],
+        'table': ['class'],
+        'tbody': ['class'],
+        'td': ['class', 'colspan', 'rowspan'],
+        'tfoot': ['class'],
+        'th': ['class', 'colspan', 'rowspan', 'scope'],
+        'thead': ['class'],
+        'tr': ['class'],
+        'ul': ['class'],
+        'video': [
+            'autoplay', 'class', 'controls', 'data-aspect-ratio', 'height',
+            'loop', 'muted', 'playsinline', 'poster', 'preload', 'src',
+            'style', 'width',
+        ],
+    }
+
+    DANGEROUS_TAGS = {
+        'applet', 'base', 'embed', 'form', 'meta', 'noscript', 'object',
+        'script', 'style', 'template',
+    }
+    URL_ATTRIBUTES = {'data-src', 'href', 'poster', 'src'}
+    SAFE_URL_SCHEMES = {'http', 'https', 'mailto'}
+    SAFE_MEDIA_URL_SCHEMES = {'http', 'https'}
+    SAFE_CSS_PROPERTIES = {
+        'align-items', 'aspect-ratio', 'background-color', 'border',
+        'border-radius', 'box-shadow', 'color', 'display', 'flex-direction',
+        'gap', 'grid-template-columns', 'height', 'justify-content',
+        'margin', 'margin-left', 'margin-right', 'max-height', 'max-width',
+        'min-width', 'object-fit', 'overflow', 'padding', 'text-align',
+        'text-decoration', 'width',
+    }
+    DANGEROUS_CSS_PATTERNS = (
+        'expression', 'javascript', 'vbscript', 'url(', '@import',
+        'behavior', '-moz-binding',
+    )
 
     @classmethod
     def sanitize(cls, html_content: str) -> str:
+        return cls._sanitize(
+            html_content,
+            allowed_tags=cls.ALLOWED_TAGS,
+            allowed_attributes=cls.ALLOWED_ATTRIBUTES,
+            allow_data_attributes=False,
+        )
+
+    @classmethod
+    def sanitize_content(cls, html_content: str) -> str:
+        """Sanitize post/comment HTML while preserving editor markup."""
+        return cls._sanitize(
+            html_content,
+            allowed_tags=cls.CONTENT_ALLOWED_TAGS,
+            allowed_attributes=cls.CONTENT_ALLOWED_ATTRIBUTES,
+            allow_data_attributes=True,
+        )
+
+    @classmethod
+    def _sanitize(
+        cls,
+        html_content: str,
+        *,
+        allowed_tags: list[str],
+        allowed_attributes: dict[str, list[str]],
+        allow_data_attributes: bool,
+    ) -> str:
         if not html_content:
             return ''
 
         soup = BeautifulSoup(html_content, 'lxml')
         cls.remove_dangerous_tags(soup)
 
-        for tag in soup.find_all(True):
-            cls.sanitize_tag(tag)
+        for tag in list(soup.find_all(True)):
+            if tag.name:
+                cls.sanitize_tag(
+                    tag,
+                    allowed_tags=allowed_tags,
+                    allowed_attributes=allowed_attributes,
+                    allow_data_attributes=allow_data_attributes,
+                )
 
         return cls.extract_body_content(soup)
 
     @classmethod
     def remove_dangerous_tags(cls, soup):
-        for tag_name in ['script', 'style']:
+        for tag_name in cls.DANGEROUS_TAGS:
             for tag in soup.find_all(tag_name):
                 tag.decompose()
 
     @classmethod
-    def sanitize_tag(cls, tag):
-        if tag.name not in cls.ALLOWED_TAGS:
-            tag.unwrap()
+    def sanitize_tag(
+        cls,
+        tag,
+        *,
+        allowed_tags=None,
+        allowed_attributes=None,
+        allow_data_attributes=False,
+    ):
+        allowed_tags = allowed_tags or cls.ALLOWED_TAGS
+        allowed_attributes = allowed_attributes or cls.ALLOWED_ATTRIBUTES
+
+        if tag.name not in allowed_tags:
+            if tag.name in cls.DANGEROUS_TAGS:
+                tag.decompose()
+            else:
+                tag.unwrap()
             return
 
-        allowed_attrs = cls.ALLOWED_ATTRIBUTES.get(tag.name, [])
-        for attr in cls.get_attrs_to_remove(tag, allowed_attrs):
-            del tag.attrs[attr]
+        allowed_attrs = set(allowed_attributes.get(tag.name, []))
+        for attr in list(tag.attrs):
+            attr_name = attr.lower()
+            if cls.is_event_handler(attr_name):
+                del tag.attrs[attr]
+                continue
+
+            is_data_attribute = allow_data_attributes and attr_name.startswith('data-')
+            if attr_name not in allowed_attrs and not is_data_attribute:
+                del tag.attrs[attr]
+                continue
+
+            if attr_name in cls.URL_ATTRIBUTES:
+                allowed_schemes = (
+                    cls.SAFE_URL_SCHEMES
+                    if attr_name == 'href'
+                    else cls.SAFE_MEDIA_URL_SCHEMES
+                )
+                if not cls.is_safe_url(
+                    tag.attrs[attr],
+                    allowed_schemes=allowed_schemes,
+                    allow_relative=True,
+                ):
+                    del tag.attrs[attr]
+                continue
+
+            if attr_name == 'srcset':
+                sanitized_srcset = cls.sanitize_srcset(tag.attrs[attr])
+                if sanitized_srcset:
+                    tag.attrs[attr] = sanitized_srcset
+                else:
+                    del tag.attrs[attr]
+                continue
+
+            if attr_name == 'style':
+                sanitized_style = cls.sanitize_css(tag.attrs[attr])
+                if sanitized_style:
+                    tag.attrs[attr] = sanitized_style
+                else:
+                    del tag.attrs[attr]
+
+        if tag.name == 'a' and tag.get('target') == '_blank':
+            rel = tag.get('rel', [])
+            if isinstance(rel, str):
+                rel = rel.split()
+            tag['rel'] = sorted(set(rel) | {'noopener', 'noreferrer'})
 
     @classmethod
     def get_attrs_to_remove(cls, tag, allowed_attrs: list) -> list:
-        attrs_to_remove = []
-        for attr in tag.attrs:
-            if cls.is_event_handler(attr):
-                attrs_to_remove.append(attr)
-            elif attr not in allowed_attrs:
-                attrs_to_remove.append(attr)
-            elif attr in ['href', 'src'] and cls.is_javascript_url(tag.attrs[attr]):
-                attrs_to_remove.append(attr)
-            elif attr == 'style' and cls.has_dangerous_css(tag.attrs[attr]):
-                attrs_to_remove.append(attr)
-        return attrs_to_remove
+        """Return unsafe attributes for callers using the legacy API."""
+        return [
+            attr for attr in tag.attrs
+            if cls.is_event_handler(attr)
+            or attr not in allowed_attrs
+            or (
+                attr in cls.URL_ATTRIBUTES
+                and not cls.is_safe_url(
+                    tag.attrs[attr],
+                    allowed_schemes=cls.SAFE_URL_SCHEMES,
+                    allow_relative=True,
+                )
+            )
+            or (
+                attr == 'style'
+                and not cls.sanitize_css(tag.attrs[attr])
+            )
+        ]
 
     @staticmethod
     def is_event_handler(attr: str) -> bool:
-        return attr.startswith('on')
+        return attr.lower().startswith('on')
 
     @staticmethod
     def is_javascript_url(url) -> bool:
-        return isinstance(url, str) and url.strip().lower().startswith('javascript:')
+        if not isinstance(url, str):
+            return False
+        normalized = re.sub(r'[\x00-\x20]+', '', unescape(url)).lower()
+        return normalized.startswith(('javascript:', 'vbscript:', 'data:'))
+
+    @classmethod
+    def is_safe_url(
+        cls,
+        url,
+        *,
+        allowed_schemes=None,
+        allow_relative=True,
+    ) -> bool:
+        if not isinstance(url, str):
+            return False
+
+        value = unescape(url).strip()
+        if any(char in value for char in '\x00\r\n\t'):
+            return False
+
+        normalized = re.sub(r'[\x00-\x20]+', '', value).lower()
+        if normalized.startswith(('javascript:', 'vbscript:', 'data:')):
+            return False
+
+        try:
+            parsed = urlsplit(value)
+        except ValueError:
+            return False
+
+        scheme = parsed.scheme.lower()
+        allowed_schemes = allowed_schemes or cls.SAFE_URL_SCHEMES
+        if scheme:
+            if scheme not in allowed_schemes or not parsed.netloc and scheme in {'http', 'https'}:
+                return False
+        elif parsed.netloc or not allow_relative:
+            # Protocol-relative URLs are intentionally rejected because their
+            # effective scheme depends on the embedding page.
+            return False
+
+        return True
+
+    @classmethod
+    def sanitize_srcset(cls, srcset) -> str:
+        if not isinstance(srcset, str):
+            return ''
+
+        candidates = []
+        for candidate in srcset.split(','):
+            parts = candidate.strip().split()
+            if not parts:
+                continue
+            if cls.is_safe_url(
+                parts[0],
+                allowed_schemes=cls.SAFE_MEDIA_URL_SCHEMES,
+                allow_relative=True,
+            ):
+                candidates.append(' '.join(parts[:2]))
+        return ', '.join(candidates)
+
+    @classmethod
+    def sanitize_css(cls, style_value) -> str:
+        if not isinstance(style_value, str):
+            return ''
+
+        safe_declarations = []
+        for declaration in style_value.split(';'):
+            if ':' not in declaration:
+                continue
+            property_name, value = declaration.split(':', 1)
+            property_name = property_name.strip().lower()
+            value = value.strip()
+            normalized_value = value.lower()
+
+            if property_name not in cls.SAFE_CSS_PROPERTIES:
+                continue
+            if any(pattern in normalized_value for pattern in cls.DANGEROUS_CSS_PATTERNS):
+                continue
+            if any(char in value for char in '<>\x00\r\n'):
+                continue
+
+            safe_declarations.append(f'{property_name}: {value}')
+
+        return '; '.join(safe_declarations)
 
     @classmethod
     def has_dangerous_css(cls, style_value) -> bool:
-        if not isinstance(style_value, str):
-            return False
-        return any(pattern in style_value.lower() for pattern in cls.DANGEROUS_CSS_PATTERNS)
+        return bool(style_value) and not cls.sanitize_css(style_value)
 
     @staticmethod
     def extract_body_content(soup) -> str:
@@ -108,6 +357,41 @@ class HtmlSanitizer:
 def sanitize_html(html_content: str) -> str:
     """Backward compatible function for HTML sanitization."""
     return HtmlSanitizer.sanitize(html_content)
+
+
+def safe_external_url(url: str) -> str:
+    """Return an absolute HTTP(S) URL or an empty string for unsafe input."""
+    if not isinstance(url, str):
+        return ''
+
+    value = unescape(url).strip()
+    if not HtmlSanitizer.is_safe_url(
+        value,
+        allowed_schemes={'http', 'https'},
+        allow_relative=False,
+    ):
+        return ''
+    return value
+
+
+def safe_navigation_url(url: str) -> str:
+    """Return a safe relative or HTTP(S) navigation URL."""
+    if not isinstance(url, str):
+        return ''
+
+    value = unescape(url).strip()
+    if not HtmlSanitizer.is_safe_url(
+        value,
+        allowed_schemes={'http', 'https', 'mailto'},
+        allow_relative=True,
+    ):
+        return ''
+    return value
+
+
+def sanitize_content_html(html_content: str) -> str:
+    """Sanitize HTML stored as post or comment content."""
+    return HtmlSanitizer.sanitize_content(html_content)
 
 
 class TableOfContentsExtractor:

--- a/backend/src/board/models/accounts.py
+++ b/backend/src/board/models/accounts.py
@@ -16,6 +16,7 @@ from board.constants.social_auth import (
 from board.services.profile_image_service import ProfileImageService
 from board.services.two_factor_auth_secret_service import TwoFactorAuthSecretService
 from board.services.user_config_meta_service import UserConfigMetaService
+from board.html_utils import safe_external_url
 
 from .helpers import avatar_path, cover_path
 from .posts import Post
@@ -136,10 +137,13 @@ class Profile(models.Model):
     def collect_social(self):
         socials = []
         for meta in UserLinkMeta.objects.filter(user=self.user).order_by('order'):
+            value = safe_external_url(meta.value)
+            if not value:
+                continue
             socials.append({
                 'id': meta.id,
                 'name': meta.name,
-                'value': meta.value,
+                'value': value,
                 'order': meta.order
             })
         return socials

--- a/backend/src/board/services/auth_login_service.py
+++ b/backend/src/board/services/auth_login_service.py
@@ -1,3 +1,6 @@
+import ipaddress
+
+from django.conf import settings
 from django.contrib import auth
 from django.contrib.auth.models import User
 from django.core.cache import cache
@@ -20,7 +23,30 @@ class AuthLoginService:
 
     @staticmethod
     def get_client_ip(request) -> str:
-        return request.META.get('HTTP_X_FORWARDED_FOR', request.META.get('REMOTE_ADDR'))
+        remote_addr = request.META.get('REMOTE_ADDR', '')
+        trusted_proxy_ips = {
+            AuthLoginService._normalize_ip(address)
+            for address in getattr(settings, 'TRUSTED_PROXY_IPS', [])
+        }
+        trusted_proxy_ips.discard(None)
+
+        if AuthLoginService._normalize_ip(remote_addr) not in trusted_proxy_ips:
+            return remote_addr or 'unknown'
+
+        forwarded_for = request.META.get('HTTP_X_FORWARDED_FOR', '')
+        for address in reversed(forwarded_for.split(',')):
+            normalized_address = AuthLoginService._normalize_ip(address)
+            if normalized_address and normalized_address not in trusted_proxy_ips:
+                return normalized_address
+
+        return remote_addr or 'unknown'
+
+    @staticmethod
+    def _normalize_ip(address: str):
+        try:
+            return ipaddress.ip_address(address.strip()).compressed
+        except (ValueError, AttributeError):
+            return None
 
     @staticmethod
     def get_attempt_cache_key(request) -> str:
@@ -42,11 +68,23 @@ class AuthLoginService:
     @staticmethod
     def increment_login_attempts(request) -> None:
         cache_key = AuthLoginService.get_attempt_cache_key(request)
-        cache.set(
+        if cache.add(
             cache_key,
-            cache.get(cache_key, 0) + 1,
+            1,
             AuthLoginService.LOGIN_ATTEMPT_TTL_SECONDS,
-        )
+        ):
+            return
+
+        try:
+            cache.incr(cache_key)
+        except (ValueError, NotImplementedError):
+            # Some cache backends can expire a key between add() and incr().
+            # Recreate it with the short login-attempt TTL in that case.
+            cache.set(
+                cache_key,
+                1,
+                AuthLoginService.LOGIN_ATTEMPT_TTL_SECONDS,
+            )
 
     @staticmethod
     def common_auth(request, user: User, two_factor_code=None, is_oauth=False):

--- a/backend/src/board/services/banner_service.py
+++ b/backend/src/board/services/banner_service.py
@@ -6,6 +6,7 @@ from typing import List, Dict
 from django.contrib.auth.models import User
 from django.db.models import Q
 
+from board.html_utils import sanitize_html
 from board.models import SiteBanner, SiteContentScope, BannerType, BannerPosition
 
 
@@ -29,7 +30,7 @@ class BannerService:
         Returns:
             List of combined banners sorted by order and created_date
         """
-        return list(
+        banners = list(
             SiteBanner.objects.filter(
                 is_active=True,
                 banner_type=banner_type,
@@ -39,6 +40,10 @@ class BannerService:
                 Q(scope=SiteContentScope.USER, user=author)
             ).select_related('user').order_by('order', '-created_date')
         )
+        for banner in banners:
+            if banner.scope == SiteContentScope.USER:
+                banner.content_html = sanitize_html(banner.content_html)
+        return banners
 
     @staticmethod
     def get_all_banners_for_author(author: User) -> Dict[str, List[SiteBanner]]:
@@ -73,6 +78,8 @@ class BannerService:
 
         for banner in banners:
             if banner.position in result:
+                if banner.scope == SiteContentScope.USER:
+                    banner.content_html = sanitize_html(banner.content_html)
                 result[banner.position].append(banner)
 
         return result

--- a/backend/src/board/services/comment_list_service.py
+++ b/backend/src/board/services/comment_list_service.py
@@ -9,6 +9,7 @@ from django.db.models import (
     When,
 )
 
+from board.html_utils import sanitize_content_html
 from board.models import Comment, Post
 from board.services.public_post_service import PublicPostService
 
@@ -169,7 +170,7 @@ class CommentListService:
             'is_mine': is_mine,
             'is_edited': comment.edited,
             'is_deleted': is_deleted,
-            'rendered_content': comment.get_text_html(),
+            'rendered_content': sanitize_content_html(comment.get_text_html()),
             'created_date': comment.time_since(),
             'count_likes': CommentListService.get_count_likes(comment),
             'is_liked': CommentListService.get_has_liked(comment, user_id),

--- a/backend/src/board/services/post_content_service.py
+++ b/backend/src/board/services/post_content_service.py
@@ -4,6 +4,7 @@ from urllib.parse import urlsplit, urlunsplit
 
 from django.conf import settings
 
+from board.html_utils import sanitize_content_html
 from modules.markdown import parse_post_to_html
 
 from board.modules.read_time import calc_read_time
@@ -222,7 +223,9 @@ class PostContentService:
 
     @staticmethod
     def html_input_to_content_html(html: str) -> str:
-        return PostContentService.normalize_content_html(html)
+        return sanitize_content_html(
+            PostContentService.normalize_content_html(html)
+        )
 
     @staticmethod
     def markdown_input_to_content_html(markdown_text: str) -> str:

--- a/backend/src/board/services/post_detail_render_service.py
+++ b/backend/src/board/services/post_detail_render_service.py
@@ -5,7 +5,11 @@ from django.urls import reverse
 from django.utils import timezone
 from django.utils.cache import patch_vary_headers
 
-from board.html_utils import extract_table_of_contents
+from board.html_utils import (
+    extract_table_of_contents,
+    safe_external_url,
+    sanitize_content_html,
+)
 from board.models import Post
 from board.services.agent_content_service import AgentContentService
 from board.services.banner_service import BannerService
@@ -33,7 +37,9 @@ class PostDetailRenderService:
 
         author_profile = getattr(author, 'profile', None)
         author_bio = author_profile.bio.strip() if author_profile and author_profile.bio else ''
-        author_homepage = author_profile.homepage.strip() if author_profile and author_profile.homepage else ''
+        author_homepage = safe_external_url(
+            author_profile.homepage if author_profile else '',
+        )
 
         post.series_total = 0
         post.visible_series_posts = []
@@ -43,9 +49,8 @@ class PostDetailRenderService:
         if post.series and not is_post_preview:
             post.visible_series_posts = PostService.get_visible_series_posts(post)
 
-        content_html_with_ids, table_of_contents = extract_table_of_contents(
-            post.content.content_html,
-        )
+        content_html = sanitize_content_html(post.content.content_html)
+        content_html_with_ids, table_of_contents = extract_table_of_contents(content_html)
         banners = BannerService.get_all_banners_for_author(author)
 
         canonical_url = ''

--- a/backend/src/board/services/series_service.py
+++ b/backend/src/board/services/series_service.py
@@ -10,6 +10,7 @@ from django.contrib.auth.models import User
 from django.db import transaction
 from django.db.models import F
 
+from board.html_utils import sanitize_content_html
 from board.models import Series, Post
 from board.services.authoring_permission_service import AuthoringPermissionService
 from board.services.public_post_service import PublicPostService
@@ -150,7 +151,7 @@ class SeriesService:
             owner=user,
             name=name.strip(),
             text_md=description.strip(),
-            text_html=description.strip()
+            text_html=sanitize_content_html(description.strip()),
         )
 
         if auto_generate_url:
@@ -213,7 +214,7 @@ class SeriesService:
 
         if description is not None:
             series.text_md = description.strip()
-            series.text_html = description.strip()
+            series.text_html = sanitize_content_html(description.strip())
 
         series.save()
 

--- a/backend/src/board/services/setting_account_profile_service.py
+++ b/backend/src/board/services/setting_account_profile_service.py
@@ -8,6 +8,7 @@ from typing import Any, Mapping
 from django.contrib.auth.models import User
 from django.core.files.uploadedfile import UploadedFile
 
+from board.html_utils import safe_external_url
 from board.models import Profile
 from board.modules.response import ErrorCode
 from board.services.auth_service import AuthService, AuthValidationError
@@ -113,8 +114,14 @@ class SettingAccountProfileService:
         homepage: str,
     ) -> None:
         profile = Profile.objects.get(user=user)
+        safe_homepage = safe_external_url(homepage or '')
+        if homepage and not safe_homepage:
+            raise SettingAccountProfileError(
+                ErrorCode.VALIDATE,
+                '홈페이지는 http 또는 https URL이어야 합니다.',
+            )
         profile.bio = bio
-        profile.homepage = homepage
+        profile.homepage = safe_homepage
         profile.save()
 
     @staticmethod

--- a/backend/src/board/services/site_content_api_service.py
+++ b/backend/src/board/services/site_content_api_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from django.contrib.auth.models import User
 from django.db.models import QuerySet
 
-from board.html_utils import sanitize_html
+from board.html_utils import safe_navigation_url, sanitize_html
 from board.models import (
     BannerPosition,
     BannerType,
@@ -74,7 +74,7 @@ class SiteContentApiService:
         return {
             'id': notice.id,
             'title': notice.title,
-            'url': notice.url,
+            'url': safe_navigation_url(notice.url),
             'is_active': notice.is_active,
             'created_date': notice.created_date.isoformat(),
             'updated_date': notice.updated_date.isoformat(),
@@ -86,6 +86,7 @@ class SiteContentApiService:
         return [
             {
                 **notice,
+                'url': safe_navigation_url(notice['url']),
                 'created_date': notice['created_date'].isoformat(),
                 'updated_date': notice['updated_date'].isoformat(),
             }
@@ -93,11 +94,20 @@ class SiteContentApiService:
         ]
 
     @staticmethod
-    def serialize_banner(banner: SiteBanner, *, include_created_by: bool = False) -> dict:
+    def serialize_banner(
+        banner: SiteBanner,
+        *,
+        include_created_by: bool = False,
+        sanitize_content: bool = False,
+    ) -> dict:
         data = {
             'id': banner.id,
             'title': banner.title,
-            'content_html': banner.content_html,
+            'content_html': (
+                sanitize_html(banner.content_html)
+                if sanitize_content
+                else banner.content_html
+            ),
             'banner_type': banner.banner_type,
             'position': banner.position,
             'is_active': banner.is_active,
@@ -114,6 +124,7 @@ class SiteContentApiService:
         queryset: QuerySet[SiteBanner],
         *,
         include_created_by: bool = False,
+        sanitize_content: bool = False,
     ) -> list[dict]:
         """Serialize banners with one lean values query, including only creator username."""
         fields = SiteContentApiService.BANNER_LIST_FIELDS
@@ -124,6 +135,8 @@ class SiteContentApiService:
         for banner in queryset.values(*fields):
             banner['created_date'] = banner['created_date'].isoformat()
             banner['updated_date'] = banner['updated_date'].isoformat()
+            if sanitize_content:
+                banner['content_html'] = sanitize_html(banner['content_html'])
             if include_created_by:
                 banner['created_by'] = banner.pop('user__username')
             result.append(banner)

--- a/backend/src/board/services/user_service.py
+++ b/backend/src/board/services/user_service.py
@@ -18,6 +18,7 @@ from django.db.models import (
 from django.db.models.functions import Coalesce
 from django.utils import timezone
 
+from board.html_utils import sanitize_content_html
 from board.models import (
     Profile, UsernameChangeLog, Post, PinnedPost,
     Series, Comment, Tag, PostLikes
@@ -330,7 +331,7 @@ class UserService:
         """
         return {
             'about_md': user.profile.about_md,
-            'about_html': user.profile.about_html
+            'about_html': sanitize_content_html(user.profile.about_html),
         }
 
     @staticmethod

--- a/backend/src/board/services/webhook_service.py
+++ b/backend/src/board/services/webhook_service.py
@@ -14,6 +14,7 @@ from django.db.models import Q
 from board.models import Post, PostConfig, WebhookSubscription, Profile, SiteContentScope
 from board.services.site_url_service import SiteUrlService
 from board.services.webhook_subscription_state_service import WebhookSubscriptionStateService
+from board.services.webhook_url_service import WebhookUrlService
 from modules.sub_task import SubTaskProcessor
 
 
@@ -40,6 +41,10 @@ class WebhookService:
         Returns:
             True if successful, False otherwise
         """
+        if not WebhookUrlService.is_safe_url(url, resolve_host=True):
+            logger.warning('Webhook delivery rejected unsafe destination')
+            return False
+
         try:
             # Detect webhook type and format payload accordingly
             if 'discord' in url.lower():
@@ -61,7 +66,8 @@ class WebhookService:
             response = requests.post(
                 url,
                 json=payload,
-                timeout=WebhookService.WEBHOOK_TIMEOUT
+                timeout=WebhookService.WEBHOOK_TIMEOUT,
+                allow_redirects=False,
             )
             response.raise_for_status()
             return True

--- a/backend/src/board/services/webhook_url_service.py
+++ b/backend/src/board/services/webhook_url_service.py
@@ -1,0 +1,78 @@
+"""Validation helpers for outbound webhook URLs."""
+
+import ipaddress
+import socket
+from urllib.parse import urlsplit
+
+
+class WebhookUrlService:
+    """Reject webhook destinations that can reach local network resources."""
+
+    ALLOWED_SCHEMES = {'http', 'https'}
+    BLOCKED_HOSTNAMES = {
+        'instance-data.ec2.internal',
+        'localhost',
+        'metadata.google.internal',
+    }
+
+    @classmethod
+    def is_safe_url(cls, url: str, *, resolve_host: bool = False) -> bool:
+        if not isinstance(url, str) or not url or len(url) > 500:
+            return False
+        if any(character in url for character in '\x00\r\n\t\\'):
+            return False
+
+        try:
+            parsed = urlsplit(url)
+            hostname = parsed.hostname
+            port = parsed.port
+        except ValueError:
+            return False
+
+        scheme = parsed.scheme.lower()
+        hostname = (hostname or '').rstrip('.').lower()
+        if scheme not in cls.ALLOWED_SCHEMES or not hostname:
+            return False
+        if parsed.username or parsed.password or parsed.fragment:
+            return False
+        if port is not None and not (1 <= port <= 65535):
+            return False
+        if hostname in cls.BLOCKED_HOSTNAMES or hostname.endswith('.localhost'):
+            return False
+        if hostname.endswith('.local'):
+            return False
+
+        try:
+            address = ipaddress.ip_address(hostname)
+        except ValueError:
+            address = None
+
+        if address is not None:
+            return address.is_global
+
+        if not resolve_host:
+            return True
+
+        try:
+            resolved_addresses = {
+                result[4][0]
+                for result in socket.getaddrinfo(
+                    hostname,
+                    port or (443 if scheme == 'https' else 80),
+                    type=socket.SOCK_STREAM,
+                )
+            }
+        except (OSError, socket.gaierror):
+            return False
+
+        if not resolved_addresses:
+            return False
+
+        return all(cls._is_global_address(address) for address in resolved_addresses)
+
+    @staticmethod
+    def _is_global_address(address: str) -> bool:
+        try:
+            return ipaddress.ip_address(address).is_global
+        except ValueError:
+            return False

--- a/backend/src/board/templates/board/author/components/author_header.html
+++ b/backend/src/board/templates/board/author/components/author_header.html
@@ -1,6 +1,7 @@
 {% load static %}
 {% load island %}
 {% load resource %}
+{% load security_tags %}
 
 <div class="relative overflow-hidden pb-12 sm:pb-16">
     {% if author.profile.cover %}
@@ -52,23 +53,25 @@
             </p>
             {% endif %}
 
-            {% if author.profile.homepage %}
+            {% with safe_homepage=author.profile.homepage|safe_external_url %}
+            {% if safe_homepage %}
             <div class="mb-8">
-                <a href="{{ author.profile.homepage }}" target="_blank"
+                <a href="{{ safe_homepage }}" target="_blank"
                    class="group inline-flex items-center gap-2 rounded-full border border-line bg-surface px-5 py-2.5 text-sm font-semibold text-content-secondary transition-colors duration-150 hover:border-line-strong hover:text-content">
                     <i class="fas fa-link text-xs text-content-hint transition-colors group-hover:text-content"></i>
                     <span>
-                        {% if 'https://' in author.profile.homepage %}
-                            {{ author.profile.homepage|slice:"8:"|truncatechars:30 }}
-                        {% elif 'http://' in author.profile.homepage %}
-                            {{ author.profile.homepage|slice:"7:"|truncatechars:30 }}
+                        {% if 'https://' in safe_homepage %}
+                            {{ safe_homepage|slice:"8:"|truncatechars:30 }}
+                        {% elif 'http://' in safe_homepage %}
+                            {{ safe_homepage|slice:"7:"|truncatechars:30 }}
                         {% else %}
-                            {{ author.profile.homepage|truncatechars:30 }}
+                            {{ safe_homepage|truncatechars:30 }}
                         {% endif %}
                     </span>
                 </a>
             </div>
             {% endif %}
+            {% endwith %}
 
             {% with author.profile.collect_social as social_links %}
             {% if social_links %}

--- a/backend/src/board/templates/board/author/components/author_notice_list.html
+++ b/backend/src/board/templates/board/author/components/author_notice_list.html
@@ -1,3 +1,5 @@
+{% load security_tags %}
+
 <section>
     <div class="mb-4 flex items-end justify-between gap-4">
         <div>
@@ -11,7 +13,7 @@
 
     <div class="divide-y divide-line-light border-y border-line-light">
         {% for notice in notices %}
-        <a href="{{ notice.url }}" class="group block py-3.5 transition-colors duration-150 hover:bg-surface-subtle/50 active:bg-surface-subtle/70">
+        <a href="{{ notice.url|safe_navigation_url }}" class="group block py-3.5 transition-colors duration-150 hover:bg-surface-subtle/50 active:bg-surface-subtle/70">
             <div class="flex items-center justify-between gap-4 px-1">
                 <div class="min-w-0 flex-1">
                     <h3 class="truncate text-base font-semibold leading-snug text-content transition-colors group-hover:text-content-secondary">

--- a/backend/src/board/templates/board/series/series_detail.html
+++ b/backend/src/board/templates/board/series/series_detail.html
@@ -32,9 +32,9 @@
             {{ series.name }}
         </h1>
 
-        {% if series.text_html %}
+        {% if series_description_html %}
         <div class="text-lg text-content-secondary mb-8 leading-relaxed max-w-2xl mx-auto">
-            {{ series.text_html | safe }}
+            {{ series_description_html | safe }}
         </div>
         {% endif %}
 

--- a/backend/src/board/templates/components/notice_carousel.html
+++ b/backend/src/board/templates/components/notice_carousel.html
@@ -1,3 +1,5 @@
+{% load security_tags %}
+
 <!-- Notice Carousel Component
     Parameters:
     - notices: 공지사항 리스트
@@ -13,7 +15,8 @@
     <!-- ==================== Large ==================== -->
     <div class="relative overflow-hidden rounded-2xl">
         {% for notice in notices %}
-        <a href="{% if url_prefix %}{{ url_prefix }}{{ notice.author.username }}/{% endif %}{{ notice.url }}"
+        {% with safe_url=notice.url|safe_navigation_url %}
+        <a href="{% if url_prefix %}{{ url_prefix }}{{ notice.author.username }}/{% endif %}{{ safe_url }}"
            class="group block rounded-2xl border border-line/50 bg-transparent px-5 py-4 transition-colors duration-150 hover:border-line/70 active:bg-surface-subtle/40 {% if forloop.first %}relative z-10 opacity-100{% else %}pointer-events-none absolute inset-0 z-0 opacity-0{% endif %}"
            :style="{
                opacity: currentIndex === {{ forloop.counter0 }} ? 1 : 0,
@@ -44,6 +47,7 @@
                 </span>
             </div>
         </a>
+        {% endwith %}
         {% endfor %}
     </div>
 
@@ -70,7 +74,8 @@
     <!-- ==================== Small ==================== -->
     <div class="relative overflow-hidden rounded-xl">
         {% for notice in notices %}
-        <a href="{% if url_prefix %}{{ url_prefix }}{{ notice.author.username }}/{% endif %}{{ notice.url }}"
+        {% with safe_url=notice.url|safe_navigation_url %}
+        <a href="{% if url_prefix %}{{ url_prefix }}{{ notice.author.username }}/{% endif %}{{ safe_url }}"
            class="group block rounded-xl border border-line/50 bg-transparent px-4 py-3 transition-colors duration-150 hover:border-line/70 active:bg-surface-subtle/40 {% if forloop.first %}relative z-10 opacity-100{% else %}pointer-events-none absolute inset-0 z-0 opacity-0{% endif %}"
            :style="{
                opacity: currentIndex === {{ forloop.counter0 }} ? 1 : 0,
@@ -97,6 +102,7 @@
                 <i class="fas fa-arrow-right flex-shrink-0 text-xs text-content-hint"></i>
             </div>
         </a>
+        {% endwith %}
         {% endfor %}
     </div>
 

--- a/backend/src/board/templatetags/security_tags.py
+++ b/backend/src/board/templatetags/security_tags.py
@@ -1,0 +1,19 @@
+from django import template
+
+from board.html_utils import (
+    safe_external_url as normalize_external_url,
+    safe_navigation_url as normalize_navigation_url,
+)
+
+
+register = template.Library()
+
+
+@register.filter
+def safe_external_url(value):
+    return normalize_external_url(value)
+
+
+@register.filter
+def safe_navigation_url(value):
+    return normalize_navigation_url(value)

--- a/backend/src/board/tests/api/test_banner.py
+++ b/backend/src/board/tests/api/test_banner.py
@@ -71,6 +71,31 @@ class BannerAPITestCase(TestCase):
         self.assertEqual(content['status'], 'DONE')
         self.assertEqual(len(content['body']['banners']), 0)
 
+    def test_get_legacy_user_banner_sanitizes_content(self):
+        self._create_user_banner(
+            content_html='<div>Safe</div><script>alert(1)</script><img src="javascript:alert(2)">',
+        )
+
+        response = self.client.get('/v1/banners')
+
+        self.assertEqual(response.status_code, 200)
+        banner = json.loads(response.content)['body']['banners'][0]
+        self.assertIn('<div>Safe</div>', banner['contentHtml'])
+        self.assertNotIn('<script', banner['contentHtml'])
+        self.assertNotIn('javascript:', banner['contentHtml'])
+
+    def test_get_legacy_user_banner_detail_sanitizes_content(self):
+        banner = self._create_user_banner(
+            content_html='<div>Safe</div><script>alert(1)</script>',
+        )
+
+        response = self.client.get(f'/v1/banners/{banner.id}')
+
+        self.assertEqual(response.status_code, 200)
+        content_html = json.loads(response.content)['body']['contentHtml']
+        self.assertIn('<div>Safe</div>', content_html)
+        self.assertNotIn('<script', content_html)
+
     def test_create_banner(self):
         """배너 생성 테스트"""
         data = {

--- a/backend/src/board/tests/api/test_notice.py
+++ b/backend/src/board/tests/api/test_notice.py
@@ -68,6 +68,15 @@ class NoticeAPITestCase(TestCase):
         self.assertEqual(content['status'], 'DONE')
         self.assertEqual(len(content['body']['notices']), 0)
 
+    def test_get_legacy_notice_rejects_unsafe_navigation_url(self):
+        self._create_user_notice(url='javascript:alert(1)')
+
+        response = self.client.get('/v1/notices')
+
+        self.assertEqual(response.status_code, 200)
+        notice = json.loads(response.content)['body']['notices'][0]
+        self.assertEqual(notice['url'], '')
+
     def test_create_notice(self):
         """공지 생성 테스트"""
         data = {

--- a/backend/src/board/tests/api/test_setting.py
+++ b/backend/src/board/tests/api/test_setting.py
@@ -1091,6 +1091,23 @@ class SettingTestCase(TestCase):
         self.assertEqual(profile.bio, 'JSON bio')
         self.assertEqual(profile.homepage, '')
 
+    def test_update_profile_rejects_unsafe_homepage_url(self):
+        self.client.login(username='test', password='test')
+
+        response = self.client.put(
+            '/v1/setting/profile',
+            'bio=Safe+bio&homepage=javascript%3Aalert%281%29',
+            content_type='application/x-www-form-urlencoded',
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['status'], 'ERROR')
+        self.assertEqual(response.json()['errorCode'], 'error:VA')
+        self.assertEqual(
+            Profile.objects.get(user=User.objects.get(username='test')).homepage,
+            '',
+        )
+
     def test_update_social_links(self):
         """소셜 링크 생성/수정/삭제 테스트"""
         user = User.objects.get(username='test')

--- a/backend/src/board/tests/api/test_webhook.py
+++ b/backend/src/board/tests/api/test_webhook.py
@@ -128,6 +128,25 @@ class WebhookAPITestCase(TestCase):
         data = response.json()
         self.assertEqual(data['status'], 'ERROR')
 
+    def test_add_channel_rejects_private_network_url(self):
+        """내부 네트워크를 가리키는 웹훅 URL은 저장하지 않는다."""
+        self.client.login(username='testauthor', password='testpass123')
+
+        response = self.client.post(
+            '/v1/webhook/channels',
+            data=json.dumps({'webhook_url': 'http://127.0.0.1:8000/internal'}),
+            content_type='application/json'
+        )
+
+        data = response.json()
+        self.assertEqual(data['status'], 'ERROR')
+        self.assertFalse(
+            WebhookSubscription.objects.filter(
+                author=self.profile,
+                webhook_url='http://127.0.0.1:8000/internal',
+            ).exists()
+        )
+
     def test_add_channel_duplicate_reactivates(self):
         """비활성화된 동일 URL 채널 재추가 시 활성화"""
         self.client.login(username='testauthor', password='testpass123')
@@ -291,6 +310,20 @@ class WebhookAPITestCase(TestCase):
         data = response.json()
         self.assertEqual(data['status'], 'DONE')
         self.assertFalse(data['body']['success'])
+
+    @patch('board.services.webhook_service.WebhookService.test_webhook')
+    def test_test_webhook_rejects_private_network_url(self, mock_test):
+        self.client.login(username='testauthor', password='testpass123')
+
+        response = self.client.post(
+            '/v1/webhook/test',
+            data=json.dumps({'webhook_url': 'http://localhost:8000/admin'}),
+            content_type='application/json'
+        )
+
+        data = response.json()
+        self.assertEqual(data['status'], 'ERROR')
+        mock_test.assert_not_called()
 
 
 class GlobalWebhookAPITestCase(TestCase):

--- a/backend/src/board/tests/services/test_auth_login_service.py
+++ b/backend/src/board/tests/services/test_auth_login_service.py
@@ -18,6 +18,24 @@ class AuthLoginServiceTestCase(TestCase):
 
         self.assertEqual(AuthLoginService.get_client_ip(request), '203.0.113.1')
 
+    def test_get_client_ip_ignores_forwarded_for_from_untrusted_source(self):
+        request = self.factory.post(
+            '/v1/login',
+            HTTP_X_FORWARDED_FOR='203.0.113.1',
+            REMOTE_ADDR='198.51.100.10',
+        )
+
+        self.assertEqual(AuthLoginService.get_client_ip(request), '198.51.100.10')
+
+    def test_get_client_ip_uses_rightmost_untrusted_forwarded_address(self):
+        request = self.factory.post(
+            '/v1/login',
+            HTTP_X_FORWARDED_FOR='198.51.100.10, 127.0.0.1, 203.0.113.1',
+            REMOTE_ADDR='127.0.0.1',
+        )
+
+        self.assertEqual(AuthLoginService.get_client_ip(request), '203.0.113.1')
+
     def test_login_rate_limit_allows_under_limit(self):
         request = self.factory.post('/v1/login', REMOTE_ADDR='127.0.0.1')
         for _ in range(AuthLoginService.LOGIN_ATTEMPT_LIMIT - 1):

--- a/backend/src/board/tests/services/test_comment_list_service.py
+++ b/backend/src/board/tests/services/test_comment_list_service.py
@@ -85,6 +85,26 @@ class CommentListServiceTestCase(TestCase):
             'can_reply': False,
         })
 
+    def test_serialize_comment_sanitizes_legacy_html(self):
+        Comment.objects.filter(id=self.parent.id).update(
+            text_html=(
+                '<p>Legacy comment</p>'
+                '<img src="javascript:alert(1)" onerror="alert(2)">'
+                '<script>alert(3)</script>'
+            ),
+        )
+
+        payload = CommentListService.serialize_post_comments(
+            self.post.url,
+            self.viewer,
+        )
+
+        rendered_content = payload['comments'][0]['rendered_content'].lower()
+        self.assertIn('legacy comment', rendered_content)
+        self.assertNotIn('<script', rendered_content)
+        self.assertNotIn('javascript:', rendered_content)
+        self.assertNotIn('onerror', rendered_content)
+
     def test_serialize_blocked_post_comment_marks_reply_permission_false(self):
         self.post.config.block_comment = True
         self.post.config.save(update_fields=['block_comment'])

--- a/backend/src/board/tests/services/test_post_content_service.py
+++ b/backend/src/board/tests/services/test_post_content_service.py
@@ -185,3 +185,22 @@ class PostContentServiceTest(SimpleTestCase):
             PostContentService.normalize_content_html(html),
             '<img src=/resources/media/images/content/a.png>',
         )
+
+    @override_settings(
+        SITE_URL='https://blex.example',
+        MEDIA_URL='/resources/media/',
+    )
+    def test_html_input_to_content_html_sanitizes_untrusted_markup(self):
+        html = (
+            '<p onclick="alert(1)">Text</p>'
+            '<img src="javascript:alert(2)" onerror="alert(3)">'
+            '<script>alert(4)</script>'
+        )
+
+        sanitized = PostContentService.html_input_to_content_html(html)
+
+        self.assertIn('<p>Text</p>', sanitized)
+        self.assertNotIn('onclick=', sanitized)
+        self.assertNotIn('onerror=', sanitized)
+        self.assertNotIn('javascript:', sanitized)
+        self.assertNotIn('<script', sanitized)

--- a/backend/src/board/tests/services/test_user_social_link_service.py
+++ b/backend/src/board/tests/services/test_user_social_link_service.py
@@ -70,3 +70,22 @@ class UserSocialLinkServiceTestCase(TestCase):
         UserSocialLinkService.delete_social_links(self.user, str(other_link.id))
 
         self.assertTrue(UserLinkMeta.objects.filter(id=other_link.id).exists())
+
+    def test_collect_social_omits_unsafe_urls(self):
+        UserLinkMeta.objects.create(
+            user=self.user,
+            name='unsafe',
+            value='javascript:alert(1)',
+            order=1,
+        )
+        UserLinkMeta.objects.create(
+            user=self.user,
+            name='safe',
+            value='https://example.com',
+            order=2,
+        )
+
+        self.assertEqual(
+            [link['name'] for link in self.user.profile.collect_social()],
+            ['safe'],
+        )

--- a/backend/src/board/tests/services/test_webhook_url_service.py
+++ b/backend/src/board/tests/services/test_webhook_url_service.py
@@ -1,0 +1,65 @@
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+
+from board.services.webhook_url_service import WebhookUrlService
+
+
+class WebhookUrlServiceTestCase(SimpleTestCase):
+    def test_rejects_private_ip_literals(self):
+        for url in (
+            'http://127.0.0.1:8000/hook',
+            'http://10.0.0.1/hook',
+            'http://[::1]/hook',
+            'http://169.254.169.254/latest/meta-data',
+        ):
+            with self.subTest(url=url):
+                self.assertFalse(WebhookUrlService.is_safe_url(url))
+
+    def test_rejects_credentials_fragments_and_local_hostnames(self):
+        for url in (
+            'https://user:password@example.com/hook',
+            'https://example.com/hook#fragment',
+            'https://service.local/hook',
+            'https://localhost/hook',
+        ):
+            with self.subTest(url=url):
+                self.assertFalse(WebhookUrlService.is_safe_url(url))
+
+    @patch(
+        'board.services.webhook_url_service.socket.getaddrinfo',
+        return_value=[(
+            2,
+            1,
+            6,
+            '',
+            ('93.184.216.34', 443),
+        )],
+    )
+    def test_resolves_and_allows_public_hostname(self, mock_getaddrinfo):
+        self.assertTrue(
+            WebhookUrlService.is_safe_url(
+                'https://hooks.example.com/webhook',
+                resolve_host=True,
+            )
+        )
+        mock_getaddrinfo.assert_called_once()
+
+    @patch(
+        'board.services.webhook_url_service.socket.getaddrinfo',
+        return_value=[(
+            2,
+            1,
+            6,
+            '',
+            ('10.0.0.5', 443),
+        )],
+    )
+    def test_rejects_hostname_resolving_to_private_address(self, mock_getaddrinfo):
+        self.assertFalse(
+            WebhookUrlService.is_safe_url(
+                'https://hooks.example.com/webhook',
+                resolve_host=True,
+            )
+        )
+        mock_getaddrinfo.assert_called_once()

--- a/backend/src/board/tests/templates/test_auth.py
+++ b/backend/src/board/tests/templates/test_auth.py
@@ -78,6 +78,12 @@ class LoginViewTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context['next_url'], '')
 
+    def test_login_page_rejects_protocol_relative_path_variants(self):
+        for next_url in ('///evil.example', '%5C%5Cevil.example'):
+            response = self.client.get(reverse('login') + f'?next={next_url}')
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.context['next_url'], '')
+
     def test_login_page_accepts_relative_url(self):
         """상대 URL은 허용"""
         response = self.client.get(reverse('login') + '?next=/setting/profile')

--- a/backend/src/board/tests/templates/test_author.py
+++ b/backend/src/board/tests/templates/test_author.py
@@ -296,6 +296,25 @@ class AuthorPostsPageTestCase(TestCase):
         self.assertNotContains(owner_response, f'href="{edit_path}"')
         self.assertContains(owner_response, 'x-show=hasRenderedContent')
 
+    def test_author_overview_sanitizes_legacy_intro_html(self):
+        self.user.profile.about_html = (
+            '<p>Legacy intro</p>'
+            '<img src="javascript:alert(1)" onerror="alert(2)">'
+            '<script>alert(3)</script>'
+        )
+        self.user.profile.save(update_fields=['about_html'])
+
+        response = self.client.get(
+            reverse('user_profile', kwargs={'username': self.user.username})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        about_html = response.context['about_html'].lower()
+        self.assertIn('legacy intro', about_html)
+        self.assertNotIn('<script', about_html)
+        self.assertNotIn('javascript:', about_html)
+        self.assertNotIn('onerror', about_html)
+
     def test_author_overview_inline_intro_editor_updates_without_reload(self):
         """소개글 인라인 편집은 저장 후 페이지 새로고침 없이 렌더 HTML을 갱신한다."""
         self.client.login(username='testauthor', password='testpass123')

--- a/backend/src/board/tests/templates/test_oauth_callback.py
+++ b/backend/src/board/tests/templates/test_oauth_callback.py
@@ -260,7 +260,7 @@ class OAuthCallbackTestCase(TestCase):
         # Should redirect to login page with oauth_token and next parameter
         self.assertEqual(response.status_code, 302)
         self.assertTrue(response.url.startswith('/login?oauth_token='))
-        self.assertIn('next=/setting/posts', response.url)
+        self.assertIn('next=%2Fsetting%2Fposts', response.url)
 
         # Extract oauth_token from redirect URL
         from urllib.parse import urlparse, parse_qs
@@ -326,3 +326,18 @@ class OAuthCallbackTestCase(TestCase):
         user = User.objects.get(username='usernext')
         user_from_session = self.client.session.get('_auth_user_id')
         self.assertEqual(int(user_from_session), user.id)
+
+    @patch('modules.oauth.auth_github', return_value=oauth.State(success=True, user={
+        'node_id': 'GITHUB_NODE_ID_EXTERNAL_NEXT',
+        'login': 'userexternalnext',
+        'name': 'User with External Next URL',
+        'avatar_url': 'https://avatars.githubusercontent.com/u/external-next',
+    }))
+    def test_github_oauth_callback_rejects_external_next_url(self, mock_github):
+        """OAuth 콜백은 외부 next URL로 리다이렉트하지 않는다."""
+        response = self.client.get(
+            '/login/callback/github?code=test_code&next=https://evil.example/phishing'
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, '/')

--- a/backend/src/board/tests/templates/test_post_detail.py
+++ b/backend/src/board/tests/templates/test_post_detail.py
@@ -74,6 +74,28 @@ class PostDetailViewTestCase(TestCase):
         self.assertEqual(toc[1]['text'], 'Header 2')
         self.assertEqual(toc[1]['level'], 2)
 
+    def test_post_detail_sanitizes_legacy_content_html(self):
+        PostContent.objects.filter(post=self.post).update(
+            content_html=(
+                '<h1>Legacy heading</h1>'
+                '<p>Legacy content</p>'
+                '<img src="javascript:alert(1)" onerror="alert(2)">'
+                '<script>alert(3)</script>'
+            ),
+        )
+
+        response = self.client.get(reverse('post_detail', kwargs={
+            'username': 'testauthor',
+            'post_url': 'test-post',
+        }))
+
+        self.assertEqual(response.status_code, 200)
+        rendered_content = response.context['content_html'].lower()
+        self.assertIn('legacy content', rendered_content)
+        self.assertNotIn('<script', rendered_content)
+        self.assertNotIn('javascript:', rendered_content)
+        self.assertNotIn('onerror', rendered_content)
+
     def test_post_detail_series_list_hides_drafts_and_future_posts(self):
         """본문 상세의 시리즈 목록은 공개 발행 글만 노출한다."""
         series = Series.objects.create(

--- a/backend/src/board/tests/templates/test_series_static_seo.py
+++ b/backend/src/board/tests/templates/test_series_static_seo.py
@@ -83,6 +83,32 @@ class SeriesSeoMetadataTestCase(StructuredDataAssertionMixin, TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.context['posts']), 2)
 
+    def test_series_detail_sanitizes_legacy_description_html(self):
+        Series.objects.filter(id=self.series.id).update(
+            text_html=(
+                '<p>Legacy description</p>'
+                '<img src="javascript:alert(1)" onerror="alert(2)">'
+                '<script>alert(3)</script>'
+            ),
+        )
+
+        response = self.client.get(
+            reverse(
+                'series_detail',
+                kwargs={
+                    'username': self.author.username,
+                    'series_url': self.series.url,
+                },
+            )
+        )
+
+        self.assertEqual(response.status_code, 200)
+        description = response.context['series_description_html'].lower()
+        self.assertIn('legacy description', description)
+        self.assertNotIn('<script', description)
+        self.assertNotIn('javascript:', description)
+        self.assertNotIn('onerror', description)
+
 
     def test_series_detail_returns_404_for_hidden_series(self):
         self.series.hide = True

--- a/backend/src/board/tests/test_html_utils.py
+++ b/backend/src/board/tests/test_html_utils.py
@@ -3,7 +3,61 @@ Tests for board app utility functions
 """
 from django.test import TestCase
 
-from board.html_utils import extract_table_of_contents
+from board.html_utils import (
+    extract_table_of_contents,
+    safe_external_url,
+    sanitize_content_html,
+    sanitize_html,
+)
+
+
+class HtmlSanitizerTestCase(TestCase):
+    def test_safe_external_url_rejects_script_and_relative_urls(self):
+        self.assertEqual(safe_external_url('javascript:alert(1)'), '')
+        self.assertEqual(safe_external_url('/settings'), '')
+        self.assertEqual(safe_external_url('https://example.com/profile'), 'https://example.com/profile')
+
+    def test_sanitize_html_rejects_non_http_url_protocols_and_css_urls(self):
+        html = (
+            '<a href="vbscript:alert(1)">link</a>'
+            '<img src="data:text/html,<script>alert(1)</script>">'
+            '<div style="background:url(javascript:alert(1))">text</div>'
+        )
+
+        sanitized = sanitize_html(html)
+
+        self.assertNotIn('vbscript:', sanitized)
+        self.assertNotIn('data:text/html', sanitized)
+        self.assertNotIn('javascript:', sanitized)
+        self.assertNotIn('style=', sanitized)
+
+    def test_content_sanitizer_preserves_safe_editor_markup(self):
+        html = (
+            '<figure style="display:flex">'
+            '<img src="https://cdn.example/image.png" alt="safe">'
+            '<figcaption>Caption</figcaption>'
+            '</figure>'
+        )
+
+        sanitized = sanitize_content_html(html)
+
+        self.assertIn('<figure', sanitized)
+        self.assertIn('src="https://cdn.example/image.png"', sanitized)
+        self.assertIn('<figcaption>Caption</figcaption>', sanitized)
+
+    def test_content_sanitizer_removes_scripts_events_and_unsafe_urls(self):
+        html = (
+            '<p onclick="alert(1)">Text</p>'
+            '<iframe src="javascript:alert(1)" onload="alert(2)"></iframe>'
+            '<script>alert(3)</script>'
+        )
+
+        sanitized = sanitize_content_html(html)
+
+        self.assertNotIn('<script', sanitized)
+        self.assertNotIn('onclick=', sanitized)
+        self.assertNotIn('onload=', sanitized)
+        self.assertNotIn('javascript:', sanitized)
 
 
 class TableOfContentsTestCase(TestCase):

--- a/backend/src/board/tests/test_markdown.py
+++ b/backend/src/board/tests/test_markdown.py
@@ -142,6 +142,31 @@ class ParseToHtmlTest(TestCase):
         self.assertIn('class="mention"', result)
         self.assertIn('href="/@author"', result)
 
+    def test_markdown_removes_unsafe_link_protocols(self):
+        result = parse_post_to_html('[unsafe](javascript:alert(1))')
+
+        self.assertNotIn('javascript:', result)
+        self.assertNotIn('href=', result)
+
+    def test_markdown_removes_unsafe_image_protocols(self):
+        result = parse_comment_to_html('![unsafe](javascript:alert(1))')
+
+        self.assertNotIn('javascript:', result)
+        self.assertNotIn('src=', result)
+        self.assertNotIn('data-src=', result)
+
+    def test_youtube_markup_rejects_attribute_injection(self):
+        result = parse_post_to_html('@youtube[abc" onload=alert(1)]')
+
+        self.assertNotIn('<iframe', result)
+
+    def test_gif_markup_rejects_attribute_injection(self):
+        result = parse_post_to_html(
+            '@gif[https://example.com/video.mp4" onerror=alert(1)]'
+        )
+
+        self.assertNotIn('<video', result)
+
     def test_parse_to_html_defaults_to_post_markdown(self):
         """Backward compatible parse_to_html should follow post rules."""
         md = '`@author`'

--- a/backend/src/board/tests/test_runtime_settings.py
+++ b/backend/src/board/tests/test_runtime_settings.py
@@ -276,8 +276,8 @@ class RuntimeSettingsTestCase(SimpleTestCase):
 
         self.assertEqual(result.stdout.strip(), 'None')
 
-    def test_allowed_hosts_default_keeps_existing_wildcard(self):
-        """ALLOWED_HOSTS 미설정 배포는 기존처럼 와일드카드 호스트를 유지한다."""
+    def test_allowed_hosts_default_uses_site_url_host(self):
+        """ALLOWED_HOSTS 미설정 배포는 SITE_URL 호스트만 허용한다."""
         env = {
             **os.environ,
             'SECRET_KEY': 'test-secret',
@@ -302,7 +302,7 @@ class RuntimeSettingsTestCase(SimpleTestCase):
             check=True,
         )
 
-        self.assertEqual(result.stdout.strip(), "['*']")
+        self.assertEqual(result.stdout.strip(), "['blex.example']")
 
     def test_allowed_hosts_reads_comma_separated_env(self):
         """ALLOWED_HOSTS를 설정하면 쉼표 목록을 사용한다."""

--- a/backend/src/board/tests/test_sub_task_processor.py
+++ b/backend/src/board/tests/test_sub_task_processor.py
@@ -168,8 +168,16 @@ class SubTaskProcessorTestCase(SimpleTestCase):
 
         self.assertEqual(completed_tasks, ['first', 'second'])
 
+    @patch(
+        'board.services.webhook_url_service.socket.getaddrinfo',
+        return_value=[(2, 1, 6, '', ('93.184.216.34', 443))],
+    )
     @patch('board.services.webhook_service.requests.post')
-    def test_webhook_request_failure_does_not_log_webhook_url(self, mock_post):
+    def test_webhook_request_failure_does_not_log_webhook_url(
+        self,
+        mock_post,
+        mock_getaddrinfo,
+    ):
         webhook_url = 'https://discord.example/webhook/private-secret'
         error_secret = 'request-error-secret'
         mock_post.side_effect = requests.RequestException(

--- a/backend/src/board/views/api/v1/banner.py
+++ b/backend/src/board/views/api/v1/banner.py
@@ -30,7 +30,10 @@ def banner(request, banner_id=None):
     if request.method == 'GET' and banner_id is None:
         banners = queryset.order_by('order', '-created_date')
         return StatusDone({
-            'banners': SiteContentApiService.serialize_banner_list(banners),
+            'banners': SiteContentApiService.serialize_banner_list(
+                banners,
+                sanitize_content=True,
+            ),
         })
 
     if request.method == 'GET' and banner_id:
@@ -38,7 +41,12 @@ def banner(request, banner_id=None):
             queryset.only(*SiteContentApiService.BANNER_LIST_FIELDS),
             id=banner_id,
         )
-        return StatusDone(SiteContentApiService.serialize_banner(banner_item))
+        return StatusDone(
+            SiteContentApiService.serialize_banner(
+                banner_item,
+                sanitize_content=True,
+            )
+        )
 
     if request.method == 'POST':
         post_data, body_error = ApiRequestBodyService.parse_json_or_error(request)
@@ -55,7 +63,12 @@ def banner(request, banner_id=None):
         except SiteContentApiError as error:
             return _banner_error(error)
 
-        return StatusDone(SiteContentApiService.serialize_banner(banner_item))
+        return StatusDone(
+            SiteContentApiService.serialize_banner(
+                banner_item,
+                sanitize_content=True,
+            )
+        )
 
     if request.method == 'PUT' and banner_id:
         banner_item = get_object_or_404(queryset, id=banner_id)
@@ -70,7 +83,12 @@ def banner(request, banner_id=None):
         except SiteContentApiError as error:
             return _banner_error(error)
 
-        return StatusDone(SiteContentApiService.serialize_banner(banner_item))
+        return StatusDone(
+            SiteContentApiService.serialize_banner(
+                banner_item,
+                sanitize_content=True,
+            )
+        )
 
     if request.method == 'DELETE' and banner_id:
         banner_item = get_object_or_404(queryset, id=banner_id)

--- a/backend/src/board/views/api/v1/comment.py
+++ b/backend/src/board/views/api/v1/comment.py
@@ -3,6 +3,7 @@ from django.http import Http404
 from django.shortcuts import get_object_or_404
 
 from board.models import Comment, Post
+from board.html_utils import sanitize_content_html
 from board.modules.response import StatusDone, StatusError
 from board.modules.paginator import Paginator
 from board.services.api_request_body_service import ApiRequestBodyService
@@ -122,7 +123,7 @@ def user_comment(request):
                     'title': comment.post_title,
                     'url': comment.post_url,
                 },
-                'content': comment.text_html,
+                'content': sanitize_content_html(comment.text_html),
                 'created_date': comment.time_since(),
             }, comments)),
             'last_page': comments.paginator.num_pages,

--- a/backend/src/board/views/api/v1/draft.py
+++ b/backend/src/board/views/api/v1/draft.py
@@ -4,6 +4,7 @@ from django.shortcuts import get_object_or_404
 
 from board.models import Post
 from board.decorators import api_editor_required
+from board.html_utils import sanitize_content_html
 from board.services.api_request_body_service import ApiRequestBodyService
 from board.services.post_service import PostService, PostValidationError
 from board.services.post_trash_service import PostTrashService
@@ -102,7 +103,7 @@ def drafts_detail(request, url):
 
     if request.method == 'GET':
         if hasattr(draft, 'content'):
-            raw_content = draft.content.content_html
+            raw_content = sanitize_content_html(draft.content.content_html)
         else:
             raw_content = ''
 

--- a/backend/src/board/views/api/v1/post.py
+++ b/backend/src/board/views/api/v1/post.py
@@ -3,6 +3,7 @@ from django.shortcuts import get_object_or_404
 from django.utils import timezone
 
 from board.models import Post, PinnedPost
+from board.html_utils import sanitize_content_html
 from board.modules.requests import BooleanType
 from board.modules.response import StatusDone, StatusError, ErrorCode
 from board.modules.time import convert_to_localtime, time_since
@@ -85,7 +86,9 @@ def user_posts(request, username, url=None):
                 if not PostService.can_user_edit_post(request.user, post):
                     raise Http404
 
-                content_html = post.content.content_html if hasattr(post, 'content') else ''
+                content_html = sanitize_content_html(
+                    post.content.content_html if hasattr(post, 'content') else ''
+                )
 
                 return StatusDone({
                     'image': post.get_thumbnail(),
@@ -130,7 +133,7 @@ def user_posts(request, username, url=None):
                     'updated_date': convert_to_localtime(post.updated_date).strftime('%Y-%m-%d %H:%M'),
                     'author_image': str(post.author_image),
                     'author': post.author_username,
-                    'rendered_content': post.content.content_html,
+                    'rendered_content': sanitize_content_html(post.content.content_html),
                     'count_likes': post.count_likes,
                     'count_comments': post.count_comments,
                     'is_ad': post.config.advertise,

--- a/backend/src/board/views/api/v1/setting.py
+++ b/backend/src/board/views/api/v1/setting.py
@@ -309,11 +309,14 @@ def setting(request, parameter):
             return StatusDone()
 
         if parameter == 'profile':
-            SettingAccountProfileService.update_profile(
-                user,
-                bio=put.get('bio', ''),
-                homepage=put.get('homepage', ''),
-            )
+            try:
+                SettingAccountProfileService.update_profile(
+                    user,
+                    bio=put.get('bio', ''),
+                    homepage=put.get('homepage', ''),
+                )
+            except SettingAccountProfileError as error:
+                return StatusError(error.code, error.message)
             return StatusDone()
     
         if parameter == 'social':

--- a/backend/src/board/views/api/v1/webhook.py
+++ b/backend/src/board/views/api/v1/webhook.py
@@ -13,6 +13,7 @@ from board.decorators import api_editor_required
 from board.services import WebhookService
 from board.services.api_request_body_service import ApiRequestBodyService
 from board.services.webhook_api_service import WebhookApiService
+from board.services.webhook_url_service import WebhookUrlService
 from board.modules.response import StatusDone, StatusError, ErrorCode
 
 
@@ -36,7 +37,7 @@ def _validate_webhook_payload(request):
     if not webhook_url:
         return None, None, StatusError(ErrorCode.REQUIRE, 'webhook_url is required')
 
-    if not webhook_url.startswith(('http://', 'https://')):
+    if not WebhookUrlService.is_safe_url(webhook_url):
         return None, None, StatusError(ErrorCode.VALIDATE, 'Invalid webhook URL')
 
     if len(webhook_url) > 500:
@@ -197,7 +198,7 @@ def test_channel(request):
     if not webhook_url:
         return StatusError(ErrorCode.REQUIRE, 'webhook_url is required')
 
-    if not webhook_url.startswith(('http://', 'https://')):
+    if not WebhookUrlService.is_safe_url(webhook_url):
         return StatusError(ErrorCode.VALIDATE, 'Invalid webhook URL')
 
     success = WebhookService.test_webhook(webhook_url)

--- a/backend/src/board/views/auth.py
+++ b/backend/src/board/views/auth.py
@@ -1,5 +1,6 @@
 from django.shortcuts import render, redirect
-from urllib.parse import urlparse, urljoin
+from urllib.parse import unquote, urlparse
+from django.utils.http import url_has_allowed_host_and_scheme
 
 from board.services.hcaptcha_service import HCaptchaService
 from board.services.initial_setup_service import InitialSetupService
@@ -16,17 +17,26 @@ def get_safe_redirect_url(request):
     if not next_url:
         return None
 
-    parsed = urlparse(next_url)
-
-    if parsed.netloc:
-        request_host = request.get_host()
-        if parsed.netloc != request_host:
-            return None
-
-    if parsed.scheme and parsed.scheme not in ['http', 'https', '']:
+    if not url_has_allowed_host_and_scheme(
+        next_url,
+        allowed_hosts={request.get_host()},
+        require_https=request.is_secure(),
+    ):
         return None
 
-    return parsed.path or '/'
+    parsed = urlparse(next_url)
+    path = parsed.path or '/'
+    decoded_path = unquote(path)
+    if (
+        not path.startswith('/')
+        or path.startswith('//')
+        or '\\' in path
+        or decoded_path.startswith('//')
+        or '\\' in decoded_path
+    ):
+        return None
+
+    return path
 
 
 def login_view(request):

--- a/backend/src/board/views/author.py
+++ b/backend/src/board/views/author.py
@@ -9,6 +9,7 @@ from django.http import HttpResponse, JsonResponse
 from django.urls import reverse
 from django.views.decorators.http import require_GET
 
+from board.html_utils import sanitize_content_html
 from board.modules.paginator import Paginator
 from board.modules.time import time_since
 from board.services.user_service import UserService
@@ -42,7 +43,7 @@ def author_overview(request, username):
     recent_activities = UserService.get_public_author_activities(author)[:10]
 
     about_md = profile.about_md if profile else ''
-    about_html = profile.about_html if profile else ''
+    about_html = sanitize_content_html(profile.about_html) if profile else ''
 
     # Check if author is a reader (not an editor)
     is_reader = not AuthoringPermissionService.is_active_editor(author)

--- a/backend/src/board/views/oauth_callback.py
+++ b/backend/src/board/views/oauth_callback.py
@@ -1,4 +1,5 @@
 import json
+from urllib.parse import urlencode
 
 from django.shortcuts import render, redirect
 from django.http import Http404
@@ -10,22 +11,24 @@ from board.services.auth_service import AuthService, OAuthService
 from board.services.initial_setup_service import InitialSetupService
 from board.services.social_auth_provider_service import SocialAuthProviderService
 from board.models import SocialAuth, UserLinkMeta
+from board.views.auth import get_safe_redirect_url
 
 
 def handle_oauth_auth(request, user):
     """
     Handle OAuth authentication with 2FA support
     """
-    next_url = request.GET.get('next', '')
+    next_url = get_safe_redirect_url(request) or ''
 
     if not settings.DEBUG and user.config.has_two_factor_auth():
         oauth_token = OAuthService.create_2fa_token(user.id, next_url)
 
         messages.info(request, '2차 인증이 필요합니다. 인증 앱에서 생성된 코드를 입력해주세요.')
 
-        redirect_url = f'/login?oauth_token={oauth_token}'
+        redirect_params = {'oauth_token': oauth_token}
         if next_url:
-            redirect_url += f'&next={next_url}'
+            redirect_params['next'] = next_url
+        redirect_url = f'/login?{urlencode(redirect_params)}'
         return redirect(redirect_url)
 
     auth.login(request, user)

--- a/backend/src/board/views/series.py
+++ b/backend/src/board/views/series.py
@@ -1,6 +1,7 @@
 from django.shortcuts import render, get_object_or_404
 from django.http import Http404
 
+from board.html_utils import sanitize_content_html
 from board.models import Series
 from board.services.agent_content_service import AgentContentService
 from board.services.discovery_metadata_service import DiscoveryMetadataService
@@ -73,6 +74,7 @@ def series_detail(request, username, series_url):
     context = {
         'author': author,
         'series': series,
+        'series_description_html': sanitize_content_html(series.text_html),
         'posts': posts_with_numbers,
         'is_loading': False,
         'page': page,

--- a/backend/src/main/settings.py
+++ b/backend/src/main/settings.py
@@ -84,8 +84,14 @@ VITE_DEV_SERVER_URL = os.environ.get('VITE_DEV_SERVER_URL', 'http://localhost:81
 TESTING = sys.argv[1:2] == ['test']
 TEST_RUNNER = 'main.test_runner.IsolatedMediaDiscoverRunner'
 
-ALLOWED_HOSTS = get_env_list('ALLOWED_HOSTS', ['*'])
 SITE_URL_ORIGIN = get_env_http_origin('SITE_URL')
+site_url_host = urlsplit(SITE_URL_ORIGIN).hostname if SITE_URL_ORIGIN else None
+default_allowed_hosts = (
+    ['localhost', '127.0.0.1', '::1', 'testserver']
+    if DEBUG
+    else ([site_url_host] if site_url_host else [])
+)
+ALLOWED_HOSTS = get_env_list('ALLOWED_HOSTS', default_allowed_hosts)
 CSRF_TRUSTED_ORIGINS = get_env_list(
     'CSRF_TRUSTED_ORIGINS',
     [SITE_URL_ORIGIN] if SITE_URL_ORIGIN else [],
@@ -94,6 +100,18 @@ CSRF_TRUSTED_ORIGINS = get_env_list(
 SESSION_COOKIE_SECURE = not DEBUG
 CSRF_COOKIE_SECURE = not DEBUG
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+SECURE_SSL_REDIRECT = os.environ.get(
+    'SECURE_SSL_REDIRECT',
+    'FALSE' if DEBUG else 'TRUE',
+) == 'TRUE'
+SECURE_HSTS_SECONDS = get_env_int(
+    'SECURE_HSTS_SECONDS',
+    0 if DEBUG else 31536000,
+)
+TRUSTED_PROXY_IPS = get_env_list(
+    'TRUSTED_PROXY_IPS',
+    ['127.0.0.1', '::1'],
+)
 
 INSTALLED_APPS = [
     'main.admin_app.BlexAdminConfig',

--- a/backend/src/modules/markdown.py
+++ b/backend/src/modules/markdown.py
@@ -1,9 +1,14 @@
 import re
+from html import escape
+from urllib.parse import urlsplit
+
 import markdown
 from markdown.extensions import Extension
 from markdown.treeprocessors import Treeprocessor
 from markdown.preprocessors import Preprocessor
 from markdown.extensions.toc import slugify_unicode
+
+from board.html_utils import HtmlSanitizer, sanitize_content_html
 
 class HeaderHashTreeprocessor(Treeprocessor):
     def __init__(self, md):
@@ -98,23 +103,64 @@ class CustomPreprocessor(Preprocessor):
         return new_lines
 
 class CustomPostprocessor:
+    GIF_PATTERN = re.compile(r'@gif\[([^\]\s]+)\]')
+    YOUTUBE_PATTERN = re.compile(r'@youtube\[([^\]]+)\](?:\{([^\}]+)\})?')
+    YOUTUBE_ID_PATTERN = re.compile(r'^[A-Za-z0-9_-]{1,64}$')
+    ASPECT_RATIO_PATTERN = re.compile(r'^[1-9]\d{0,2}(?::[1-9]\d{0,2})?$')
+
+    @staticmethod
+    def _is_safe_video_url(url):
+        try:
+            parsed = urlsplit(url)
+        except ValueError:
+            return False
+
+        return (
+            bool(parsed.netloc)
+            and parsed.path.lower().endswith('.mp4')
+            and HtmlSanitizer.is_safe_url(
+                url,
+                allowed_schemes={'http', 'https'},
+                allow_relative=False,
+            )
+        )
+
     @staticmethod
     def process(html_content, enable_mentions=False):
         # Custom Markdown
-        html_content = re.sub(
-            r'@gif\[.*(https?://.*\.mp4).*\]',
-            r'<video class="lazy" autoplay muted loop playsinline poster="\1.preview.jpg"><source data-src="\1" type="video/mp4"/></video>',
-            html_content
+        def gif_replace(match):
+            video_url = match.group(1)
+            if not CustomPostprocessor._is_safe_video_url(video_url):
+                return match.group(0)
+
+            escaped_url = escape(video_url, quote=True)
+            escaped_poster_url = escape(f'{video_url}.preview.jpg', quote=True)
+            return (
+                '<video class="lazy" autoplay muted loop playsinline '
+                f'poster="{escaped_poster_url}">'
+                f'<source data-src="{escaped_url}" type="video/mp4"/>'
+                '</video>'
+            )
+
+        html_content = CustomPostprocessor.GIF_PATTERN.sub(
+            gif_replace,
+            html_content,
         )
+
         # YouTube with aspect ratio: @youtube[ID]{16:9} or @youtube[ID]
         def youtube_replace(match):
             video_id = match.group(1)
-            aspect_ratio = match.group(2) if match.group(2) else '16:9'
+            aspect_ratio = match.group(2) or '16:9'
+
+            if not CustomPostprocessor.YOUTUBE_ID_PATTERN.fullmatch(video_id):
+                return match.group(0)
+            if not CustomPostprocessor.ASPECT_RATIO_PATTERN.fullmatch(aspect_ratio):
+                return match.group(0)
+
             aspect_css = aspect_ratio.replace(':', ' / ')
             return f'<figure style="text-align: center; display: flex; justify-content: center; flex-direction: column; align-items: center;"><iframe style="width: 100%; aspect-ratio: {aspect_css}; border: 0;" data-aspect-ratio="{aspect_ratio}" src="https://www.youtube.com/embed/{video_id}" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></figure>'
 
-        html_content = re.sub(
-            r'@youtube\[([^\]]+)\](?:\{([^\}]+)\})?',
+        html_content = CustomPostprocessor.YOUTUBE_PATTERN.sub(
             youtube_replace,
             html_content
         )
@@ -139,7 +185,7 @@ class CustomPostprocessor:
         html_content = re.sub(r'&lt;caption&gt;(.*)&lt;/caption&gt;', r'<figcaption>\1</figcaption>', html_content)
         html_content = re.sub(r'&lt;/grid-image&gt;', '</figure>', html_content)
 
-        return html_content
+        return sanitize_content_html(html_content)
 
 def _parse_to_html(text, enable_mentions=False):
     """Parse markdown text to HTML with optional mention rendering."""

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,190 +10,11 @@
             "hasInstallScript": true,
             "license": "ISC",
             "devDependencies": {
-                "concurrently": "^10.0.3",
-                "pnpm": "11.12.0"
+                "concurrently": "^10.0.4",
+                "pnpm": "11.17.0"
             },
             "engines": {
                 "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
-            }
-        },
-        "node_modules/@isaacs/fs-minipass": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-            "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "minipass": "^7.0.4"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@reflink/reflink": {
-            "version": "0.1.19",
-            "resolved": "https://registry.npmjs.org/@reflink/reflink/-/reflink-0.1.19.tgz",
-            "integrity": "sha512-DmCG8GzysnCZ15bres3N5AHCmwBwYgp0As6xjhQ47rAUTUXxJiK+lLUxaGsX3hd/30qUpVElh05PbGuxRPgJwA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 10"
-            },
-            "optionalDependencies": {
-                "@reflink/reflink-darwin-arm64": "0.1.19",
-                "@reflink/reflink-darwin-x64": "0.1.19",
-                "@reflink/reflink-linux-arm64-gnu": "0.1.19",
-                "@reflink/reflink-linux-arm64-musl": "0.1.19",
-                "@reflink/reflink-linux-x64-gnu": "0.1.19",
-                "@reflink/reflink-linux-x64-musl": "0.1.19",
-                "@reflink/reflink-win32-arm64-msvc": "0.1.19",
-                "@reflink/reflink-win32-x64-msvc": "0.1.19"
-            }
-        },
-        "node_modules/@reflink/reflink-darwin-arm64": {
-            "version": "0.1.19",
-            "resolved": "https://registry.npmjs.org/@reflink/reflink-darwin-arm64/-/reflink-darwin-arm64-0.1.19.tgz",
-            "integrity": "sha512-ruy44Lpepdk1FqDz38vExBY/PVUsjxZA+chd9wozjUH9JjuDT/HEaQYA6wYN9mf041l0yLVar6BCZuWABJvHSA==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@reflink/reflink-darwin-x64": {
-            "version": "0.1.19",
-            "resolved": "https://registry.npmjs.org/@reflink/reflink-darwin-x64/-/reflink-darwin-x64-0.1.19.tgz",
-            "integrity": "sha512-By85MSWrMZa+c26TcnAy8SDk0sTUkYlNnwknSchkhHpGXOtjNDUOxJE9oByBnGbeuIE1PiQsxDG3Ud+IVV9yuA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@reflink/reflink-linux-arm64-gnu": {
-            "version": "0.1.19",
-            "resolved": "https://registry.npmjs.org/@reflink/reflink-linux-arm64-gnu/-/reflink-linux-arm64-gnu-0.1.19.tgz",
-            "integrity": "sha512-7P+er8+rP9iNeN+bfmccM4hTAaLP6PQJPKWSA4iSk2bNvo6KU6RyPgYeHxXmzNKzPVRcypZQTpFgstHam6maVg==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@reflink/reflink-linux-arm64-musl": {
-            "version": "0.1.19",
-            "resolved": "https://registry.npmjs.org/@reflink/reflink-linux-arm64-musl/-/reflink-linux-arm64-musl-0.1.19.tgz",
-            "integrity": "sha512-37iO/Dp6m5DDaC2sf3zPtx/hl9FV3Xze4xoYidrxxS9bgP3S8ALroxRK6xBG/1TtfXKTvolvp+IjrUU6ujIGmA==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@reflink/reflink-linux-x64-gnu": {
-            "version": "0.1.19",
-            "resolved": "https://registry.npmjs.org/@reflink/reflink-linux-x64-gnu/-/reflink-linux-x64-gnu-0.1.19.tgz",
-            "integrity": "sha512-jbI8jvuYCaA3MVUdu8vLoLAFqC+iNMpiSuLbxlAgg7x3K5bsS8nOpTRnkLF7vISJ+rVR8W+7ThXlXlUQ93ulkw==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@reflink/reflink-linux-x64-musl": {
-            "version": "0.1.19",
-            "resolved": "https://registry.npmjs.org/@reflink/reflink-linux-x64-musl/-/reflink-linux-x64-musl-0.1.19.tgz",
-            "integrity": "sha512-e9FBWDe+lv7QKAwtKOt6A2W/fyy/aEEfr0g6j/hWzvQcrzHCsz07BNQYlNOjTfeytrtLU7k449H1PI95jA4OjQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@reflink/reflink-win32-arm64-msvc": {
-            "version": "0.1.19",
-            "resolved": "https://registry.npmjs.org/@reflink/reflink-win32-arm64-msvc/-/reflink-win32-arm64-msvc-0.1.19.tgz",
-            "integrity": "sha512-09PxnVIQcd+UOn4WAW73WU6PXL7DwGS6wPlkMhMg2zlHHG65F3vHepOw06HFCq+N42qkaNAc8AKIabWvtk6cIQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@reflink/reflink-win32-x64-msvc": {
-            "version": "0.1.19",
-            "resolved": "https://registry.npmjs.org/@reflink/reflink-win32-x64-msvc/-/reflink-win32-x64-msvc-0.1.19.tgz",
-            "integrity": "sha512-E//yT4ni2SyhwP8JRjVGWr3cbnhWDiPLgnQ66qqaanjjnMiu3O/2tjCPQXlcGc/DEYofpDc9fvhv6tALQsMV9w==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/abbrev": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
-            "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/ansi-regex": {
@@ -235,16 +56,6 @@
                 "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
-        "node_modules/chownr": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-            "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "engines": {
-                "node": ">=18"
-            }
-        },
         "node_modules/cliui": {
             "version": "9.0.1",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
@@ -261,15 +72,15 @@
             }
         },
         "node_modules/concurrently": {
-            "version": "10.0.3",
-            "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-10.0.3.tgz",
-            "integrity": "sha512-hc3LH4UaKWd/bbyDK/IGVa4RB6PtQ3CUYwtrkzqHn+wIG3Hr5fhpRlk0L/gCa8ZE1L/Ufj50Zho69cI5w8SQBA==",
+            "version": "10.0.4",
+            "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-10.0.4.tgz",
+            "integrity": "sha512-trZql+7l/0+WRAsAnEdctr4+iiOS6ZrViI6H8QWcCF9MFS/LT0dKpe8vluB1to6it+OxSI4VospFTIFMW8DJRw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "chalk": "5.6.2",
                 "rxjs": "7.8.2",
-                "shell-quote": "1.8.4",
+                "shell-quote": "1.9.0",
                 "supports-color": "10.2.2",
                 "tree-kill": "1.2.2",
                 "yargs": "18.0.0"
@@ -292,16 +103,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/env-paths": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-            "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/escalade": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -310,31 +111,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/exponential-backoff": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
-            "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
-            "dev": true,
-            "license": "Apache-2.0"
-        },
-        "node_modules/fdir": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "peerDependencies": {
-                "picomatch": "^3 || ^4"
-            },
-            "peerDependenciesMeta": {
-                "picomatch": {
-                    "optional": true
-                }
             }
         },
         "node_modules/get-caller-file": {
@@ -360,111 +136,12 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/graceful-fs": {
-            "version": "4.2.11",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-            "dev": true,
-            "license": "ISC"
-        },
-        "node_modules/isexe": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
-            "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "engines": {
-                "node": ">=20"
-            }
-        },
-        "node_modules/minipass": {
-            "version": "7.1.3",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-            "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            }
-        },
-        "node_modules/minizlib": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
-            "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "minipass": "^7.1.2"
-            },
-            "engines": {
-                "node": ">= 18"
-            }
-        },
-        "node_modules/node-gyp": {
-            "version": "12.4.0",
-            "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.4.0.tgz",
-            "integrity": "sha512-OMcPNvqTCFUnNaBlmdgq+lfNqY7gTiSmNRDjY3uAXRyudeKZEZxu3CLtjMQrx4zZxCX2b/mpNqTtwuCJgXhHkw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "env-paths": "^2.2.0",
-                "exponential-backoff": "^3.1.1",
-                "graceful-fs": "^4.2.6",
-                "nopt": "^9.0.0",
-                "proc-log": "^6.0.0",
-                "semver": "^7.3.5",
-                "tar": "^7.5.4",
-                "tinyglobby": "^0.2.12",
-                "undici": "^6.25.0",
-                "which": "^6.0.0"
-            },
-            "bin": {
-                "node-gyp": "bin/node-gyp.js"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/nopt": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
-            "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "abbrev": "^4.0.0"
-            },
-            "bin": {
-                "nopt": "bin/nopt.js"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/picomatch": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
         "node_modules/pnpm": {
-            "version": "11.12.0",
-            "resolved": "https://registry.npmjs.org/pnpm/-/pnpm-11.12.0.tgz",
-            "integrity": "sha512-ggpvvQ2fBMImY4ACrq0eRTQKkTndXcB3wdg+9EqiSByOtmN7TJqmlqPH41uoGOSc8nIT5fK5ETjQm3o+JuiYug==",
+            "version": "11.17.0",
+            "resolved": "https://registry.npmjs.org/pnpm/-/pnpm-11.17.0.tgz",
+            "integrity": "sha512-zKPOozKtJUu4QUX5ZtGfSHlhUhA0b8kseaBH8joNezzKPDeS8AdrofGDHSd++88KkRmzGppg7Kf7PWIx8zHvcg==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "@reflink/reflink": "0.1.19",
-                "node-gyp": "^12.3.0",
-                "v8-compile-cache": "2.4.0"
-            },
             "bin": {
                 "pn": "bin/pnpm.mjs",
                 "pnpm": "bin/pnpm.mjs",
@@ -478,16 +155,6 @@
                 "url": "https://opencollective.com/pnpm"
             }
         },
-        "node_modules/proc-log": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
-            "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
         "node_modules/rxjs": {
             "version": "7.8.2",
             "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
@@ -498,23 +165,10 @@
                 "tslib": "^2.1.0"
             }
         },
-        "node_modules/semver": {
-            "version": "7.8.5",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/shell-quote": {
-            "version": "1.8.4",
-            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-            "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+            "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -571,40 +225,6 @@
                 "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
         },
-        "node_modules/tar": {
-            "version": "7.5.19",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.19.tgz",
-            "integrity": "sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "@isaacs/fs-minipass": "^4.0.0",
-                "chownr": "^3.0.0",
-                "minipass": "^7.1.2",
-                "minizlib": "^3.1.0",
-                "yallist": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tinyglobby": {
-            "version": "0.2.17",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
-            "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fdir": "^6.5.0",
-                "picomatch": "^4.0.4"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/SuperchupuDev"
-            }
-        },
         "node_modules/tree-kill": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -621,39 +241,6 @@
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
             "dev": true,
             "license": "0BSD"
-        },
-        "node_modules/undici": {
-            "version": "6.27.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-            "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18.17"
-            }
-        },
-        "node_modules/v8-compile-cache": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.4.0.tgz",
-            "integrity": "sha512-ocyWc3bAHBB/guyqJQVI5o4BZkPhznPYUG2ea80Gond/BgNWpap8TOmLSeeQG7bnh2KMISxskdADG59j7zruhw==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/which": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
-            "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "isexe": "^4.0.0"
-            },
-            "bin": {
-                "node-which": "bin/which.js"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
         },
         "node_modules/wrap-ansi": {
             "version": "9.0.2",
@@ -681,16 +268,6 @@
             "license": "ISC",
             "engines": {
                 "node": ">=10"
-            }
-        },
-        "node_modules/yallist": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-            "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "engines": {
-                "node": ">=18"
             }
         },
         "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     },
     "homepage": "https://github.com/baealex/BLEX#readme",
     "devDependencies": {
-        "concurrently": "^10.0.3",
-        "pnpm": "11.12.0"
+        "concurrently": "^10.0.4",
+        "pnpm": "11.17.0"
     }
 }


### PR DESCRIPTION
## 🎯 Goal
- Prevent untrusted HTML, Markdown, public metadata, redirects, and webhook destinations from crossing security boundaries.
- Address the issue now because these values can reach browsers or trigger server-side outbound requests.

## 🔧 Core Changes
- Add allowlist-based HTML/Markdown sanitization and safe URL handling across public rendering, APIs, feeds, banners, profiles, and series.
- Validate webhook URLs against private, loopback, link-local, metadata, reserved, credential-bearing, and unsafe destinations before saving and sending.
- Harden OAuth/navigation redirects, proxy-aware login rate limiting, runtime security defaults, and frontend dependency versions.
- Add regression coverage for XSS, SSRF, open redirects, authentication limits, and public output behavior.

## 🤔 Key Decisions
- Enforce validation at both input/output boundaries and again immediately before webhook delivery.
- Fail closed for unsafe schemes, destinations, and redirects while preserving safe relative and HTTPS URLs.
- Keep the changes centralized in reusable sanitization and URL-validation helpers so all affected surfaces share the same policy.

## 🧪 Verification Guide
### How to verify
1. Run npm run server:test -- --verbosity 0 and npm run server:check-migrations.
2. Run npm run islands:test, npm run islands:type-check, and npm run islands:lint.
3. Run npm audit and pnpm --dir backend/islands audit --prod; start npm run dev and check the home page, search input, login redirect handling, and browser console in Chromium.

### Expected result
- Backend: 1,412 tests pass and no migration changes are detected.
- Islands tests and type checks pass; lint has no errors (8 existing warnings remain).
- No known dependency vulnerabilities are reported.
- Browser pages render and interact normally, unsafe external next redirects are blocked, and there are no JavaScript runtime errors. The local dev database may still produce three unrelated missing-media 404s.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (if needed)