### PR TITLE
📦 Patch backend and frontend security dependencies

### DIFF
--- a/backend/islands/pnpm-lock.yaml
+++ b/backend/islands/pnpm-lock.yaml
@@ -14,7 +14,7 @@ overrides:
   linkify-it: 5.0.1
   markdown-it: 14.2.0
   minimatch: 10.2.5
-  nanoid: 3.3.17
+  nanoid: 3.3.18
 
 importers:
 
@@ -3236,8 +3236,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -6862,7 +6862,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -7024,13 +7024,13 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
   postcss@8.5.24:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/backend/islands/pnpm-workspace.yaml
+++ b/backend/islands/pnpm-workspace.yaml
@@ -19,4 +19,4 @@ overrides:
   linkify-it: 5.0.1
   markdown-it: 14.2.0
   minimatch: 10.2.5
-  nanoid: 3.3.17
+  nanoid: 3.3.18

--- a/backend/src/requirements.txt
+++ b/backend/src/requirements.txt
@@ -9,7 +9,7 @@ click==8.4.2
 cryptography==50.0.0
 cssselect==1.4.0
 defusedxml==0.7.1
-Django==6.0.7
+Django==6.0.8
 django-cors-headers==4.9.0
 django-ninja==1.6.2
 graphene==3.4.3
@@ -43,7 +43,7 @@ readtime==3.0.0
 requests==2.34.2
 six==1.17.0
 soupsieve==2.8.4
-sqlparse==0.5.5
+sqlparse==0.6.0
 text-unidecode==1.3
 typing_extensions==4.16.0
 typing-inspection==0.4.2


### PR DESCRIPTION
## 🎯 Goal
- Resolve the current backend and frontend dependency security findings.
- Apply patch-level fixes now because they remove known vulnerabilities without changing application contracts or database schema.

## 🔧 Core Changes
- Upgrade Django from 6.0.7 to 6.0.8 for the latest 6.0 security fixes.
- Upgrade sqlparse from 0.5.5 to 0.6.0 for the current Dependabot advisories.
- Upgrade the transitive development dependency nanoid from 3.3.17 to 3.3.18 through the existing pnpm override.

## 🤔 Key Decisions
- Keep Django on the existing 6.0 release line instead of mixing a framework feature upgrade into a security patch.
- Limit the JavaScript change to the existing transitive override because nanoid is only reached through build tooling.
- Avoid unrelated dependency refreshes so the patch remains small and reviewable.

## 🧪 Verification Guide
### How to verify
1. Run `npm audit --audit-level=high`, `pnpm audit --audit-level=high`, `pnpm audit --prod --audit-level=high`, and `pip-audit -r backend/src/requirements.txt`.
2. Run `npm run server:check-migrations` and `npm run server:test`.
3. Run `npm run islands:test`, `npm run islands:type-check`, `npm run islands:lint`, and `npm run islands:build`.

### Expected result
- All dependency audits report no known vulnerabilities.
- All 1,470 backend tests pass with no migration changes.
- Islands tests, type checks, lint, and production build pass; lint retains seven existing warnings and no errors.

## ✅ Checklist
- [x] Lint completed
- [x] Type-check completed
- [x] Tests completed
- [x] Documentation updated (not needed: dependency-only patch)
