### PR TITLE
📦 Patch high-severity dependencies

### DIFF
--- a/backend/islands/pnpm-lock.yaml
+++ b/backend/islands/pnpm-lock.yaml
@@ -6,13 +6,15 @@ settings:
 
 overrides:
   '@babel/core': 7.29.6
+  brace-expansion: 5.0.9
   dompurify: 3.4.12
   esbuild: 0.28.1
   form-data: 4.0.6
-  js-yaml: 4.3.0
+  js-yaml: 4.3.1
   linkify-it: 5.0.1
   markdown-it: 14.2.0
   minimatch: 10.2.5
+  nanoid: 3.3.17
 
 importers:
 
@@ -2317,8 +2319,8 @@ packages:
     peerDependencies:
       react: '>=17.0.1'
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -3028,8 +3030,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -3234,8 +3236,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -4404,7 +4406,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 10.2.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -5882,7 +5884,7 @@ snapshots:
     dependencies:
       react: 19.2.7
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -6694,7 +6696,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -6839,7 +6841,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minipass@7.1.3: {}
 
@@ -6860,7 +6862,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   natural-compare@1.4.0: {}
 
@@ -7022,13 +7024,13 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
   postcss@8.5.24:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/backend/islands/pnpm-workspace.yaml
+++ b/backend/islands/pnpm-workspace.yaml
@@ -11,10 +11,12 @@ minimumReleaseAgeExclude:
 
 overrides:
   '@babel/core': 7.29.6
+  brace-expansion: 5.0.9
   dompurify: 3.4.12
   esbuild: 0.28.1
   form-data: 4.0.6
-  js-yaml: 4.3.0
+  js-yaml: 4.3.1
   linkify-it: 5.0.1
   markdown-it: 14.2.0
   minimatch: 10.2.5
+  nanoid: 3.3.17

--- a/backend/src/requirements.txt
+++ b/backend/src/requirements.txt
@@ -6,7 +6,7 @@ certifi==2026.6.17
 cffi==2.1.0
 charset-normalizer==3.4.9
 click==8.4.2
-cryptography==49.0.0
+cryptography==50.0.0
 cssselect==1.4.0
 defusedxml==0.7.1
 Django==6.0.7


### PR DESCRIPTION
## Summary

- Upgrade cryptography from 49.0.0 to 50.0.0 for CVE-2026-69247.
- Pin js-yaml 4.3.1 for GHSA-5p4m-2wfm-xmqj.
- Pin brace-expansion 5.0.9 for CVE-2026-69152.
- Pin nanoid 3.3.17 for CVE-2026-67213.
- Keep the JavaScript fixes scoped to transitive development dependencies through workspace overrides.

## Verification

- 36 focused Django encryption, integration-setting, 2FA, and Telegram tests passed with cryptography 50.0.0.
- Frozen pnpm install and supply-chain policy verification passed.
- pnpm audit --audit-level high reports no known vulnerabilities.
- Islands lint and production build passed.