### PR TITLE
♻️ Streamline project README

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -8,7 +8,7 @@
 <h1 align="center">BLEX</h1>
 
 <p align="center">
-  자기 도메인과 서버에서 운영하는 셀프 호스팅 블로그 애플리케이션.
+  글쓰기부터 발행과 운영까지 다루는 오픈소스 블로그 플랫폼.
 </p>
 
 <p align="center">
@@ -22,22 +22,25 @@
   <a href="README.md">English</a> · 한국어
 </p>
 
-BLEX는 브라우저 에디터와 사이트 관리를 하나의 Docker 이미지로
-제공합니다. 콘텐츠는 SQLite에 저장하며 웹, RSS, sitemap, Markdown,
-Developer API로 발행할 수 있습니다.
+BLEX는 글을 쓰고, 정리하고, 발행하고, 오래 운영하는 흐름에 맞춰 만든
+오픈소스 블로그 플랫폼입니다. 브라우저 에디터와 관리 도구를 함께
+제공하며 Docker 배포를 기본으로 지원합니다.
 
-## 주요 기능
+## 프로젝트 방향
 
-- 임시저장, 자동저장 복구, 수정 이력, 미리보기, 예약 발행을 갖춘 리치
-  텍스트 에디터
-- 작가, 시리즈, 태그, 검색, 정적 페이지로 구성하는 공개 블로그
-- 브랜딩, 사용자, 공지, 연동, 소셜 로그인, TOTP 2단계 인증을 위한 관리
-  기능
-- RSS, sitemap, Open Graph 메타데이터, 공개 Markdown, 권한 범위를 지정할 수
-  있는 API 토큰
-- 작성 콘텐츠의 언어는 그대로 유지하는 영어·한국어 UI
+- **글쓰기와 발행:** 리치 텍스트 에디터, 임시저장, 자동저장 복구, 수정
+  이력, 미리보기, 커버 이미지, 예약 발행
+- **콘텐츠 관리:** 작가, 시리즈, 태그, 검색, 정적 페이지, 댓글, 좋아요,
+  고정 글
+- **블로그 운영:** 브랜딩, 공지와 배너, 사용자와 역할, webhook, 텔레그램
+  연동
+- **외부 활용:** RSS, sitemap, canonical과 Open Graph 메타데이터, 공개
+  Markdown, 권한별 토큰을 제공하는 Developer API
 
-## 빠른 시작
+GitHub 및 Google 로그인, TOTP 2단계 인증, 영어·한국어 UI도 제공합니다.
+사용자가 작성한 콘텐츠는 번역하지 않고 원문 그대로 표시합니다.
+
+## Docker로 로컬 실행
 
 요구사항: Docker.
 
@@ -59,14 +62,30 @@ docker run -d \
 docker logs blex
 ```
 
-`http://localhost:20002`에 접속하세요. 로그의 `Initial setup URL`에서
-최초 관리자를 만들 수 있습니다. 컨테이너를 교체해도 `blex-db`와
-`blex-media` 볼륨에 데이터베이스와 업로드 파일이 유지됩니다.
+위 명령은 로컬 HTTP에서 실행하기 위해 개발용 설정인 `DEBUG=TRUE`를
+사용합니다. 운영 환경에서는 이 값을 그대로 사용하면 안 됩니다.
 
-이 명령은 로컬 체험용입니다. 외부에 공개하기 전에는 고유한 비밀 키를
-사용하고 `DEBUG=FALSE`로 바꾼 뒤 공개 주소와 HTTPS를 설정하고 두 볼륨을
-백업하세요. 자세한 내용은 [셀프 호스팅 가이드](docs/SELF_HOSTING.md)를
-확인하세요.
+`http://localhost:20002`에 접속한 뒤 `docker logs blex`에 출력된
+`Initial setup URL`에서 최초 관리자를 만드세요. 컨테이너를 교체해도
+`blex-db`와 `blex-media` 볼륨에 데이터베이스와 업로드 파일이 유지됩니다.
+
+### 운영 배포
+
+고유한 비밀 키를 사용하고 `DEBUG=FALSE`로 바꾼 뒤 `SITE_URL`,
+`ALLOWED_HOSTS`, `CSRF_TRUSTED_ORIGINS`를 공개 도메인에 맞게 설정하세요.
+BLEX 앞단에는 HTTPS 프록시를 두고 두 볼륨을 함께 백업해야 합니다. 전체
+설정과 업데이트 방법은 [셀프 호스팅 가이드](docs/SELF_HOSTING.md)에서
+확인할 수 있습니다.
+
+## 발행 인터페이스
+
+| 경로 | 용도 |
+| --- | --- |
+| `/rss` | RSS 피드 |
+| `/sitemap.xml` | sitemap index |
+| `/llms.txt` | 선택형 AI 에이전트 진입점 |
+| `/@{username}/{post_url}.md` | 공개 글 Markdown |
+| `/api/developer/v1/docs` | Developer API 문서 |
 
 ## 개발
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -22,55 +22,22 @@
   <a href="README.md">English</a> · 한국어
 </p>
 
-## 소개
-
-BLEX는 직접 관리하는 인프라에서 실행하는 블로그 애플리케이션입니다.
-브라우저 기반 에디터와 Docker 배포, 개인 블로그나 작은 퍼블리케이션을
-운영하는 데 필요한 설정을 제공합니다.
-
-공개 글은 일반 웹페이지뿐 아니라 RSS, sitemap, Markdown endpoint로도
-제공됩니다. 기본 배포는 SQLite를 사용하며 작은 서버에서도 시작할 수
-있도록 구성되어 있습니다.
+BLEX는 브라우저 에디터와 사이트 관리를 하나의 Docker 이미지로
+제공합니다. 콘텐츠는 SQLite에 저장하며 웹, RSS, sitemap, Markdown,
+Developer API로 발행할 수 있습니다.
 
 ## 주요 기능
 
-**글쓰기와 발행**
+- 임시저장, 자동저장 복구, 수정 이력, 미리보기, 예약 발행을 갖춘 리치
+  텍스트 에디터
+- 작가, 시리즈, 태그, 검색, 정적 페이지로 구성하는 공개 블로그
+- 브랜딩, 사용자, 공지, 연동, 소셜 로그인, TOTP 2단계 인증을 위한 관리
+  기능
+- RSS, sitemap, Open Graph 메타데이터, 공개 Markdown, 권한 범위를 지정할 수
+  있는 API 토큰
+- 작성 콘텐츠의 언어는 그대로 유지하는 영어·한국어 UI
 
-- Tiptap 기반 리치 텍스트 에디터
-- 임시저장, 자동저장 복구, 수정 이력, 미리보기
-- 예약 발행과 숨김 글
-- 커버 이미지, 시리즈, 태그
-- Developer API를 통한 Markdown 또는 HTML 발행
-
-**공개 블로그**
-
-- 글, 작가, 시리즈, 태그, 검색, 정적 페이지
-- 댓글, 좋아요, 고정 글
-- RSS, sitemap, canonical URL, Open Graph 메타데이터
-- 공개 Markdown URL과 선택형 `/llms.txt`
-
-**운영**
-
-- Docker 기반 배포
-- 최초 관리자 설정
-- 사이트 이름, 로고, 아이콘 설정
-- 공지, 배너, 알림, webhook, 텔레그램 연동
-- 사용자 역할과 관리 도구
-
-**계정과 보안**
-
-- GitHub, Google 소셜 로그인
-- TOTP 2단계 인증
-- scope 권한을 가진 개인 Developer API 토큰
-
-**언어**
-
-- 영어와 한국어 제품 UI
-- 영어 UI 지원이 활성화된 경우 요청 언어에 따른 협상
-- Django, React island, 에디터별 번역 카탈로그
-- 글과 사용자가 작성한 콘텐츠는 원문 그대로 표시
-
-## Docker로 실행
+## 빠른 시작
 
 요구사항: Docker.
 
@@ -89,52 +56,24 @@ docker run -d \
   -e SITE_URL=http://localhost:20002 \
   baealex/blex:latest
 
-docker logs -f blex
+docker logs blex
 ```
 
 `http://localhost:20002`에 접속하세요. 로그의 `Initial setup URL`에서
 최초 관리자를 만들 수 있습니다. 컨테이너를 교체해도 `blex-db`와
 `blex-media` 볼륨에 데이터베이스와 업로드 파일이 유지됩니다.
 
-이 명령은 로컬 체험용이며 영어와 한국어 UI 협상을 활성화합니다. 기존
-설치에서는 `ENABLE_ENGLISH_UI=TRUE`를 설정해 활성화할 수 있습니다.
+이 명령은 로컬 체험용입니다. 외부에 공개하기 전에는 고유한 비밀 키를
+사용하고 `DEBUG=FALSE`로 바꾼 뒤 공개 주소와 HTTPS를 설정하고 두 볼륨을
+백업하세요. 자세한 내용은 [셀프 호스팅 가이드](docs/SELF_HOSTING.md)를
+확인하세요.
 
-외부에 공개하기 전에는 고유한 secret을 사용하고 `DEBUG=FALSE`로 바꾼 뒤
-공개 사이트 URL과 허용 호스트를 설정해야 합니다. BLEX 앞단에 HTTPS
-프록시를 두고 두 Docker 볼륨을 함께 백업하세요. 자세한 내용은
-[셀프 호스팅 가이드](docs/SELF_HOSTING.md)를 확인하세요.
-
-## 공개 URL
-
-| 경로 | 설명 |
-| --- | --- |
-| `/rss` | 사이트 RSS 피드 |
-| `/sitemap.xml` | sitemap index |
-| `/posts/sitemap.xml` | 공개 글 sitemap |
-| `/llms.txt` | AEO가 활성화된 경우 AI 에이전트 진입점 |
-| `/@{username}/{post_url}.md` | 공개 글 Markdown |
-| `/@{username}/series/{series_url}.md` | 공개 시리즈 Markdown |
-| `/static/{slug}.md` | 공개 정적 페이지 Markdown |
-| `/api/developer/v1/docs` | Developer API 문서 |
-| `/api/developer/v1/openapi.json` | Developer API OpenAPI schema |
-
-비공개 글, 숨김 글, 임시저장, 삭제된 글과 아직 발행되지 않은 예약 글은
-RSS, sitemap과 공개 Markdown endpoint에서 제외됩니다.
-
-## Developer API
-
-Developer API는 개인 토큰, scope 권한, 글과 임시저장 관리, Markdown 또는
-HTML 입력, 이미지 업로드, 발행, 태그와 시리즈를 지원합니다.
-
-BLEX 실행 후 `/docs/developer-api/quickstart`에서 빠른 시작을,
-`/api/developer/v1/docs`에서 전체 API 문서를 확인할 수 있습니다.
-
-## 로컬 개발
+## 개발
 
 요구사항:
 
 - Python 3.12+
-- Node.js 22.22.2, 24.15+, or 26+
+- Node.js 22(22.22.2 이상), 24(24.15 이상) 또는 26 이상
 - npm
 
 ```bash
@@ -145,25 +84,11 @@ npm run dev
 
 `http://localhost:8000`에 접속하세요.
 
-자주 사용하는 검사 명령어:
-
-```bash
-npm run server:test
-npm run islands:i18n:check
-npm run islands:test
-npm run islands:lint
-npm run islands:type-check
-```
-
 ## 문서
 
 - [셀프 호스팅 가이드](docs/SELF_HOSTING.md)
 - [개발 규칙](docs/DEV_CONVENTION.md)
-- [백엔드 가이드](docs/BACKEND_GUIDE.md)
-- [프론트엔드 가이드](docs/FRONTEND_GUIDE.md)
 - [번역 가이드](docs/TRANSLATION_GUIDE.md)
-- [테스트 가이드](docs/TESTING_GUIDE.md)
-- [디자인 가이드](docs/DESIGN_GUIDE.md)
 
 ## 라이선스
 

--- a/README.md
+++ b/README.md
@@ -22,55 +22,21 @@
   English · <a href="README.ko.md">한국어</a>
 </p>
 
-## About
+BLEX combines a browser editor and site administration in a single Docker
+image. It stores content in SQLite and publishes through the web, RSS,
+sitemaps, Markdown, and a Developer API.
 
-BLEX is a blog application that you run on infrastructure you control. It
-provides a browser-based editor, Docker deployment, and the settings needed to
-operate a personal blog or a small publication.
+## Highlights
 
-Public posts are available as regular web pages as well as RSS, sitemap, and
-Markdown endpoints. The default deployment uses SQLite and is configured to
-start with modest server resources.
+- Rich-text writing with drafts, autosave recovery, revision history, previews,
+  and scheduled publishing
+- Public posts organized by authors, series, tags, search, and static pages
+- Administration for branding, users, notices, integrations, social login, and
+  TOTP two-factor authentication
+- RSS, sitemaps, Open Graph metadata, public Markdown, and scoped API tokens
+- English and Korean UI without changing user-authored content
 
-## Features
-
-**Writing and publishing**
-
-- Tiptap-based rich-text editor
-- Drafts, autosave recovery, revision history, and previews
-- Scheduled publishing and hidden posts
-- Cover images, series, and tags
-- Markdown or HTML publishing through the Developer API
-
-**Public blog**
-
-- Post, author, series, tag, search, and static pages
-- Comments, likes, and pinned posts
-- RSS, sitemaps, canonical URLs, and Open Graph metadata
-- Public Markdown URLs and optional `/llms.txt`
-
-**Operations**
-
-- Docker-based deployment
-- Initial administrator setup
-- Site name, logo, and icon settings
-- Notices, banners, notifications, webhooks, and Telegram integration
-- User roles and administration tools
-
-**Accounts and security**
-
-- GitHub and Google social login
-- TOTP two-factor authentication
-- Personal Developer API tokens with scoped permissions
-
-**Languages**
-
-- English and Korean product UI
-- Request-language negotiation when English UI support is enabled
-- Separate translation catalogs for Django, React islands, and the editor
-- Posts and other user-authored content are displayed exactly as written
-
-## Run with Docker
+## Quick start
 
 Requirement: Docker.
 
@@ -89,54 +55,23 @@ docker run -d \
   -e SITE_URL=http://localhost:20002 \
   baealex/blex:latest
 
-docker logs -f blex
+docker logs blex
 ```
 
 Open `http://localhost:20002`. The logs include an `Initial setup URL` for
 creating the first administrator. The `blex-db` and `blex-media` volumes keep
 the database and uploads when the container is replaced.
 
-This command is for a local trial and enables English and Korean UI
-negotiation. Existing installations can enable it with
-`ENABLE_ENGLISH_UI=TRUE`.
+This command is for a local trial. Before a public deployment, use unique
+secrets, set `DEBUG=FALSE`, configure the public origin and HTTPS, and back up
+both volumes. See the [Self-hosting Guide](docs/SELF_HOSTING.md).
 
-Before a public deployment, use unique secrets, set `DEBUG=FALSE`, configure
-the public site URL and allowed hosts, place an HTTPS proxy in front of BLEX,
-and back up both Docker volumes. See the
-[Self-hosting Guide](docs/SELF_HOSTING.md) for details.
-
-## Public URLs
-
-| Path | Description |
-| --- | --- |
-| `/rss` | Site RSS feed |
-| `/sitemap.xml` | Sitemap index |
-| `/posts/sitemap.xml` | Public post sitemap |
-| `/llms.txt` | Agent entry point when AEO is enabled |
-| `/@{username}/{post_url}.md` | Public post as Markdown |
-| `/@{username}/series/{series_url}.md` | Public series as Markdown |
-| `/static/{slug}.md` | Public static page as Markdown |
-| `/api/developer/v1/docs` | Developer API documentation |
-| `/api/developer/v1/openapi.json` | Developer API OpenAPI schema |
-
-Private posts, hidden posts, drafts, deleted posts, and scheduled posts that
-are not yet published are excluded from RSS, sitemaps, and public Markdown
-endpoints.
-
-## Developer API
-
-The Developer API supports personal tokens, scoped permissions, post and draft
-management, Markdown or HTML input, image upload, publishing, tags, and series.
-
-After starting BLEX, open `/docs/developer-api/quickstart` for the quickstart or
-`/api/developer/v1/docs` for the complete API documentation.
-
-## Local development
+## Development
 
 Requirements:
 
 - Python 3.12+
-- Node.js 22.22.2, 24.15+, or 26+
+- Node.js 22 (22.22.2+), 24 (24.15+), or 26+
 - npm
 
 ```bash
@@ -147,25 +82,11 @@ npm run dev
 
 Open `http://localhost:8000`.
 
-Common checks:
-
-```bash
-npm run server:test
-npm run islands:i18n:check
-npm run islands:test
-npm run islands:lint
-npm run islands:type-check
-```
-
 ## Documentation
 
 - [Self-hosting Guide](docs/SELF_HOSTING.md)
 - [Development Convention](docs/DEV_CONVENTION.md)
-- [Backend Guide](docs/BACKEND_GUIDE.md)
-- [Frontend Guide](docs/FRONTEND_GUIDE.md)
 - [Translation Guide](docs/TRANSLATION_GUIDE.md)
-- [Testing Guide](docs/TESTING_GUIDE.md)
-- [Design Guide](docs/DESIGN_GUIDE.md)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <h1 align="center">BLEX</h1>
 
 <p align="center">
-  A self-hosted blog application for your own domain and server.
+  An open-source platform for writing, publishing, and running a blog.
 </p>
 
 <p align="center">
@@ -22,21 +22,25 @@
   English · <a href="README.ko.md">한국어</a>
 </p>
 
-BLEX combines a browser editor and site administration in a single Docker
-image. It stores content in SQLite and publishes through the web, RSS,
-sitemaps, Markdown, and a Developer API.
+BLEX is built around one workflow: write, organize, publish, and maintain a
+blog over time. It provides a browser editor and administration tools, with
+Docker as the supported deployment path.
 
-## Highlights
+## Project focus
 
-- Rich-text writing with drafts, autosave recovery, revision history, previews,
-  and scheduled publishing
-- Public posts organized by authors, series, tags, search, and static pages
-- Administration for branding, users, notices, integrations, social login, and
-  TOTP two-factor authentication
-- RSS, sitemaps, Open Graph metadata, public Markdown, and scoped API tokens
-- English and Korean UI without changing user-authored content
+- **Writing and publishing:** rich-text editing, drafts, autosave recovery,
+  revision history, previews, cover images, and scheduled publishing
+- **Content management:** authors, series, tags, search, static pages, comments,
+  likes, and pinned posts
+- **Blog operations:** branding, notices and banners, users and roles, webhooks,
+  and Telegram integration
+- **Open publishing:** RSS, sitemaps, canonical and Open Graph metadata, public
+  Markdown, and a Developer API with scoped tokens
 
-## Quick start
+GitHub and Google login, TOTP two-factor authentication, and English and Korean
+product UI are included. User-authored content is always displayed as written.
+
+## Run locally with Docker
 
 Requirement: Docker.
 
@@ -58,13 +62,31 @@ docker run -d \
 docker logs blex
 ```
 
-Open `http://localhost:20002`. The logs include an `Initial setup URL` for
-creating the first administrator. The `blex-db` and `blex-media` volumes keep
-the database and uploads when the container is replaced.
+The command uses `DEBUG=TRUE` so BLEX works over local HTTP. This is a
+development setting and must not be carried into a public deployment.
 
-This command is for a local trial. Before a public deployment, use unique
-secrets, set `DEBUG=FALSE`, configure the public origin and HTTPS, and back up
-both volumes. See the [Self-hosting Guide](docs/SELF_HOSTING.md).
+Open `http://localhost:20002`, then use the `Initial setup URL` from
+`docker logs blex` to create the first administrator. The `blex-db` and
+`blex-media` volumes keep the database and uploads when the container is
+replaced.
+
+### Production deployment
+
+Use unique secrets, set `DEBUG=FALSE`, and configure `SITE_URL`,
+`ALLOWED_HOSTS`, and `CSRF_TRUSTED_ORIGINS` for the public domain. Place an
+HTTPS proxy in front of BLEX and back up both volumes. The
+[Self-hosting Guide](docs/SELF_HOSTING.md) covers the complete setup and upgrade
+path.
+
+## Publishing interfaces
+
+| Path | Purpose |
+| --- | --- |
+| `/rss` | RSS feed |
+| `/sitemap.xml` | Sitemap index |
+| `/llms.txt` | Optional agent entry point |
+| `/@{username}/{post_url}.md` | Public post as Markdown |
+| `/api/developer/v1/docs` | Developer API documentation |
 
 ## Development
 


### PR DESCRIPTION
## 🎯 Goal
- Explain what BLEX focuses on and make the local Docker path easy to follow without turning the README into a full product specification.
- Clearly separate local development settings from production deployment requirements.

## 🔧 Core Changes
- Reduced the English README from 172 to 115 lines and the Korean README from 170 to 114 lines while preserving essential product context.
- Organized the project focus around writing and publishing, content management, blog operations, and open publishing.
- Kept a clone-free Docker command and restored a compact table of publishing interfaces.
- Clarified that `DEBUG=TRUE` is a local development setting and documented production requirements separately.

## 🤔 Key Decisions
- Use the concise structure common in mature open-source projects while retaining product-specific reasons to use BLEX.
- Describe BLEX directly through its workflow and capabilities instead of generic self-hosting copy.
- Keep detailed operations in the self-hosting guide while documenting the safety boundary around the local command.
- Preserve English and Korean content parity without changing runtime behavior or configuration.

## 🧪 Verification Guide
### How to verify
1. Read each README from the top and confirm the product purpose, focus, and Docker path are clear.
2. Confirm `DEBUG=TRUE` is identified as a development setting and production requirements are separated.
3. Open the local documentation, license, and language links.
4. Compare the English and Korean sections for equivalent meaning.

### Expected result
- Both README files remain concise while giving readers enough context to understand, try, and evaluate BLEX.

## ✅ Checklist
- [x] `git diff --check`
- [x] Local Markdown links verified
- [x] English and Korean parity reviewed
- [x] Runtime tests not run (documentation-only change)